### PR TITLE
markdown: add theme selector (Light/Dark/Auto/Stage 11 Gold) + refresh controls

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		A58689DE /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C229 /* MermaidRenderer.swift */; };
 		A58689DF /* FencedCodeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C22A /* FencedCodeRenderer.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
+		A5C11101 /* MarkdownTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C11102 /* MarkdownTheme.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
@@ -218,6 +219,7 @@
 		A537C229 /* MermaidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MermaidRenderer.swift; sourceTree = "<group>"; };
 		A537C22A /* FencedCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FencedCodeRenderer.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
+		A5C11102 /* MarkdownTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTheme.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5C11006 /* AgentChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChip.swift; sourceTree = "<group>"; };
 		A5C11008 /* AgentChipBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChipBadge.swift; sourceTree = "<group>"; };
@@ -454,6 +456,7 @@
 				A537C229 /* MermaidRenderer.swift */,
 				A537C22A /* FencedCodeRenderer.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
+				A5C11102 /* MarkdownTheme.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001211 /* UpdateController.swift */,
@@ -754,6 +757,7 @@
 				A58689DE /* MermaidRenderer.swift in Sources */,
 				A58689DF /* FencedCodeRenderer.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
+				A5C11101 /* MarkdownTheme.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -76063,6 +76063,23 @@
         }
       }
     },
+    "markdown.action.cycleTheme.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cycle Markdown Theme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マークダウンテーマを切り替える"
+          }
+        }
+      }
+    },
     "markdown.action.refresh": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59321,6 +59321,23 @@
         }
       }
     },
+    "shortcut.cycleMarkdownTheme.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cycle Markdown Theme"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown テーマを切り替える"
+          }
+        }
+      }
+    },
     "shortcut.flashFocusedPanel.label": {
       "extractionState": "manual",
       "localizations": {
@@ -61125,6 +61142,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Önceki Çalışma Alanı"
+          }
+        }
+      }
+    },
+    "shortcut.refreshMarkdown.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh Markdown"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown を再読み込み"
           }
         }
       }
@@ -76008,6 +76042,108 @@
           "stringUnit": {
             "state": "translated",
             "value": "ファイルを利用できません"
+          }
+        }
+      }
+    },
+    "markdown.action.cycleTheme": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テーマ: %@"
+          }
+        }
+      }
+    },
+    "markdown.action.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reload from disk"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスクから再読み込み"
+          }
+        }
+      }
+    },
+    "markdown.theme.auto": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        }
+      }
+    },
+    "markdown.theme.dark": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダーク"
+          }
+        }
+      }
+    },
+    "markdown.theme.gold": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stage 11 Gold"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stage 11 ゴールド"
+          }
+        }
+      }
+    },
+    "markdown.theme.light": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライト"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9523,6 +9523,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if tabManager?.focusedBrowserPanel != nil {
                 return false
             }
+            // Let Cmd+R reach the markdown refresh handler below instead of the rename-tab palette.
+            if tabManager?.focusedMarkdownPanel != nil {
+                return false
+            }
             let targetWindow = commandPaletteTargetWindow ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
             requestCommandPaletteRenameTab(preferredWindow: targetWindow, source: "shortcut.renameTab")
             return true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9712,6 +9712,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // Markdown: refresh (⌘R) and cycle theme (⌘⇧T). Only fire when a
+        // markdown panel is focused so ⌘R etc. remain available to terminals
+        // and browsers in their own contexts.
+        if tabManager?.focusedMarkdownPanel != nil {
+            if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .refreshMarkdown)) {
+                _ = tabManager?.reloadFocusedMarkdown()
+                return true
+            }
+            if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .cycleMarkdownTheme)) {
+                _ = tabManager?.cycleFocusedMarkdownTheme()
+                return true
+            }
+        }
+
         // Focus browser address bar: Cmd+L
         if matchShortcut(
             event: event,

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -45,6 +45,10 @@ enum KeyboardShortcutSettings {
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
 
+        // Markdown
+        case refreshMarkdown
+        case cycleMarkdownTheme
+
         var id: String { rawValue }
 
         var label: String {
@@ -79,6 +83,8 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
+            case .refreshMarkdown: return String(localized: "shortcut.refreshMarkdown.label", defaultValue: "Refresh Markdown")
+            case .cycleMarkdownTheme: return String(localized: "shortcut.cycleMarkdownTheme.label", defaultValue: "Cycle Markdown Theme")
             }
         }
 
@@ -114,6 +120,8 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
+            case .refreshMarkdown: return "shortcut.refreshMarkdown"
+            case .cycleMarkdownTheme: return "shortcut.cycleMarkdownTheme"
             }
         }
 
@@ -181,6 +189,12 @@ enum KeyboardShortcutSettings {
             case .showBrowserJavaScriptConsole:
                 // Safari default: Show JavaScript Console.
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
+            case .refreshMarkdown:
+                // Standard "reload" — only fires when a markdown panel is focused.
+                return StoredShortcut(key: "r", command: true, shift: false, option: false, control: false)
+            case .cycleMarkdownTheme:
+                // ⌘⇧T cycles theme — fires only when a markdown panel is focused.
+                return StoredShortcut(key: "t", command: true, shift: true, option: false, control: false)
             }
         }
 

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -19,6 +19,15 @@ enum MarkdownSegment: Identifiable {
 /// When the file changes on disk, the content is automatically reloaded.
 @MainActor
 final class MarkdownPanel: Panel, ObservableObject {
+    /// UserDefaults key for the app-wide default markdown theme. Used as the
+    /// initial value for any newly-created panel that doesn't have a persisted
+    /// per-panel override.
+    static let defaultThemeDefaultsKey = "markdownThemeDefault"
+
+    /// Notification posted when `themeChoice` changes so external observers
+    /// (session persistence) can react.
+    static let themeChoiceDidChangeNotification = Notification.Name("cmux.markdownPanel.themeChoiceDidChange")
+
     let id: UUID
     let panelType: PanelType = .markdown
 
@@ -46,6 +55,10 @@ final class MarkdownPanel: Panel, ObservableObject {
     /// Parsed segments of the content (markdown + mermaid blocks).
     @Published private(set) var segments: [MarkdownSegment] = []
 
+    /// User-selected theme for this panel. Defaults to the app-wide
+    /// `markdownThemeDefault` setting, or `.auto` if never set.
+    @Published private(set) var themeChoice: MarkdownThemeChoice
+
     /// Tracks the appearance used for the last mermaid render pass.
     private var lastRenderedDark: Bool?
 
@@ -68,11 +81,12 @@ final class MarkdownPanel: Panel, ObservableObject {
 
     // MARK: - Init
 
-    init(workspaceId: UUID, filePath: String) {
+    init(workspaceId: UUID, filePath: String, themeChoice: MarkdownThemeChoice? = nil) {
         self.id = UUID()
         self.workspaceId = workspaceId
         self.filePath = filePath
         self.displayTitle = (filePath as NSString).lastPathComponent
+        self.themeChoice = themeChoice ?? Self.appWideDefaultThemeChoice()
 
         loadFileContent()
         startFileWatcher()
@@ -82,6 +96,59 @@ final class MarkdownPanel: Panel, ObservableObject {
             scheduleReattach(attempt: 1)
         }
         startAppearanceObserver()
+    }
+
+    // MARK: - Theme
+
+    /// Reads the app-wide default markdown theme from UserDefaults. Used when
+    /// constructing a new panel that has no persisted per-panel override.
+    static func appWideDefaultThemeChoice() -> MarkdownThemeChoice {
+        guard let raw = UserDefaults.standard.string(forKey: defaultThemeDefaultsKey),
+              let parsed = MarkdownThemeChoice(rawValue: raw) else {
+            return .auto
+        }
+        return parsed
+    }
+
+    /// Sets the theme choice for this panel. Triggers mermaid re-render if the
+    /// effective dark/light resolution changes.
+    func setTheme(_ choice: MarkdownThemeChoice) {
+        guard themeChoice != choice else { return }
+        themeChoice = choice
+        NotificationCenter.default.post(
+            name: Self.themeChoiceDidChangeNotification,
+            object: self
+        )
+        handleAppearanceChangeIfNeeded()
+    }
+
+    /// Advance to the next theme in the cycle order (Auto → Light → Dark → Gold → Auto).
+    func cycleTheme() {
+        setTheme(themeChoice.next)
+    }
+
+    /// True when the current theme (after resolving `.auto` against the system
+    /// appearance) wants a dark palette. Used to drive mermaid rendering.
+    var effectiveIsDark: Bool {
+        switch themeChoice {
+        case .auto:
+            return NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        case .light:
+            return false
+        case .dark, .gold:
+            return true
+        }
+    }
+
+    // MARK: - Public reload
+
+    /// Re-read the source file from disk. Safe to call from any UI affordance
+    /// (refresh button, keyboard shortcut, command palette). The existing
+    /// DispatchSource watcher covers most cases automatically; this method is
+    /// a manual fallback for network mounts, atomic rewrites the watcher may
+    /// miss, or cases where the user just wants certainty.
+    func reload() {
+        loadFileContent()
     }
 
     // MARK: - Panel protocol
@@ -218,7 +285,7 @@ final class MarkdownPanel: Panel, ObservableObject {
 
     /// Render fenced code segments asynchronously via their registered renderers.
     private func renderFencedCodeSegments() {
-        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let isDark = effectiveIsDark
         lastRenderedDark = isDark
 
         let registry = FencedCodeRendererRegistry.shared
@@ -285,7 +352,7 @@ final class MarkdownPanel: Panel, ObservableObject {
     }
 
     private func handleAppearanceChangeIfNeeded() {
-        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let isDark = effectiveIsDark
         guard isDark != lastRenderedDark else { return }
         // Clear rendered images so they re-render with the new theme
         for (i, segment) in segments.enumerated() {

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -24,10 +24,6 @@ final class MarkdownPanel: Panel, ObservableObject {
     /// per-panel override.
     static let defaultThemeDefaultsKey = "markdownThemeDefault"
 
-    /// Notification posted when `themeChoice` changes so external observers
-    /// (session persistence) can react.
-    static let themeChoiceDidChangeNotification = Notification.Name("cmux.markdownPanel.themeChoiceDidChange")
-
     let id: UUID
     let panelType: PanelType = .markdown
 
@@ -61,6 +57,11 @@ final class MarkdownPanel: Panel, ObservableObject {
 
     /// Tracks the appearance used for the last mermaid render pass.
     private var lastRenderedDark: Bool?
+
+    /// Bumped every time the effective theme changes so that late completions
+    /// from a prior render pass cannot overwrite the current theme's images
+    /// during rapid ⌘⇧T cycling.
+    private var renderGeneration: Int = 0
 
     /// Observer for system appearance changes.
     private var appearanceObserver: NSObjectProtocol?
@@ -115,10 +116,6 @@ final class MarkdownPanel: Panel, ObservableObject {
     func setTheme(_ choice: MarkdownThemeChoice) {
         guard themeChoice != choice else { return }
         themeChoice = choice
-        NotificationCenter.default.post(
-            name: Self.themeChoiceDidChangeNotification,
-            object: self
-        )
         handleAppearanceChangeIfNeeded()
     }
 
@@ -287,6 +284,7 @@ final class MarkdownPanel: Panel, ObservableObject {
     private func renderFencedCodeSegments() {
         let isDark = effectiveIsDark
         lastRenderedDark = isDark
+        let generation = renderGeneration
 
         let registry = FencedCodeRendererRegistry.shared
 
@@ -309,6 +307,10 @@ final class MarkdownPanel: Panel, ObservableObject {
             guard let renderer = registry.renderer(for: language) else { continue }
             renderer.render(code: code, isDark: isDark) { [weak self] image in
                 guard let self else { return }
+                // Theme changed since this render started — drop the result so
+                // a late completion from a prior theme cannot corrupt the
+                // current theme's rendered images.
+                guard generation == self.renderGeneration else { return }
                 guard index < self.segments.count,
                       case .fencedCode(let currentId, _, _, _) = self.segments[index],
                       currentId == id else { return }
@@ -354,6 +356,9 @@ final class MarkdownPanel: Panel, ObservableObject {
     private func handleAppearanceChangeIfNeeded() {
         let isDark = effectiveIsDark
         guard isDark != lastRenderedDark else { return }
+        // Invalidate any in-flight renders kicked off for the prior theme so
+        // their completions become no-ops (see `renderFencedCodeSegments`).
+        renderGeneration &+= 1
         // Clear rendered images so they re-render with the new theme
         for (i, segment) in segments.enumerated() {
             if case .fencedCode(let id, let lang, let code, let image) = segment, image != nil {

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -182,9 +182,10 @@ struct MarkdownPanelView: View {
                 )
             ))
             .accessibilityLabel(Text(String(
-                localized: "markdown.action.cycleTheme",
-                defaultValue: "Theme: \(panel.themeChoice.label)"
+                localized: "markdown.action.cycleTheme.accessibilityLabel",
+                defaultValue: "Cycle Markdown Theme"
             )))
+            .accessibilityValue(Text(panel.themeChoice.label))
         }
     }
 

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -14,6 +14,11 @@ struct MarkdownPanelView: View {
     @State private var focusFlashAnimationGeneration: Int = 0
     @Environment(\.colorScheme) private var colorScheme
 
+    /// Resolved palette for the current theme choice + system appearance.
+    private var palette: MarkdownPalette {
+        panel.themeChoice.palette(systemColorScheme: colorScheme)
+    }
+
     var body: some View {
         Group {
             if panel.isFileUnavailable {
@@ -23,7 +28,7 @@ struct MarkdownPanelView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(backgroundColor)
+        .background(palette.background)
         .overlay {
             RoundedRectangle(cornerRadius: FocusFlashPattern.ringCornerRadius)
                 .stroke(cmuxAccentColor().opacity(focusFlashOpacity), lineWidth: 3)
@@ -54,7 +59,9 @@ struct MarkdownPanelView: View {
                     .padding(.top, 16)
                     .padding(.bottom, 8)
 
-                Divider()
+                Rectangle()
+                    .fill(palette.divider)
+                    .frame(height: 1)
                     .padding(.horizontal, 16)
 
                 // Rendered content segments
@@ -102,21 +109,17 @@ struct MarkdownPanelView: View {
             ScrollView(.horizontal, showsIndicators: true) {
                 Text(code)
                     .font(.system(size: 13, design: .monospaced))
-                    .foregroundColor(colorScheme == .dark
-                        ? Color(red: 0.9, green: 0.9, blue: 0.9)
-                        : Color(red: 0.2, green: 0.2, blue: 0.2))
+                    .foregroundColor(palette.codeBlockForeground)
                     .textSelection(.enabled)
                     .padding(12)
             }
-            .background(colorScheme == .dark
-                ? Color(nsColor: NSColor(white: 0.08, alpha: 1.0))
-                : Color(nsColor: NSColor(white: 0.93, alpha: 1.0)))
+            .background(palette.codeBlockBackground)
             .clipShape(RoundedRectangle(cornerRadius: 6))
 
             if let renderer, !renderer.isAvailable, let hint = renderer.installHint {
                 Text(hint)
                     .font(.system(size: 11))
-                    .foregroundColor(.secondary)
+                    .foregroundColor(palette.secondary)
             }
         }
         .padding(.horizontal, 24)
@@ -126,14 +129,62 @@ struct MarkdownPanelView: View {
     private var filePathHeader: some View {
         HStack(spacing: 6) {
             Image(systemName: "doc.richtext")
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondary)
                 .font(.system(size: 12))
             Text(panel.filePath)
                 .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
-            Spacer()
+            Spacer(minLength: 8)
+            headerActions
+        }
+    }
+
+    /// Refresh + theme-cycle buttons shown at the right of the header.
+    /// Discoverable alternatives to the keyboard shortcuts (⌘R, ⌘⇧T).
+    private var headerActions: some View {
+        HStack(spacing: 4) {
+            Button {
+                panel.reload()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(palette.secondary)
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(KeyboardShortcutSettings.Action.refreshMarkdown.tooltip(
+                String(localized: "markdown.action.refresh", defaultValue: "Reload from disk")
+            ))
+            .accessibilityLabel(Text(String(
+                localized: "markdown.action.refresh",
+                defaultValue: "Reload from disk"
+            )))
+
+            Button {
+                panel.cycleTheme()
+            } label: {
+                Image(systemName: panel.themeChoice.iconName)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(
+                        panel.themeChoice == .gold ? BrandColors.goldSwiftUI : palette.secondary
+                    )
+                    .frame(width: 22, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .help(KeyboardShortcutSettings.Action.cycleMarkdownTheme.tooltip(
+                String(
+                    localized: "markdown.action.cycleTheme",
+                    defaultValue: "Theme: \(panel.themeChoice.label)"
+                )
+            ))
+            .accessibilityLabel(Text(String(
+                localized: "markdown.action.cycleTheme",
+                defaultValue: "Theme: \(panel.themeChoice.label)"
+            )))
         }
     }
 
@@ -141,39 +192,33 @@ struct MarkdownPanelView: View {
         VStack(spacing: 12) {
             Image(systemName: "doc.questionmark")
                 .font(.system(size: 40))
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondary)
             Text(String(localized: "markdown.fileUnavailable.title", defaultValue: "File unavailable"))
                 .font(.headline)
-                .foregroundColor(.primary)
+                .foregroundColor(palette.body)
             Text(panel.filePath)
                 .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondary)
                 .multilineTextAlignment(.center)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 24)
             Text(String(localized: "markdown.fileUnavailable.message", defaultValue: "The file may have been moved or deleted."))
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundColor(palette.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Theme
 
-    private var backgroundColor: Color {
-        colorScheme == .dark
-            ? Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
-            : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
-    }
-
     private var cmuxMarkdownTheme: Theme {
-        let isDark = colorScheme == .dark
+        let p = palette
 
         return Theme()
             // Text
             .text {
-                ForegroundColor(isDark ? .white.opacity(0.9) : .primary)
+                ForegroundColor(p.body)
                 FontSize(14)
             }
             // Headings
@@ -183,9 +228,11 @@ struct MarkdownPanelView: View {
                         .markdownTextStyle {
                             FontWeight(.bold)
                             FontSize(28)
-                            ForegroundColor(isDark ? .white : .primary)
+                            ForegroundColor(p.heading)
                         }
-                    Divider()
+                    Rectangle()
+                        .fill(p.divider)
+                        .frame(height: 1)
                 }
                 .markdownMargin(top: 24, bottom: 16)
             }
@@ -195,9 +242,11 @@ struct MarkdownPanelView: View {
                         .markdownTextStyle {
                             FontWeight(.bold)
                             FontSize(22)
-                            ForegroundColor(isDark ? .white : .primary)
+                            ForegroundColor(p.heading)
                         }
-                    Divider()
+                    Rectangle()
+                        .fill(p.divider)
+                        .frame(height: 1)
                 }
                 .markdownMargin(top: 20, bottom: 12)
             }
@@ -206,7 +255,7 @@ struct MarkdownPanelView: View {
                     .markdownTextStyle {
                         FontWeight(.semibold)
                         FontSize(18)
-                        ForegroundColor(isDark ? .white : .primary)
+                        ForegroundColor(p.heading)
                     }
                     .markdownMargin(top: 16, bottom: 8)
             }
@@ -215,7 +264,7 @@ struct MarkdownPanelView: View {
                     .markdownTextStyle {
                         FontWeight(.semibold)
                         FontSize(16)
-                        ForegroundColor(isDark ? .white : .primary)
+                        ForegroundColor(p.heading)
                     }
                     .markdownMargin(top: 12, bottom: 6)
             }
@@ -224,7 +273,7 @@ struct MarkdownPanelView: View {
                     .markdownTextStyle {
                         FontWeight(.medium)
                         FontSize(14)
-                        ForegroundColor(isDark ? .white : .primary)
+                        ForegroundColor(p.heading)
                     }
                     .markdownMargin(top: 10, bottom: 4)
             }
@@ -233,7 +282,7 @@ struct MarkdownPanelView: View {
                     .markdownTextStyle {
                         FontWeight(.medium)
                         FontSize(13)
-                        ForegroundColor(isDark ? .white.opacity(0.7) : .secondary)
+                        ForegroundColor(p.secondary)
                     }
                     .markdownMargin(top: 8, bottom: 4)
             }
@@ -244,13 +293,11 @@ struct MarkdownPanelView: View {
                         .markdownTextStyle {
                             FontFamilyVariant(.monospaced)
                             FontSize(13)
-                            ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
+                            ForegroundColor(p.codeBlockForeground)
                         }
                         .padding(12)
                 }
-                .background(isDark
-                    ? Color(nsColor: NSColor(white: 0.08, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.93, alpha: 1.0)))
+                .background(p.codeBlockBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
                 .markdownMargin(top: 8, bottom: 8)
             }
@@ -258,20 +305,18 @@ struct MarkdownPanelView: View {
             .code {
                 FontFamilyVariant(.monospaced)
                 FontSize(13)
-                ForegroundColor(isDark ? Color(red: 0.85, green: 0.6, blue: 0.95) : Color(red: 0.6, green: 0.2, blue: 0.7))
-                BackgroundColor(isDark
-                    ? Color(nsColor: NSColor(white: 0.18, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.92, alpha: 1.0)))
+                ForegroundColor(p.inlineCodeForeground)
+                BackgroundColor(p.inlineCodeBackground)
             }
             // Block quotes
             .blockquote { configuration in
                 HStack(spacing: 0) {
                     RoundedRectangle(cornerRadius: 1.5)
-                        .fill(isDark ? Color.white.opacity(0.2) : Color.gray.opacity(0.4))
+                        .fill(p.blockquoteBar)
                         .frame(width: 3)
                     configuration.label
                         .markdownTextStyle {
-                            ForegroundColor(isDark ? .white.opacity(0.6) : .secondary)
+                            ForegroundColor(p.blockquoteText)
                             FontSize(14)
                         }
                         .padding(.leading, 12)
@@ -280,7 +325,7 @@ struct MarkdownPanelView: View {
             }
             // Links
             .link {
-                ForegroundColor(Color.accentColor)
+                ForegroundColor(p.link)
             }
             // Strong
             .strong {
@@ -289,22 +334,17 @@ struct MarkdownPanelView: View {
             // Tables
             .table { configuration in
                 configuration.label
-                    .markdownTableBorderStyle(.init(color: isDark ? .white.opacity(0.15) : .gray.opacity(0.3)))
+                    .markdownTableBorderStyle(.init(color: p.tableBorder))
                     .markdownTableBackgroundStyle(
-                        .alternatingRows(
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.14, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 0.96, alpha: 1.0)),
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.10, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 1.0, alpha: 1.0))
-                        )
+                        .alternatingRows(p.tableRowA, p.tableRowB)
                     )
                     .markdownMargin(top: 8, bottom: 8)
             }
             // Thematic break (horizontal rule)
             .thematicBreak {
-                Divider()
+                Rectangle()
+                    .fill(p.divider)
+                    .frame(height: 1)
                     .markdownMargin(top: 16, bottom: 16)
             }
             // List items

--- a/Sources/Panels/MarkdownTheme.swift
+++ b/Sources/Panels/MarkdownTheme.swift
@@ -1,0 +1,144 @@
+import AppKit
+import SwiftUI
+
+/// Theme choice for a markdown panel. `auto` follows the macOS appearance;
+/// `gold` is the Stage 11 brand theme (void background, gold accent).
+enum MarkdownThemeChoice: String, CaseIterable, Codable, Identifiable, Sendable {
+    case auto
+    case light
+    case dark
+    case gold
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .auto: return String(localized: "markdown.theme.auto", defaultValue: "Auto")
+        case .light: return String(localized: "markdown.theme.light", defaultValue: "Light")
+        case .dark: return String(localized: "markdown.theme.dark", defaultValue: "Dark")
+        case .gold: return String(localized: "markdown.theme.gold", defaultValue: "Stage 11 Gold")
+        }
+    }
+
+    /// SF Symbol shown in the header toolbar for the current selection.
+    var iconName: String {
+        switch self {
+        case .auto: return "circle.lefthalf.filled"
+        case .light: return "sun.max"
+        case .dark: return "moon"
+        case .gold: return "sparkles"
+        }
+    }
+
+    /// Next choice in the cycle order (Auto → Light → Dark → Gold → Auto …).
+    var next: MarkdownThemeChoice {
+        switch self {
+        case .auto: return .light
+        case .light: return .dark
+        case .dark: return .gold
+        case .gold: return .auto
+        }
+    }
+
+    /// Resolve to a concrete palette given the current system ColorScheme.
+    func palette(systemColorScheme: ColorScheme) -> MarkdownPalette {
+        switch self {
+        case .auto:
+            return systemColorScheme == .dark ? .dark : .light
+        case .light:
+            return .light
+        case .dark:
+            return .dark
+        case .gold:
+            return .gold
+        }
+    }
+}
+
+/// Concrete color palette used by `MarkdownPanelView` when rendering content.
+///
+/// Each palette is a pre-baked set of colors for a single theme. Gold pulls
+/// directly from `BrandColors` (the canonical Stage 11 palette); light and
+/// dark mirror the pre-existing MarkdownUI styling so behavior is preserved
+/// when the user opts to stay on system appearance.
+struct MarkdownPalette {
+    var isDark: Bool
+    var background: Color
+    var body: Color
+    var heading: Color
+    var secondary: Color
+    var codeBlockBackground: Color
+    var codeBlockForeground: Color
+    var inlineCodeForeground: Color
+    var inlineCodeBackground: Color
+    var blockquoteBar: Color
+    var blockquoteText: Color
+    var link: Color
+    var divider: Color
+    var tableBorder: Color
+    var tableRowA: Color
+    var tableRowB: Color
+
+    /// True if mermaid diagrams should render in their dark theme.
+    var mermaidUsesDarkTheme: Bool { isDark }
+
+    static let light = MarkdownPalette(
+        isDark: false,
+        background: Color(nsColor: NSColor(white: 0.98, alpha: 1.0)),
+        body: .primary,
+        heading: .primary,
+        secondary: .secondary,
+        codeBlockBackground: Color(nsColor: NSColor(white: 0.93, alpha: 1.0)),
+        codeBlockForeground: Color(red: 0.2, green: 0.2, blue: 0.2),
+        inlineCodeForeground: Color(red: 0.6, green: 0.2, blue: 0.7),
+        inlineCodeBackground: Color(nsColor: NSColor(white: 0.92, alpha: 1.0)),
+        blockquoteBar: Color.gray.opacity(0.4),
+        blockquoteText: .secondary,
+        link: .accentColor,
+        divider: Color.gray.opacity(0.3),
+        tableBorder: Color.gray.opacity(0.3),
+        tableRowA: Color(nsColor: NSColor(white: 0.96, alpha: 1.0)),
+        tableRowB: Color(nsColor: NSColor(white: 1.0, alpha: 1.0))
+    )
+
+    static let dark = MarkdownPalette(
+        isDark: true,
+        background: Color(nsColor: NSColor(white: 0.12, alpha: 1.0)),
+        body: .white.opacity(0.9),
+        heading: .white,
+        secondary: .white.opacity(0.6),
+        codeBlockBackground: Color(nsColor: NSColor(white: 0.08, alpha: 1.0)),
+        codeBlockForeground: Color(red: 0.9, green: 0.9, blue: 0.9),
+        inlineCodeForeground: Color(red: 0.85, green: 0.6, blue: 0.95),
+        inlineCodeBackground: Color(nsColor: NSColor(white: 0.18, alpha: 1.0)),
+        blockquoteBar: Color.white.opacity(0.2),
+        blockquoteText: .white.opacity(0.6),
+        link: .accentColor,
+        divider: Color.white.opacity(0.15),
+        tableBorder: Color.white.opacity(0.15),
+        tableRowA: Color(nsColor: NSColor(white: 0.14, alpha: 1.0)),
+        tableRowB: Color(nsColor: NSColor(white: 0.10, alpha: 1.0))
+    )
+
+    /// Stage 11 void-dominant palette. Gold is the single accent, used for
+    /// headings, links, and inline code. Body text stays at `#e8e8e8` for
+    /// extended-reading comfort.
+    static let gold = MarkdownPalette(
+        isDark: true,
+        background: BrandColors.blackSwiftUI,
+        body: BrandColors.whiteSwiftUI,
+        heading: BrandColors.goldSwiftUI,
+        secondary: BrandColors.dimSwiftUI,
+        codeBlockBackground: BrandColors.surfaceSwiftUI,
+        codeBlockForeground: BrandColors.whiteSwiftUI,
+        inlineCodeForeground: BrandColors.goldSwiftUI,
+        inlineCodeBackground: BrandColors.goldFaintSwiftUI,
+        blockquoteBar: BrandColors.goldSwiftUI,
+        blockquoteText: BrandColors.whiteSwiftUI.opacity(0.75),
+        link: BrandColors.goldSwiftUI,
+        divider: BrandColors.ruleSwiftUI,
+        tableBorder: BrandColors.ruleSwiftUI,
+        tableRowA: BrandColors.surfaceSwiftUI,
+        tableRowB: BrandColors.blackSwiftUI
+    )
+}

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -238,8 +238,10 @@ struct SessionBrowserPanelSnapshot: Codable, Sendable {
 
 struct SessionMarkdownPanelSnapshot: Codable, Sendable {
     var filePath: String
-    /// Raw value of `MarkdownThemeChoice` when the user picked a per-panel
-    /// override. `nil` means "inherit the app-wide default at restore time".
+    /// Raw value of `MarkdownThemeChoice`. Current writers always serialize a
+    /// concrete choice (including `"auto"`), so restore pins exactly what the
+    /// user had. `nil` only appears in legacy snapshots predating per-panel
+    /// theme persistence; those restore under the app-wide default.
     var themeChoice: String?
 }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -238,6 +238,9 @@ struct SessionBrowserPanelSnapshot: Codable, Sendable {
 
 struct SessionMarkdownPanelSnapshot: Codable, Sendable {
     var filePath: String
+    /// Raw value of `MarkdownThemeChoice` when the user picked a per-panel
+    /// override. `nil` means "inherit the app-wide default at restore time".
+    var themeChoice: String?
 }
 
 struct SessionPanelSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2579,6 +2579,31 @@ class TabManager: ObservableObject {
         return tab.panels[panelId] as? BrowserPanel
     }
 
+    /// Returns the focused panel if it's a MarkdownPanel, nil otherwise.
+    var focusedMarkdownPanel: MarkdownPanel? {
+        guard let tab = selectedWorkspace,
+              let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId] as? MarkdownPanel
+    }
+
+    /// Reload the focused markdown panel from disk. No-op (returns false) when
+    /// the focused panel is not a markdown panel.
+    @discardableResult
+    func reloadFocusedMarkdown() -> Bool {
+        guard let panel = focusedMarkdownPanel else { return false }
+        panel.reload()
+        return true
+    }
+
+    /// Cycle the theme for the focused markdown panel. No-op when the focused
+    /// panel is not a markdown panel.
+    @discardableResult
+    func cycleFocusedMarkdownTheme() -> Bool {
+        guard let panel = focusedMarkdownPanel else { return false }
+        panel.cycleTheme()
+        return true
+    }
+
     @discardableResult
     func zoomInFocusedBrowser() -> Bool {
         focusedBrowserPanel?.zoomIn() ?? false

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -385,7 +385,10 @@ extension Workspace {
             guard let markdownPanel = panel as? MarkdownPanel else { return nil }
             terminalSnapshot = nil
             browserSnapshot = nil
-            markdownSnapshot = SessionMarkdownPanelSnapshot(filePath: markdownPanel.filePath)
+            markdownSnapshot = SessionMarkdownPanelSnapshot(
+                filePath: markdownPanel.filePath,
+                themeChoice: markdownPanel.themeChoice.rawValue
+            )
         }
 
         return SessionPanelSnapshot(
@@ -567,11 +570,14 @@ extension Workspace {
             applySessionPanelMetadata(snapshot, toPanelId: browserPanel.id)
             return browserPanel.id
         case .markdown:
-            guard let filePath = snapshot.markdown?.filePath,
-                  let markdownPanel = newMarkdownSurface(
+            guard let filePath = snapshot.markdown?.filePath else { return nil }
+            let restoredTheme = snapshot.markdown?.themeChoice
+                .flatMap(MarkdownThemeChoice.init(rawValue:))
+            guard let markdownPanel = newMarkdownSurface(
                     inPane: paneId,
                     filePath: filePath,
-                    focus: false
+                    focus: false,
+                    themeChoice: restoredTheme
                   ) else {
                 return nil
             }
@@ -7000,7 +7006,8 @@ final class Workspace: Identifiable, ObservableObject {
         orientation: SplitOrientation,
         insertFirst: Bool = false,
         filePath: String,
-        focus: Bool = true
+        focus: Bool = true,
+        themeChoice: MarkdownThemeChoice? = nil
     ) -> MarkdownPanel? {
         guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
         var sourcePaneId: PaneID?
@@ -7014,7 +7021,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         guard let paneId = sourcePaneId else { return nil }
 
-        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath)
+        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath, themeChoice: themeChoice)
         panels[markdownPanel.id] = markdownPanel
         panelTitles[markdownPanel.id] = markdownPanel.displayTitle
 
@@ -7061,13 +7068,14 @@ final class Workspace: Identifiable, ObservableObject {
     func newMarkdownSurface(
         inPane paneId: PaneID,
         filePath: String,
-        focus: Bool? = nil
+        focus: Bool? = nil,
+        themeChoice: MarkdownThemeChoice? = nil
     ) -> MarkdownPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalPanel?.hostedView
 
-        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath)
+        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath, themeChoice: themeChoice)
         panels[markdownPanel.id] = markdownPanel
         panelTitles[markdownPanel.id] = markdownPanel.displayTitle
 

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -26,6 +26,7 @@ final class SessionPersistenceTests: XCTestCase {
                 focus: true
             )
         )
+        panel.setTheme(.gold)
         workspace.setCustomTitle("Docs")
         workspace.setPanelCustomTitle(panelId: panel.id, title: "Readme")
 
@@ -37,8 +38,45 @@ final class SessionPersistenceTests: XCTestCase {
         let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
         let restoredPanel = try XCTUnwrap(restored.markdownPanel(for: restoredPanelId))
         XCTAssertEqual(restoredPanel.filePath, markdownURL.path)
+        XCTAssertEqual(restoredPanel.themeChoice, .gold)
         XCTAssertEqual(restored.customTitle, "Docs")
         XCTAssertEqual(restored.panelTitle(panelId: restoredPanelId), "Readme")
+    }
+
+    @MainActor
+    func testWorkspaceSessionSnapshotRoundTripsEveryMarkdownThemeChoice() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-markdown-themes-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let markdownURL = root.appendingPathComponent("note.md")
+        try "# hi\n".write(to: markdownURL, atomically: true, encoding: .utf8)
+
+        for choice in MarkdownThemeChoice.allCases {
+            let workspace = Workspace()
+            let paneId = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+            let panel = try XCTUnwrap(
+                workspace.newMarkdownSurface(
+                    inPane: paneId,
+                    filePath: markdownURL.path,
+                    focus: true
+                )
+            )
+            panel.setTheme(choice)
+
+            let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+            let restored = Workspace()
+            restored.restoreSessionSnapshot(snapshot)
+
+            let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+            let restoredPanel = try XCTUnwrap(restored.markdownPanel(for: restoredPanelId))
+            XCTAssertEqual(
+                restoredPanel.themeChoice,
+                choice,
+                "themeChoice round-trip failed for \(choice)"
+            )
+        }
     }
 
     func testSaveAndLoadRoundTripWithCustomSnapshotPath() throws {


### PR DESCRIPTION
## Summary

- Extract the hard-coded MarkdownUI theme into a `MarkdownTheme` type with four choices: **Auto** (follows system), **Light**, **Dark**, **Stage 11 Gold**. The Gold palette is a third explicit theme built on the Stage 11 brand palette (void-dominant black, single gold accent). `MarkdownPanelView` consumes a `MarkdownPalette` as the single source of truth — every existing `isDark ? X : Y` branch collapses to a palette field lookup.
- Per-panel `themeChoice` with an app-wide default stored in `UserDefaults` (`markdownThemeDefault`). Users can set a global default and override per panel. Mermaid rendering keys on `effectiveIsDark` so diagrams stay in sync (Gold uses the dark mermaid skin).
- Header controls make both affordances discoverable:
  - Refresh button (`arrow.clockwise`) + ⌘R `Refresh Markdown` — reloads the current file from disk.
  - Theme button (cycles icon + tints gold when Gold is active) + ⌘⇧T `Cycle Markdown Theme` — cycles Auto → Light → Dark → Gold.
  - Both shortcuts are user-rebindable via the standard `KeyboardShortcutSettings` path with tooltips rendering the effective key combo.
- Session persistence: `SessionMarkdownPanelSnapshot` gains an optional `themeChoice` (nil means inherit app-wide default), so per-panel theme survives a restart. Old snapshots fall through gracefully.
- Localizable.xcstrings: 7 new keys (en + ja) — `markdown.theme.auto/light/dark/gold`, `markdown.action.refresh/cycleTheme`, `shortcut.refreshMarkdown.label`, `shortcut.cycleMarkdownTheme.label`.

## Test plan

- [ ] Open a `.md` file — the panel renders in Auto mode and matches system appearance.
- [ ] Click the theme button (or press ⌘⇧T) — cycles Auto → Light → Dark → Gold; the active theme icon tints gold when Gold is selected.
- [ ] Click the refresh button (or press ⌘R) — reloads the file from disk; external edits become visible.
- [ ] Quit and relaunch — the per-panel theme choice persists.
- [ ] Rebind either shortcut in Settings → Keyboard Shortcuts; the new binding activates immediately and the tooltip updates.
- [ ] Verify mermaid diagrams re-render with the dark skin under Dark and Gold themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)