### PR TITLE
markdown: regression tests for ⌘R dispatch + legacy-nil themeChoice

### DIFF
--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2990,6 +2990,94 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(activateApplicationCallCount, 1)
     }
 
+    func testCmdRRoutesToMarkdownRefreshWhenMarkdownPanelIsFocused() throws {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let targetWindow = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace,
+              let paneId = workspace.bonsplitController.allPaneIds.first else {
+            XCTFail("Expected test window, manager, workspace, and pane")
+            return
+        }
+
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-markdown-refresh-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let markdownURL = tempRoot.appendingPathComponent("note.md")
+        try "# before\n".write(to: markdownURL, atomically: true, encoding: .utf8)
+
+        guard let panel = workspace.newMarkdownSurface(
+            inPane: paneId,
+            filePath: markdownURL.path,
+            focus: true
+        ) else {
+            XCTFail("Expected markdown panel")
+            return
+        }
+
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        XCTAssertTrue(
+            manager.focusedMarkdownPanel === panel,
+            "Markdown panel must be focused for the dispatch test"
+        )
+        XCTAssertEqual(panel.content, "# before\n")
+
+        try "# after\n".write(to: markdownURL, atomically: true, encoding: .utf8)
+
+        // The carve-out in the renameTab branch must prevent the command
+        // palette rename-tab request from firing when a markdown panel is
+        // focused. If the bypass regresses, this observer will count a post.
+        var renameTabRequests = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: .commandPaletteRenameTabRequested,
+            object: nil,
+            queue: .main
+        ) { _ in
+            renameTabRequests += 1
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        guard let event = makeKeyDownEvent(
+            key: "r",
+            modifiers: [.command],
+            keyCode: 15, // kVK_ANSI_R
+            windowNumber: targetWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+R event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(
+            appDelegate.debugHandleCustomShortcut(event: event),
+            "Cmd+R should be consumed when a markdown panel is focused"
+        )
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertEqual(
+            renameTabRequests,
+            0,
+            "renameTab command palette must not fire when a markdown panel is focused"
+        )
+        XCTAssertEqual(
+            panel.content,
+            "# after\n",
+            "Cmd+R should trigger markdown refresh, pulling the updated file from disk"
+        )
+    }
+
     private func makeKeyDownEvent(
         key: String,
         modifiers: NSEvent.ModifierFlags,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -44,6 +44,73 @@ final class SessionPersistenceTests: XCTestCase {
     }
 
     @MainActor
+    func testLegacyMarkdownSnapshotWithNilThemeChoiceRestoresUnderAppWideDefault() throws {
+        let defaultsKey = MarkdownPanel.defaultThemeDefaultsKey
+        let previous = UserDefaults.standard.string(forKey: defaultsKey)
+        UserDefaults.standard.set(MarkdownThemeChoice.dark.rawValue, forKey: defaultsKey)
+        defer {
+            if let previous {
+                UserDefaults.standard.set(previous, forKey: defaultsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: defaultsKey)
+            }
+        }
+
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-markdown-legacynil-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let markdownURL = root.appendingPathComponent("note.md")
+        try "# legacy\n".write(to: markdownURL, atomically: true, encoding: .utf8)
+
+        // Seed a fully-populated snapshot by creating a markdown panel and
+        // taking its snapshot, then strip the themeChoice so we're exercising
+        // the "legacy snapshot predates per-panel theme persistence" decode
+        // path that the docstring promises restores under the app-wide default.
+        let source = Workspace()
+        let sourcePaneId = try XCTUnwrap(source.bonsplitController.allPaneIds.first)
+        _ = try XCTUnwrap(
+            source.newMarkdownSurface(
+                inPane: sourcePaneId,
+                filePath: markdownURL.path,
+                focus: true
+            )
+        )
+
+        var snapshot = source.sessionSnapshot(includeScrollback: false)
+        var stripped = false
+        for i in snapshot.panels.indices where snapshot.panels[i].type == .markdown {
+            snapshot.panels[i].markdown?.themeChoice = nil
+            stripped = true
+        }
+        XCTAssertTrue(stripped, "Expected a markdown panel snapshot to strip themeChoice on")
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        XCTAssertFalse(
+            try XCTUnwrap(String(data: encoded, encoding: .utf8)).contains("\"themeChoice\""),
+            "Legacy snapshots should not encode themeChoice when nil"
+        )
+        let decoded = try JSONDecoder().decode(SessionWorkspaceSnapshot.self, from: encoded)
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(decoded)
+
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        let restoredPanel = try XCTUnwrap(restored.markdownPanel(for: restoredPanelId))
+        XCTAssertEqual(
+            restoredPanel.themeChoice,
+            MarkdownPanel.appWideDefaultThemeChoice(),
+            "Legacy snapshot with themeChoice=nil should restore under the current app-wide default"
+        )
+        XCTAssertEqual(
+            restoredPanel.themeChoice,
+            .dark,
+            "App-wide default we seeded should be reflected in the restored panel"
+        )
+    }
+
+    @MainActor
     func testWorkspaceSessionSnapshotRoundTripsEveryMarkdownThemeChoice() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-markdown-themes-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

The feature itself (Light/Dark/Auto/Gold theme, ⌘R/⌘⇧T shortcuts, session persistence, render-generation guard, a11y label fix) already landed on `features/c11mux-1-8` via PR #4 (squash-merge `8e709018`). This PR is the two missing regression tests flagged in the trident review pack `20260417-0241`:

- **⌘R dispatch routing** (`cmuxTests/AppDelegateShortcutRoutingTests.swift`) — synthesizes a Cmd+R NSEvent against a real AppDelegate with a focused markdown panel; asserts the file reloads from disk and the rename-tab command palette does **not** fire. Catches the original dispatch-race bug that let `.renameTab` swallow ⌘R.
- **Legacy-nil themeChoice decode** (`cmuxTests/SessionPersistenceTests.swift`) — seeds `UserDefaults[markdownThemeDefault] = .dark`, strips `themeChoice` from an encoded `SessionWorkspaceSnapshot`, decodes, restores, and asserts the panel lands on `MarkdownPanel.appWideDefaultThemeChoice()`. Locks in the forward-compat contract for snapshots predating per-panel theme persistence.

## Test plan

- [x] `xcodebuild -scheme cmux-unit build-for-testing` — green.
- [x] `./scripts/reload.sh --tag markdown-fix` — Debug build launches.
- [ ] CI: `tests` job exercises both new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)