### PR TITLE
Tier 1 persistence, Phase 1: stable panel UUIDs

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 					D7001BF0A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */; };
 					D7002BF0A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */; };
+					D7003BF0A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -307,6 +308,7 @@
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 				D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarRenderTests.swift; sourceTree = "<group>"; };
 				D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionSanitizerTests.swift; sourceTree = "<group>"; };
+			D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelIdentityRestoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -571,6 +573,7 @@
 					10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 					D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */,
 					D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */,
+					D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -841,6 +844,7 @@
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 					D7001BF0A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift in Sources */,
 					D7002BF0A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift in Sources */,
+					D7003BF0A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2630,6 +2630,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     var currentKeyStateIndicatorText: String? { surfaceView.currentKeyStateIndicatorText }
 
     init(
+        id: UUID? = nil,
         tabId: UUID,
         context: ghostty_surface_context_e,
         configTemplate: ghostty_surface_config_s?,
@@ -2638,7 +2639,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         initialEnvironmentOverrides: [String: String] = [:],
         additionalEnvironment: [String: String] = [:]
     ) {
-        self.id = UUID()
+        self.id = id ?? UUID()
         self.tabId = tabId
         self.surfaceContext = context
         self.configTemplate = configTemplate

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2541,7 +2541,11 @@ final class BrowserPanel: Panel, ObservableObject {
         return instanceID == webViewInstanceID
     }
 
+    /// - Parameter id: Stable panel UUID. Pass `nil` for fresh creation; pass a
+    ///   snapshot's panel id during session restore to keep IDs stable across
+    ///   app restarts (Tier 1 persistence, Phase 1).
     init(
+        id: UUID? = nil,
         workspaceId: UUID,
         profileID: UUID? = nil,
         initialURL: URL? = nil,
@@ -2550,7 +2554,7 @@ final class BrowserPanel: Panel, ObservableObject {
         isRemoteWorkspace: Bool = false,
         remoteWebsiteDataStoreIdentifier: UUID? = nil
     ) {
-        self.id = UUID()
+        self.id = id ?? UUID()
         self.workspaceId = workspaceId
         let requestedProfileID = profileID ?? BrowserProfileStore.shared.effectiveLastUsedProfileID
         let resolvedProfileID = BrowserProfileStore.shared.profileDefinition(id: requestedProfileID) != nil

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -68,8 +68,11 @@ final class MarkdownPanel: Panel, ObservableObject {
 
     // MARK: - Init
 
-    init(workspaceId: UUID, filePath: String) {
-        self.id = UUID()
+    /// - Parameter id: Stable panel UUID. Pass `nil` for fresh creation; pass a
+    ///   snapshot's panel id during session restore to keep IDs stable across
+    ///   app restarts (Tier 1 persistence, Phase 1).
+    init(id: UUID? = nil, workspaceId: UUID, filePath: String) {
+        self.id = id ?? UUID()
         self.workspaceId = workspaceId
         self.filePath = filePath
         self.displayTitle = (filePath as NSString).lastPathComponent

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -82,8 +82,13 @@ final class TerminalPanel: Panel, ObservableObject {
             .store(in: &cancellables)
     }
 
-    /// Create a new terminal panel with a fresh surface
+    /// Create a new terminal panel with a fresh surface.
+    ///
+    /// `id` is the stable panel UUID. Pass `nil` for fresh creation; pass a
+    /// snapshot's panel id during session restore to keep IDs stable across
+    /// app restarts (Tier 1 persistence, Phase 1).
     convenience init(
+        id: UUID? = nil,
         workspaceId: UUID,
         context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_SPLIT,
         configTemplate: ghostty_surface_config_s? = nil,
@@ -94,6 +99,7 @@ final class TerminalPanel: Panel, ObservableObject {
         additionalEnvironment: [String: String] = [:]
     ) {
         let surface = TerminalSurface(
+            id: id,
             tabId: workspaceId,
             context: context,
             configTemplate: configTemplate,

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -19,6 +19,27 @@ enum SessionPersistencePolicy {
     static let maxScrollbackLinesPerTerminal: Int = 4000
     static let maxScrollbackCharactersPerTerminal: Int = 400_000
 
+    /// Tier 1 persistence, Phase 1: stable panel UUIDs across app restarts.
+    ///
+    /// When `true` (default), session-restore injects each `SessionPanelSnapshot.id`
+    /// into the restored panel's constructor so external consumers (Lattice, CLI,
+    /// scripted tests) can cache panel IDs across restarts.
+    ///
+    /// Setting `CMUX_DISABLE_STABLE_PANEL_IDS=1` reverts to the old behavior (fresh
+    /// UUID per restored panel + `oldToNewPanelIds` remap inside the workspace).
+    /// Kept as a one-release rollback safety net; delete in a followup PR.
+    static var stablePanelIdsEnabled: Bool {
+        !envFlagEnabled("CMUX_DISABLE_STABLE_PANEL_IDS")
+    }
+
+    private static func envFlagEnabled(_ name: String) -> Bool {
+        guard let raw = ProcessInfo.processInfo.environment[name] else { return false }
+        switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
+        case "1", "true", "yes", "on": return true
+        default: return false
+        }
+    }
+
     static func sanitizedSidebarWidth(_ candidate: Double?) -> Double {
         let fallback = defaultSidebarWidth
         guard let candidate, candidate.isFinite else { return fallback }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2439,6 +2439,8 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugPanelSnapshotReset(params: params))
         case "debug.window.screenshot":
             return v2Result(id: id, self.v2DebugScreenshot(params: params))
+        case "debug.session.round_trip":
+            return v2Result(id: id, self.v2DebugSessionRoundTrip(params: params))
 #endif
 
             default:
@@ -2639,6 +2641,7 @@ class TerminalController {
             "debug.panel_snapshot",
             "debug.panel_snapshot.reset",
             "debug.window.screenshot",
+            "debug.session.round_trip",
         ])
 #endif
 
@@ -11496,6 +11499,38 @@ class TerminalController {
         return .ok([
             "screenshot_id": parts[0],
             "path": parts[1]
+        ])
+    }
+
+    /// Test-only: snapshot the resolved workspace and immediately restore the
+    /// snapshot onto the same workspace. Phase 1 uses this to assert that panel
+    /// UUIDs survive the round-trip without a full app restart.
+    ///
+    /// Returns `{ "before": [uuid,...], "after": [uuid,...] }` — callers
+    /// compare the sets to verify stability.
+    private func v2DebugSessionRoundTrip(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        var before: [String] = []
+        var after: [String] = []
+        var failureMessage: String?
+        v2MainSync {
+            guard let workspace = self.v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                failureMessage = "workspace_not_found"
+                return
+            }
+            before = workspace.panels.keys.map { $0.uuidString }.sorted()
+            let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+            workspace.restoreSessionSnapshot(snapshot)
+            after = workspace.panels.keys.map { $0.uuidString }.sorted()
+        }
+        if let failureMessage {
+            return .err(code: "workspace_not_found", message: failureMessage, data: nil)
+        }
+        return .ok([
+            "before": before,
+            "after": after
         ])
     }
 #endif

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -221,6 +221,13 @@ extension Workspace {
 
         let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
         let leafEntries = restoreSessionLayout(snapshot.layout)
+        // When `SessionPersistencePolicy.stablePanelIdsEnabled` is true (default),
+        // this map is an identity: snapshot id == restored panel id, because
+        // `createPanel` threads `snapshot.id` into the panel constructor. When
+        // `CMUX_DISABLE_STABLE_PANEL_IDS=1` is set, restored panels mint fresh
+        // UUIDs and this map genuinely remaps old→new. Both focus restore (below)
+        // and pane selection (inside `restorePane`) route through this map so the
+        // two paths share one lookup.
         var oldToNewPanelIds: [UUID: UUID] = [:]
 
         for entry in leafEntries {
@@ -532,6 +539,14 @@ extension Workspace {
     }
 
     private func createPanel(from snapshot: SessionPanelSnapshot, inPane paneId: PaneID) -> UUID? {
+        // Phase 1 of the Tier 1 persistence plan: restore-time ID injection.
+        // When stable panel IDs are enabled, pass the snapshot's id through to
+        // the panel constructor so external consumers (surface.list callers,
+        // cached-id scripts) see the same UUID across restarts.
+        let restoredPanelId: UUID? = SessionPersistencePolicy.stablePanelIdsEnabled
+            ? snapshot.id
+            : nil
+
         switch snapshot.type {
         case .terminal:
             let workingDirectory = snapshot.terminal?.workingDirectory ?? snapshot.directory ?? currentDirectory
@@ -542,7 +557,8 @@ extension Workspace {
                 inPane: paneId,
                 focus: false,
                 workingDirectory: workingDirectory,
-                startupEnvironment: replayEnvironment
+                startupEnvironment: replayEnvironment,
+                panelId: restoredPanelId
             ) else {
                 return nil
             }
@@ -560,7 +576,8 @@ extension Workspace {
                 inPane: paneId,
                 url: initialURL,
                 focus: false,
-                preferredProfileID: snapshot.browser?.profileID
+                preferredProfileID: snapshot.browser?.profileID,
+                panelId: restoredPanelId
             ) else {
                 return nil
             }
@@ -571,7 +588,8 @@ extension Workspace {
                   let markdownPanel = newMarkdownSurface(
                     inPane: paneId,
                     filePath: filePath,
-                    focus: false
+                    focus: false,
+                    panelId: restoredPanelId
                   ) else {
                 return nil
             }
@@ -6764,7 +6782,8 @@ final class Workspace: Identifiable, ObservableObject {
         inPane paneId: PaneID,
         focus: Bool? = nil,
         workingDirectory: String? = nil,
-        startupEnvironment: [String: String] = [:]
+        startupEnvironment: [String: String] = [:],
+        panelId: UUID? = nil
     ) -> TerminalPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let previousFocusedPanelId = focusedPanelId
@@ -6775,6 +6794,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         // Create new terminal panel
         let newPanel = TerminalPanel(
+            id: panelId,
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
@@ -6932,7 +6952,8 @@ final class Workspace: Identifiable, ObservableObject {
         focus: Bool? = nil,
         insertAtEnd: Bool = false,
         preferredProfileID: UUID? = nil,
-        bypassInsecureHTTPHostOnce: String? = nil
+        bypassInsecureHTTPHostOnce: String? = nil,
+        panelId: UUID? = nil
     ) -> BrowserPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let sourcePanelId = effectiveSelectedPanelId(inPane: paneId)
@@ -6940,6 +6961,7 @@ final class Workspace: Identifiable, ObservableObject {
         let previousHostedView = focusedTerminalPanel?.hostedView
 
         let browserPanel = BrowserPanel(
+            id: panelId,
             workspaceId: id,
             profileID: resolvedNewBrowserProfileID(
                 preferredProfileID: preferredProfileID,
@@ -7063,13 +7085,14 @@ final class Workspace: Identifiable, ObservableObject {
     func newMarkdownSurface(
         inPane paneId: PaneID,
         filePath: String,
-        focus: Bool? = nil
+        focus: Bool? = nil,
+        panelId: UUID? = nil
     ) -> MarkdownPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalPanel?.hostedView
 
-        let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath)
+        let markdownPanel = MarkdownPanel(id: panelId, workspaceId: id, filePath: filePath)
         panels[markdownPanel.id] = markdownPanel
         panelTitles[markdownPanel.id] = markdownPanel.displayTitle
 

--- a/cmuxTests/PanelIdentityRestoreTests.swift
+++ b/cmuxTests/PanelIdentityRestoreTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tier 1 persistence, Phase 1 — stable panel UUIDs via restore-time ID injection.
+///
+/// These tests exercise the contract: after snapshotting a workspace and
+/// restoring it into a fresh workspace, each panel's UUID matches the UUID it
+/// had in the snapshot. External consumers (Lattice, CLI, socket tests) cache
+/// panel IDs, so the restore path must preserve them — not mint fresh UUIDs and
+/// remap them internally the way pre-Phase-1 code did.
+final class PanelIdentityRestoreTests: XCTestCase {
+    @MainActor
+    func testTerminalPanelIdIsStableAcrossRoundTrip() throws {
+        let workspace = Workspace()
+        let originalPanelIds = Set(workspace.panels.keys)
+        XCTAssertEqual(originalPanelIds.count, 1, "Workspace() should seed exactly one terminal panel")
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        let snapshotPanelIds = Set(snapshot.panels.map(\.id))
+        XCTAssertEqual(snapshotPanelIds, originalPanelIds)
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredPanelIds = Set(restored.panels.keys)
+        XCTAssertEqual(
+            restoredPanelIds,
+            snapshotPanelIds,
+            "Restored terminal panels should keep the UUIDs from the snapshot"
+        )
+    }
+
+    @MainActor
+    func testMarkdownPanelIdIsStableAcrossRoundTrip() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-panel-identity-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let markdownURL = root.appendingPathComponent("note.md")
+        try "# hello\n".write(to: markdownURL, atomically: true, encoding: .utf8)
+
+        let workspace = Workspace()
+        let paneId = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let markdownPanel = try XCTUnwrap(
+            workspace.newMarkdownSurface(inPane: paneId, filePath: markdownURL.path, focus: true)
+        )
+        let expectedIds = Set(workspace.panels.keys)
+        XCTAssertTrue(expectedIds.contains(markdownPanel.id))
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredIds = Set(restored.panels.keys)
+        XCTAssertEqual(restoredIds, expectedIds)
+        XCTAssertNotNil(
+            restored.markdownPanel(for: markdownPanel.id),
+            "Markdown panel UUID should round-trip and resolve on the restored workspace"
+        )
+    }
+
+    @MainActor
+    func testBrowserPanelIdIsStableAcrossRoundTrip() throws {
+        let workspace = Workspace()
+        let paneId = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let browserPanel = try XCTUnwrap(
+            workspace.newBrowserSurface(
+                inPane: paneId,
+                url: URL(string: "https://example.com"),
+                focus: false
+            )
+        )
+        let expectedIds = Set(workspace.panels.keys)
+        XCTAssertTrue(expectedIds.contains(browserPanel.id))
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredIds = Set(restored.panels.keys)
+        XCTAssertEqual(restoredIds, expectedIds)
+    }
+
+    @MainActor
+    func testMixedPanelTypesAllSurviveRoundTripWithSameIds() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-panel-identity-mixed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let markdownURL = root.appendingPathComponent("mixed.md")
+        try "mixed\n".write(to: markdownURL, atomically: true, encoding: .utf8)
+
+        let workspace = Workspace()
+        let paneId = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let terminalPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneId, focus: false))
+        let browserPanel = try XCTUnwrap(
+            workspace.newBrowserSurface(
+                inPane: paneId,
+                url: URL(string: "https://example.com"),
+                focus: false
+            )
+        )
+        let markdownPanel = try XCTUnwrap(
+            workspace.newMarkdownSurface(inPane: paneId, filePath: markdownURL.path, focus: false)
+        )
+
+        let expected = Set(workspace.panels.keys)
+        XCTAssertTrue(expected.contains(terminalPanel.id))
+        XCTAssertTrue(expected.contains(browserPanel.id))
+        XCTAssertTrue(expected.contains(markdownPanel.id))
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        XCTAssertEqual(Set(restored.panels.keys), expected)
+    }
+
+    @MainActor
+    func testStablePanelIdsPolicyIsOnByDefault() {
+        XCTAssertTrue(
+            SessionPersistencePolicy.stablePanelIdsEnabled,
+            "Phase 1 default: panel IDs are stable across restarts unless CMUX_DISABLE_STABLE_PANEL_IDS is set"
+        )
+    }
+}

--- a/docs/socket-api-reference.md
+++ b/docs/socket-api-reference.md
@@ -88,6 +88,12 @@ Legacy values `"full"` and `"notifications"` still accepted.
 {"id":"split","method":"surface.split","params":{"direction":"right"}}
 ```
 
+Panel IDs (also called surface IDs) are stable across app restarts within the
+same machine. External consumers may cache them across sessions. Set
+`CMUX_DISABLE_STABLE_PANEL_IDS=1` in the app's environment to revert to
+per-restart UUID regeneration (one-release rollback safety net; will be removed
+in a followup release).
+
 ### Input
 
 | Method | CLI | Description |

--- a/tests_v2/test_panel_id_stability.py
+++ b/tests_v2/test_panel_id_stability.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Tier 1 persistence, Phase 1 — stable panel UUID regression test.
+
+Creates a mix of terminal / browser / markdown surfaces in a new workspace,
+then uses the debug-only `debug.session.round_trip` socket command to
+snapshot-and-restore the workspace in place. Panel UUIDs must survive the
+round-trip so external consumers (Lattice, CLI, scripted tests) can safely
+cache them across c11mux restarts.
+
+Notes:
+- Requires a DEBUG cmux build. The `debug.session.round_trip` method is
+  gated on `#if DEBUG`.
+- Do NOT run locally per project testing policy (run via the VM or CI with
+  `CMUX_SOCKET=/tmp/cmux-debug-<tag>.sock` pointed at a tagged build).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+from typing import Set
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cmux import cmux, cmuxError
+
+
+def wait_for_socket(path: str, timeout_s: float = 5.0) -> None:
+    start = time.time()
+    while not os.path.exists(path):
+        if time.time() - start >= timeout_s:
+            raise RuntimeError(f"Socket not found at {path}")
+        time.sleep(0.1)
+
+
+def _surface_ids_in_workspace(client: cmux, workspace_id: str) -> Set[str]:
+    rows = client.list_surfaces(workspace_id)
+    ids: Set[str] = set()
+    for _idx, sid, _focused in rows:
+        if sid:
+            ids.add(str(sid))
+    return ids
+
+
+def test_round_trip_preserves_panel_ids(client: cmux) -> tuple[bool, str]:
+    ws_id = client.new_workspace()
+    client.select_workspace(ws_id)
+    time.sleep(0.4)
+
+    # Workspace starts with one terminal surface; add two more panel types.
+    browser_id = client.new_surface(panel_type="browser", url="https://example.com")
+    time.sleep(0.4)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+        f.write("# round-trip\n")
+        markdown_path = f.name
+    try:
+        # The v2 socket has no dedicated "new markdown" helper; reuse the
+        # terminal path to round-trip at least two panel types. That already
+        # exercises the surface-id preservation contract for terminals and
+        # browsers, which is what matters for Phase 1.
+        _ = client.new_surface(panel_type="terminal")
+        time.sleep(0.4)
+
+        pre_round_trip = _surface_ids_in_workspace(client, ws_id)
+        if len(pre_round_trip) < 3:
+            return False, f"Expected >=3 surfaces pre-round-trip, got {pre_round_trip}"
+        if str(browser_id) not in pre_round_trip:
+            return False, f"Browser id {browser_id} missing pre-round-trip: {pre_round_trip}"
+
+        result = client._call(
+            "debug.session.round_trip",
+            params={"workspace_id": ws_id},
+        )
+        if not isinstance(result, dict):
+            return False, f"Unexpected round-trip payload type: {type(result).__name__}"
+
+        before = set(result.get("before") or [])
+        after = set(result.get("after") or [])
+        if not before:
+            return False, f"Round-trip returned no 'before' IDs: {result}"
+        if before != after:
+            missing = before - after
+            unexpected = after - before
+            return False, (
+                f"Panel IDs changed across round-trip. missing={missing} unexpected={unexpected}"
+            )
+        if not before.issubset(pre_round_trip | set([str(browser_id)])):
+            return False, (
+                f"Round-trip reported IDs outside the observed workspace: before={before} "
+                f"observed={pre_round_trip}"
+            )
+
+        post_round_trip = _surface_ids_in_workspace(client, ws_id)
+        if post_round_trip != before:
+            return False, (
+                f"surface.list disagrees with debug.session.round_trip after restore: "
+                f"socket={post_round_trip} round_trip_after={after}"
+            )
+    finally:
+        try:
+            os.unlink(markdown_path)
+        except OSError:
+            pass
+        try:
+            client.close_workspace(ws_id)
+        except Exception:
+            pass
+
+    return True, "Panel IDs preserved across in-process session round-trip"
+
+
+def run_tests() -> int:
+    print("=" * 60)
+    print("cmux Panel UUID Stability Test (Tier 1 Phase 1)")
+    print("=" * 60)
+    print()
+
+    probe = cmux()
+    wait_for_socket(probe.socket_path, timeout_s=5.0)
+
+    tests = [
+        ("round-trip preserves panel ids", test_round_trip_preserves_panel_ids),
+    ]
+
+    passed = 0
+    failed = 0
+
+    try:
+        with cmux(socket_path=probe.socket_path) as client:
+            caps = client.capabilities()
+            methods = set((caps or {}).get("methods") or [])
+            if "debug.session.round_trip" not in methods:
+                print(
+                    "SKIP: socket does not expose debug.session.round_trip "
+                    "(likely a non-DEBUG build). Run against a `cmux DEV` tagged build."
+                )
+                return 0
+
+            for name, fn in tests:
+                print(f"  Running: {name} ... ", end="", flush=True)
+                try:
+                    ok, msg = fn(client)
+                except Exception as e:
+                    ok, msg = False, str(e)
+                status = "PASS" if ok else "FAIL"
+                print(f"{status}: {msg}")
+                if ok:
+                    passed += 1
+                else:
+                    failed += 1
+    except cmuxError as e:
+        print(f"Error: {e}")
+        return 1
+
+    print()
+    print(f"Results: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_tests())


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the c11mux Tier 1 Persistence plan (`docs/c11mux-tier1-persistence-plan.md`): panel UUIDs now survive c11mux restart, so external consumers (Lattice, CLI sessions, scripted tests) can cache them across app runs.

The mechanism is **restore-time ID injection**: each panel initializer gains an optional `id: UUID? = nil` parameter, and `Workspace.restoreSessionSnapshot` threads `SessionPanelSnapshot.id` into the panel it creates. The previous `oldToNewPanelIds` remap still exists inside the restore function — it is now an identity map in the default path and still shares one lookup with focus restore — but is semantically unnecessary.

Out of scope: Phases 2–5 (`SurfaceMetadataStore` durability, `statusEntries` continuity, `ClaudeSessionIndex`, recovery UI) — separate followup PRs.

## Files touched

Constructors:
- `Sources/GhosttyTerminalView.swift` — `TerminalSurface.init` accepts `id: UUID? = nil`
- `Sources/Panels/TerminalPanel.swift` — convenience init threads `id` through
- `Sources/Panels/BrowserPanel.swift` — `BrowserPanel.init` accepts `id: UUID? = nil`
- `Sources/Panels/MarkdownPanel.swift` — `MarkdownPanel.init` accepts `id: UUID? = nil`

Restore path + rollback flag:
- `Sources/SessionPersistence.swift` — `SessionPersistencePolicy.stablePanelIdsEnabled` reads `CMUX_DISABLE_STABLE_PANEL_IDS`
- `Sources/Workspace.swift` — `newTerminalSurface` / `newBrowserSurface` / `newMarkdownSurface` gain an optional `panelId`, and `createPanel(from:inPane:)` passes `snapshot.id` through when the flag is on

Socket + tests + docs:
- `Sources/TerminalController.swift` — new DEBUG-only method `debug.session.round_trip`
- `cmuxTests/PanelIdentityRestoreTests.swift` — Swift unit round-trip for each panel type plus a mixed case; also asserts the flag default
- `tests_v2/test_panel_id_stability.py` — Python socket test that drives `debug.session.round_trip` and asserts before/after IDs match (skips cleanly on non-DEBUG builds)
- `GhosttyTabs.xcodeproj/project.pbxproj` — wires the new Swift test into the `cmux-unit` target
- `docs/socket-api-reference.md` — documents the stability guarantee and the rollback env var

## Rollback

Setting `CMUX_DISABLE_STABLE_PANEL_IDS=1` in the app's environment reverts to the old behavior (fresh UUID per restored panel, real `oldToNewPanelIds` remap). Kept as a one-release safety net per the plan; removable in a followup PR.

## Decisions made along the way

- **The `oldToNewPanelIds` map was not deleted.** Keeping it populated (as an identity map in the default path) lets the focus-restore and selected-tab-lookup blocks inside `restoreSessionSnapshot` stay on a single code path for both the stable-IDs and disabled-IDs cases. The plan asked for "keep the remap code paths present but dead by default"; this is closer to "present and harmless" since it is genuinely exercised when the flag is off.
- **The Python socket test uses a new DEBUG-only `debug.session.round_trip` method** rather than attempting to drive a real relaunch from the socket. The existing socket surface has no save/restore command, and a full relaunch is outside the Python harness's reach. The in-process round-trip exercises the same `sessionSnapshot()` + `restoreSessionSnapshot()` pair that the real relaunch path uses, so it's a faithful proxy for the contract.
- **No view-level `restoredFromSnapshot: Bool` was needed.** The audit of `.id(...)` modifiers (grep for `\.id\(.*panel` / `\.id\(.*surface`) found two hits: `TerminalPanelView:38` uses `panel.id` for stable identity (its intent is "don't recreate on bonsplit churn", which stable IDs preserve), and `BrowserPanelView:1150` keys off `webViewInstanceID` + `paneId`, neither of which is the panel UUID. `TabItemView` keys off the workspace UUID (`tab.id`), not the panel UUID, so Phase 1 does not affect it.

## Audit findings relevant to later phases

- **`SurfaceMetadataStore` pruning is already keyed on panel UUIDs** (`pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))` in `Workspace.restoreSessionSnapshot`). With stable IDs, metadata keyed on panel id could naturally survive restart — Phase 2's persistence layer will want this.
- **Workspace UUIDs are NOT stable across restart.** `TabManager.restoreSessionSnapshot` still mints a fresh `Workspace()` per workspace snapshot (no `id:` injection). Out of scope for Phase 1, but worth flagging for the Phase 2 fingerprint work — any workspace-scoped metadata persistence will need the equivalent constructor refactor up one level.
- **No fourth panel type** beyond terminal / browser / markdown was found in the audit.

## Plan reference

Full plan: `docs/c11mux-tier1-persistence-plan.md` → \`Phase 1 — Stable panel UUIDs (constructor refactor)\`.

## Test plan

- [ ] `cmuxTests/PanelIdentityRestoreTests.swift` passes in CI (`cmux-unit` scheme)
- [ ] `tests_v2/test_panel_id_stability.py` passes in the VM / harness run against a tagged DEBUG socket
- [ ] Manual: tag-built DEBUG app, create 2+ panels, relaunch, `surface.list` reports the same UUIDs
- [ ] Manual: same flow with `CMUX_DISABLE_STABLE_PANEL_IDS=1` — IDs regenerate and the app still works (focus restore + tab selection still land on the right panels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)