### PR TITLE
workspace metadata: persistence + socket + CLI (Phase 1)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2274,6 +2274,53 @@ struct CMUXCLI {
                 windowOverride: windowId
             )
 
+        case "set-workspace-metadata":
+            try runSetWorkspaceMetadataCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "get-workspace-metadata":
+            try runGetWorkspaceMetadataCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "clear-workspace-metadata":
+            try runClearWorkspaceMetadataCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "set-workspace-description":
+            try runSetWorkspaceCanonicalKeyCommand(
+                key: "description",
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "set-workspace-icon":
+            try runSetWorkspaceCanonicalKeyCommand(
+                key: "icon",
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
         case "claude-hook":
             cliTelemetry.breadcrumb("claude-hook.dispatch")
             do {
@@ -7340,6 +7387,61 @@ struct CMUXCLI {
               cmux clear-metadata --key terminal_type
               cmux clear-metadata --surface surface:2
             """
+        case "set-workspace-metadata":
+            return """
+            Usage: cmux set-workspace-metadata <key> <value> [flags]
+                   cmux set-workspace-metadata --key <K> --value <V> [flags]
+                   cmux set-workspace-metadata --json '{"description":"..."}' [flags]
+
+            Write one or more operator-authored metadata keys on a workspace via
+            workspace.set_metadata. Values are strings; canonical keys are
+            "description" (≤2048 chars) and "icon" (≤32 chars). Custom keys
+            must match [A-Za-z0-9_.-]+ and cap at 1024 chars each.
+
+            Flags:
+              --workspace <id|ref>     Target workspace (default: current)
+              --json '{...}'           Full JSON object of keys/values
+              --json                   Emit raw JSON result
+
+            Examples:
+              cmux set-workspace-metadata description "Backend API refactor"
+              cmux set-workspace-metadata icon 🦊
+            """
+        case "get-workspace-metadata":
+            return """
+            Usage: cmux get-workspace-metadata [<key>] [--workspace <id|ref>] [--json]
+
+            Read workspace metadata via workspace.get_metadata. With a key, prints
+            just that value. Without a key, prints all keys/values.
+
+            Examples:
+              cmux get-workspace-metadata
+              cmux get-workspace-metadata description
+            """
+        case "clear-workspace-metadata":
+            return """
+            Usage: cmux clear-workspace-metadata [<key>] [--key <K> ...] [--workspace <id|ref>] [--json]
+
+            Clear workspace metadata keys via workspace.clear_metadata. With no
+            key, clears the entire workspace metadata dictionary.
+
+            Examples:
+              cmux clear-workspace-metadata description
+              cmux clear-workspace-metadata
+            """
+        case "set-workspace-description":
+            return """
+            Usage: cmux set-workspace-description <text> [--workspace <id|ref>]
+
+            Sugar for `cmux set-workspace-metadata description <text>`.
+            """
+        case "set-workspace-icon":
+            return """
+            Usage: cmux set-workspace-icon <glyph> [--workspace <id|ref>]
+
+            Sugar for `cmux set-workspace-metadata icon <glyph>`. Supports emoji
+            or the prefix "sf:" + SF Symbol name (e.g. "sf:star.fill").
+            """
         case "set-app-focus":
             return """
             Usage: cmux set-app-focus <active|inactive|clear>
@@ -8535,6 +8637,193 @@ struct CMUXCLI {
 
         let payload = try client.sendV2(method: "surface.clear_metadata", params: params)
         printMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// Resolve the `workspace_id` param for a workspace metadata CLI call.
+    /// Honors `--workspace`, `CMUX_WORKSPACE_ID`, then falls back to the
+    /// currently selected workspace (server-side default).
+    private func resolveWorkspaceMetadataTarget(
+        commandArgs: [String],
+        client: SocketClient,
+        windowOverride: String?
+    ) throws -> String? {
+        let raw = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowOverride)
+        return try normalizeWorkspaceHandle(raw, client: client)
+    }
+
+    /// `cmux set-workspace-metadata <key> <value>` — wraps workspace.set_metadata.
+    private func runSetWorkspaceMetadataCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        var metadata: [String: String] = [:]
+        var singleKey: String?
+        var singleValue: String?
+
+        if let jsonStr = optionValue(commandArgs, name: "--json") {
+            guard let data = jsonStr.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw CLIError(message: "invalid_json: --json must be a JSON object string")
+            }
+            for (k, v) in obj {
+                guard let s = v as? String else {
+                    throw CLIError(message: "invalid_value: workspace metadata values must be strings (key '\(k)')")
+                }
+                metadata[k] = s
+            }
+        } else if let keyOpt = optionValue(commandArgs, name: "--key"),
+                  let valueOpt = optionValue(commandArgs, name: "--value") {
+            singleKey = keyOpt
+            singleValue = valueOpt
+        } else if positional.count >= 2 {
+            singleKey = positional[0]
+            singleValue = positional.dropFirst().joined(separator: " ")
+        } else {
+            throw CLIError(message: "set-workspace-metadata requires <key> <value>, --key/--value, or --json '{...}'")
+        }
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+
+        var params: [String: Any] = [:]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        if !metadata.isEmpty {
+            params["metadata"] = metadata
+        } else if let singleKey, let singleValue {
+            params["key"] = singleKey
+            params["value"] = singleValue
+        }
+
+        let payload = try client.sendV2(method: "workspace.set_metadata", params: params)
+        printWorkspaceMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// `cmux get-workspace-metadata [<key>]` — wraps workspace.get_metadata.
+    private func runGetWorkspaceMetadataCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        let keyFilter = optionValue(commandArgs, name: "--key") ?? positional.first
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        var params: [String: Any] = [:]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        if let keyFilter { params["key"] = keyFilter }
+
+        let payload = try client.sendV2(method: "workspace.get_metadata", params: params)
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+            return
+        }
+        let metadata = payload["metadata"] as? [String: String] ?? [:]
+        if let keyFilter {
+            if let v = metadata[keyFilter] {
+                print(v)
+            } else {
+                print("(unset)")
+            }
+            return
+        }
+        if metadata.isEmpty {
+            print("(empty)")
+            return
+        }
+        for key in metadata.keys.sorted() {
+            print("\(key) = \(metadata[key] ?? "")")
+        }
+    }
+
+    /// `cmux clear-workspace-metadata [<key>]` — wraps workspace.clear_metadata.
+    private func runClearWorkspaceMetadataCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        var keys: [String] = collectRepeatedOption(commandArgs, name: "--key")
+        if keys.isEmpty, let first = positional.first {
+            keys = [first]
+        }
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        var params: [String: Any] = [:]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        if !keys.isEmpty { params["keys"] = keys }
+
+        let payload = try client.sendV2(method: "workspace.clear_metadata", params: params)
+        printWorkspaceMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// `cmux set-workspace-description <text>` / `cmux set-workspace-icon <glyph>`
+    /// — thin sugar over `set-workspace-metadata <canonical-key> <value>`.
+    private func runSetWorkspaceCanonicalKeyCommand(
+        key: String,
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        guard let value = optionValue(commandArgs, name: "--value") ?? positional.first else {
+            throw CLIError(message: "set-workspace-\(key) requires a value")
+        }
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        var params: [String: Any] = ["key": key, "value": value]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        let payload = try client.sendV2(method: "workspace.set_metadata", params: params)
+        printWorkspaceMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// Print a workspace.set_metadata / workspace.clear_metadata result.
+    private func printWorkspaceMetadataResult(
+        _ payload: [String: Any],
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) {
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+            return
+        }
+        var parts = ["OK"]
+        if let handle = formatHandle(payload, kind: "workspace", idFormat: idFormat) {
+            parts.append(handle)
+        }
+        print(parts.joined(separator: " "))
+        let metadata = payload["metadata"] as? [String: String] ?? [:]
+        if metadata.isEmpty {
+            print("  (empty)")
+            return
+        }
+        for key in metadata.keys.sorted() {
+            print("  \(key) = \(metadata[key] ?? "")")
+        }
     }
 
     /// Print a `surface.set_metadata` / `surface.clear_metadata` result.
@@ -12349,6 +12638,11 @@ struct CMUXCLI {
           set-metadata (--json '{...}' | --key <K> --value <V> [--type string|number|bool|json]) [--surface <id|ref>] [--workspace <id|ref>] [--mode merge|replace] [--source <src>]
           get-metadata [--key <K> ...] [--sources] [--surface <id|ref>] [--workspace <id|ref>]
           clear-metadata [--key <K> ...] [--source <src>] [--surface <id|ref>] [--workspace <id|ref>]
+          set-workspace-metadata <key> <value> | --key <K> --value <V> | --json '{...}'  [--workspace <id|ref>]
+          get-workspace-metadata [<key>] [--workspace <id|ref>]
+          clear-workspace-metadata [<key>] [--key <K> ...] [--workspace <id|ref>]
+          set-workspace-description <text> [--workspace <id|ref>]
+          set-workspace-icon <glyph> [--workspace <id|ref>]
           set-app-focus <active|inactive|clear>
           simulate-app-active
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 			A5001534 /* BrowserWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001533 /* BrowserWindowPortal.swift */; };
 		A5001540 /* PortScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001541 /* PortScanner.swift */; };
 		A5001542 /* SurfaceMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001543 /* SurfaceMetadataStore.swift */; };
+		D7003BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7003BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */; };
+		D7004BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7004BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
 		A5001544 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* AgentDetector.swift */; };
 		A5008F11 /* SurfaceTitleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F12 /* SurfaceTitleBarView.swift */; };
 		A5008F21 /* TitleFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F22 /* TitleFormatting.swift */; };
@@ -197,6 +199,8 @@
 			A5001533 /* BrowserWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindowPortal.swift; sourceTree = "<group>"; };
 		A5001541 /* PortScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScanner.swift; sourceTree = "<group>"; };
 		A5001543 /* SurfaceMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetadataStore.swift; sourceTree = "<group>"; };
+		D7003BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataKeys.swift; sourceTree = "<group>"; };
+		D7004BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
 		A5001545 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		A5008F12 /* SurfaceTitleBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarView.swift; sourceTree = "<group>"; };
 		A5008F22 /* TitleFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleFormatting.swift; sourceTree = "<group>"; };
@@ -439,6 +443,7 @@
 				A5001019 /* TerminalController.swift */,
 				A5001541 /* PortScanner.swift */,
 				A5001543 /* SurfaceMetadataStore.swift */,
+				D7003BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */,
 				A5001545 /* AgentDetector.swift */,
 				A5008F12 /* SurfaceTitleBarView.swift */,
 				A5008F22 /* TitleFormatting.swift */,
@@ -571,6 +576,7 @@
 					10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 					D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */,
 					D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */,
+					D7004BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -742,6 +748,7 @@
 				A5001007 /* TerminalController.swift in Sources */,
 				A5001540 /* PortScanner.swift in Sources */,
 				A5001542 /* SurfaceMetadataStore.swift in Sources */,
+				D7003BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */,
 				A5001544 /* AgentDetector.swift in Sources */,
 				A5008F11 /* SurfaceTitleBarView.swift in Sources */,
 				A5008F21 /* TitleFormatting.swift in Sources */,
@@ -841,6 +848,7 @@
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 					D7001BF0A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift in Sources */,
 					D7002BF0A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift in Sources */,
+					D7004BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -340,6 +340,9 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var logEntries: [SessionLogEntrySnapshot]
     var progress: SessionProgressSnapshot?
     var gitBranch: SessionGitBranchSnapshot?
+    /// Operator-authored workspace metadata (e.g. description, icon).
+    /// Optional for backward compatibility with pre-metadata snapshots.
+    var metadata: [String: String]?
 }
 
 struct SessionTabManagerSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4891,6 +4891,14 @@ extension TabManager {
             hasher.combine(workspace.panels.count)
             hasher.combine(workspace.statusEntries.count)
             hasher.combine(workspace.metadataBlocks.count)
+            // Hash operator-authored workspace metadata by sorted keys so
+            // value-only edits still change the fingerprint. Without this,
+            // metadata edits could be deferred up to the forced-save window.
+            hasher.combine(workspace.metadata.count)
+            for key in workspace.metadata.keys.sorted() {
+                hasher.combine(key)
+                hasher.combine(workspace.metadata[key] ?? "")
+            }
             hasher.combine(workspace.logEntries.count)
             hasher.combine(workspace.panelDirectories.count)
             hasher.combine(workspace.panelTitles.count)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2089,6 +2089,12 @@ class TerminalController {
             return v2Result(id: id, self.v2WorkspaceRemoteStatus(params: params))
         case "workspace.remote.terminal_session_end":
             return v2Result(id: id, self.v2WorkspaceRemoteTerminalSessionEnd(params: params))
+        case "workspace.set_metadata":
+            return v2Result(id: id, self.v2WorkspaceSetMetadata(params: params))
+        case "workspace.get_metadata":
+            return v2Result(id: id, self.v2WorkspaceGetMetadata(params: params))
+        case "workspace.clear_metadata":
+            return v2Result(id: id, self.v2WorkspaceClearMetadata(params: params))
 
         // Settings
         case "settings.open":
@@ -2477,6 +2483,9 @@ class TerminalController {
             "workspace.remote.disconnect",
             "workspace.remote.status",
             "workspace.remote.terminal_session_end",
+            "workspace.set_metadata",
+            "workspace.get_metadata",
+            "workspace.clear_metadata",
             "settings.open",
             "feedback.open",
             "feedback.submit",
@@ -4193,6 +4202,222 @@ class TerminalController {
         }
 
         return result
+    }
+
+    /// Resolve the Workspace referenced by `workspace_id`. Falls back to the
+    /// currently selected workspace on the caller's TabManager if no explicit
+    /// id is supplied. Returns nil when the workspace cannot be located.
+    ///
+    /// Performs a main-actor read to locate the Workspace instance; callers
+    /// should mutate `workspace.metadata` via `v2MainSync` since `Workspace`
+    /// is `@MainActor` (see `Workspace.swift` class declaration).
+    private func v2ResolveWorkspaceForMetadata(
+        params: [String: Any]
+    ) -> (tabManager: TabManager, workspaceId: UUID)? {
+        guard let tabManager = v2ResolveTabManager(params: params) else { return nil }
+        if let explicit = v2UUID(params, "workspace_id") {
+            return v2MainSync {
+                guard tabManager.tabs.contains(where: { $0.id == explicit }) else { return nil }
+                return (tabManager, explicit)
+            }
+        }
+        return v2MainSync {
+            guard let selected = tabManager.selectedTabId,
+                  tabManager.tabs.contains(where: { $0.id == selected }) else {
+                return nil
+            }
+            return (tabManager, selected)
+        }
+    }
+
+    private func v2WorkspaceSetMetadata(params: [String: Any]) -> V2CallResult {
+        // Parse + validate off-main per the socket command threading policy
+        // (CLAUDE.md "Socket command threading policy").
+        let rawMetadata = v2StringMap(params, "metadata")
+        let singleKey = v2String(params, "key")
+        let singleValueRaw = params["value"]
+
+        var writes: [String: String?] = [:]
+        if let rawMetadata {
+            for (k, v) in rawMetadata { writes[k] = v }
+        }
+        if let singleKey {
+            if singleValueRaw is NSNull {
+                writes[singleKey] = nil
+            } else if let s = singleValueRaw as? String {
+                writes[singleKey] = s
+            } else if singleValueRaw == nil {
+                return .err(code: "invalid_params", message: "Missing 'value' for key '\(singleKey)'", data: nil)
+            } else {
+                return .err(code: "invalid_params", message: "metadata value must be a string or null", data: nil)
+            }
+        }
+
+        if writes.isEmpty {
+            return .err(
+                code: "invalid_params",
+                message: "Provide 'metadata' object or 'key'/'value' pair",
+                data: nil
+            )
+        }
+
+        // Validate all keys and non-nil values off-main before taking the
+        // main-actor critical section.
+        for (k, maybeValue) in writes {
+            do {
+                if let value = maybeValue {
+                    try WorkspaceMetadataValidator.validate(key: k, value: value)
+                } else {
+                    try WorkspaceMetadataValidator.validateKey(k)
+                }
+            } catch let err as WorkspaceMetadataValidator.ValidationError {
+                return .err(code: err.code, message: err.message, data: err.detail)
+            } catch {
+                return .err(code: "internal_error", message: "\(error)", data: nil)
+            }
+        }
+
+        guard let resolved = v2ResolveWorkspaceForMetadata(params: params) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+
+        var capacityError: WorkspaceMetadataValidator.CapacityError?
+        var resultMetadata: [String: String] = [:]
+        // Workspace is @MainActor; the mutation must run on the main actor.
+        // Precedent: workspace.rename handler (v2WorkspaceRename).
+        v2MainSync {
+            guard let ws = resolved.tabManager.tabs.first(where: { $0.id == resolved.workspaceId }) else {
+                return
+            }
+            var next = ws.metadata
+            for (k, maybeValue) in writes {
+                if let value = maybeValue {
+                    next[k] = value
+                } else {
+                    next.removeValue(forKey: k)
+                }
+            }
+            do {
+                try WorkspaceMetadataValidator.validateCapacity(after: next)
+            } catch let err as WorkspaceMetadataValidator.CapacityError {
+                capacityError = err
+                return
+            } catch {
+                // Unreachable: validateCapacity only throws CapacityError.
+                return
+            }
+            ws.metadata = next
+            resultMetadata = next
+        }
+
+        if let err = capacityError {
+            return .err(code: err.code, message: err.message, data: err.detail)
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: resolved.tabManager)
+        return .ok([
+            "workspace_id": resolved.workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: resolved.workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "metadata": resultMetadata
+        ])
+    }
+
+    private func v2WorkspaceGetMetadata(params: [String: Any]) -> V2CallResult {
+        let requestedKey = v2String(params, "key")
+        let requestedKeys = v2StringArray(params, "keys")
+
+        guard let resolved = v2ResolveWorkspaceForMetadata(params: params) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+
+        var full: [String: String] = [:]
+        v2MainSync {
+            guard let ws = resolved.tabManager.tabs.first(where: { $0.id == resolved.workspaceId }) else {
+                return
+            }
+            full = ws.metadata
+        }
+
+        var metadataOut: [String: String] = full
+        if let filterKeys = requestedKeys {
+            metadataOut = [:]
+            for k in filterKeys {
+                if let v = full[k] { metadataOut[k] = v }
+            }
+        } else if let single = requestedKey {
+            metadataOut = [:]
+            if let v = full[single] { metadataOut[single] = v }
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: resolved.tabManager)
+        var payload: [String: Any] = [
+            "workspace_id": resolved.workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: resolved.workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "metadata": metadataOut
+        ]
+        if let single = requestedKey {
+            payload["key"] = single
+            payload["value"] = v2OrNull(metadataOut[single])
+        }
+        return .ok(payload)
+    }
+
+    private func v2WorkspaceClearMetadata(params: [String: Any]) -> V2CallResult {
+        let keys: [String]?
+        if params["keys"] == nil || params["keys"] is NSNull {
+            keys = nil
+        } else if let arr = v2StringArray(params, "keys") {
+            keys = arr
+        } else {
+            return .err(code: "invalid_keys_param", message: "keys must be an array of strings", data: nil)
+        }
+
+        // Validate key grammar off-main when a filter is provided; malformed
+        // keys could never have been written but reject them explicitly so
+        // callers see a consistent error shape.
+        if let keys {
+            for k in keys {
+                do {
+                    try WorkspaceMetadataValidator.validateKey(k)
+                } catch let err as WorkspaceMetadataValidator.ValidationError {
+                    return .err(code: err.code, message: err.message, data: err.detail)
+                } catch {
+                    return .err(code: "internal_error", message: "\(error)", data: nil)
+                }
+            }
+        }
+
+        guard let resolved = v2ResolveWorkspaceForMetadata(params: params) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+
+        var resultMetadata: [String: String] = [:]
+        v2MainSync {
+            guard let ws = resolved.tabManager.tabs.first(where: { $0.id == resolved.workspaceId }) else {
+                return
+            }
+            if let keys {
+                var next = ws.metadata
+                for k in keys { next.removeValue(forKey: k) }
+                ws.metadata = next
+            } else {
+                ws.metadata = [:]
+            }
+            resultMetadata = ws.metadata
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: resolved.tabManager)
+        return .ok([
+            "workspace_id": resolved.workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: resolved.workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "metadata": resultMetadata
+        ])
     }
 
     private func v2WorkspaceAction(params: [String: Any]) -> V2CallResult {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -195,6 +195,8 @@ extension Workspace {
             SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
         }
 
+        let metadataSnapshot: [String: String]? = metadata.isEmpty ? nil : metadata
+
         return SessionWorkspaceSnapshot(
             processTitle: processTitle,
             customTitle: customTitle,
@@ -207,7 +209,8 @@ extension Workspace {
             statusEntries: statusSnapshots,
             logEntries: logSnapshots,
             progress: progressSnapshot,
-            gitBranch: gitBranchSnapshot
+            gitBranch: gitBranchSnapshot,
+            metadata: metadataSnapshot
         )
     }
 
@@ -239,6 +242,7 @@ extension Workspace {
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
+        metadata = snapshot.metadata ?? [:]
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -4823,6 +4827,12 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published var currentDirectory: String
+
+    /// Operator-authored workspace metadata (e.g. "description", "icon").
+    /// Workspace-scoped; not to be confused with surface-scoped
+    /// `SurfaceMetadataStore`. Persisted across restart via
+    /// `SessionWorkspaceSnapshot.metadata`.
+    @Published var metadata: [String: String] = [:]
     private(set) var preferredBrowserProfileID: UUID?
 
     /// Ordinal for CMUX_PORT range assignment (monotonically increasing per app session)

--- a/Sources/WorkspaceMetadataKeys.swift
+++ b/Sources/WorkspaceMetadataKeys.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Canonical operator-authored workspace metadata keys.
+///
+/// Workspace-scoped. Distinct from `MetadataKey` in `SurfaceMetadataStore.swift`
+/// (surface-scoped). The same string literal (e.g. `"description"`) carries
+/// different meaning in each namespace; do not cross them.
+public enum WorkspaceMetadataKey {
+    public static let description = "description"
+    public static let icon = "icon"
+
+    public static let canonical: Set<String> = [description, icon]
+}
+
+/// Validation for workspace metadata writes.
+///
+/// Values for canonical keys have specific caps; unknown keys are accepted up
+/// to the generic caps below. All keys must match a conservative ASCII
+/// grammar to keep the socket wire shape stable and to avoid escape surprises
+/// in logs and CLI output.
+public enum WorkspaceMetadataValidator {
+    public static let maxDescriptionLen = 2048
+    public static let maxIconLen = 32
+    public static let maxCustomKeys = 32
+    public static let maxCustomKeyLen = 64
+    public static let maxCustomValueLen = 1024
+
+    /// Key grammar: non-empty ASCII letters/digits/underscore/dot/hyphen.
+    /// Pattern: `^[A-Za-z0-9_.\-]+$`. No whitespace, no arbitrary UTF-8.
+    public static let keyPattern = #"^[A-Za-z0-9_.\-]+$"#
+
+    public enum ValidationError: Error, Equatable {
+        case emptyKey
+        case keyTooLong(limit: Int)
+        case keyInvalidCharacters
+        case valueTooLong(key: String, limit: Int)
+
+        public var code: String {
+            switch self {
+            case .emptyKey: return "invalid_key"
+            case .keyTooLong: return "invalid_key"
+            case .keyInvalidCharacters: return "invalid_key"
+            case .valueTooLong: return "value_too_long"
+            }
+        }
+
+        public var message: String {
+            switch self {
+            case .emptyKey:
+                return "metadata key must be non-empty"
+            case .keyTooLong(let limit):
+                return "metadata key exceeds max length \(limit)"
+            case .keyInvalidCharacters:
+                return "metadata key must match [A-Za-z0-9_.-]+"
+            case .valueTooLong(let key, let limit):
+                return "metadata value for '\(key)' exceeds max length \(limit)"
+            }
+        }
+
+        public var detail: [String: Any]? {
+            switch self {
+            case .valueTooLong(let key, let limit):
+                return ["key": key, "limit": limit]
+            case .keyTooLong(let limit):
+                return ["limit": limit]
+            default:
+                return nil
+            }
+        }
+    }
+
+    public enum CapacityError: Error, Equatable {
+        case tooManyKeys(limit: Int)
+
+        public var code: String { "too_many_keys" }
+        public var message: String {
+            switch self {
+            case .tooManyKeys(let limit):
+                return "workspace metadata exceeds max \(limit) keys"
+            }
+        }
+        public var detail: [String: Any]? {
+            switch self {
+            case .tooManyKeys(let limit):
+                return ["limit": limit]
+            }
+        }
+    }
+
+    private static let keyRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: keyPattern, options: [])
+    }()
+
+    /// Validate a key/value pair for writing.
+    public static func validate(key: String, value: String) throws {
+        try validateKey(key)
+        try validateValue(key: key, value: value)
+    }
+
+    /// Validate a key grammar only (used for deletion paths).
+    public static func validateKey(_ key: String) throws {
+        if key.isEmpty { throw ValidationError.emptyKey }
+        if key.count > maxCustomKeyLen {
+            throw ValidationError.keyTooLong(limit: maxCustomKeyLen)
+        }
+        let range = NSRange(location: 0, length: (key as NSString).length)
+        if keyRegex.firstMatch(in: key, options: [], range: range) == nil {
+            throw ValidationError.keyInvalidCharacters
+        }
+    }
+
+    private static func validateValue(key: String, value: String) throws {
+        let limit = valueLimit(for: key)
+        if value.count > limit {
+            throw ValidationError.valueTooLong(key: key, limit: limit)
+        }
+    }
+
+    /// Cap (in characters) for a given key. Canonical keys have dedicated
+    /// limits; anything else falls back to the generic custom-value cap.
+    public static func valueLimit(for key: String) -> Int {
+        switch key {
+        case WorkspaceMetadataKey.description: return maxDescriptionLen
+        case WorkspaceMetadataKey.icon: return maxIconLen
+        default: return maxCustomValueLen
+        }
+    }
+
+    /// Validate the post-write map does not exceed the custom-key count cap.
+    /// Canonical keys do not count against the custom-key budget.
+    public static func validateCapacity(after candidate: [String: String]) throws {
+        let customCount = candidate.keys.filter { !WorkspaceMetadataKey.canonical.contains($0) }.count
+        if customCount > maxCustomKeys {
+            throw CapacityError.tooManyKeys(limit: maxCustomKeys)
+        }
+    }
+}

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -47,6 +47,58 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertNotNil(manager.selectedTabId)
     }
 
+    func testSessionSnapshotRoundtripsWorkspaceMetadata() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+        workspace.metadata = [
+            WorkspaceMetadataKey.description: "Backend refactor",
+            WorkspaceMetadataKey.icon: "🦊",
+            "custom.tag": "v2"
+        ]
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        XCTAssertEqual(snapshot.workspaces.count, 1)
+        XCTAssertEqual(snapshot.workspaces[0].metadata?["description"], "Backend refactor")
+        XCTAssertEqual(snapshot.workspaces[0].metadata?["icon"], "🦊")
+        XCTAssertEqual(snapshot.workspaces[0].metadata?["custom.tag"], "v2")
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+        XCTAssertEqual(restored.tabs.count, 1)
+        XCTAssertEqual(restored.tabs[0].metadata["description"], "Backend refactor")
+        XCTAssertEqual(restored.tabs[0].metadata["icon"], "🦊")
+        XCTAssertEqual(restored.tabs[0].metadata["custom.tag"], "v2")
+    }
+
+    func testEmptyMetadataIsOmittedFromSnapshot() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+        XCTAssertTrue(workspace.metadata.isEmpty)
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        XCTAssertNil(snapshot.workspaces.first?.metadata)
+    }
+
+    func testAutosaveFingerprintChangesOnMetadataValueEdit() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+        workspace.metadata = ["description": "one"]
+        let before = manager.sessionAutosaveFingerprint()
+        workspace.metadata = ["description": "two"]
+        let after = manager.sessionAutosaveFingerprint()
+        XCTAssertNotEqual(before, after,
+            "Autosave fingerprint must change on value-only metadata edit (plan contract).")
+    }
+
     func testSessionSnapshotExcludesRemoteWorkspacesFromRestore() throws {
         let manager = TabManager()
         let remoteWorkspace = manager.addWorkspace(select: true)

--- a/cmuxTests/WorkspaceMetadataValidatorTests.swift
+++ b/cmuxTests/WorkspaceMetadataValidatorTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class WorkspaceMetadataValidatorTests: XCTestCase {
+    func testAcceptsCanonicalDescriptionAtMaxLen() throws {
+        let value = String(repeating: "a", count: WorkspaceMetadataValidator.maxDescriptionLen)
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.description,
+            value: value
+        ))
+    }
+
+    func testRejectsDescriptionOverMaxLen() {
+        let value = String(repeating: "a", count: WorkspaceMetadataValidator.maxDescriptionLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.description,
+            value: value
+        )) { error in
+            guard let err = error as? WorkspaceMetadataValidator.ValidationError else {
+                XCTFail("Expected ValidationError, got \(error)")
+                return
+            }
+            XCTAssertEqual(
+                err,
+                .valueTooLong(
+                    key: WorkspaceMetadataKey.description,
+                    limit: WorkspaceMetadataValidator.maxDescriptionLen
+                )
+            )
+        }
+    }
+
+    func testAcceptsIconAtMaxLen() throws {
+        let value = String(repeating: "x", count: WorkspaceMetadataValidator.maxIconLen)
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: value
+        ))
+    }
+
+    func testRejectsIconOverMaxLen() {
+        let value = String(repeating: "x", count: WorkspaceMetadataValidator.maxIconLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: value
+        ))
+    }
+
+    func testAcceptsEmojiValues() throws {
+        // Emoji-with-modifier + ZWJ sequences commonly have count > 1 unit even
+        // though they look like a single glyph. Confirm they pass within caps.
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: "🦊"
+        ))
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: "👍🏽"
+        ))
+    }
+
+    func testCustomKeyAcceptsValidGrammar() throws {
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(key: "project.id", value: "abc"))
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(key: "My-Key_1", value: "abc"))
+    }
+
+    func testRejectsEmptyKey() {
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "", value: "ok")) { err in
+            XCTAssertEqual(err as? WorkspaceMetadataValidator.ValidationError, .emptyKey)
+        }
+    }
+
+    func testRejectsKeyWithWhitespace() {
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "my key", value: "ok")) { err in
+            XCTAssertEqual(err as? WorkspaceMetadataValidator.ValidationError, .keyInvalidCharacters)
+        }
+    }
+
+    func testRejectsKeyWithNonASCII() {
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "キー", value: "ok")) { err in
+            XCTAssertEqual(err as? WorkspaceMetadataValidator.ValidationError, .keyInvalidCharacters)
+        }
+    }
+
+    func testRejectsKeyOverMaxLen() {
+        let key = String(repeating: "a", count: WorkspaceMetadataValidator.maxCustomKeyLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: key, value: "ok")) { err in
+            XCTAssertEqual(
+                err as? WorkspaceMetadataValidator.ValidationError,
+                .keyTooLong(limit: WorkspaceMetadataValidator.maxCustomKeyLen)
+            )
+        }
+    }
+
+    func testRejectsCustomValueOverMaxLen() {
+        let value = String(repeating: "a", count: WorkspaceMetadataValidator.maxCustomValueLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "note", value: value)) { err in
+            XCTAssertEqual(
+                err as? WorkspaceMetadataValidator.ValidationError,
+                .valueTooLong(key: "note", limit: WorkspaceMetadataValidator.maxCustomValueLen)
+            )
+        }
+    }
+
+    func testCapacityAcceptsCanonicalPlusCustomAtLimit() throws {
+        var map: [String: String] = [
+            WorkspaceMetadataKey.description: "desc",
+            WorkspaceMetadataKey.icon: "🦊"
+        ]
+        for i in 0..<WorkspaceMetadataValidator.maxCustomKeys {
+            map["custom_\(i)"] = "value"
+        }
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validateCapacity(after: map))
+    }
+
+    func testCapacityRejectsOverCustomKeyLimit() {
+        var map: [String: String] = [:]
+        for i in 0..<(WorkspaceMetadataValidator.maxCustomKeys + 1) {
+            map["custom_\(i)"] = "value"
+        }
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validateCapacity(after: map)) { err in
+            XCTAssertEqual(
+                err as? WorkspaceMetadataValidator.CapacityError,
+                .tooManyKeys(limit: WorkspaceMetadataValidator.maxCustomKeys)
+            )
+        }
+    }
+}

--- a/tests_v2/test_workspace_metadata_limits.py
+++ b/tests_v2/test_workspace_metadata_limits.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""workspace.set_metadata rejects oversize values, bad keys, and over-capacity writes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+MAX_DESCRIPTION = 2048
+MAX_ICON = 32
+MAX_CUSTOM_KEY = 64
+MAX_CUSTOM_VALUE = 1024
+MAX_CUSTOM_KEYS = 32
+
+
+def _expect_error(client, method, params, *, code_prefix: str = "") -> str:
+    try:
+        client._call(method, params)
+    except cmuxError as e:
+        msg = str(e)
+        if code_prefix and not msg.startswith(code_prefix):
+            raise cmuxError(f"Expected error starting with {code_prefix!r}, got: {msg}")
+        return msg
+    raise cmuxError(f"{method} with {params!r} should have failed but succeeded")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        workspace_id = client.new_workspace()
+        try:
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "description",
+                    "value": "a" * (MAX_DESCRIPTION + 1),
+                },
+                code_prefix="value_too_long",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "icon",
+                    "value": "x" * (MAX_ICON + 1),
+                },
+                code_prefix="value_too_long",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "my key",
+                    "value": "hi",
+                },
+                code_prefix="invalid_key",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "キー",
+                    "value": "hi",
+                },
+                code_prefix="invalid_key",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "a" * (MAX_CUSTOM_KEY + 1),
+                    "value": "hi",
+                },
+                code_prefix="invalid_key",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "note",
+                    "value": "a" * (MAX_CUSTOM_VALUE + 1),
+                },
+                code_prefix="value_too_long",
+            )
+
+            # Fill the custom-key budget to the cap, then try one more.
+            batch = {f"k_{i}": "v" for i in range(MAX_CUSTOM_KEYS)}
+            ok = client._call(
+                "workspace.set_metadata",
+                {"workspace_id": workspace_id, "metadata": batch},
+            )
+            stored = ok.get("metadata") or {}
+            if len([k for k in stored if k not in ("description", "icon")]) != MAX_CUSTOM_KEYS:
+                raise cmuxError(
+                    f"Expected exactly {MAX_CUSTOM_KEYS} custom keys after batch fill: {stored!r}"
+                )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "over_the_limit",
+                    "value": "x",
+                },
+                code_prefix="too_many_keys",
+            )
+
+            # Canonical keys still allowed past the custom cap (they don't count).
+            ok_canonical = client._call(
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "description",
+                    "value": "ok",
+                },
+            )
+            assert (ok_canonical.get("metadata") or {}).get("description") == "ok"
+        finally:
+            try:
+                client.close_workspace(workspace_id)
+            except Exception:
+                pass
+
+    print("PASS: workspace.set_metadata enforces key/value/capacity limits")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_workspace_metadata_roundtrip.py
+++ b/tests_v2/test_workspace_metadata_roundtrip.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""workspace.set_metadata / workspace.get_metadata / workspace.clear_metadata roundtrip."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        workspace_id = client.new_workspace()
+        try:
+            set_payload = client._call(
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "description",
+                    "value": "Backend refactor",
+                },
+            )
+            metadata = set_payload.get("metadata") or {}
+            _must(
+                metadata.get("description") == "Backend refactor",
+                f"set_metadata should return the new description: {set_payload!r}",
+            )
+
+            get_payload = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            stored = get_payload.get("metadata") or {}
+            _must(
+                stored.get("description") == "Backend refactor",
+                f"get_metadata should return the stored description: {get_payload!r}",
+            )
+
+            _ = client._call(
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "metadata": {"icon": "🦊", "project.tag": "alpha"},
+                },
+            )
+            get_all = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            stored = get_all.get("metadata") or {}
+            _must(stored.get("description") == "Backend refactor", f"description persisted after subsequent write: {stored!r}")
+            _must(stored.get("icon") == "🦊", f"icon stored via batch write: {stored!r}")
+            _must(stored.get("project.tag") == "alpha", f"custom key stored: {stored!r}")
+
+            get_single = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id, "key": "icon"},
+            )
+            _must(get_single.get("value") == "🦊", f"single-key get should expose 'value': {get_single!r}")
+
+            # Delete a single key via value=null.
+            _ = client._call(
+                "workspace.set_metadata",
+                {"workspace_id": workspace_id, "key": "project.tag", "value": None},
+            )
+            after_delete = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            after = after_delete.get("metadata") or {}
+            _must("project.tag" not in after, f"project.tag should be deleted: {after!r}")
+            _must(after.get("description") == "Backend refactor", f"description survives delete: {after!r}")
+
+            # Clear a specific key.
+            _ = client._call(
+                "workspace.clear_metadata",
+                {"workspace_id": workspace_id, "keys": ["icon"]},
+            )
+            after_clear_one = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            remaining = after_clear_one.get("metadata") or {}
+            _must("icon" not in remaining, f"icon should be cleared: {remaining!r}")
+
+            # Clear all.
+            _ = client._call(
+                "workspace.clear_metadata",
+                {"workspace_id": workspace_id},
+            )
+            after_all = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            _must(
+                (after_all.get("metadata") or {}) == {},
+                f"clear_metadata without keys should empty the store: {after_all!r}",
+            )
+        finally:
+            try:
+                client.close_workspace(workspace_id)
+            except Exception:
+                pass
+
+    print("PASS: workspace metadata roundtrip (set/get/clear) via socket")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the c11mux Workspace Metadata Persistence plan (`docs/c11mux-workspace-metadata-persistence-plan.md`). Adds a durable operator-authored key/value store at the workspace level, wired end-to-end but with no UI consumer yet — Phases 3 (sidebar description render) and 4 (workspace icon) ship in separate PRs.

- `Workspace.metadata: [String: String]` — `@MainActor @Published`, persisted through `SessionWorkspaceSnapshot.metadata` (optional field, no schema bump needed).
- Two canonical keys: `description` (≤2048 chars) and `icon` (≤32 chars). Custom keys accepted up to 32 total, 64-char key length, 1024-char value length, matching `^[A-Za-z0-9_.-]+$`.
- Three new v2 socket methods: `workspace.set_metadata`, `workspace.get_metadata`, `workspace.clear_metadata`. Handlers parse/validate off-main, marshal to main for the mutation (precedent: `workspace.rename`).
- CLI: `set-workspace-metadata`, `get-workspace-metadata`, `clear-workspace-metadata` plus `set-workspace-description` / `set-workspace-icon` aliases.
- `TabManager.sessionAutosaveFingerprint()` now hashes metadata by sorted keys so value-only edits aren't deferred into the forced-save window.

## Files touched

- `Sources/WorkspaceMetadataKeys.swift` (new) — canonical keys + validator.
- `Sources/SessionPersistence.swift` — optional `metadata: [String: String]?` on `SessionWorkspaceSnapshot`.
- `Sources/Workspace.swift` — new `@Published var metadata`, save in `sessionSnapshot`, restore in `restoreSessionSnapshot`.
- `Sources/TabManager.swift` — autosave fingerprint includes sorted-key metadata hash.
- `Sources/TerminalController.swift` — three new v2 methods, capabilities list update.
- `CLI/cmux.swift` — 5 new commands + help text + usage banner entry.
- `cmuxTests/WorkspaceMetadataValidatorTests.swift` (new) — validator unit tests.
- `cmuxTests/TabManagerSessionSnapshotTests.swift` — roundtrip + fingerprint test cases.
- `tests_v2/test_workspace_metadata_roundtrip.py` (new).
- `tests_v2/test_workspace_metadata_limits.py` (new).
- `GhosttyTabs.xcodeproj/project.pbxproj` — wires new Swift files into main + test targets.

## Decisions made along the way

- **Kept `metadata` out of `resetSidebarContext`.** Operator-authored state should survive agent context changes (same as `customTitle`).
- **Autosave fingerprint fix is mandatory, not optional.** The existing fingerprint reads `workspace.metadataBlocks.count` (distinct — agent-emitted markdown blocks, not operator metadata). Without hashing the new `metadata` map by key+value, value-only edits would get deferred up to the 60-second forced-save window.
- **No new `WorkspaceMetadataStore` class.** Session-snapshot roundtrip already provides durability. Per the plan's appendix, extracting a full store is deferred until the feature grows to need source-precedence tracking.
- **CLI strings are plain English.** The plan called for `String(localized:defaultValue:)` on CLI help / error messages. Existing CLI (`CLI/cmux.swift`) has zero `String(localized:)` usages — CLI output isn't routed through SwiftUI localization in this repo. Followed the existing convention rather than introducing a one-off pattern. Happy to change if reviewer disagrees; it's a repo-wide convention question.

## Phase ordering (from the plan)

Phase 1 — persistence + socket + CLI (this PR). No UI change. Safe to revert.
Phase 2 — no-op unless the M7 agent privatizes shared markdown helpers.
Phase 3 — sidebar description render (depends on Phase 1 + gold-on-void sidebar PR).
Phase 4 — workspace icon render (depends on Phase 1).
Phase 5 — docs.

## Plan reference

Full plan: `docs/c11mux-workspace-metadata-persistence-plan.md` → `Phase 1 — Persistence layer`.

## Test plan

- [ ] `cmuxTests/WorkspaceMetadataValidatorTests.swift` passes on CI (`cmux-unit` scheme).
- [ ] `cmuxTests/TabManagerSessionSnapshotTests.swift` new roundtrip + fingerprint cases pass.
- [ ] `tests_v2/test_workspace_metadata_roundtrip.py` passes against a running DEBUG socket.
- [ ] `tests_v2/test_workspace_metadata_limits.py` passes — validator rejects over-cap, bad-key, over-capacity writes.
- [ ] Manual: tagged DEBUG build, `cmux set-workspace-description "x"`, `cmux get-workspace-metadata` reads it back, relaunch app, description survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)