### PR TITLE
Tier 1 persistence, Phase 1.5: stable workspace UUIDs

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 					D7001BF0A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */; };
 					D7002BF0A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */; };
 					D7003BF0A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */; };
+					D7004BF0A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -309,6 +310,7 @@
 				D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarRenderTests.swift; sourceTree = "<group>"; };
 				D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionSanitizerTests.swift; sourceTree = "<group>"; };
 			D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelIdentityRestoreTests.swift; sourceTree = "<group>"; };
+			D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIdentityRestoreTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -574,6 +576,7 @@
 					D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */,
 					D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */,
 					D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */,
+					D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -845,6 +848,7 @@
 					D7001BF0A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift in Sources */,
 					D7002BF0A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift in Sources */,
 					D7003BF0A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift in Sources */,
+					D7004BF0A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -32,6 +32,24 @@ enum SessionPersistencePolicy {
         !envFlagEnabled("CMUX_DISABLE_STABLE_PANEL_IDS")
     }
 
+    /// Tier 1 persistence, Phase 1.5: stable workspace UUIDs across app restarts.
+    ///
+    /// When `true` (default), `TabManager.restoreSessionSnapshot` injects each
+    /// `SessionWorkspaceSnapshot.id` into the restored workspace's constructor so
+    /// external consumers (Lattice, CLI, scripted tests) can cache the
+    /// `(workspaceId, surfaceId)` tuple across restarts. This is a hard
+    /// prerequisite for Phase 2 (persistent `SurfaceMetadataStore`), which keys
+    /// on that tuple.
+    ///
+    /// Setting `CMUX_DISABLE_STABLE_WORKSPACE_IDS=1` reverts to the old behavior
+    /// (fresh UUID per restored workspace). App launch scope only — set via
+    /// `launchctl setenv` or the parent shell before launching the app; setting
+    /// it on the `cmux` CLI invocation has no effect. Kept as a one-release
+    /// rollback safety net; delete in a followup PR.
+    static var stableWorkspaceIdsEnabled: Bool {
+        !envFlagEnabled("CMUX_DISABLE_STABLE_WORKSPACE_IDS")
+    }
+
     private static func envFlagEnabled(_ name: String) -> Bool {
         guard let raw = ProcessInfo.processInfo.environment[name] else { return false }
         switch raw.trimmingCharacters(in: .whitespaces).lowercased() {
@@ -349,6 +367,7 @@ indirect enum SessionWorkspaceLayoutSnapshot: Codable, Sendable {
 }
 
 struct SessionWorkspaceSnapshot: Codable, Sendable {
+    var id: UUID
     var processTitle: String
     var customTitle: String?
     var customColor: String?

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4964,7 +4964,16 @@ extension TabManager {
         for workspaceSnapshot in workspaceSnapshots {
             let ordinal = Self.nextPortOrdinal
             Self.nextPortOrdinal += 1
+            // Tier 1 persistence, Phase 1.5: thread the snapshot's workspace
+            // UUID into the restored workspace so `(workspaceId, surfaceId)`
+            // tuples cached by external consumers (Lattice, CLI, scripted
+            // tests) stay valid across restart. `CMUX_DISABLE_STABLE_WORKSPACE_IDS=1`
+            // reverts to fresh-UUID minting for one-release rollback.
+            let restoredWorkspaceId: UUID? = SessionPersistencePolicy.stableWorkspaceIdsEnabled
+                ? workspaceSnapshot.id
+                : nil
             let workspace = Workspace(
+                id: restoredWorkspaceId,
                 title: workspaceSnapshot.processTitle,
                 workingDirectory: workspaceSnapshot.currentDirectory,
                 portOrdinal: ordinal

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2441,6 +2441,8 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugScreenshot(params: params))
         case "debug.session.round_trip":
             return v2Result(id: id, self.v2DebugSessionRoundTrip(params: params))
+        case "debug.session.round_trip_workspaces":
+            return v2Result(id: id, self.v2DebugSessionRoundTripWorkspaces(params: params))
 #endif
 
             default:
@@ -2642,6 +2644,7 @@ class TerminalController {
             "debug.panel_snapshot.reset",
             "debug.window.screenshot",
             "debug.session.round_trip",
+            "debug.session.round_trip_workspaces",
         ])
 #endif
 
@@ -11527,6 +11530,28 @@ class TerminalController {
         }
         if let failureMessage {
             return .err(code: "workspace_not_found", message: failureMessage, data: nil)
+        }
+        return .ok([
+            "before": before,
+            "after": after
+        ])
+    }
+
+    /// Phase 1.5 workspace-id round-trip: snapshot the entire `TabManager`
+    /// (all workspaces in the target window), then restore it in place.
+    /// Returns the ordered workspace UUIDs before and after so callers can
+    /// assert that workspace IDs survive a save/load cycle.
+    private func v2DebugSessionRoundTripWorkspaces(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        var before: [String] = []
+        var after: [String] = []
+        v2MainSync {
+            before = tabManager.tabs.map { $0.id.uuidString }
+            let snapshot = tabManager.sessionSnapshot(includeScrollback: false)
+            tabManager.restoreSessionSnapshot(snapshot)
+            after = tabManager.tabs.map { $0.id.uuidString }
         }
         return .ok([
             "before": before,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5149,7 +5149,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         // Create initial terminal panel
         let terminalPanel = TerminalPanel(
-            workspaceId: id,
+            workspaceId: self.id,
             context: GHOSTTY_SURFACE_CONTEXT_TAB,
             configTemplate: configTemplate,
             workingDirectory: hasWorkingDirectory ? trimmedWorkingDirectory : nil,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -196,6 +196,7 @@ extension Workspace {
         }
 
         return SessionWorkspaceSnapshot(
+            id: id,
             processTitle: processTitle,
             customTitle: customTitle,
             customColor: customColor,
@@ -5097,6 +5098,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     init(
+        id: UUID? = nil,
         title: String = "Terminal",
         workingDirectory: String? = nil,
         portOrdinal: Int = 0,
@@ -5104,7 +5106,11 @@ final class Workspace: Identifiable, ObservableObject {
         initialTerminalCommand: String? = nil,
         initialTerminalEnvironment: [String: String] = [:]
     ) {
-        self.id = UUID()
+        // Tier 1 persistence, Phase 1.5: accept an optional restore-time id so
+        // workspace UUIDs can survive across app restarts. Nil mints a fresh
+        // UUID (the normal creation path); a supplied id is used as-is (the
+        // restore path in `TabManager.restoreSessionSnapshot`).
+        self.id = id ?? UUID()
         self.portOrdinal = portOrdinal
         self.processTitle = title
         self.title = title

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -766,6 +766,7 @@ final class SessionPersistenceTests: XCTestCase {
 
     private func makeSnapshot(version: Int) -> AppSessionSnapshot {
         let workspace = SessionWorkspaceSnapshot(
+            id: UUID(),
             processTitle: "Terminal",
             customTitle: "Restored",
             customColor: nil,

--- a/cmuxTests/WorkspaceIdentityRestoreTests.swift
+++ b/cmuxTests/WorkspaceIdentityRestoreTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tier 1 persistence, Phase 1.5 — stable workspace UUIDs via restore-time ID
+/// injection.
+///
+/// Mirrors `PanelIdentityRestoreTests` one level up: after capturing a
+/// `SessionTabManagerSnapshot` and restoring it into a fresh `TabManager`,
+/// each workspace's UUID must match the UUID it had in the snapshot.
+/// `SurfaceMetadataStore` (Phase 2) keys on `(workspaceId, surfaceId)`, so
+/// workspace ids must be stable across restart for external consumers
+/// (Lattice, CLI, scripted tests) to safely cache the tuple.
+@MainActor
+final class WorkspaceIdentityRestoreTests: XCTestCase {
+    func testSingleWorkspaceIdIsStableAcrossTabManagerRoundTrip() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let originalId = workspace.id
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        XCTAssertEqual(snapshot.workspaces.count, 1)
+        XCTAssertEqual(snapshot.workspaces.first?.id, originalId)
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+
+        XCTAssertEqual(restored.tabs.count, 1)
+        XCTAssertEqual(
+            restored.tabs.first?.id,
+            originalId,
+            "Restored workspace should keep the UUID from the snapshot"
+        )
+    }
+
+    func testMultipleWorkspaceIdsSurviveRoundTripWithoutCollisionOrSwap() throws {
+        let manager = TabManager()
+        let first = try XCTUnwrap(manager.selectedWorkspace)
+        first.setCustomTitle("First")
+        let second = manager.addWorkspace(select: false)
+        second.setCustomTitle("Second")
+        let third = manager.addWorkspace(select: true)
+        third.setCustomTitle("Third")
+
+        let orderedIds = manager.tabs.map(\.id)
+        XCTAssertEqual(orderedIds.count, 3)
+        XCTAssertEqual(Set(orderedIds).count, 3, "Pre-snapshot workspace ids must be distinct")
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        let snapshotIds = snapshot.workspaces.map(\.id)
+        XCTAssertEqual(snapshotIds, orderedIds)
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredIds = restored.tabs.map(\.id)
+        XCTAssertEqual(
+            restoredIds,
+            orderedIds,
+            "Restored workspace ids should equal the pre-snapshot ids in the same order (no collision, no swap)"
+        )
+        XCTAssertEqual(Set(restoredIds).count, 3, "Restored workspace ids must still be distinct")
+
+        // Workspace-scoped metadata (customTitle) must still track the correct workspace
+        // after restore — a sanity check that the id stability doesn't cross ids.
+        XCTAssertEqual(restored.tabs[0].customTitle, "First")
+        XCTAssertEqual(restored.tabs[1].customTitle, "Second")
+        XCTAssertEqual(restored.tabs[2].customTitle, "Third")
+    }
+
+    func testFallbackWorkspaceOnEmptySnapshotGetsFreshId() {
+        let manager = TabManager()
+        let emptySnapshot = SessionTabManagerSnapshot(
+            selectedWorkspaceIndex: nil,
+            workspaces: []
+        )
+
+        manager.restoreSessionSnapshot(emptySnapshot)
+
+        XCTAssertEqual(manager.tabs.count, 1)
+        // The empty-snapshot fallback has no snapshot id to inject; it must still
+        // mint a valid fresh UUID — this guards the fallback code path at
+        // TabManager.restoreSessionSnapshot.
+        XCTAssertNotNil(manager.selectedTabId)
+        XCTAssertEqual(manager.selectedTabId, manager.tabs.first?.id)
+    }
+
+    func testStableWorkspaceIdsPolicyIsOnByDefault() {
+        XCTAssertTrue(
+            SessionPersistencePolicy.stableWorkspaceIdsEnabled,
+            "Phase 1.5 default: workspace IDs are stable across restarts unless CMUX_DISABLE_STABLE_WORKSPACE_IDS is set"
+        )
+    }
+}

--- a/docs/socket-api-reference.md
+++ b/docs/socket-api-reference.md
@@ -94,6 +94,14 @@ same machine. External consumers may cache them across sessions. Set
 per-restart UUID regeneration (one-release rollback safety net; will be removed
 in a followup release).
 
+Workspace IDs are also stable across app restarts within the same machine.
+External consumers may cache `(workspace_id, surface_id)` tuples across
+sessions. Set `CMUX_DISABLE_STABLE_WORKSPACE_IDS=1` in the app's launch
+environment (via `launchctl setenv` or the parent shell before launching the
+app — setting it on the `cmux` CLI invocation has no effect) to revert to
+per-restart UUID regeneration. One-release rollback safety net; will be removed
+in a followup release.
+
 ### Input
 
 | Method | CLI | Description |

--- a/tests_v2/test_workspace_id_stability.py
+++ b/tests_v2/test_workspace_id_stability.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+Tier 1 persistence, Phase 1.5 — stable workspace UUID regression test.
+
+Creates a handful of workspaces, then uses the debug-only
+`debug.session.round_trip_workspaces` socket command to snapshot-and-restore
+the whole `TabManager` in place. Workspace UUIDs must survive the round-trip
+so external consumers (Lattice, CLI, scripted tests) can safely cache
+`(workspace_id, surface_id)` tuples across c11mux restarts.
+
+Notes:
+- Requires a DEBUG cmux build. The `debug.session.round_trip_workspaces`
+  method is gated on `#if DEBUG`.
+- Do NOT run locally per project testing policy (run via the VM or CI with
+  `CMUX_SOCKET=/tmp/cmux-debug-<tag>.sock` pointed at a tagged build).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import List
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cmux import cmux, cmuxError
+
+
+def wait_for_socket(path: str, timeout_s: float = 5.0) -> None:
+    start = time.time()
+    while not os.path.exists(path):
+        if time.time() - start >= timeout_s:
+            raise RuntimeError(f"Socket not found at {path}")
+        time.sleep(0.1)
+
+
+def test_round_trip_preserves_workspace_ids(client: cmux) -> tuple[bool, str]:
+    # Seed a few extra workspaces so the test exercises the multi-workspace
+    # path, not just the single-workspace happy path.
+    created_ids: List[str] = []
+    for _ in range(3):
+        ws_id = client.new_workspace()
+        created_ids.append(str(ws_id))
+        time.sleep(0.2)
+
+    try:
+        result = client._call("debug.session.round_trip_workspaces", params={})
+        if not isinstance(result, dict):
+            return False, f"Unexpected round-trip payload type: {type(result).__name__}"
+
+        before = list(result.get("before") or [])
+        after = list(result.get("after") or [])
+        if not before:
+            return False, f"Round-trip returned no 'before' IDs: {result}"
+        if before != after:
+            return False, (
+                f"Workspace IDs changed across TabManager round-trip. "
+                f"before={before} after={after}"
+            )
+        for ws_id in created_ids:
+            if ws_id not in before:
+                return False, (
+                    f"Created workspace {ws_id} missing from round-trip before list: {before}"
+                )
+    finally:
+        for ws_id in created_ids:
+            try:
+                client.close_workspace(ws_id)
+            except Exception:
+                pass
+
+    return True, "Workspace IDs preserved across in-process TabManager round-trip"
+
+
+def run_tests() -> int:
+    print("=" * 60)
+    print("cmux Workspace UUID Stability Test (Tier 1 Phase 1.5)")
+    print("=" * 60)
+    print()
+
+    probe = cmux()
+    wait_for_socket(probe.socket_path, timeout_s=5.0)
+
+    tests = [
+        ("round-trip preserves workspace ids", test_round_trip_preserves_workspace_ids),
+    ]
+
+    passed = 0
+    failed = 0
+
+    try:
+        with cmux(socket_path=probe.socket_path) as client:
+            caps = client.capabilities()
+            methods = set((caps or {}).get("methods") or [])
+            if "debug.session.round_trip_workspaces" not in methods:
+                print(
+                    "SKIP: socket does not expose debug.session.round_trip_workspaces "
+                    "(likely a non-DEBUG build). Run against a `cmux DEV` tagged build."
+                )
+                return 0
+
+            for name, fn in tests:
+                print(f"  Running: {name} ... ", end="", flush=True)
+                try:
+                    ok, msg = fn(client)
+                except Exception as e:
+                    ok, msg = False, str(e)
+                status = "PASS" if ok else "FAIL"
+                print(f"{status}: {msg}")
+                if ok:
+                    passed += 1
+                else:
+                    failed += 1
+    except cmuxError as e:
+        print(f"Error: {e}")
+        return 1
+
+    print()
+    print(f"Results: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(run_tests())


### PR DESCRIPTION
## Summary

Mirrors Phase 1 (#10) one level up: workspace UUIDs now survive app restart so external consumers can safely cache `(workspaceId, surfaceId)` tuples. This is a hard prerequisite for Phase 2 (persistent `SurfaceMetadataStore`), which keys on that tuple — without both halves stable, every restart would orphan the persisted metadata.

**Link:** Tier 1 plan at `docs/c11mux-tier1-persistence-plan.md`. Phase 1.5 isn't a named section in the plan; it was surfaced by the Phase 1 implementer's handoff when they noticed `TabManager.restoreSessionSnapshot` was still minting fresh `Workspace()` objects per snapshot with no id injection.

## Files touched

- `Sources/SessionPersistence.swift` — add required `id: UUID` to `SessionWorkspaceSnapshot`; add `stableWorkspaceIdsEnabled` policy flag
- `Sources/Workspace.swift` — add optional `id: UUID? = nil` param to `Workspace.init`; thread `self.id` into initial `TerminalPanel`; populate `id` in `sessionSnapshot()`
- `Sources/TabManager.swift` — inject `workspaceSnapshot.id` into restored `Workspace` in `restoreSessionSnapshot`, gated on the rollback flag
- `Sources/TerminalController.swift` — add debug-only socket method `debug.session.round_trip_workspaces` (reusable by Phase 2)
- `cmuxTests/WorkspaceIdentityRestoreTests.swift` — Swift round-trip tests (single workspace, multi-workspace no-collision-no-swap, empty-snapshot fallback, default policy flag)
- `tests_v2/test_workspace_id_stability.py` — Python socket test driving `debug.session.round_trip_workspaces`
- `GhosttyTabs.xcodeproj/project.pbxproj` — wire new Swift test into the unit-test target
- `docs/socket-api-reference.md` — document the workspace-ID stability guarantee + `CMUX_DISABLE_STABLE_WORKSPACE_IDS=1` rollback env var
- `cmuxTests/SessionPersistenceTests.swift` — update test helper for the new required `id` field

## Decisions made (not pre-specified)

- **Required `id: UUID` (not optional).** `SessionWorkspaceSnapshot` didn't carry a workspace id at all. Per user direction, backwards compatibility with pre-Phase-1.5 snapshots is not a concern, so the field is required rather than optional-with-fallback. Simpler code, cleaner contract: post-Phase-1.5 snapshots always carry the workspace id. Old snapshots fail to decode — the session-persistence layer already handles decode failure by starting fresh.
- **Added `debug.session.round_trip_workspaces` here, not in Phase 2.** The prompt offered it as an option; Phase 2 will need the tab-manager-level round-trip path anyway. Doing it here lets the Phase 1.5 Python test verify workspace-id stability end-to-end.
- **Empty-snapshot fallback leaves `id:` nil (fresh UUID).** The "Terminal 1" fallback at the bottom of `TabManager.restoreSessionSnapshot` has no snapshot to restore from, so no id to inject.

## Findings relevant to Phase 2

- `Workspace.init` creates an initial `TerminalPanel` via `workspaceId: self.id` — correct with either fresh or injected workspace id. Phase 2's persistent metadata will flow through `SurfaceMetadataStore.shared.getMetadata(workspaceId: id, surfaceId: ...)` using the stable ids.
- `.id(...)` SwiftUI audit found **zero** workspace-UUID dependencies; no view reset signal work was needed (unlike the hypothetical raised in the prompt).
- `restoreSessionSnapshot` already calls `pruneSurfaceMetadata(validSurfaceIds:)` after panels are rebuilt — Phase 2's load path can land right before that prune call as the plan describes, and the pruner will see restored entries as live.

## Rollback

`CMUX_DISABLE_STABLE_WORKSPACE_IDS=1` in the app's launch environment reverts to pre-Phase-1.5 fresh-UUID minting. App-launch scope only (setting on the `cmux` CLI invocation has no effect — has to be set via `launchctl setenv` or the parent shell before launching the app). One-release rollback safety net; deletable followup.

## Test plan

- [ ] CI unit tests: `WorkspaceIdentityRestoreTests` passes
- [ ] CI socket test: `tests_v2/test_workspace_id_stability.py` passes against a tagged DEBUG build
- [ ] Manual: open a workspace, note `cmux identify` id, restart c11mux, same id on the restored workspace
- [ ] Manual rollback: `launchctl setenv CMUX_DISABLE_STABLE_WORKSPACE_IDS 1`, restart, confirm workspace id regenerates
- [ ] No typing-latency regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)