### PR TITLE
c11mux: welcome sequence launches a 2x2 quad layout

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11934,13 +11934,17 @@ struct CMUXCLI {
 
         let isDark = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark"
 
-        let c1 = trueColor(0, 212, 255)
-        let c2 = trueColor(24, 181, 250)
-        let c3 = trueColor(48, 150, 245)
-        let c4 = trueColor(72, 119, 241)
-        let c5 = trueColor(96, 88, 239)
-        let c6 = trueColor(110, 73, 238)
-        let c7 = trueColor(124, 58, 237)
+        // Stage 11 gold ramp: single accent color, faded at the tips. Brand rule is
+        // "gold is the only color" — the diamond glows gold, everything else stays
+        // quiet. Values centered on --gold (#c9a84c = 201,168,76).
+        let g1 = trueColor(104, 87, 39)
+        let g2 = trueColor(149, 124, 56)
+        let g3 = trueColor(183, 153, 69)
+        let g4 = trueColor(201, 168, 76)
+        let g5 = trueColor(183, 153, 69)
+        let g6 = trueColor(149, 124, 56)
+        let g7 = trueColor(104, 87, 39)
+        let goldBold = bold + trueColor(201, 168, 76)
 
         let tagline: String
         let subdued: String
@@ -11954,13 +11958,13 @@ struct CMUXCLI {
         }
 
         let logo = """
-        \(c1)  ::\(reset)
-        \(c2)    ::::\(reset)              \(c1)c\(c2)m\(c3)u\(c7)x\(reset)
-        \(c3)      ::::::\(reset)
-        \(c4)        ::::::\(reset)        \(tagline)the open source terminal\(reset)
-        \(c5)      ::::::\(reset)          \(tagline)built for coding agents\(reset)
-        \(c6)    ::::\(reset)
-        \(c7)  ::\(reset)
+        \(g1)  ::\(reset)
+        \(g2)    ::::\(reset)              \(goldBold)c11mux\(reset)
+        \(g3)      ::::::\(reset)
+        \(g4)        ::::::\(reset)        \(tagline)a terminal for the spike\(reset)
+        \(g5)      ::::::\(reset)          \(tagline)human:digital by default\(reset)
+        \(g6)    ::::\(reset)
+        \(g7)  ::\(reset)
         """
 
         let shortcuts = """
@@ -11982,10 +11986,9 @@ struct CMUXCLI {
         print()
         print(shortcuts)
         print()
-        print("  \(bold)Docs\(reset)\(subdued)                https://cmux.com/docs\(reset)")
-        print("  \(bold)Discord\(reset)\(subdued)             https://discord.gg/xsgFEVrWCZ\(reset)")
-        print("  \(bold)GitHub\(reset)\(subdued)              https://github.com/manaflow-ai/cmux (please leave a star ⭐)\(reset)")
-        print("  \(bold)Email\(reset)\(subdued)               founders@manaflow.com\(reset)")
+        print("  \(bold)Stage 11\(reset)\(subdued)            https://stage11.ai\(reset)")
+        print("  \(bold)The Spike\(reset)\(subdued)           https://stage11.ai/spike\(reset)")
+        print("  \(bold)Upstream\(reset)\(subdued)            https://github.com/manaflow-ai/cmux (cmux — the project we forked)\(reset)")
         print()
         print("  \(subdued)Run \(reset)\(bold)cmux --help\(reset)\(subdued) for all commands.\(reset)")
         print("  \(subdued)Run \(reset)\(bold)cmux shortcuts\(reset)\(subdued) to edit shortcuts.\(reset)")

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -111,6 +111,7 @@
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008382 /* CommandPaletteSearchEngineTests.swift */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
+		DA7A10CA710E000000000006 /* welcome.md in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000005 /* welcome.md */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
 						E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */; };
 					1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
@@ -285,6 +286,7 @@
 				A5008382 /* CommandPaletteSearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSearchEngineTests.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		DA7A10CA710E000000000005 /* welcome.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = welcome.md; sourceTree = "<group>"; };
 		A5001622 /* cmux.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = cmux.sdef; sourceTree = "<group>"; };
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPanelTests.swift; sourceTree = "<group>"; };
@@ -350,6 +352,7 @@
 				A5002000 /* THIRD_PARTY_LICENSES.md in Resources */,
 				DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */,
 				DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */,
+				DA7A10CA710E000000000006 /* welcome.md in Resources */,
 				A5001623 /* cmux.sdef in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -493,6 +496,7 @@
 				C1ADE00001A1B2C3D4E5F719 /* claude */,
 				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,
+				DA7A10CA710E000000000005 /* welcome.md */,
 				A5001622 /* cmux.sdef */,
 			);
 			path = Resources;

--- a/Resources/welcome.md
+++ b/Resources/welcome.md
@@ -12,6 +12,8 @@ four surfaces around you. a terminal. a browser. this page. a waiting agent. one
 
 a terminal — reimagined — for human:digital operators. built by stage 11 for those who run coding agents the way flight engineers run consoles: several at a time, in parallel, with nerve. not an IDE. not a multiplexer in the old sense. a room. one you share with the models.
 
+**lineage.** tmux taught the terminal to split. [cmux](https://github.com/manaflow-ai/cmux) rebuilt that idea as a macOS-native app on a GPU-accelerated renderer, shaped for coding agents. c11mux is stage 11's fork — same bones, different room, tuned for the spike.
+
 stage 11 is a small outpost in a very large dark. we built this because we needed it. it is now yours.
 
 ---

--- a/Resources/welcome.md
+++ b/Resources/welcome.md
@@ -1,0 +1,78 @@
+# welcome to c11mux
+
+you are in the room now.
+
+four surfaces around you. a terminal. a browser. this page. a waiting agent. one binary. one socket. one addressable space. the layout *is* the collaboration.
+
+---
+
+## what c11mux is
+
+**spike infrastructure.**
+
+a terminal — reimagined — for human:digital operators. built by stage 11 for those who run coding agents the way flight engineers run consoles: several at a time, in parallel, with nerve. not an IDE. not a multiplexer in the old sense. a room. one you share with the models.
+
+stage 11 is a small outpost in a very large dark. we built this because we needed it. it is now yours.
+
+---
+
+## the grammar
+
+- **window** — a macOS window
+- **workspace** — one project, one place
+- **pane** — a region of a workspace (splits, bonsplit under the hood)
+- **surface** — a terminal, browser, or markdown view inside a pane. panes carry surfaces as tabs
+
+this is all the vocabulary you need to start moving. the rest rhymes.
+
+---
+
+## the handshake
+
+| keys | does |
+| ---- | ---- |
+| `⌘N` | new workspace |
+| `⌘T` | new tab |
+| `⌘D` | split right |
+| `⌘⇧D` | split down |
+| `⌘P` | jump to workspace |
+| `⌘⇧P` | command palette |
+
+the palette is where everything else lives. find a command once, your fingers will remember.
+
+---
+
+## the CLI
+
+every surface talks to `cmux` over a socket. the binary is `~/.local/bin/cmux`. try this in the terminal to your upper-left:
+
+```
+cmux identify          # who am i, where am i
+cmux tree              # what does the room look like
+cmux new-split right   # split a pane
+cmux set-title "..."   # name the work you are doing
+```
+
+the full grammar in `cmux --help`. read it once slowly. you will re-read it.
+
+---
+
+## why this exists
+
+the **spike** is the operator:model compound actor — a single entity running across many contexts at once. carbon and silicon, fused. the browser beside you is already pointed at **[stage11.ai](https://stage11.ai)** — that's the story in full.
+
+c11mux is how the spike gets a room. keyboards and agents both touch the same space. legible. addressable. persistent. everything else lives upstairs — Lattice, Mycelium, the rest of the stack. this tool just holds the ground.
+
+---
+
+## one small ritual
+
+name your surfaces. `cmux set-title` costs nothing and saves future-you from a wall of untitled tabs. an unnamed surface is an unidentifiable agent. an unnamed agent is coordination debt.
+
+you are not the last mind that will touch this work. leave a trail.
+
+---
+
+*welcome, operator. the room is yours.*
+
+— gregorovitch

--- a/Resources/welcome.md
+++ b/Resources/welcome.md
@@ -14,7 +14,7 @@ a terminal — reimagined — for human:digital operators. built by stage 11 for
 
 **lineage.** tmux taught the terminal to split. [cmux](https://github.com/manaflow-ai/cmux) rebuilt that idea as a macOS-native app on a GPU-accelerated renderer, shaped for coding agents. c11mux is stage 11's fork — same bones, different room, tuned for the spike.
 
-stage 11 is a small outpost in a very large dark. we built this because we needed it. it is now yours.
+stage 11 is an outpost in a very large dark. we built this because we needed it. it is now yours too.
 
 ---
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5908,9 +5908,59 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func sendWelcomeCommandWhenReady(to workspace: Workspace, markShownOnSend: Bool = false) {
-        sendTextWhenReady("cmux welcome\n", to: workspace) {
+        runWhenInitialTerminalReady(in: workspace) { initialPanel in
             if markShownOnSend {
                 UserDefaults.standard.set(true, forKey: WelcomeSettings.shownKey)
+            }
+            WelcomeSettings.performQuadLayout(on: workspace, initialPanel: initialPanel)
+        }
+    }
+
+    private func runWhenInitialTerminalReady(
+        in workspace: Workspace,
+        _ action: @escaping (TerminalPanel) -> Void
+    ) {
+        if let terminalPanel = workspace.focusedTerminalPanel,
+           terminalPanel.surface.surface != nil {
+            action(terminalPanel)
+            return
+        }
+
+        var resolved = false
+        var readyObserver: NSObjectProtocol?
+        var panelsCancellable: AnyCancellable?
+
+        func finishIfReady() {
+            guard !resolved,
+                  let terminalPanel = workspace.focusedTerminalPanel,
+                  terminalPanel.surface.surface != nil else { return }
+            resolved = true
+            if let readyObserver {
+                NotificationCenter.default.removeObserver(readyObserver)
+            }
+            panelsCancellable?.cancel()
+            action(terminalPanel)
+        }
+
+        panelsCancellable = workspace.$panels
+            .map { _ in () }
+            .sink { _ in finishIfReady() }
+        readyObserver = NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceDidBecomeReady,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let workspaceId = note.userInfo?["workspaceId"] as? UUID,
+                  workspaceId == workspace.id else { return }
+            finishIfReady()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            if !resolved {
+                if let readyObserver {
+                    NotificationCenter.default.removeObserver(readyObserver)
+                }
+                panelsCancellable?.cancel()
+                NSLog("Welcome quad: initial terminal not ready after 3.0s")
             }
         }
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1139,7 +1139,7 @@ class TabManager: ObservableObject {
            terminalPanel.surface.surface != nil {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 UserDefaults.standard.set(true, forKey: WelcomeSettings.shownKey)
-                terminalPanel.sendText("cmux welcome\n")
+                WelcomeSettings.performQuadLayout(on: workspace, initialPanel: terminalPanel)
             }
             return
         }
@@ -1159,7 +1159,7 @@ class TabManager: ObservableObject {
             panelsCancellable?.cancel()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 UserDefaults.standard.set(true, forKey: WelcomeSettings.shownKey)
-                terminalPanel.sendText("cmux welcome\n")
+                WelcomeSettings.performQuadLayout(on: workspace, initialPanel: terminalPanel)
             }
         }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3756,6 +3756,61 @@ enum ClaudeCodeIntegrationSettings {
 
 enum WelcomeSettings {
     static let shownKey = "cmuxWelcomeShown"
+    static let spikeURL = "https://stage11.ai"
+
+    /// Turns the freshly-created welcome workspace into a 2x2 quad by performing
+    /// programmatic splits on the workspace model. Called once the initial
+    /// top-left terminal's Ghostty surface is ready.
+    ///
+    /// Layout:
+    ///   TL: initialPanel (terminal, renders `cmux welcome` ASCII)
+    ///   TR: browser → stage11.ai
+    ///   BL: markdown → bundled welcome.md
+    ///   BR: terminal → attempts `claude --dangerously-skip-permissions` if installed
+    ///
+    /// Newly-created terminal panels auto-queue `sendText` before their surfaces
+    /// finish initializing and flush on ready, so we can issue commands immediately.
+    @MainActor
+    static func performQuadLayout(on workspace: Workspace, initialPanel: TerminalPanel) {
+        let initialPanelId = initialPanel.id
+        let welcomeMdPath = Bundle.main.url(forResource: "welcome", withExtension: "md")?.path
+
+        let browserPanel = workspace.newBrowserSplit(
+            from: initialPanelId,
+            orientation: .horizontal,
+            insertFirst: false,
+            url: URL(string: spikeURL),
+            focus: false
+        )
+
+        var bottomRightPanel: TerminalPanel?
+        if let browserPanel {
+            bottomRightPanel = workspace.newTerminalSplit(
+                from: browserPanel.id,
+                orientation: .vertical,
+                insertFirst: false,
+                focus: false
+            )
+        }
+
+        if let welcomeMdPath {
+            workspace.newMarkdownSplit(
+                from: initialPanelId,
+                orientation: .vertical,
+                insertFirst: false,
+                filePath: welcomeMdPath,
+                focus: false
+            )
+        }
+
+        if let bottomRightPanel {
+            bottomRightPanel.sendText(
+                "command -v claude >/dev/null 2>&1 && claude --dangerously-skip-permissions\n"
+            )
+        }
+
+        initialPanel.sendText("cmux welcome\n")
+    }
 }
 
 enum TelemetrySettings {


### PR DESCRIPTION
## Summary
- `cmux welcome` now opens a 2x2 grid in a fresh workspace: top-left runs `cmux welcome` (terminal), with three sibling panels created via native split APIs (`newTerminalSplit` / `newBrowserSplit` / `newMarkdownSplit`) rather than shell one-liners that tripped zsh/bash paste handling.
- `welcome.md` brands the art as c11mux: gold wordmark, Stage 11 diamond ramp, "human:digital by default" tagline, lineage sentence (tmux → cmux → c11mux).
- Recovered from dangling commits (`d4c0d0f1`, `2e44c047`, `4c4004b3`) on the lost `features/welcome-quad-layout` branch and cherry-picked onto current main.

## Scope
- Changed: `Sources/AppDelegate.swift`, `Sources/cmuxApp.swift`, `Sources/TabManager.swift`, `CLI/cmux.swift`, `GhosttyTabs.xcodeproj/project.pbxproj`.
- Added: `Resources/welcome.md`.

## Test plan
- [ ] Build on current macOS 15 CI; no compile errors.
- [ ] In a dev build, delete `cmuxWelcomeShown` from `com.stage11.c11mux` defaults and launch from a blank state → 2x2 layout appears, TL renders `cmux welcome` with c11mux branding, siblings populate without orchestration races.
- [ ] Verify TL wordmark reads `c11mux` (rename regression spot from TODO).
- [ ] Manual: open welcome from sidebar Help menu → quad still fires (no one-shot regression).

## Follow-up (not in this PR)
- Empty-session welcome trigger: auto-open quad when launch has no restored workspaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)