### PR TITLE
Tier 1 persistence Phase 2: persist SurfaceMetadataStore (supersedes #11)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2274,6 +2274,53 @@ struct CMUXCLI {
                 windowOverride: windowId
             )
 
+        case "set-workspace-metadata":
+            try runSetWorkspaceMetadataCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "get-workspace-metadata":
+            try runGetWorkspaceMetadataCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "clear-workspace-metadata":
+            try runClearWorkspaceMetadataCommand(
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "set-workspace-description":
+            try runSetWorkspaceCanonicalKeyCommand(
+                key: "description",
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
+        case "set-workspace-icon":
+            try runSetWorkspaceCanonicalKeyCommand(
+                key: "icon",
+                commandArgs: commandArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
         case "claude-hook":
             cliTelemetry.breadcrumb("claude-hook.dispatch")
             do {
@@ -7340,6 +7387,61 @@ struct CMUXCLI {
               cmux clear-metadata --key terminal_type
               cmux clear-metadata --surface surface:2
             """
+        case "set-workspace-metadata":
+            return """
+            Usage: cmux set-workspace-metadata <key> <value> [flags]
+                   cmux set-workspace-metadata --key <K> --value <V> [flags]
+                   cmux set-workspace-metadata --json '{"description":"..."}' [flags]
+
+            Write one or more operator-authored metadata keys on a workspace via
+            workspace.set_metadata. Values are strings; canonical keys are
+            "description" (≤2048 chars) and "icon" (≤32 chars). Custom keys
+            must match [A-Za-z0-9_.-]+ and cap at 1024 chars each.
+
+            Flags:
+              --workspace <id|ref>     Target workspace (default: current)
+              --json '{...}'           Full JSON object of keys/values
+              --json                   Emit raw JSON result
+
+            Examples:
+              cmux set-workspace-metadata description "Backend API refactor"
+              cmux set-workspace-metadata icon 🦊
+            """
+        case "get-workspace-metadata":
+            return """
+            Usage: cmux get-workspace-metadata [<key>] [--workspace <id|ref>] [--json]
+
+            Read workspace metadata via workspace.get_metadata. With a key, prints
+            just that value. Without a key, prints all keys/values.
+
+            Examples:
+              cmux get-workspace-metadata
+              cmux get-workspace-metadata description
+            """
+        case "clear-workspace-metadata":
+            return """
+            Usage: cmux clear-workspace-metadata [<key>] [--key <K> ...] [--workspace <id|ref>] [--json]
+
+            Clear workspace metadata keys via workspace.clear_metadata. With no
+            key, clears the entire workspace metadata dictionary.
+
+            Examples:
+              cmux clear-workspace-metadata description
+              cmux clear-workspace-metadata
+            """
+        case "set-workspace-description":
+            return """
+            Usage: cmux set-workspace-description <text> [--workspace <id|ref>]
+
+            Sugar for `cmux set-workspace-metadata description <text>`.
+            """
+        case "set-workspace-icon":
+            return """
+            Usage: cmux set-workspace-icon <glyph> [--workspace <id|ref>]
+
+            Sugar for `cmux set-workspace-metadata icon <glyph>`. Supports emoji
+            or the prefix "sf:" + SF Symbol name (e.g. "sf:star.fill").
+            """
         case "set-app-focus":
             return """
             Usage: cmux set-app-focus <active|inactive|clear>
@@ -8535,6 +8637,193 @@ struct CMUXCLI {
 
         let payload = try client.sendV2(method: "surface.clear_metadata", params: params)
         printMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// Resolve the `workspace_id` param for a workspace metadata CLI call.
+    /// Honors `--workspace`, `CMUX_WORKSPACE_ID`, then falls back to the
+    /// currently selected workspace (server-side default).
+    private func resolveWorkspaceMetadataTarget(
+        commandArgs: [String],
+        client: SocketClient,
+        windowOverride: String?
+    ) throws -> String? {
+        let raw = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowOverride)
+        return try normalizeWorkspaceHandle(raw, client: client)
+    }
+
+    /// `cmux set-workspace-metadata <key> <value>` — wraps workspace.set_metadata.
+    private func runSetWorkspaceMetadataCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        var metadata: [String: String] = [:]
+        var singleKey: String?
+        var singleValue: String?
+
+        if let jsonStr = optionValue(commandArgs, name: "--json") {
+            guard let data = jsonStr.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                throw CLIError(message: "invalid_json: --json must be a JSON object string")
+            }
+            for (k, v) in obj {
+                guard let s = v as? String else {
+                    throw CLIError(message: "invalid_value: workspace metadata values must be strings (key '\(k)')")
+                }
+                metadata[k] = s
+            }
+        } else if let keyOpt = optionValue(commandArgs, name: "--key"),
+                  let valueOpt = optionValue(commandArgs, name: "--value") {
+            singleKey = keyOpt
+            singleValue = valueOpt
+        } else if positional.count >= 2 {
+            singleKey = positional[0]
+            singleValue = positional.dropFirst().joined(separator: " ")
+        } else {
+            throw CLIError(message: "set-workspace-metadata requires <key> <value>, --key/--value, or --json '{...}'")
+        }
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+
+        var params: [String: Any] = [:]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        if !metadata.isEmpty {
+            params["metadata"] = metadata
+        } else if let singleKey, let singleValue {
+            params["key"] = singleKey
+            params["value"] = singleValue
+        }
+
+        let payload = try client.sendV2(method: "workspace.set_metadata", params: params)
+        printWorkspaceMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// `cmux get-workspace-metadata [<key>]` — wraps workspace.get_metadata.
+    private func runGetWorkspaceMetadataCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        let keyFilter = optionValue(commandArgs, name: "--key") ?? positional.first
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        var params: [String: Any] = [:]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        if let keyFilter { params["key"] = keyFilter }
+
+        let payload = try client.sendV2(method: "workspace.get_metadata", params: params)
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+            return
+        }
+        let metadata = payload["metadata"] as? [String: String] ?? [:]
+        if let keyFilter {
+            if let v = metadata[keyFilter] {
+                print(v)
+            } else {
+                print("(unset)")
+            }
+            return
+        }
+        if metadata.isEmpty {
+            print("(empty)")
+            return
+        }
+        for key in metadata.keys.sorted() {
+            print("\(key) = \(metadata[key] ?? "")")
+        }
+    }
+
+    /// `cmux clear-workspace-metadata [<key>]` — wraps workspace.clear_metadata.
+    private func runClearWorkspaceMetadataCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        var keys: [String] = collectRepeatedOption(commandArgs, name: "--key")
+        if keys.isEmpty, let first = positional.first {
+            keys = [first]
+        }
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        var params: [String: Any] = [:]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        if !keys.isEmpty { params["keys"] = keys }
+
+        let payload = try client.sendV2(method: "workspace.clear_metadata", params: params)
+        printWorkspaceMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// `cmux set-workspace-description <text>` / `cmux set-workspace-icon <glyph>`
+    /// — thin sugar over `set-workspace-metadata <canonical-key> <value>`.
+    private func runSetWorkspaceCanonicalKeyCommand(
+        key: String,
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat,
+        windowOverride: String?
+    ) throws {
+        let positional = commandArgs.filter { !$0.hasPrefix("--") }
+        guard let value = optionValue(commandArgs, name: "--value") ?? positional.first else {
+            throw CLIError(message: "set-workspace-\(key) requires a value")
+        }
+
+        let workspaceId = try resolveWorkspaceMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        var params: [String: Any] = ["key": key, "value": value]
+        if let workspaceId { params["workspace_id"] = workspaceId }
+        let payload = try client.sendV2(method: "workspace.set_metadata", params: params)
+        printWorkspaceMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    /// Print a workspace.set_metadata / workspace.clear_metadata result.
+    private func printWorkspaceMetadataResult(
+        _ payload: [String: Any],
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) {
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+            return
+        }
+        var parts = ["OK"]
+        if let handle = formatHandle(payload, kind: "workspace", idFormat: idFormat) {
+            parts.append(handle)
+        }
+        print(parts.joined(separator: " "))
+        let metadata = payload["metadata"] as? [String: String] ?? [:]
+        if metadata.isEmpty {
+            print("  (empty)")
+            return
+        }
+        for key in metadata.keys.sorted() {
+            print("  \(key) = \(metadata[key] ?? "")")
+        }
     }
 
     /// Print a `surface.set_metadata` / `surface.clear_metadata` result.
@@ -12349,6 +12638,11 @@ struct CMUXCLI {
           set-metadata (--json '{...}' | --key <K> --value <V> [--type string|number|bool|json]) [--surface <id|ref>] [--workspace <id|ref>] [--mode merge|replace] [--source <src>]
           get-metadata [--key <K> ...] [--sources] [--surface <id|ref>] [--workspace <id|ref>]
           clear-metadata [--key <K> ...] [--source <src>] [--surface <id|ref>] [--workspace <id|ref>]
+          set-workspace-metadata <key> <value> | --key <K> --value <V> | --json '{...}'  [--workspace <id|ref>]
+          get-workspace-metadata [<key>] [--workspace <id|ref>]
+          clear-workspace-metadata [<key>] [--key <K> ...] [--workspace <id|ref>]
+          set-workspace-description <text> [--workspace <id|ref>]
+          set-workspace-icon <glyph> [--workspace <id|ref>]
           set-app-focus <active|inactive|clear>
           simulate-app-active
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -594,6 +594,10 @@
 					D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */,
 					D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */,
 					D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */,
+					D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */,
+					D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */,
+					D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */,
+					D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -869,6 +873,10 @@
 					D7003BF0A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift in Sources */,
 					D7004BF0A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift in Sources */,
 					D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */,
+					D7006BF0A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift in Sources */,
+					D7007BF0A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift in Sources */,
+					D7008BF0A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift in Sources */,
+					D7009BF0A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 			A5001534 /* BrowserWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001533 /* BrowserWindowPortal.swift */; };
 		A5001540 /* PortScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001541 /* PortScanner.swift */; };
 		A5001542 /* SurfaceMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001543 /* SurfaceMetadataStore.swift */; };
+		D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */; };
+		D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
 		A5001544 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* AgentDetector.swift */; };
 		A5008F11 /* SurfaceTitleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F12 /* SurfaceTitleBarView.swift */; };
 		A5008F21 /* TitleFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F22 /* TitleFormatting.swift */; };
@@ -199,6 +201,8 @@
 			A5001533 /* BrowserWindowPortal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserWindowPortal.swift; sourceTree = "<group>"; };
 		A5001541 /* PortScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScanner.swift; sourceTree = "<group>"; };
 		A5001543 /* SurfaceMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetadataStore.swift; sourceTree = "<group>"; };
+		D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataKeys.swift; sourceTree = "<group>"; };
+		D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
 		A5001545 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		A5008F12 /* SurfaceTitleBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarView.swift; sourceTree = "<group>"; };
 		A5008F22 /* TitleFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleFormatting.swift; sourceTree = "<group>"; };
@@ -443,6 +447,7 @@
 				A5001019 /* TerminalController.swift */,
 				A5001541 /* PortScanner.swift */,
 				A5001543 /* SurfaceMetadataStore.swift */,
+				D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */,
 				A5001545 /* AgentDetector.swift */,
 				A5008F12 /* SurfaceTitleBarView.swift */,
 				A5008F22 /* TitleFormatting.swift */,
@@ -577,6 +582,7 @@
 					D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */,
 					D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */,
 					D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */,
+					D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -748,6 +754,7 @@
 				A5001007 /* TerminalController.swift in Sources */,
 				A5001540 /* PortScanner.swift in Sources */,
 				A5001542 /* SurfaceMetadataStore.swift in Sources */,
+				D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */,
 				A5001544 /* AgentDetector.swift in Sources */,
 				A5008F11 /* SurfaceTitleBarView.swift in Sources */,
 				A5008F21 /* TitleFormatting.swift in Sources */,
@@ -849,6 +856,7 @@
 					D7002BF0A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift in Sources */,
 					D7003BF0A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift in Sources */,
 					D7004BF0A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift in Sources */,
+					D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -20,6 +20,11 @@
 		A5001542 /* SurfaceMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001543 /* SurfaceMetadataStore.swift */; };
 		D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */; };
 		D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
+		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
+		D7006BF0A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */; };
+		D7007BF0A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */; };
+		D7008BF0A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */; };
+		D7009BF0A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */; };
 		A5001544 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* AgentDetector.swift */; };
 		A5008F11 /* SurfaceTitleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F12 /* SurfaceTitleBarView.swift */; };
 		A5008F21 /* TitleFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F22 /* TitleFormatting.swift */; };
@@ -203,6 +208,11 @@
 		A5001543 /* SurfaceMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetadataStore.swift; sourceTree = "<group>"; };
 		D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataKeys.swift; sourceTree = "<group>"; };
 		D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
+		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
+		D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceRoundTripTests.swift; sourceTree = "<group>"; };
+		D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistencePrecedenceTests.swift; sourceTree = "<group>"; };
+		D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceUncoercibleTests.swift; sourceTree = "<group>"; };
+		D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataStoreRevisionCounterTests.swift; sourceTree = "<group>"; };
 		A5001545 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		A5008F12 /* SurfaceTitleBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarView.swift; sourceTree = "<group>"; };
 		A5008F22 /* TitleFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleFormatting.swift; sourceTree = "<group>"; };
@@ -448,6 +458,7 @@
 				A5001541 /* PortScanner.swift */,
 				A5001543 /* SurfaceMetadataStore.swift */,
 				D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */,
+				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
 				A5001545 /* AgentDetector.swift */,
 				A5008F12 /* SurfaceTitleBarView.swift */,
 				A5008F22 /* TitleFormatting.swift */,
@@ -755,6 +766,7 @@
 				A5001540 /* PortScanner.swift in Sources */,
 				A5001542 /* SurfaceMetadataStore.swift in Sources */,
 				D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */,
+				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
 				A5001544 /* AgentDetector.swift in Sources */,
 				A5008F11 /* SurfaceTitleBarView.swift in Sources */,
 				A5008F21 /* TitleFormatting.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3744,6 +3744,78 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func debugSessionNumber(_ value: Double) -> String {
         String(format: "%.1f", value)
     }
+
+    /// DEBUG-only helper for Tier 1 Phase 2 socket tests: force a
+    /// synchronous session snapshot write to disk, clear in-memory
+    /// `SurfaceMetadataStore` entries for every currently-open surface,
+    /// then reload the snapshot from disk and replay metadata back into
+    /// the store. Proves actual on-disk round-trip (not just in-memory
+    /// encode/decode) for tests_v2/test_metadata_persistence.py.
+    ///
+    /// Returns true on success. Safe to call on a live window — only
+    /// touches `SurfaceMetadataStore`; panels, layouts, and all other
+    /// workspace state remain untouched.
+    func debugForceMetadataSaveAndLoad() -> Bool {
+        // 1. Force a synchronous disk write of the live state.
+        let saved = saveSessionSnapshot(includeScrollback: false, removeWhenEmpty: false)
+        guard saved else {
+            dlog("debug.session.save_and_load step=save result=failed")
+            return false
+        }
+
+        // 2. Load the snapshot back from disk. If the file is missing
+        // (rollback env var set → we still wrote, but workspace.metadata
+        // persistence is separate from surface metadata — this method
+        // remains usable) we treat it as a recoverable no-op.
+        guard let loaded = SessionPersistenceStore.load() else {
+            dlog("debug.session.save_and_load step=load result=not_found")
+            return false
+        }
+
+        // 3. Walk live (window, workspace) pairs and match each
+        // corresponding snapshot workspace by index; workspace IDs are
+        // not re-serialized in the snapshot so index-matching is the
+        // most robust way to pair them. For each panel in the snapshot,
+        // clear the live store entry and replay persisted metadata.
+        for (windowIdx, windowSnapshot) in loaded.windows.enumerated() {
+            let contexts = mainWindowContexts.values.sorted(by: {
+                $0.windowId.uuidString < $1.windowId.uuidString
+            })
+            guard windowIdx < contexts.count else { continue }
+            let context = contexts[windowIdx]
+            for (wsIdx, wsSnapshot) in windowSnapshot.tabManager.workspaces.enumerated() {
+                guard wsIdx < context.tabManager.tabs.count else { continue }
+                let workspace = context.tabManager.tabs[wsIdx]
+                // Clear every live panel's metadata on this workspace so the
+                // only surviving data path is "loaded from disk".
+                for panelId in workspace.panels.keys {
+                    SurfaceMetadataStore.shared.removeSurface(
+                        workspaceId: workspace.id,
+                        surfaceId: panelId
+                    )
+                }
+                // Replay persisted metadata from the snapshot. Skipped when
+                // CMUX_DISABLE_METADATA_PERSIST=1 is set — matches the
+                // production restore path's rollback semantics.
+                if PersistedMetadataBridge.isPersistDisabled { continue }
+                for panelSnapshot in wsSnapshot.panels {
+                    guard let persistedValues = panelSnapshot.metadata else { continue }
+                    let values = PersistedMetadataBridge.decodeValues(persistedValues)
+                    let sources = PersistedMetadataBridge.decodeSources(
+                        panelSnapshot.metadataSources ?? [:]
+                    )
+                    SurfaceMetadataStore.shared.restoreFromSnapshot(
+                        workspaceId: workspace.id,
+                        surfaceId: panelSnapshot.id,
+                        values: values,
+                        sources: sources
+                    )
+                }
+            }
+        }
+        dlog("debug.session.save_and_load step=done windows=\(loaded.windows.count)")
+        return true
+    }
 #endif
 
     private func notifyMainWindowContextsDidChange() {

--- a/Sources/PersistedMetadata.swift
+++ b/Sources/PersistedMetadata.swift
@@ -74,6 +74,46 @@ struct PersistedMetadataSource: Codable, Sendable, Equatable {
 // MARK: - Persist-direction bridge ([String: Any] → persisted)
 
 enum PersistedMetadataBridge {
+    /// Rollback safety net. When `CMUX_DISABLE_METADATA_PERSIST=1` is in
+    /// the app's launch environment, metadata is omitted from snapshots
+    /// on write and ignored on restore. App-launch-scope only — the CLI
+    /// is a separate process, so setting the var on a `cmux` invocation
+    /// has no effect. Deletable in a followup PR once Phase 2 is stable.
+    static var isPersistDisabled: Bool {
+        ProcessInfo.processInfo.environment["CMUX_DISABLE_METADATA_PERSIST"] == "1"
+    }
+
+    /// Enforce the 64 KiB per-surface cap at the persistence boundary.
+    /// Bug-guard only — the live store already caps writes. If exceeded,
+    /// drop keys (largest encoded first) until under cap, logging each
+    /// drop. Never throws.
+    static func enforceSizeCap(
+        _ values: [String: PersistedJSONValue],
+        surfaceId: UUID
+    ) -> [String: PersistedJSONValue] {
+        var current = values
+        while let data = try? JSONEncoder().encode(current),
+              data.count > SurfaceMetadataStore.payloadCapBytes {
+            // Drop the largest single-key encoding. Deterministic tie-break
+            // by sorted key name so the behavior is test-stable.
+            let sizedKeys: [(key: String, size: Int)] = current.keys.sorted().map { key in
+                let wrapper: [String: PersistedJSONValue] = [key: current[key]!]
+                let size = (try? JSONEncoder().encode(wrapper).count) ?? 0
+                return (key, size)
+            }
+            guard let victim = sizedKeys.max(by: { $0.size < $1.size }) else { break }
+            #if DEBUG
+            dlog(
+                "metadata.persist.overcap.drop surface=\(surfaceId.uuidString.prefix(8)) " +
+                "key=\(victim.key) droppedSize=\(victim.size)"
+            )
+            #endif
+            current.removeValue(forKey: victim.key)
+            if current.isEmpty { break }
+        }
+        return current
+    }
+
     /// Coerce a live metadata blob into its persisted representation.
     /// Values that cannot be represented as JSON are dropped with a debug
     /// log; the rest of the blob survives. Never throws — snapshot writes

--- a/Sources/PersistedMetadata.swift
+++ b/Sources/PersistedMetadata.swift
@@ -70,3 +70,178 @@ struct PersistedMetadataSource: Codable, Sendable, Equatable {
     /// Seconds since 1970, matching `SurfaceMetadataStore.SourceRecord.ts`.
     var ts: TimeInterval
 }
+
+// MARK: - Persist-direction bridge ([String: Any] → persisted)
+
+enum PersistedMetadataBridge {
+    /// Coerce a live metadata blob into its persisted representation.
+    /// Values that cannot be represented as JSON are dropped with a debug
+    /// log; the rest of the blob survives. Never throws — snapshot writes
+    /// must be side-effect-free with respect to persistence failures.
+    static func encodeValues(
+        _ values: [String: Any],
+        surfaceIdForLog: UUID? = nil
+    ) -> [String: PersistedJSONValue] {
+        var result: [String: PersistedJSONValue] = [:]
+        for (key, value) in values {
+            if let persisted = encode(value: value, key: key, surfaceIdForLog: surfaceIdForLog) {
+                result[key] = persisted
+            }
+        }
+        return result
+    }
+
+    /// Convert sidecar entries as returned by
+    /// `SurfaceMetadataStore.getMetadata().sources` (`[String: [String: Any]]`
+    /// via `SourceRecord.toJSON()`) into persisted form.
+    static func encodeSources(
+        _ sources: [String: [String: Any]]
+    ) -> [String: PersistedMetadataSource] {
+        var result: [String: PersistedMetadataSource] = [:]
+        for (key, record) in sources {
+            guard let source = record["source"] as? String else { continue }
+            let ts = (record["ts"] as? Double) ?? 0.0
+            result[key] = PersistedMetadataSource(source: source, ts: ts)
+        }
+        return result
+    }
+
+    // MARK: - Restore-direction bridge (persisted → [String: Any])
+
+    static func decodeValues(_ persisted: [String: PersistedJSONValue]) -> [String: Any] {
+        var result: [String: Any] = [:]
+        for (key, value) in persisted {
+            result[key] = decode(value: value)
+        }
+        return result
+    }
+
+    /// Convert persisted sidecar into live `SourceRecord`s. Unknown source
+    /// raw values are downgraded to `.heuristic` with a debug log — this
+    /// matches the precedence contract (an unreadable origin can never
+    /// outrank a new `.explicit` write).
+    static func decodeSources(
+        _ persisted: [String: PersistedMetadataSource]
+    ) -> [String: SurfaceMetadataStore.SourceRecord] {
+        var result: [String: SurfaceMetadataStore.SourceRecord] = [:]
+        for (key, ps) in persisted {
+            let source: MetadataSource
+            if let known = MetadataSource(rawValue: ps.source) {
+                source = known
+            } else {
+                #if DEBUG
+                dlog("metadata.restore.unknownSource key=\(key) raw=\(ps.source) fallback=heuristic")
+                #endif
+                source = .heuristic
+            }
+            result[key] = SurfaceMetadataStore.SourceRecord(source: source, ts: ps.ts)
+        }
+        return result
+    }
+
+    // MARK: - Internals
+
+    private static func encode(
+        value: Any,
+        key: String,
+        surfaceIdForLog: UUID?
+    ) -> PersistedJSONValue? {
+        if value is NSNull {
+            return .null
+        }
+
+        // Bool must be checked before NSNumber. Swift's `as? Bool` matches
+        // NSNumber(value: 0) and NSNumber(value: 1) as well as actual bools,
+        // so a naive Bool-first check would misencode plain numbers. CFBoolean
+        // is the concrete bridged type JSONSerialization emits for JSON
+        // `true`/`false`, and native Swift `Bool` bridges to it at the CF
+        // level; both share `CFBooleanGetTypeID()`.
+        let cfTypeID = CFGetTypeID(value as CFTypeRef)
+        if cfTypeID == CFBooleanGetTypeID() {
+            if let b = value as? Bool {
+                return .bool(b)
+            }
+        }
+
+        if let n = value as? NSNumber {
+            let d = n.doubleValue
+            guard d.isFinite else {
+                #if DEBUG
+                dlog("metadata.persist.drop key=\(key) reason=non_finite value=\(d)")
+                #endif
+                return nil
+            }
+            return .number(d)
+        }
+
+        // Native Swift numeric types (not bridged via NSNumber — rare, but
+        // possible if a caller writes a Swift `Int` directly into the
+        // `[String: Any]` dictionary without letting ObjC bridging happen).
+        if let i = value as? Int    { return .number(Double(i)) }
+        if let d = value as? Double {
+            guard d.isFinite else {
+                #if DEBUG
+                dlog("metadata.persist.drop key=\(key) reason=non_finite value=\(d)")
+                #endif
+                return nil
+            }
+            return .number(d)
+        }
+        if let f = value as? Float {
+            let d = Double(f)
+            guard d.isFinite else {
+                #if DEBUG
+                dlog("metadata.persist.drop key=\(key) reason=non_finite value=\(d)")
+                #endif
+                return nil
+            }
+            return .number(d)
+        }
+
+        if let s = value as? String {
+            return .string(s)
+        }
+
+        if let arr = value as? [Any] {
+            var out: [PersistedJSONValue] = []
+            out.reserveCapacity(arr.count)
+            for (idx, element) in arr.enumerated() {
+                if let p = encode(value: element, key: "\(key)[\(idx)]", surfaceIdForLog: surfaceIdForLog) {
+                    out.append(p)
+                } else {
+                    // An element dropped: keep the array but preserve length
+                    // by substituting null, since JSON arrays are position-
+                    // sensitive (consumer code may index into them).
+                    out.append(.null)
+                }
+            }
+            return .array(out)
+        }
+
+        if let obj = value as? [String: Any] {
+            return .object(encodeValues(obj, surfaceIdForLog: surfaceIdForLog))
+        }
+
+        #if DEBUG
+        dlog("metadata.persist.drop key=\(key) type=\(String(describing: type(of: value)))")
+        #endif
+        return nil
+    }
+
+    private static func decode(value: PersistedJSONValue) -> Any {
+        switch value {
+        case .null:
+            return NSNull()
+        case .bool(let b):
+            return b
+        case .number(let d):
+            return d
+        case .string(let s):
+            return s
+        case .array(let a):
+            return a.map(decode(value:))
+        case .object(let o):
+            return decodeValues(o)
+        }
+    }
+}

--- a/Sources/PersistedMetadata.swift
+++ b/Sources/PersistedMetadata.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if DEBUG
+import Bonsplit
+#endif
 
 /// Codable JSON value used to persist `SurfaceMetadataStore` contents across
 /// c11mux restarts. Numbers are stored as `Double`; consumers needing integer

--- a/Sources/PersistedMetadata.swift
+++ b/Sources/PersistedMetadata.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Codable JSON value used to persist `SurfaceMetadataStore` contents across
+/// c11mux restarts. Numbers are stored as `Double`; consumers needing integer
+/// fidelity must convert explicitly. `Bool` is distinct from number on the
+/// wire and on the Swift side, matching JSON semantics.
+enum PersistedJSONValue: Codable, Sendable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case array([PersistedJSONValue])
+    case object([String: PersistedJSONValue])
+    case null
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+            return
+        }
+        // Decode Bool before Double: JSON `true`/`false` are bools, numbers
+        // are numbers, and JSONDecoder respects the distinction. Keeping this
+        // order ensures a persisted `.bool(true)` never surfaces as `.number`.
+        if let bool = try? container.decode(Bool.self) {
+            self = .bool(bool)
+            return
+        }
+        if let double = try? container.decode(Double.self) {
+            self = .number(double)
+            return
+        }
+        if let string = try? container.decode(String.self) {
+            self = .string(string)
+            return
+        }
+        if let array = try? container.decode([PersistedJSONValue].self) {
+            self = .array(array)
+            return
+        }
+        if let object = try? container.decode([String: PersistedJSONValue].self) {
+            self = .object(object)
+            return
+        }
+        throw DecodingError.dataCorruptedError(
+            in: container,
+            debugDescription: "PersistedJSONValue: unsupported JSON shape"
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let s): try container.encode(s)
+        case .number(let d): try container.encode(d)
+        case .bool(let b):   try container.encode(b)
+        case .array(let a):  try container.encode(a)
+        case .object(let o): try container.encode(o)
+        case .null:          try container.encodeNil()
+        }
+    }
+}
+
+/// Codable sidecar preserving the `(source, ts)` record alongside a persisted
+/// metadata value so the precedence chain survives a restart.
+struct PersistedMetadataSource: Codable, Sendable, Equatable {
+    /// `MetadataSource` raw value: `"explicit" | "declare" | "osc" | "heuristic"`.
+    /// Unknown strings decode cleanly (no Codable error); the bridge downgrades
+    /// them to `.heuristic` with a debug log on the way back into the store.
+    var source: String
+    /// Seconds since 1970, matching `SurfaceMetadataStore.SourceRecord.ts`.
+    var ts: TimeInterval
+}

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -380,6 +380,9 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var logEntries: [SessionLogEntrySnapshot]
     var progress: SessionProgressSnapshot?
     var gitBranch: SessionGitBranchSnapshot?
+    /// Operator-authored workspace metadata (e.g. description, icon).
+    /// Optional for backward compatibility with pre-metadata snapshots.
+    var metadata: [String: String]?
 }
 
 struct SessionTabManagerSnapshot: Codable, Sendable {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -293,6 +293,15 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var terminal: SessionTerminalPanelSnapshot?
     var browser: SessionBrowserPanelSnapshot?
     var markdown: SessionMarkdownPanelSnapshot?
+
+    /// Tier 1 Phase 2: persisted `SurfaceMetadataStore` values for this
+    /// surface. Optional for backcompat with pre-Phase-2 snapshots; older
+    /// builds ignore the field. Numbers round-trip as `Double`; see
+    /// `PersistedJSONValue`.
+    var metadata: [String: PersistedJSONValue]?
+    /// Parallel sidecar: per-key `(source, ts)` record preserving the
+    /// precedence chain across restarts. See `PersistedMetadataSource`.
+    var metadataSources: [String: PersistedMetadataSource]?
 }
 
 enum SessionSplitOrientation: String, Codable, Sendable {

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -130,6 +130,13 @@ final class SurfaceMetadataStore: @unchecked Sendable {
     /// Per-workspace per-surface parallel source sidecar.
     private var sources: [UUID: [UUID: [String: SourceRecord]]] = [:]
 
+    /// Monotonic revision counter (Tier 1 Phase 2). Bumped on every mutation
+    /// that actually changes state — no-op writes of the same (key, value,
+    /// source) do not bump. Included in the autosave fingerprint so
+    /// metadata-only changes between 8s ticks trigger a write instead of
+    /// being silently skipped.
+    private var metadataStoreRevision: UInt64 = 0
+
     // MARK: - Canonical key validation
 
     /// Reserved canonical keys. Keys not in this set accept any JSON value.
@@ -262,6 +269,12 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         }
     }
 
+    /// Read the monotonic revision counter. Used by the autosave fingerprint
+    /// so metadata-only mutations trigger a write at the next tick.
+    func currentRevision() -> UInt64 {
+        return queue.sync { metadataStoreRevision }
+    }
+
     /// Returns whether a specific key is currently set on a surface, and its source.
     func getSource(workspaceId: UUID, surfaceId: UUID, key: String) -> MetadataSource? {
         return queue.sync {
@@ -283,15 +296,23 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 guard source == .explicit else {
                     throw WriteError.replaceRequiresExplicit
                 }
+                let existing = metadata[workspaceId]?[surfaceId] ?? [:]
+                let existingSrc = sources[workspaceId]?[surfaceId] ?? [:]
                 metadata[workspaceId]?[surfaceId] = [:]
                 sources[workspaceId]?[surfaceId] = [:]
                 result.metadata = [:]
                 result.sources = [:]
+                // No-op skip: clear-all against an already-empty store
+                // must not bump the revision.
+                if !existing.isEmpty || !existingSrc.isEmpty {
+                    metadataStoreRevision &+= 1
+                }
                 return result
             }
 
             var blob = metadata[workspaceId]?[surfaceId] ?? [:]
             var sblob = sources[workspaceId]?[surfaceId] ?? [:]
+            var removedAny = false
 
             for key in keys! {
                 if let cur = sblob[key] {
@@ -301,8 +322,9 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                         continue
                     }
                 }
-                blob.removeValue(forKey: key)
-                sblob.removeValue(forKey: key)
+                let hadValue = blob.removeValue(forKey: key) != nil
+                let hadSource = sblob.removeValue(forKey: key) != nil
+                if hadValue || hadSource { removedAny = true }
                 result.applied[key] = true
             }
 
@@ -310,6 +332,7 @@ final class SurfaceMetadataStore: @unchecked Sendable {
             sources[workspaceId, default: [:]][surfaceId] = sblob
             result.metadata = blob
             result.sources = sblob.mapValues { $0.toJSON() }
+            if removedAny { metadataStoreRevision &+= 1 }
             return result
         }
     }
@@ -333,6 +356,10 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         queue.sync {
             metadata[workspaceId, default: [:]][surfaceId] = values
             self.sources[workspaceId, default: [:]][surfaceId] = sources
+            // Bump the revision so a post-restore autosave tick sees the
+            // fingerprint differ from the pre-restore state, writing the
+            // restored contents back to disk with a fresh createdAt.
+            metadataStoreRevision &+= 1
         }
     }
 
@@ -404,6 +431,7 @@ final class SurfaceMetadataStore: @unchecked Sendable {
 
             metadata[workspaceId, default: [:]][surfaceId] = blob
             sources[workspaceId, default: [:]][surfaceId] = sblob
+            metadataStoreRevision &+= 1
             return true
         }
     }
@@ -444,6 +472,16 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         }
 
         let ts = Date().timeIntervalSince1970
+        var mutated = false
+
+        if mode == .replace {
+            // `mode == .replace` discarded the prior blob above. If that prior
+            // blob was non-empty, the replace is itself a mutation even when
+            // the new partial is a subset; flag accordingly.
+            let priorBlob = metadata[workspaceId]?[surfaceId] ?? [:]
+            let priorSrc = sources[workspaceId]?[surfaceId] ?? [:]
+            if !priorBlob.isEmpty || !priorSrc.isEmpty { mutated = true }
+        }
 
         for (k, v) in partial {
             if mode == .merge, let cur = sblob[k], source.precedence < cur.source.precedence {
@@ -451,9 +489,22 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 result.reasons[k] = "lower_precedence"
                 continue
             }
+            // No-op skip for revision counter: same value and same source
+            // preserves the prior SourceRecord (original ts) and does not
+            // bump the revision. The key is still reported as applied so
+            // callers see idempotent semantics.
+            let existing = blob[k]
+            let existingSource = sblob[k]?.source
+            let isSameWrite = existing.map { sameJSONValue($0, v) } ?? false
+                && existingSource == source
+            if isSameWrite {
+                result.applied[k] = true
+                continue
+            }
             blob[k] = v
             sblob[k] = SourceRecord(source: source, ts: ts)
             result.applied[k] = true
+            mutated = true
         }
 
         // Size check after merge.
@@ -469,6 +520,7 @@ final class SurfaceMetadataStore: @unchecked Sendable {
 
         result.metadata = blob
         result.sources = sblob.mapValues { $0.toJSON() }
+        if mutated { metadataStoreRevision &+= 1 }
         return result
     }
 

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -314,6 +314,28 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         }
     }
 
+    /// Restore metadata + sources for a surface from a session snapshot
+    /// (Tier 1 Phase 2). Bypasses the precedence chain — the snapshot IS
+    /// the prior session's source of truth. A `.heuristic` value in the
+    /// snapshot restores as `.heuristic` with its original `ts`, even if
+    /// the newly-initialized surface has already written a `.declare`
+    /// value to the same key: the snapshot wins.
+    ///
+    /// Silent by design. The store has no observer infrastructure today;
+    /// any consumer wanting post-restore data queries it on demand.
+    /// Adding a notification pipeline is Phase 3 scope.
+    func restoreFromSnapshot(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        values: [String: Any],
+        sources: [String: SourceRecord]
+    ) {
+        queue.sync {
+            metadata[workspaceId, default: [:]][surfaceId] = values
+            self.sources[workspaceId, default: [:]][surfaceId] = sources
+        }
+    }
+
     /// Remove all metadata for a surface. Called from `pruneSurfaceMetadata`
     /// when a surface closes. Bypasses precedence (the surface is gone).
     func removeSurface(workspaceId: UUID, surfaceId: UUID) {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4880,6 +4880,11 @@ extension TabManager {
         var hasher = Hasher()
         hasher.combine(selectedTabId)
         hasher.combine(tabs.count)
+        // Tier 1 Phase 2: fold in the monotonic per-process revision counter
+        // from SurfaceMetadataStore so metadata-only changes (which never
+        // touch workspace/panel counts or titles) still flip the fingerprint
+        // and trigger an autosave at the next 8s tick.
+        hasher.combine(SurfaceMetadataStore.shared.currentRevision())
 
         for workspace in tabs.prefix(SessionPersistencePolicy.maxWorkspacesPerWindow) {
             hasher.combine(workspace.id)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4891,6 +4891,14 @@ extension TabManager {
             hasher.combine(workspace.panels.count)
             hasher.combine(workspace.statusEntries.count)
             hasher.combine(workspace.metadataBlocks.count)
+            // Hash operator-authored workspace metadata by sorted keys so
+            // value-only edits still change the fingerprint. Without this,
+            // metadata edits could be deferred up to the forced-save window.
+            hasher.combine(workspace.metadata.count)
+            for key in workspace.metadata.keys.sorted() {
+                hasher.combine(key)
+                hasher.combine(workspace.metadata[key] ?? "")
+            }
             hasher.combine(workspace.logEntries.count)
             hasher.combine(workspace.panelDirectories.count)
             hasher.combine(workspace.panelTitles.count)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2136,6 +2136,10 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceHealth(params: params))
         case "debug.terminals":
             return v2Result(id: id, self.v2DebugTerminals(params: params))
+#if DEBUG
+        case "debug.session.save_and_load":
+            return v2Result(id: id, self.v2DebugSessionSaveAndLoad(params: params))
+#endif
         case "surface.send_text":
             return v2Result(id: id, self.v2SurfaceSendText(params: params))
         case "surface.send_key":
@@ -5471,6 +5475,29 @@ class TerminalController {
         }
         return .ok(payload)
     }
+
+#if DEBUG
+    /// DEBUG-only: force an on-disk session snapshot round-trip through
+    /// `SurfaceMetadataStore` so `tests_v2/test_metadata_persistence.py`
+    /// can prove real disk persistence (not just in-memory encode/decode).
+    ///
+    /// Phase 1 conceptually had `debug.session.round_trip` but it was not
+    /// merged to main; Phase 2's persistence work is the first on-disk
+    /// round-trip to need this harness. Gated `#if DEBUG` — not part of
+    /// the supported socket API surface.
+    private func v2DebugSessionSaveAndLoad(params _: [String: Any]) -> V2CallResult {
+        var success = false
+        v2MainSync {
+            guard let app = AppDelegate.shared else { return }
+            success = app.debugForceMetadataSaveAndLoad()
+        }
+        if success {
+            return .ok(["ok": true])
+        }
+        return .err(code: "debug_save_and_load_failed",
+                    message: "debugForceMetadataSaveAndLoad returned false", data: nil)
+    }
+#endif
 
     private func v2DebugTerminals(params _: [String: Any]) -> V2CallResult {
         var payload: [String: Any]?

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2089,6 +2089,12 @@ class TerminalController {
             return v2Result(id: id, self.v2WorkspaceRemoteStatus(params: params))
         case "workspace.remote.terminal_session_end":
             return v2Result(id: id, self.v2WorkspaceRemoteTerminalSessionEnd(params: params))
+        case "workspace.set_metadata":
+            return v2Result(id: id, self.v2WorkspaceSetMetadata(params: params))
+        case "workspace.get_metadata":
+            return v2Result(id: id, self.v2WorkspaceGetMetadata(params: params))
+        case "workspace.clear_metadata":
+            return v2Result(id: id, self.v2WorkspaceClearMetadata(params: params))
 
         // Settings
         case "settings.open":
@@ -2481,6 +2487,9 @@ class TerminalController {
             "workspace.remote.disconnect",
             "workspace.remote.status",
             "workspace.remote.terminal_session_end",
+            "workspace.set_metadata",
+            "workspace.get_metadata",
+            "workspace.clear_metadata",
             "settings.open",
             "feedback.open",
             "feedback.submit",
@@ -4199,6 +4208,222 @@ class TerminalController {
         }
 
         return result
+    }
+
+    /// Resolve the Workspace referenced by `workspace_id`. Falls back to the
+    /// currently selected workspace on the caller's TabManager if no explicit
+    /// id is supplied. Returns nil when the workspace cannot be located.
+    ///
+    /// Performs a main-actor read to locate the Workspace instance; callers
+    /// should mutate `workspace.metadata` via `v2MainSync` since `Workspace`
+    /// is `@MainActor` (see `Workspace.swift` class declaration).
+    private func v2ResolveWorkspaceForMetadata(
+        params: [String: Any]
+    ) -> (tabManager: TabManager, workspaceId: UUID)? {
+        guard let tabManager = v2ResolveTabManager(params: params) else { return nil }
+        if let explicit = v2UUID(params, "workspace_id") {
+            return v2MainSync {
+                guard tabManager.tabs.contains(where: { $0.id == explicit }) else { return nil }
+                return (tabManager, explicit)
+            }
+        }
+        return v2MainSync {
+            guard let selected = tabManager.selectedTabId,
+                  tabManager.tabs.contains(where: { $0.id == selected }) else {
+                return nil
+            }
+            return (tabManager, selected)
+        }
+    }
+
+    private func v2WorkspaceSetMetadata(params: [String: Any]) -> V2CallResult {
+        // Parse + validate off-main per the socket command threading policy
+        // (CLAUDE.md "Socket command threading policy").
+        let rawMetadata = v2StringMap(params, "metadata")
+        let singleKey = v2String(params, "key")
+        let singleValueRaw = params["value"]
+
+        var writes: [String: String?] = [:]
+        if let rawMetadata {
+            for (k, v) in rawMetadata { writes[k] = v }
+        }
+        if let singleKey {
+            if singleValueRaw is NSNull {
+                writes[singleKey] = nil
+            } else if let s = singleValueRaw as? String {
+                writes[singleKey] = s
+            } else if singleValueRaw == nil {
+                return .err(code: "invalid_params", message: "Missing 'value' for key '\(singleKey)'", data: nil)
+            } else {
+                return .err(code: "invalid_params", message: "metadata value must be a string or null", data: nil)
+            }
+        }
+
+        if writes.isEmpty {
+            return .err(
+                code: "invalid_params",
+                message: "Provide 'metadata' object or 'key'/'value' pair",
+                data: nil
+            )
+        }
+
+        // Validate all keys and non-nil values off-main before taking the
+        // main-actor critical section.
+        for (k, maybeValue) in writes {
+            do {
+                if let value = maybeValue {
+                    try WorkspaceMetadataValidator.validate(key: k, value: value)
+                } else {
+                    try WorkspaceMetadataValidator.validateKey(k)
+                }
+            } catch let err as WorkspaceMetadataValidator.ValidationError {
+                return .err(code: err.code, message: err.message, data: err.detail)
+            } catch {
+                return .err(code: "internal_error", message: "\(error)", data: nil)
+            }
+        }
+
+        guard let resolved = v2ResolveWorkspaceForMetadata(params: params) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+
+        var capacityError: WorkspaceMetadataValidator.CapacityError?
+        var resultMetadata: [String: String] = [:]
+        // Workspace is @MainActor; the mutation must run on the main actor.
+        // Precedent: workspace.rename handler (v2WorkspaceRename).
+        v2MainSync {
+            guard let ws = resolved.tabManager.tabs.first(where: { $0.id == resolved.workspaceId }) else {
+                return
+            }
+            var next = ws.metadata
+            for (k, maybeValue) in writes {
+                if let value = maybeValue {
+                    next[k] = value
+                } else {
+                    next.removeValue(forKey: k)
+                }
+            }
+            do {
+                try WorkspaceMetadataValidator.validateCapacity(after: next)
+            } catch let err as WorkspaceMetadataValidator.CapacityError {
+                capacityError = err
+                return
+            } catch {
+                // Unreachable: validateCapacity only throws CapacityError.
+                return
+            }
+            ws.metadata = next
+            resultMetadata = next
+        }
+
+        if let err = capacityError {
+            return .err(code: err.code, message: err.message, data: err.detail)
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: resolved.tabManager)
+        return .ok([
+            "workspace_id": resolved.workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: resolved.workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "metadata": resultMetadata
+        ])
+    }
+
+    private func v2WorkspaceGetMetadata(params: [String: Any]) -> V2CallResult {
+        let requestedKey = v2String(params, "key")
+        let requestedKeys = v2StringArray(params, "keys")
+
+        guard let resolved = v2ResolveWorkspaceForMetadata(params: params) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+
+        var full: [String: String] = [:]
+        v2MainSync {
+            guard let ws = resolved.tabManager.tabs.first(where: { $0.id == resolved.workspaceId }) else {
+                return
+            }
+            full = ws.metadata
+        }
+
+        var metadataOut: [String: String] = full
+        if let filterKeys = requestedKeys {
+            metadataOut = [:]
+            for k in filterKeys {
+                if let v = full[k] { metadataOut[k] = v }
+            }
+        } else if let single = requestedKey {
+            metadataOut = [:]
+            if let v = full[single] { metadataOut[single] = v }
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: resolved.tabManager)
+        var payload: [String: Any] = [
+            "workspace_id": resolved.workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: resolved.workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "metadata": metadataOut
+        ]
+        if let single = requestedKey {
+            payload["key"] = single
+            payload["value"] = v2OrNull(metadataOut[single])
+        }
+        return .ok(payload)
+    }
+
+    private func v2WorkspaceClearMetadata(params: [String: Any]) -> V2CallResult {
+        let keys: [String]?
+        if params["keys"] == nil || params["keys"] is NSNull {
+            keys = nil
+        } else if let arr = v2StringArray(params, "keys") {
+            keys = arr
+        } else {
+            return .err(code: "invalid_keys_param", message: "keys must be an array of strings", data: nil)
+        }
+
+        // Validate key grammar off-main when a filter is provided; malformed
+        // keys could never have been written but reject them explicitly so
+        // callers see a consistent error shape.
+        if let keys {
+            for k in keys {
+                do {
+                    try WorkspaceMetadataValidator.validateKey(k)
+                } catch let err as WorkspaceMetadataValidator.ValidationError {
+                    return .err(code: err.code, message: err.message, data: err.detail)
+                } catch {
+                    return .err(code: "internal_error", message: "\(error)", data: nil)
+                }
+            }
+        }
+
+        guard let resolved = v2ResolveWorkspaceForMetadata(params: params) else {
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        }
+
+        var resultMetadata: [String: String] = [:]
+        v2MainSync {
+            guard let ws = resolved.tabManager.tabs.first(where: { $0.id == resolved.workspaceId }) else {
+                return
+            }
+            if let keys {
+                var next = ws.metadata
+                for k in keys { next.removeValue(forKey: k) }
+                ws.metadata = next
+            } else {
+                ws.metadata = [:]
+            }
+            resultMetadata = ws.metadata
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: resolved.tabManager)
+        return .ok([
+            "workspace_id": resolved.workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: resolved.workspaceId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "metadata": resultMetadata
+        ])
     }
 
     private func v2WorkspaceAction(params: [String: Any]) -> V2CallResult {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -243,6 +243,11 @@ extension Workspace {
             )
         }
 
+        restoreSurfaceMetadataFromSnapshot(
+            panels: snapshot.panels,
+            oldToNewPanelIds: oldToNewPanelIds
+        )
+
         pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))
         applySessionDividerPositions(snapshotNode: snapshot.layout, liveNode: bonsplitController.treeSnapshot())
 
@@ -400,6 +405,36 @@ extension Workspace {
             markdownSnapshot = SessionMarkdownPanelSnapshot(filePath: markdownPanel.filePath)
         }
 
+        let persistedMetadata: [String: PersistedJSONValue]?
+        let persistedMetadataSources: [String: PersistedMetadataSource]?
+        if PersistedMetadataBridge.isPersistDisabled {
+            persistedMetadata = nil
+            persistedMetadataSources = nil
+        } else {
+            let snapshot = SurfaceMetadataStore.shared.getMetadata(
+                workspaceId: id,
+                surfaceId: panelId
+            )
+            if snapshot.metadata.isEmpty && snapshot.sources.isEmpty {
+                persistedMetadata = nil
+                persistedMetadataSources = nil
+            } else {
+                let bridgedValues = PersistedMetadataBridge.encodeValues(
+                    snapshot.metadata,
+                    surfaceIdForLog: panelId
+                )
+                let cappedValues = PersistedMetadataBridge.enforceSizeCap(
+                    bridgedValues,
+                    surfaceId: panelId
+                )
+                let bridgedSources = PersistedMetadataBridge.encodeSources(snapshot.sources)
+                // If enforceSizeCap dropped keys, drop their sidecars too.
+                let alignedSources = bridgedSources.filter { cappedValues.keys.contains($0.key) }
+                persistedMetadata = cappedValues.isEmpty ? nil : cappedValues
+                persistedMetadataSources = alignedSources.isEmpty ? nil : alignedSources
+            }
+        }
+
         return SessionPanelSnapshot(
             id: panelId,
             type: panel.panelType,
@@ -413,7 +448,9 @@ extension Workspace {
             ttyName: ttyName,
             terminal: terminalSnapshot,
             browser: browserSnapshot,
-            markdown: markdownSnapshot
+            markdown: markdownSnapshot,
+            metadata: persistedMetadata,
+            metadataSources: persistedMetadataSources
         )
     }
 
@@ -6048,6 +6085,36 @@ final class Workspace: Identifiable, ObservableObject {
         payload["effective_collapsed"] = collapsed || (descriptionString?.isEmpty ?? true)
         payload["visible"] = titleBarVisible
         return payload
+    }
+
+    /// Tier 1 Phase 2: re-install persisted metadata from a session snapshot
+    /// after `restorePane` rebuilds the panel set. Silent — restore bypasses
+    /// the precedence chain (the snapshot IS the prior session's source of
+    /// truth). Runs before `pruneSurfaceMetadata` so anything not in the
+    /// current panel set gets cleaned up on the same tick.
+    ///
+    /// Respects `CMUX_DISABLE_METADATA_PERSIST=1` as a rollback safety net —
+    /// when set, the snapshot's metadata is ignored and surfaces start with
+    /// an empty store.
+    private func restoreSurfaceMetadataFromSnapshot(
+        panels snapshotPanels: [SessionPanelSnapshot],
+        oldToNewPanelIds: [UUID: UUID]
+    ) {
+        if PersistedMetadataBridge.isPersistDisabled { return }
+        for panelSnapshot in snapshotPanels {
+            guard let persistedValues = panelSnapshot.metadata else { continue }
+            let persistedSources = panelSnapshot.metadataSources ?? [:]
+            let newPanelId = oldToNewPanelIds[panelSnapshot.id] ?? panelSnapshot.id
+            guard panels[newPanelId] != nil else { continue }
+            let values = PersistedMetadataBridge.decodeValues(persistedValues)
+            let sources = PersistedMetadataBridge.decodeSources(persistedSources)
+            SurfaceMetadataStore.shared.restoreFromSnapshot(
+                workspaceId: id,
+                surfaceId: newPanelId,
+                values: values,
+                sources: sources
+            )
+        }
     }
 
     func pruneSurfaceMetadata(validSurfaceIds: Set<UUID>) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -195,6 +195,8 @@ extension Workspace {
             SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
         }
 
+        let metadataSnapshot: [String: String]? = metadata.isEmpty ? nil : metadata
+
         return SessionWorkspaceSnapshot(
             id: id,
             processTitle: processTitle,
@@ -208,7 +210,8 @@ extension Workspace {
             statusEntries: statusSnapshots,
             logEntries: logSnapshots,
             progress: progressSnapshot,
-            gitBranch: gitBranchSnapshot
+            gitBranch: gitBranchSnapshot,
+            metadata: metadataSnapshot
         )
     }
 
@@ -247,6 +250,7 @@ extension Workspace {
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
+        metadata = snapshot.metadata ?? [:]
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -4842,6 +4846,12 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published var currentDirectory: String
+
+    /// Operator-authored workspace metadata (e.g. "description", "icon").
+    /// Workspace-scoped; not to be confused with surface-scoped
+    /// `SurfaceMetadataStore`. Persisted across restart via
+    /// `SessionWorkspaceSnapshot.metadata`.
+    @Published var metadata: [String: String] = [:]
     private(set) var preferredBrowserProfileID: UUID?
 
     /// Ordinal for CMUX_PORT range assignment (monotonically increasing per app session)

--- a/Sources/WorkspaceMetadataKeys.swift
+++ b/Sources/WorkspaceMetadataKeys.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+/// Canonical operator-authored workspace metadata keys.
+///
+/// Workspace-scoped. Distinct from `MetadataKey` in `SurfaceMetadataStore.swift`
+/// (surface-scoped). The same string literal (e.g. `"description"`) carries
+/// different meaning in each namespace; do not cross them.
+public enum WorkspaceMetadataKey {
+    public static let description = "description"
+    public static let icon = "icon"
+
+    public static let canonical: Set<String> = [description, icon]
+}
+
+/// Validation for workspace metadata writes.
+///
+/// Values for canonical keys have specific caps; unknown keys are accepted up
+/// to the generic caps below. All keys must match a conservative ASCII
+/// grammar to keep the socket wire shape stable and to avoid escape surprises
+/// in logs and CLI output.
+public enum WorkspaceMetadataValidator {
+    public static let maxDescriptionLen = 2048
+    public static let maxIconLen = 32
+    public static let maxCustomKeys = 32
+    public static let maxCustomKeyLen = 64
+    public static let maxCustomValueLen = 1024
+
+    /// Key grammar: non-empty ASCII letters/digits/underscore/dot/hyphen.
+    /// Pattern: `^[A-Za-z0-9_.\-]+$`. No whitespace, no arbitrary UTF-8.
+    public static let keyPattern = #"^[A-Za-z0-9_.\-]+$"#
+
+    public enum ValidationError: Error, Equatable {
+        case emptyKey
+        case keyTooLong(limit: Int)
+        case keyInvalidCharacters
+        case valueTooLong(key: String, limit: Int)
+
+        public var code: String {
+            switch self {
+            case .emptyKey: return "invalid_key"
+            case .keyTooLong: return "invalid_key"
+            case .keyInvalidCharacters: return "invalid_key"
+            case .valueTooLong: return "value_too_long"
+            }
+        }
+
+        public var message: String {
+            switch self {
+            case .emptyKey:
+                return "metadata key must be non-empty"
+            case .keyTooLong(let limit):
+                return "metadata key exceeds max length \(limit)"
+            case .keyInvalidCharacters:
+                return "metadata key must match [A-Za-z0-9_.-]+"
+            case .valueTooLong(let key, let limit):
+                return "metadata value for '\(key)' exceeds max length \(limit)"
+            }
+        }
+
+        public var detail: [String: Any]? {
+            switch self {
+            case .valueTooLong(let key, let limit):
+                return ["key": key, "limit": limit]
+            case .keyTooLong(let limit):
+                return ["limit": limit]
+            default:
+                return nil
+            }
+        }
+    }
+
+    public enum CapacityError: Error, Equatable {
+        case tooManyKeys(limit: Int)
+
+        public var code: String { "too_many_keys" }
+        public var message: String {
+            switch self {
+            case .tooManyKeys(let limit):
+                return "workspace metadata exceeds max \(limit) keys"
+            }
+        }
+        public var detail: [String: Any]? {
+            switch self {
+            case .tooManyKeys(let limit):
+                return ["limit": limit]
+            }
+        }
+    }
+
+    private static let keyRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(pattern: keyPattern, options: [])
+    }()
+
+    /// Validate a key/value pair for writing.
+    public static func validate(key: String, value: String) throws {
+        try validateKey(key)
+        try validateValue(key: key, value: value)
+    }
+
+    /// Validate a key grammar only (used for deletion paths).
+    public static func validateKey(_ key: String) throws {
+        if key.isEmpty { throw ValidationError.emptyKey }
+        if key.count > maxCustomKeyLen {
+            throw ValidationError.keyTooLong(limit: maxCustomKeyLen)
+        }
+        let range = NSRange(location: 0, length: (key as NSString).length)
+        if keyRegex.firstMatch(in: key, options: [], range: range) == nil {
+            throw ValidationError.keyInvalidCharacters
+        }
+    }
+
+    private static func validateValue(key: String, value: String) throws {
+        let limit = valueLimit(for: key)
+        if value.count > limit {
+            throw ValidationError.valueTooLong(key: key, limit: limit)
+        }
+    }
+
+    /// Cap (in characters) for a given key. Canonical keys have dedicated
+    /// limits; anything else falls back to the generic custom-value cap.
+    public static func valueLimit(for key: String) -> Int {
+        switch key {
+        case WorkspaceMetadataKey.description: return maxDescriptionLen
+        case WorkspaceMetadataKey.icon: return maxIconLen
+        default: return maxCustomValueLen
+        }
+    }
+
+    /// Validate the post-write map does not exceed the custom-key count cap.
+    /// Canonical keys do not count against the custom-key budget.
+    public static func validateCapacity(after candidate: [String: String]) throws {
+        let customCount = candidate.keys.filter { !WorkspaceMetadataKey.canonical.contains($0) }.count
+        if customCount > maxCustomKeys {
+            throw CapacityError.tooManyKeys(limit: maxCustomKeys)
+        }
+    }
+}

--- a/cmuxTests/MetadataPersistencePrecedenceTests.swift
+++ b/cmuxTests/MetadataPersistencePrecedenceTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tier 1 Phase 2: Restore path must bypass the precedence chain — the
+/// snapshot IS the prior session's source of truth — but post-restore
+/// writes must still respect precedence against the restored record.
+final class MetadataPersistencePrecedenceTests: XCTestCase {
+    private func makeStore() -> SurfaceMetadataStore {
+        // Use the shared store but key off fresh UUIDs per test so parallel
+        // tests don't collide on a single shared (workspace, surface) pair.
+        return SurfaceMetadataStore.shared
+    }
+
+    func testRestoreInstallsExplicitAboveExistingDeclare() throws {
+        let store = makeStore()
+        let wsId = UUID()
+        let surfaceId = UUID()
+
+        // Pre-restore: surface has a .declare write in place (e.g. from an
+        // OSC sequence the reborn terminal emitted early).
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["title": "New"],
+            mode: .merge,
+            source: .declare
+        )
+
+        // Restore snapshot: previous session had an .explicit title.
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            values: ["title": "From Snapshot"],
+            sources: [
+                "title": SurfaceMetadataStore.SourceRecord(
+                    source: .explicit,
+                    ts: 123.0
+                )
+            ]
+        )
+
+        // Snapshot wins.
+        let snap = store.getMetadata(workspaceId: wsId, surfaceId: surfaceId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "From Snapshot")
+        XCTAssertEqual(store.getSource(workspaceId: wsId, surfaceId: surfaceId, key: "title"), .explicit)
+    }
+
+    func testHeuristicWritePostRestoreCannotOverwriteRestoredExplicit() throws {
+        let store = makeStore()
+        let wsId = UUID()
+        let surfaceId = UUID()
+
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            values: ["title": "Explicit Title"],
+            sources: [
+                "title": SurfaceMetadataStore.SourceRecord(source: .explicit, ts: 100.0)
+            ]
+        )
+
+        // A heuristic write lands AFTER restore. It must be rejected by
+        // precedence — .heuristic < .explicit.
+        let applied = store.setInternal(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            key: "title",
+            value: "Heuristic Title",
+            source: .heuristic
+        )
+        XCTAssertFalse(applied, "Heuristic must not overwrite restored explicit")
+
+        let snap = store.getMetadata(workspaceId: wsId, surfaceId: surfaceId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "Explicit Title")
+        XCTAssertEqual(store.getSource(workspaceId: wsId, surfaceId: surfaceId, key: "title"), .explicit)
+    }
+
+    func testRestoredHeuristicKeepsHeuristicSourceAndTs() {
+        let store = makeStore()
+        let wsId = UUID()
+        let surfaceId = UUID()
+
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            values: ["status": "idle"],
+            sources: [
+                "status": SurfaceMetadataStore.SourceRecord(source: .heuristic, ts: 42.0)
+            ]
+        )
+        let src = store.getSource(workspaceId: wsId, surfaceId: surfaceId, key: "status")
+        XCTAssertEqual(src, .heuristic)
+    }
+
+    func testExplicitWritePostRestoreUpgradesHeuristic() throws {
+        let store = makeStore()
+        let wsId = UUID()
+        let surfaceId = UUID()
+
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            values: ["status": "running"],
+            sources: [
+                "status": SurfaceMetadataStore.SourceRecord(source: .heuristic, ts: 1.0)
+            ]
+        )
+
+        // An explicit write post-restore wins over the restored heuristic.
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["status": "idle"],
+            mode: .merge,
+            source: .explicit
+        )
+        let snap = store.getMetadata(workspaceId: wsId, surfaceId: surfaceId)
+        XCTAssertEqual(snap.metadata["status"] as? String, "idle")
+        XCTAssertEqual(store.getSource(workspaceId: wsId, surfaceId: surfaceId, key: "status"), .explicit)
+    }
+}

--- a/cmuxTests/MetadataPersistenceRoundTripTests.swift
+++ b/cmuxTests/MetadataPersistenceRoundTripTests.swift
@@ -1,0 +1,220 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tier 1 Phase 2 round-trip coverage for the PersistedJSONValue /
+/// SessionPanelSnapshot encode/decode layer. All tests go through
+/// JSONEncoder/Decoder so they verify the actual wire format, not just
+/// in-memory Swift equality.
+final class MetadataPersistenceRoundTripTests: XCTestCase {
+    // MARK: - PersistedJSONValue
+
+    func testPrimitiveTypesRoundTrip() throws {
+        let cases: [PersistedJSONValue] = [
+            .string("hello"),
+            .string(""),
+            .number(0),
+            .number(42),
+            .number(-1.5),
+            .number(Double.greatestFiniteMagnitude),
+            .bool(true),
+            .bool(false),
+            .null
+        ]
+        for value in cases {
+            let data = try JSONEncoder().encode(value)
+            let decoded = try JSONDecoder().decode(PersistedJSONValue.self, from: data)
+            XCTAssertEqual(decoded, value, "Round-trip changed \(value)")
+        }
+    }
+
+    func testBoolStaysBoolNotNumber() throws {
+        // Regression guard for the Bool/NSNumber ordering bug. Once encoded as
+        // JSON `true`, decode must produce .bool not .number(1).
+        let data = try JSONEncoder().encode(PersistedJSONValue.bool(true))
+        let decoded = try JSONDecoder().decode(PersistedJSONValue.self, from: data)
+        guard case .bool(let b) = decoded else {
+            XCTFail("Expected .bool, got \(decoded)")
+            return
+        }
+        XCTAssertTrue(b)
+    }
+
+    func testNumberStaysNumberNotBool() throws {
+        // Symmetric guard: integer-valued numbers must not be coerced to bool.
+        let data = try JSONEncoder().encode(PersistedJSONValue.number(1))
+        let decoded = try JSONDecoder().decode(PersistedJSONValue.self, from: data)
+        guard case .number(let d) = decoded else {
+            XCTFail("Expected .number, got \(decoded)")
+            return
+        }
+        XCTAssertEqual(d, 1.0)
+    }
+
+    func testNestedArrayRoundTrip() throws {
+        let value: PersistedJSONValue = .array([
+            .string("a"),
+            .number(1),
+            .bool(true),
+            .null,
+            .array([.number(2), .number(3)])
+        ])
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(PersistedJSONValue.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+
+    func testNestedObjectRoundTrip() throws {
+        let value: PersistedJSONValue = .object([
+            "title": .string("Hello"),
+            "progress": .number(0.42),
+            "done": .bool(false),
+            "tags": .array([.string("one"), .string("two")]),
+            "nested": .object([
+                "deeper": .object([
+                    "deepest": .string("bottom")
+                ])
+            ])
+        ])
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(PersistedJSONValue.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+
+    // MARK: - PersistedMetadataSource
+
+    func testSourceRecordRoundTrip() throws {
+        let record = PersistedMetadataSource(source: "explicit", ts: 1_700_000_000.5)
+        let data = try JSONEncoder().encode(record)
+        let decoded = try JSONDecoder().decode(PersistedMetadataSource.self, from: data)
+        XCTAssertEqual(decoded, record)
+    }
+
+    func testAllKnownSourceRawValuesRoundTrip() throws {
+        for source in MetadataSource.allCases {
+            let record = PersistedMetadataSource(source: source.rawValue, ts: 1.0)
+            let data = try JSONEncoder().encode(record)
+            let decoded = try JSONDecoder().decode(PersistedMetadataSource.self, from: data)
+            XCTAssertEqual(decoded.source, source.rawValue)
+        }
+    }
+
+    // MARK: - SessionPanelSnapshot backcompat
+
+    func testPrePhase2SnapshotDecodesCleanlyWithoutMetadataFields() throws {
+        // A snapshot written by a pre-Phase-2 build has no `metadata` or
+        // `metadataSources` keys at all. It must decode without error; both
+        // fields must come back as nil.
+        let legacyJSON = """
+        {
+            "id": "\(UUID().uuidString)",
+            "type": "terminal",
+            "isPinned": false,
+            "isManuallyUnread": false,
+            "listeningPorts": []
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: legacyJSON)
+        XCTAssertNil(decoded.metadata)
+        XCTAssertNil(decoded.metadataSources)
+    }
+
+    func testPhase2SnapshotRoundTripPreservesMetadata() throws {
+        let panelId = UUID()
+        let metadata: [String: PersistedJSONValue] = [
+            "title": .string("Frontend"),
+            "progress": .number(0.5),
+            "active": .bool(true),
+            "tags": .array([.string("claude"), .string("code")])
+        ]
+        let sources: [String: PersistedMetadataSource] = [
+            "title": PersistedMetadataSource(source: "explicit", ts: 1_700_000_001),
+            "progress": PersistedMetadataSource(source: "osc", ts: 1_700_000_002),
+            "active": PersistedMetadataSource(source: "heuristic", ts: 1_700_000_003),
+            "tags": PersistedMetadataSource(source: "declare", ts: 1_700_000_004)
+        ]
+        let snapshot = SessionPanelSnapshot(
+            id: panelId,
+            type: .terminal,
+            title: nil,
+            customTitle: nil,
+            directory: nil,
+            isPinned: false,
+            isManuallyUnread: false,
+            gitBranch: nil,
+            listeningPorts: [],
+            ttyName: nil,
+            terminal: nil,
+            browser: nil,
+            markdown: nil,
+            metadata: metadata,
+            metadataSources: sources
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: data)
+        XCTAssertEqual(decoded.id, panelId)
+        XCTAssertEqual(decoded.metadata, metadata)
+        XCTAssertEqual(decoded.metadataSources, sources)
+    }
+
+    func testEmptyMetadataEmitsAsNilToKeepSnapshotsSmall() throws {
+        // If every panel has an empty store, snapshot should not bloat with
+        // empty dicts. The capture path assigns nil; verify the encoded JSON
+        // omits both keys entirely.
+        let snapshot = SessionPanelSnapshot(
+            id: UUID(),
+            type: .terminal,
+            title: nil,
+            customTitle: nil,
+            directory: nil,
+            isPinned: false,
+            isManuallyUnread: false,
+            gitBranch: nil,
+            listeningPorts: [],
+            ttyName: nil,
+            terminal: nil,
+            browser: nil,
+            markdown: nil,
+            metadata: nil,
+            metadataSources: nil
+        )
+        let data = try JSONEncoder().encode(snapshot)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("\"metadata\""))
+        XCTAssertFalse(json.contains("\"metadataSources\""))
+    }
+
+    // MARK: - Bridge encode/decode helpers
+
+    func testBridgeEncodeDecodeValuesIsSymmetric() {
+        let original: [String: Any] = [
+            "s": "hello",
+            "n": 42,
+            "b": true,
+            "null": NSNull(),
+            "arr": [1, "two", false] as [Any],
+            "obj": ["nested": "yes"]
+        ]
+        let encoded = PersistedMetadataBridge.encodeValues(original)
+        let decoded = PersistedMetadataBridge.decodeValues(encoded)
+        XCTAssertEqual(decoded["s"] as? String, "hello")
+        XCTAssertEqual((decoded["n"] as? Double).map { Int($0) }, 42)
+        XCTAssertEqual(decoded["b"] as? Bool, true)
+        XCTAssertTrue(decoded["null"] is NSNull)
+        let arr = decoded["arr"] as? [Any]
+        XCTAssertEqual(arr?.count, 3)
+        let obj = decoded["obj"] as? [String: Any]
+        XCTAssertEqual(obj?["nested"] as? String, "yes")
+    }
+
+    func testBridgeSourceDecodeDowngradesUnknownSource() {
+        let unknown = PersistedMetadataSource(source: "not_a_real_source", ts: 999)
+        let decoded = PersistedMetadataBridge.decodeSources(["k": unknown])
+        XCTAssertEqual(decoded["k"]?.source, .heuristic)
+        XCTAssertEqual(decoded["k"]?.ts, 999)
+    }
+}

--- a/cmuxTests/MetadataPersistenceUncoercibleTests.swift
+++ b/cmuxTests/MetadataPersistenceUncoercibleTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tier 1 Phase 2: values not representable as JSON must be dropped
+/// silently (with a debug log) so the snapshot write never crashes.
+/// The rest of the blob must survive.
+final class MetadataPersistenceUncoercibleTests: XCTestCase {
+    private final class CustomBox {
+        let payload: Int
+        init(_ p: Int) { self.payload = p }
+    }
+
+    func testCustomClassInstanceIsDroppedOtherValuesSurvive() {
+        let blob: [String: Any] = [
+            "good_string": "ok",
+            "good_number": 42,
+            "bad_custom": CustomBox(7)
+        ]
+        let encoded = PersistedMetadataBridge.encodeValues(blob)
+        XCTAssertNil(encoded["bad_custom"])
+        XCTAssertEqual(encoded["good_string"], .string("ok"))
+        if case .number(let d)? = encoded["good_number"] {
+            XCTAssertEqual(d, 42.0)
+        } else {
+            XCTFail("good_number should have survived as .number")
+        }
+    }
+
+    func testNaNIsDroppedInfIsDroppedOthersSurvive() {
+        let blob: [String: Any] = [
+            "sane": 1.5,
+            "nan": Double.nan,
+            "pos_inf": Double.infinity,
+            "neg_inf": -Double.infinity
+        ]
+        let encoded = PersistedMetadataBridge.encodeValues(blob)
+        XCTAssertNil(encoded["nan"])
+        XCTAssertNil(encoded["pos_inf"])
+        XCTAssertNil(encoded["neg_inf"])
+        if case .number(let d)? = encoded["sane"] {
+            XCTAssertEqual(d, 1.5)
+        } else {
+            XCTFail("sane should have survived as .number")
+        }
+    }
+
+    func testDateAndURLAreDropped() {
+        let blob: [String: Any] = [
+            "when": Date(timeIntervalSince1970: 0),
+            "where": URL(string: "https://example.com")!,
+            "survives": "hello"
+        ]
+        let encoded = PersistedMetadataBridge.encodeValues(blob)
+        XCTAssertNil(encoded["when"])
+        XCTAssertNil(encoded["where"])
+        XCTAssertEqual(encoded["survives"], .string("hello"))
+    }
+
+    func testNestedArrayPreservesIndexStabilityOnDrop() {
+        // Element-level drops should preserve positional semantics — a
+        // dropped element becomes .null so indexing into the array stays
+        // consistent for consumer code.
+        let arr: [Any] = ["a", CustomBox(1), "c"]
+        let blob: [String: Any] = ["tags": arr]
+        let encoded = PersistedMetadataBridge.encodeValues(blob)
+        guard case .array(let elements) = encoded["tags"] else {
+            XCTFail("Expected .array")
+            return
+        }
+        XCTAssertEqual(elements.count, 3)
+        XCTAssertEqual(elements[0], .string("a"))
+        XCTAssertEqual(elements[1], .null)
+        XCTAssertEqual(elements[2], .string("c"))
+    }
+
+    func testNestedObjectDropsKeysIndividually() {
+        let inner: [String: Any] = [
+            "keep": "yes",
+            "drop": Double.nan
+        ]
+        let blob: [String: Any] = ["obj": inner]
+        let encoded = PersistedMetadataBridge.encodeValues(blob)
+        guard case .object(let o) = encoded["obj"] else {
+            XCTFail("Expected .object")
+            return
+        }
+        XCTAssertEqual(o["keep"], .string("yes"))
+        XCTAssertNil(o["drop"])
+    }
+}

--- a/cmuxTests/MetadataStoreRevisionCounterTests.swift
+++ b/cmuxTests/MetadataStoreRevisionCounterTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tier 1 Phase 2: the metadataStoreRevision counter must bump on every
+/// mutation that changes state, never bump on no-op writes, and remain
+/// monotonic under concurrent mutation from many queues (atomicity is
+/// what makes it safe to read from the autosave fingerprint tick).
+final class MetadataStoreRevisionCounterTests: XCTestCase {
+    private func makeStoreAndSurface() -> (SurfaceMetadataStore, UUID, UUID) {
+        return (SurfaceMetadataStore.shared, UUID(), UUID())
+    }
+
+    func testSetMetadataBumpsCounter() throws {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        let before = store.currentRevision()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v"],
+            mode: .merge,
+            source: .explicit
+        )
+        let after = store.currentRevision()
+        XCTAssertEqual(after, before &+ 1)
+    }
+
+    func testSameValueSameSourceWriteDoesNotBump() throws {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v"],
+            mode: .merge,
+            source: .explicit
+        )
+        let before = store.currentRevision()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before,
+                       "Idempotent same-value same-source write must not bump revision")
+    }
+
+    func testDifferentValueBumpsCounter() throws {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v1"],
+            mode: .merge,
+            source: .explicit
+        )
+        let before = store.currentRevision()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v2"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before &+ 1)
+    }
+
+    func testLowerPrecedenceRejectionDoesNotBump() throws {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v"],
+            mode: .merge,
+            source: .explicit
+        )
+        let before = store.currentRevision()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v-heuristic"],
+            mode: .merge,
+            source: .heuristic
+        )
+        XCTAssertEqual(store.currentRevision(), before,
+                       "Rejected lower-precedence write must not bump revision")
+    }
+
+    func testClearRemovesExistingKeyBumps() throws {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            partial: ["k": "v"],
+            mode: .merge,
+            source: .explicit
+        )
+        let before = store.currentRevision()
+        _ = try store.clearMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            keys: ["k"],
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before &+ 1)
+    }
+
+    func testClearNonexistentKeyDoesNotBump() throws {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        let before = store.currentRevision()
+        _ = try store.clearMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            keys: ["does_not_exist"],
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before,
+                       "Clearing a non-existent key must not bump revision")
+    }
+
+    func testClearAllOnEmptyStoreDoesNotBump() throws {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        let before = store.currentRevision()
+        _ = try store.clearMetadata(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            keys: nil,
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before,
+                       "Clear-all against an empty store must not bump revision")
+    }
+
+    func testSetInternalBumpsOnNewKey() {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        let before = store.currentRevision()
+        let applied = store.setInternal(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            key: "k",
+            value: "v",
+            source: .heuristic
+        )
+        XCTAssertTrue(applied)
+        XCTAssertEqual(store.currentRevision(), before &+ 1)
+    }
+
+    func testSetInternalDoesNotBumpOnIdempotentWrite() {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        _ = store.setInternal(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            key: "k",
+            value: "v",
+            source: .heuristic
+        )
+        let before = store.currentRevision()
+        _ = store.setInternal(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            key: "k",
+            value: "v",
+            source: .heuristic
+        )
+        XCTAssertEqual(store.currentRevision(), before)
+    }
+
+    func testRestoreFromSnapshotBumpsCounter() {
+        let (store, wsId, surfaceId) = makeStoreAndSurface()
+        let before = store.currentRevision()
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            surfaceId: surfaceId,
+            values: ["k": "v"],
+            sources: [
+                "k": SurfaceMetadataStore.SourceRecord(source: .explicit, ts: 1.0)
+            ]
+        )
+        XCTAssertEqual(store.currentRevision(), before &+ 1,
+                       "Restore must bump so post-restore autosave picks up the change")
+    }
+
+    func testConcurrentMutationsYieldMonotonicNonDuplicateIncrements() {
+        let store = SurfaceMetadataStore.shared
+        let before = store.currentRevision()
+
+        // Each iteration writes to a fresh surface so every write is a
+        // genuine state change (no no-op skip). The monotonicity check
+        // is what proves atomicity of the counter under contention.
+        let totalWrites = 200
+        let group = DispatchGroup()
+        let queues: [DispatchQueue] = (0..<4).map {
+            DispatchQueue(label: "test.concurrent.revision.\($0)", attributes: .concurrent)
+        }
+        let perQueue = totalWrites / queues.count
+        for q in queues {
+            for i in 0..<perQueue {
+                group.enter()
+                q.async {
+                    _ = store.setInternal(
+                        workspaceId: UUID(),
+                        surfaceId: UUID(),
+                        key: "k\(i)",
+                        value: "v\(i)",
+                        source: .heuristic
+                    )
+                    group.leave()
+                }
+            }
+        }
+        group.wait()
+        let after = store.currentRevision()
+        // Exactly one increment per genuine mutation. If the &+= were
+        // non-atomic, concurrent writers could lose bumps and `after`
+        // would be less than `before + totalWrites`.
+        XCTAssertEqual(after, before &+ UInt64(totalWrites),
+                       "Concurrent mutations must all be accounted for in the counter")
+    }
+}

--- a/cmuxTests/TabManagerSessionSnapshotTests.swift
+++ b/cmuxTests/TabManagerSessionSnapshotTests.swift
@@ -47,6 +47,58 @@ final class TabManagerSessionSnapshotTests: XCTestCase {
         XCTAssertNotNil(manager.selectedTabId)
     }
 
+    func testSessionSnapshotRoundtripsWorkspaceMetadata() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+        workspace.metadata = [
+            WorkspaceMetadataKey.description: "Backend refactor",
+            WorkspaceMetadataKey.icon: "🦊",
+            "custom.tag": "v2"
+        ]
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        XCTAssertEqual(snapshot.workspaces.count, 1)
+        XCTAssertEqual(snapshot.workspaces[0].metadata?["description"], "Backend refactor")
+        XCTAssertEqual(snapshot.workspaces[0].metadata?["icon"], "🦊")
+        XCTAssertEqual(snapshot.workspaces[0].metadata?["custom.tag"], "v2")
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+        XCTAssertEqual(restored.tabs.count, 1)
+        XCTAssertEqual(restored.tabs[0].metadata["description"], "Backend refactor")
+        XCTAssertEqual(restored.tabs[0].metadata["icon"], "🦊")
+        XCTAssertEqual(restored.tabs[0].metadata["custom.tag"], "v2")
+    }
+
+    func testEmptyMetadataIsOmittedFromSnapshot() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+        XCTAssertTrue(workspace.metadata.isEmpty)
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        XCTAssertNil(snapshot.workspaces.first?.metadata)
+    }
+
+    func testAutosaveFingerprintChangesOnMetadataValueEdit() {
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace else {
+            XCTFail("Expected initial workspace")
+            return
+        }
+        workspace.metadata = ["description": "one"]
+        let before = manager.sessionAutosaveFingerprint()
+        workspace.metadata = ["description": "two"]
+        let after = manager.sessionAutosaveFingerprint()
+        XCTAssertNotEqual(before, after,
+            "Autosave fingerprint must change on value-only metadata edit (plan contract).")
+    }
+
     func testSessionSnapshotExcludesRemoteWorkspacesFromRestore() throws {
         let manager = TabManager()
         let remoteWorkspace = manager.addWorkspace(select: true)

--- a/cmuxTests/WorkspaceMetadataValidatorTests.swift
+++ b/cmuxTests/WorkspaceMetadataValidatorTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class WorkspaceMetadataValidatorTests: XCTestCase {
+    func testAcceptsCanonicalDescriptionAtMaxLen() throws {
+        let value = String(repeating: "a", count: WorkspaceMetadataValidator.maxDescriptionLen)
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.description,
+            value: value
+        ))
+    }
+
+    func testRejectsDescriptionOverMaxLen() {
+        let value = String(repeating: "a", count: WorkspaceMetadataValidator.maxDescriptionLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.description,
+            value: value
+        )) { error in
+            guard let err = error as? WorkspaceMetadataValidator.ValidationError else {
+                XCTFail("Expected ValidationError, got \(error)")
+                return
+            }
+            XCTAssertEqual(
+                err,
+                .valueTooLong(
+                    key: WorkspaceMetadataKey.description,
+                    limit: WorkspaceMetadataValidator.maxDescriptionLen
+                )
+            )
+        }
+    }
+
+    func testAcceptsIconAtMaxLen() throws {
+        let value = String(repeating: "x", count: WorkspaceMetadataValidator.maxIconLen)
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: value
+        ))
+    }
+
+    func testRejectsIconOverMaxLen() {
+        let value = String(repeating: "x", count: WorkspaceMetadataValidator.maxIconLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: value
+        ))
+    }
+
+    func testAcceptsEmojiValues() throws {
+        // Emoji-with-modifier + ZWJ sequences commonly have count > 1 unit even
+        // though they look like a single glyph. Confirm they pass within caps.
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: "🦊"
+        ))
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(
+            key: WorkspaceMetadataKey.icon,
+            value: "👍🏽"
+        ))
+    }
+
+    func testCustomKeyAcceptsValidGrammar() throws {
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(key: "project.id", value: "abc"))
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validate(key: "My-Key_1", value: "abc"))
+    }
+
+    func testRejectsEmptyKey() {
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "", value: "ok")) { err in
+            XCTAssertEqual(err as? WorkspaceMetadataValidator.ValidationError, .emptyKey)
+        }
+    }
+
+    func testRejectsKeyWithWhitespace() {
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "my key", value: "ok")) { err in
+            XCTAssertEqual(err as? WorkspaceMetadataValidator.ValidationError, .keyInvalidCharacters)
+        }
+    }
+
+    func testRejectsKeyWithNonASCII() {
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "キー", value: "ok")) { err in
+            XCTAssertEqual(err as? WorkspaceMetadataValidator.ValidationError, .keyInvalidCharacters)
+        }
+    }
+
+    func testRejectsKeyOverMaxLen() {
+        let key = String(repeating: "a", count: WorkspaceMetadataValidator.maxCustomKeyLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: key, value: "ok")) { err in
+            XCTAssertEqual(
+                err as? WorkspaceMetadataValidator.ValidationError,
+                .keyTooLong(limit: WorkspaceMetadataValidator.maxCustomKeyLen)
+            )
+        }
+    }
+
+    func testRejectsCustomValueOverMaxLen() {
+        let value = String(repeating: "a", count: WorkspaceMetadataValidator.maxCustomValueLen + 1)
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validate(key: "note", value: value)) { err in
+            XCTAssertEqual(
+                err as? WorkspaceMetadataValidator.ValidationError,
+                .valueTooLong(key: "note", limit: WorkspaceMetadataValidator.maxCustomValueLen)
+            )
+        }
+    }
+
+    func testCapacityAcceptsCanonicalPlusCustomAtLimit() throws {
+        var map: [String: String] = [
+            WorkspaceMetadataKey.description: "desc",
+            WorkspaceMetadataKey.icon: "🦊"
+        ]
+        for i in 0..<WorkspaceMetadataValidator.maxCustomKeys {
+            map["custom_\(i)"] = "value"
+        }
+        XCTAssertNoThrow(try WorkspaceMetadataValidator.validateCapacity(after: map))
+    }
+
+    func testCapacityRejectsOverCustomKeyLimit() {
+        var map: [String: String] = [:]
+        for i in 0..<(WorkspaceMetadataValidator.maxCustomKeys + 1) {
+            map["custom_\(i)"] = "value"
+        }
+        XCTAssertThrowsError(try WorkspaceMetadataValidator.validateCapacity(after: map)) { err in
+            XCTAssertEqual(
+                err as? WorkspaceMetadataValidator.CapacityError,
+                .tooManyKeys(limit: WorkspaceMetadataValidator.maxCustomKeys)
+            )
+        }
+    }
+}

--- a/docs/socket-api-reference.md
+++ b/docs/socket-api-reference.md
@@ -164,6 +164,32 @@ Status pills, progress bars, and log entries in the workspace sidebar.
 
 Log levels: `info`, `progress`, `success`, `warning`, `error`
 
+### Surface Metadata Persistence (Tier 1 Phase 2)
+
+Surface metadata written via `surface.set_metadata` and its heuristic/
+OSC/declare counterparts persists across c11mux restarts. On restore,
+values are reinstalled into `SurfaceMetadataStore` with their original
+source and timestamp, preserving the `explicit > declare > osc >
+heuristic` precedence chain. A `.heuristic` value from the snapshot
+survives at `.heuristic` even if the newly-initialized surface wrote
+something at `.declare` first — the snapshot wins.
+
+Coercibility: values that cannot be represented as JSON (custom
+classes, `Date`, `URL`, `NaN`/`+Inf`/`-Inf`) are dropped on persist
+with a DEBUG-only log line and never crash the snapshot write; the
+rest of the blob survives. Numbers round-trip as double-precision
+floats — callers needing integer fidelity should convert explicitly
+after reading.
+
+**Rollback:** set `CMUX_DISABLE_METADATA_PERSIST=1` in the app's launch
+environment (e.g. `launchctl setenv CMUX_DISABLE_METADATA_PERSIST 1`
+then relaunch, or export it in the parent shell that launches the
+`.app`). When set, snapshot writes emit `null` for both `metadata`
+and `metadataSources` and restore ignores any persisted values. The
+variable is **app-launch-scope only** — setting it on a `cmux` CLI
+invocation has no effect, because the CLI is a separate process from
+the running app.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -173,6 +199,7 @@ Log levels: `info`, `progress`, `success`, `warning`, `error`
 | `CMUX_SOCKET_MODE` | Override access mode (`cmuxOnly`, `allowAll`, `off`) |
 | `CMUX_WORKSPACE_ID` | Auto-set: current workspace ID |
 | `CMUX_SURFACE_ID` | Auto-set: current surface ID |
+| `CMUX_DISABLE_METADATA_PERSIST` | App-launch-scope rollback: `1` skips persist on write and ignores on restore. See Surface Metadata Persistence above. |
 | `TERM_PROGRAM` | Set to `ghostty` |
 | `TERM` | Set to `xterm-ghostty` |
 

--- a/tests_v2/test_m7_titlebar_description_roundtrip.py
+++ b/tests_v2/test_m7_titlebar_description_roundtrip.py
@@ -93,7 +93,68 @@ def main() -> int:
             finally:
                 c.close_workspace(ws_id)
 
-    print("PASS: M7 description round-trip (inline, list, image, fenced code)")
+        # Tier 1 Phase 2 extension: user-set title + description must survive
+        # an on-disk session round-trip with full source attribution. Uses
+        # the DEBUG-only debug.session.save_and_load harness; the call is
+        # wrapped in try/except so release builds (without the method)
+        # skip the assertion cleanly.
+        ws_id, surface_id = _fresh_surface(c)
+        try:
+            title_value = f"Shipping dashboard #{stamp}"
+            description_value = "Backend refactor: Tier 1 Phase 2 persistence"
+            res = c._call(
+                "surface.set_metadata",
+                {
+                    "surface_id": surface_id,
+                    "mode": "merge",
+                    "source": "explicit",
+                    "metadata": {
+                        "title": title_value,
+                        "description": description_value,
+                    },
+                },
+            ) or {}
+            applied = res.get("applied") or {}
+            _must(
+                applied.get("title") is True and applied.get("description") is True,
+                f"[persist] set_metadata should apply title+description: {res}",
+            )
+
+            try:
+                c._call("debug.session.save_and_load", {})
+            except cmuxError as e:
+                # DEBUG-only method; release builds do not have it. Skip.
+                print(f"SKIP persist case: debug.session.save_and_load unavailable ({e})")
+                return 0
+
+            got_full = c._call(
+                "surface.get_metadata",
+                {"surface_id": surface_id, "include_sources": True},
+            ) or {}
+            md = got_full.get("metadata") or {}
+            sources = got_full.get("metadata_sources") or {}
+            _must(
+                md.get("title") == title_value,
+                f"[persist] title did not survive round-trip: {md}",
+            )
+            _must(
+                md.get("description") == description_value,
+                f"[persist] description did not survive round-trip: {md}",
+            )
+            title_src = sources.get("title") or {}
+            desc_src = sources.get("description") or {}
+            _must(
+                title_src.get("source") == "explicit",
+                f"[persist] title source should be 'explicit': {title_src}",
+            )
+            _must(
+                desc_src.get("source") == "explicit",
+                f"[persist] description source should be 'explicit': {desc_src}",
+            )
+        finally:
+            c.close_workspace(ws_id)
+
+    print("PASS: M7 description round-trip (inline, list, image, fenced code, persist)")
     return 0
 
 

--- a/tests_v2/test_metadata_persistence.py
+++ b/tests_v2/test_metadata_persistence.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Tier 1 Phase 2: SurfaceMetadataStore on-disk persistence round-trip.
+
+Sets varied metadata on a surface, forces a full save-to-disk and
+reload-from-disk round-trip via the DEBUG-only `debug.session.save_and_load`
+socket command, then reads the metadata back via `surface.get_metadata`
+and asserts every typed value plus every source record survives.
+
+Two variants, selected by the `CMUX_DISABLE_METADATA_PERSIST` env var
+in the RUNNING APP (not just the test process):
+
+- Main variant (env var unset in app):
+    All metadata + sources round-trip. Sources preserve `.explicit`
+    attribution and positive `ts`.
+
+- Rollback variant (env var `=1` in app launch env):
+    Snapshot omits `metadata` / `metadataSources`; after save_and_load
+    the live store is empty and the on-disk snapshot panels carry
+    `metadata: null`.
+
+CI launches the same test file twice — once without the env var, once
+with — to cover both paths. Setting the env var on the test process
+alone has no effect because the CLI is a separate process from the
+running app; the var must reach the app's launch environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+# Whether the test process itself knows this run targets the rollback path.
+# Note: this only indicates the caller's *expectation*. The running app's
+# env is what actually controls the behavior under test.
+TEST_EXPECTS_ROLLBACK = os.environ.get("CMUX_DISABLE_METADATA_PERSIST") == "1"
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _snapshot_path() -> Path | None:
+    """Locate the session snapshot JSON on disk. The filename embeds the
+    app's bundle identifier, so glob for `session-*.json` under the
+    c11mux application-support directory."""
+    app_support = Path.home() / "Library" / "Application Support" / "c11mux"
+    if not app_support.exists():
+        return None
+    candidates = sorted(
+        app_support.glob("session-*.json"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _fresh_surface(c) -> tuple[str, str]:
+    workspace_id = c.new_workspace()
+    current = c._call("surface.current", {"workspace_id": workspace_id}) or {}
+    surface_id = str(current.get("surface_id") or "")
+    _must(bool(surface_id), f"surface.current returned no surface_id: {current}")
+    return workspace_id, surface_id
+
+
+def _run_main_variant(c) -> None:
+    workspace_id, surface_id = _fresh_surface(c)
+    try:
+        # Write varied types so the bridge path gets exercised end to end.
+        metadata_in: dict[str, Any] = {
+            "title": f"Phase 2 smoke {int(time.time())}",
+            "progress": 0.42,
+            "active": True,
+            "tags": {"team": "platform", "count": 3, "flags": ["a", "b"]},
+        }
+        set_res = c._call(
+            "surface.set_metadata",
+            {
+                "surface_id": surface_id,
+                "mode": "merge",
+                "source": "explicit",
+                "metadata": metadata_in,
+            },
+        ) or {}
+        applied = set_res.get("applied") or {}
+        for k in metadata_in:
+            _must(applied.get(k) is True, f"set_metadata didn't apply {k}: {set_res}")
+
+        # Force actual on-disk round-trip.
+        rt_res = c._call("debug.session.save_and_load", {})
+        _must(rt_res is not None, "debug.session.save_and_load returned no result")
+
+        got = c._call(
+            "surface.get_metadata",
+            {"surface_id": surface_id, "include_sources": True},
+        ) or {}
+        md = got.get("metadata") or {}
+        sources = got.get("metadata_sources") or {}
+
+        _must(md.get("title") == metadata_in["title"], f"title: {md}")
+        _must(
+            isinstance(md.get("progress"), (int, float))
+            and abs(float(md["progress"]) - 0.42) < 1e-9,
+            f"progress: {md}",
+        )
+        _must(md.get("active") is True, f"active: {md}")
+        tags = md.get("tags") or {}
+        _must(tags.get("team") == "platform", f"nested team: {tags}")
+        # Numbers round-trip as floats per the PersistedJSONValue contract.
+        _must(
+            isinstance(tags.get("count"), (int, float))
+            and abs(float(tags["count"]) - 3.0) < 1e-9,
+            f"nested count: {tags}",
+        )
+        flags = tags.get("flags") or []
+        _must(list(flags) == ["a", "b"], f"nested flags: {tags}")
+
+        # Every key must carry its source + ts sidecar.
+        for k in metadata_in:
+            src = sources.get(k) or {}
+            _must(
+                src.get("source") == "explicit",
+                f"{k} source should be 'explicit' after round-trip: {src}",
+            )
+            ts = src.get("ts")
+            _must(
+                isinstance(ts, (int, float)) and ts > 0,
+                f"{k} ts should be positive: {src}",
+            )
+
+        print("PASS: Tier 1 Phase 2 metadata persistence (main variant)")
+    finally:
+        try:
+            c.close_workspace(workspace_id)
+        except Exception:
+            pass
+
+
+def _run_rollback_variant(c) -> None:
+    workspace_id, surface_id = _fresh_surface(c)
+    try:
+        c._call(
+            "surface.set_metadata",
+            {
+                "surface_id": surface_id,
+                "mode": "merge",
+                "source": "explicit",
+                "metadata": {"title": "Rollback test", "progress": 0.5},
+            },
+        )
+        c._call("debug.session.save_and_load", {})
+        got = c._call(
+            "surface.get_metadata",
+            {"surface_id": surface_id, "include_sources": True},
+        ) or {}
+        md = got.get("metadata") or {}
+        sources = got.get("metadata_sources") or {}
+        _must(md == {}, f"Rollback: expected empty live store, got {md}")
+        _must(sources == {}, f"Rollback: expected empty live sources, got {sources}")
+
+        snap_path = _snapshot_path()
+        _must(
+            snap_path is not None and snap_path.exists(),
+            f"Rollback: session snapshot file missing at {snap_path}",
+        )
+        snap = json.loads(snap_path.read_text())
+        checked = 0
+        for win in snap.get("windows", []):
+            tabs = (win.get("tabManager") or {}).get("workspaces") or []
+            for ws in tabs:
+                for panel in ws.get("panels") or []:
+                    # Rollback contract: the capture path emits nil for both
+                    # fields, which JSONEncoder drops from the on-disk blob.
+                    _must(
+                        "metadata" not in panel or panel.get("metadata") is None,
+                        f"Rollback: snapshot panel has metadata: {panel}",
+                    )
+                    _must(
+                        "metadataSources" not in panel
+                        or panel.get("metadataSources") is None,
+                        f"Rollback: snapshot panel has metadataSources: {panel}",
+                    )
+                    checked += 1
+        _must(checked > 0, "Rollback: snapshot contained no panels to check")
+        print("PASS: Tier 1 Phase 2 metadata persistence (rollback variant)")
+    finally:
+        try:
+            c.close_workspace(workspace_id)
+        except Exception:
+            pass
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        if TEST_EXPECTS_ROLLBACK:
+            _run_rollback_variant(client)
+        else:
+            _run_main_variant(client)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_workspace_metadata_limits.py
+++ b/tests_v2/test_workspace_metadata_limits.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""workspace.set_metadata rejects oversize values, bad keys, and over-capacity writes."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+MAX_DESCRIPTION = 2048
+MAX_ICON = 32
+MAX_CUSTOM_KEY = 64
+MAX_CUSTOM_VALUE = 1024
+MAX_CUSTOM_KEYS = 32
+
+
+def _expect_error(client, method, params, *, code_prefix: str = "") -> str:
+    try:
+        client._call(method, params)
+    except cmuxError as e:
+        msg = str(e)
+        if code_prefix and not msg.startswith(code_prefix):
+            raise cmuxError(f"Expected error starting with {code_prefix!r}, got: {msg}")
+        return msg
+    raise cmuxError(f"{method} with {params!r} should have failed but succeeded")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        workspace_id = client.new_workspace()
+        try:
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "description",
+                    "value": "a" * (MAX_DESCRIPTION + 1),
+                },
+                code_prefix="value_too_long",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "icon",
+                    "value": "x" * (MAX_ICON + 1),
+                },
+                code_prefix="value_too_long",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "my key",
+                    "value": "hi",
+                },
+                code_prefix="invalid_key",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "キー",
+                    "value": "hi",
+                },
+                code_prefix="invalid_key",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "a" * (MAX_CUSTOM_KEY + 1),
+                    "value": "hi",
+                },
+                code_prefix="invalid_key",
+            )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "note",
+                    "value": "a" * (MAX_CUSTOM_VALUE + 1),
+                },
+                code_prefix="value_too_long",
+            )
+
+            # Fill the custom-key budget to the cap, then try one more.
+            batch = {f"k_{i}": "v" for i in range(MAX_CUSTOM_KEYS)}
+            ok = client._call(
+                "workspace.set_metadata",
+                {"workspace_id": workspace_id, "metadata": batch},
+            )
+            stored = ok.get("metadata") or {}
+            if len([k for k in stored if k not in ("description", "icon")]) != MAX_CUSTOM_KEYS:
+                raise cmuxError(
+                    f"Expected exactly {MAX_CUSTOM_KEYS} custom keys after batch fill: {stored!r}"
+                )
+
+            _expect_error(
+                client,
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "over_the_limit",
+                    "value": "x",
+                },
+                code_prefix="too_many_keys",
+            )
+
+            # Canonical keys still allowed past the custom cap (they don't count).
+            ok_canonical = client._call(
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "description",
+                    "value": "ok",
+                },
+            )
+            assert (ok_canonical.get("metadata") or {}).get("description") == "ok"
+        finally:
+            try:
+                client.close_workspace(workspace_id)
+            except Exception:
+                pass
+
+    print("PASS: workspace.set_metadata enforces key/value/capacity limits")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_workspace_metadata_roundtrip.py
+++ b/tests_v2/test_workspace_metadata_roundtrip.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""workspace.set_metadata / workspace.get_metadata / workspace.clear_metadata roundtrip."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        workspace_id = client.new_workspace()
+        try:
+            set_payload = client._call(
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "key": "description",
+                    "value": "Backend refactor",
+                },
+            )
+            metadata = set_payload.get("metadata") or {}
+            _must(
+                metadata.get("description") == "Backend refactor",
+                f"set_metadata should return the new description: {set_payload!r}",
+            )
+
+            get_payload = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            stored = get_payload.get("metadata") or {}
+            _must(
+                stored.get("description") == "Backend refactor",
+                f"get_metadata should return the stored description: {get_payload!r}",
+            )
+
+            _ = client._call(
+                "workspace.set_metadata",
+                {
+                    "workspace_id": workspace_id,
+                    "metadata": {"icon": "🦊", "project.tag": "alpha"},
+                },
+            )
+            get_all = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            stored = get_all.get("metadata") or {}
+            _must(stored.get("description") == "Backend refactor", f"description persisted after subsequent write: {stored!r}")
+            _must(stored.get("icon") == "🦊", f"icon stored via batch write: {stored!r}")
+            _must(stored.get("project.tag") == "alpha", f"custom key stored: {stored!r}")
+
+            get_single = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id, "key": "icon"},
+            )
+            _must(get_single.get("value") == "🦊", f"single-key get should expose 'value': {get_single!r}")
+
+            # Delete a single key via value=null.
+            _ = client._call(
+                "workspace.set_metadata",
+                {"workspace_id": workspace_id, "key": "project.tag", "value": None},
+            )
+            after_delete = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            after = after_delete.get("metadata") or {}
+            _must("project.tag" not in after, f"project.tag should be deleted: {after!r}")
+            _must(after.get("description") == "Backend refactor", f"description survives delete: {after!r}")
+
+            # Clear a specific key.
+            _ = client._call(
+                "workspace.clear_metadata",
+                {"workspace_id": workspace_id, "keys": ["icon"]},
+            )
+            after_clear_one = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            remaining = after_clear_one.get("metadata") or {}
+            _must("icon" not in remaining, f"icon should be cleared: {remaining!r}")
+
+            # Clear all.
+            _ = client._call(
+                "workspace.clear_metadata",
+                {"workspace_id": workspace_id},
+            )
+            after_all = client._call(
+                "workspace.get_metadata",
+                {"workspace_id": workspace_id},
+            )
+            _must(
+                (after_all.get("metadata") or {}) == {},
+                f"clear_metadata without keys should empty the store: {after_all!r}",
+            )
+        finally:
+            try:
+                client.close_workspace(workspace_id)
+            except Exception:
+                pass
+
+    print("PASS: workspace metadata roundtrip (set/get/clear) via socket")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

**Tier 1 persistence, Phase 2.** Surface metadata written via
`surface.set_metadata` (and its heuristic / OSC / declare counterparts)
now survives c11mux restarts with full source-record fidelity.

Stacked on top of PR #11 (workspace metadata persistence) — this PR
includes those commits and adds Phase 2 on top. **Intended to supersede
PR #11.**

Plan doc: [c11mux-tier1-persistence-plan.md](docs/c11mux-tier1-persistence-plan.md)
(Phase 2 section).

## What Phase 2 adds on top of PR #11

### Types
- `PersistedJSONValue` — Codable enum covering string / number / bool /
  array / object / null. Decode order checks Bool before Double so
  `.bool(true)` never surfaces as `.number(1)` after a round-trip.
- `PersistedMetadataSource` — sidecar preserving
  `MetadataSource` raw value + timestamp so the precedence chain
  (`explicit > declare > osc > heuristic`) survives restart.

### Schema
- `SessionPanelSnapshot` gains two optional fields: `metadata` and
  `metadataSources`. **Schema stays at v1** — the fields are optional,
  so pre-Phase-2 snapshots decode cleanly and older builds ignore them.

### Bridge
- `PersistedMetadataBridge` encode/decode between live `[String: Any]`
  and persisted types.
- **Bool vs NSNumber discrimination:** uses `CFBooleanGetTypeID()` to
  distinguish actual bools from `NSNumber(value: 0|1)` — Swift's `as?
  Bool` alone conflates them, and JSONSerialization happily emits
  `true`/`false` as `CFBoolean`.
- Drops + logs non-JSON-representable values (Date, URL, custom
  classes, NaN, ±Inf) without crashing the snapshot write.
- Array element drops substitute `.null` to keep positional semantics.

### Capture + Restore
- `Workspace.sessionPanelSnapshot(…)` captures live metadata before the
  `SessionPanelSnapshot(` constructor, bridges it, enforces the 64 KiB
  per-surface cap as a boundary guard, and emits the new optional
  fields. Empty stores emit nil so snapshots stay small.
- `SurfaceMetadataStore.restoreFromSnapshot(…)` is a new write entry
  that bypasses the precedence chain — the snapshot IS the prior
  session's truth. **Silent** — no notifications. Observer
  infrastructure is deferred to Phase 3.
- Wired into `Workspace.restoreSessionSnapshot` right before
  `pruneSurfaceMetadata`, so stale entries get cleaned up on the
  same tick.

### `metadataStoreRevision` counter + autosave fingerprint
- New monotonic counter on `SurfaceMetadataStore`, bumped only when
  state actually changes (no-op same-value same-source writes preserve
  the prior `SourceRecord` and do not bump; lower-precedence rejections
  don't bump).
- Folded into `TabManager.sessionAutosaveFingerprint()`.
- **This is correctness, not optimization.** Without it, metadata-only
  changes between 8s autosave ticks silently skip the disk write
  because the fingerprint stays unchanged — data lost on crash/quit.

### Rollback env var
- `CMUX_DISABLE_METADATA_PERSIST=1` in the **app's launch environment**
  (e.g. `launchctl setenv` or parent shell before `.app` launch) skips
  persist on write and ignores on restore. App-launch-scope only —
  setting it on the CLI has no effect because the CLI is a separate
  process.

### `debug.session.save_and_load` DEBUG socket command
- **New DEBUG-only socket method** for the Python round-trip test.
  Gated `#if DEBUG`, not advertised in `system.capabilities`. Forces a
  synchronous save to disk, clears in-memory `SurfaceMetadataStore`
  entries, then reloads from disk and replays.
- Phase 1's `debug.session.round_trip` and Phase 1.5's
  `debug.session.round_trip_workspaces` both merged and live on main,
  but they exercise in-memory encode/decode only.
  `debug.session.save_and_load` is the first on-disk round-trip harness
  — required because Phase 2 persistence lives on disk.

### Tests
Four new Swift unit test files:
- `MetadataPersistenceRoundTripTests` — primitive + nested JSON
  round-trip, Bool/number ordering regression guards,
  `PersistedMetadataSource` round-trip, `SessionPanelSnapshot`
  backcompat (both directions), bridge symmetry.
- `MetadataPersistencePrecedenceTests` — restore bypasses precedence,
  post-restore writes respect precedence against the restored record.
- `MetadataPersistenceUncoercibleTests` — custom classes, NaN/Inf,
  Date, URL all drop; array index stability via `.null` substitution.
- `MetadataStoreRevisionCounterTests` — mutations bump, no-ops don't,
  restore bumps, 200-write concurrent atomicity test.

Python tests:
- `tests_v2/test_metadata_persistence.py` — main + rollback variants,
  selected by `CMUX_DISABLE_METADATA_PERSIST` in the test env.
- `tests_v2/test_m7_titlebar_description_roundtrip.py` extended with
  a persist case proving title + description survive restart with
  `.explicit` source preserved.

### Docs
- `docs/socket-api-reference.md` — new Surface Metadata Persistence
  subsection + `CMUX_DISABLE_METADATA_PERSIST` in the env var table.

## Files touched

Phase 2 additions / edits only:
- `Sources/PersistedMetadata.swift` (new)
- `Sources/SessionPersistence.swift` (add optional fields on `SessionPanelSnapshot`)
- `Sources/SurfaceMetadataStore.swift` (restore API + revision counter + bump sites)
- `Sources/Workspace.swift` (capture + restore wiring)
- `Sources/TabManager.swift` (fingerprint folds in `currentRevision()`)
- `Sources/AppDelegate.swift` (`debugForceMetadataSaveAndLoad` DEBUG helper)
- `Sources/TerminalController.swift` (`debug.session.save_and_load` v2 handler)
- `GhosttyTabs.xcodeproj/project.pbxproj` (5 new Swift files wired in)
- `cmuxTests/MetadataPersistence{RoundTrip,Precedence,Uncoercible}Tests.swift` (new)
- `cmuxTests/MetadataStoreRevisionCounterTests.swift` (new)
- `tests_v2/test_metadata_persistence.py` (new)
- `tests_v2/test_m7_titlebar_description_roundtrip.py` (extended)
- `docs/socket-api-reference.md`

## Decisions worth noting

- **Audit finding:** `sessionFingerprint` — referenced in the plan — does
  not exist in `AppDelegate`. The actual fingerprint is
  `TabManager.sessionAutosaveFingerprint()` (already extended by PR #11
  for workspace-level metadata). Phase 2 folds
  `SurfaceMetadataStore.currentRevision()` into the same hasher.
- **`debug.session.save_and_load` is new for Phase 2** because Phase 1's
  `debug.session.round_trip` and Phase 1.5's
  `debug.session.round_trip_workspaces` (both already on main) only
  exercise in-memory encode/decode. Phase 2 persistence is on-disk, so
  a real save+load cycle is required.
- **`setInternal` bumps the revision too** (plan only named
  `setMetadata`/`clearMetadata`). AgentDetector writes go through
  `setInternal` and absolutely need to trigger autosave or
  heuristic-only sessions silently lose state between ticks.
- **Cleanup paths (`pruneWorkspace`/`removeSurface`) do NOT bump** —
  they fire when surfaces close, and panel/workspace counts already
  cover that in the existing fingerprint.
- **Array element drops substitute `.null`** (rather than compacting)
  so consumer code that indexes into arrays stays consistent.
- **Restore is silent** — no notifications. Adding observer
  infrastructure is Phase 3.

## Followups (Phase 3+)

- `statusEntries` persistence (Phase 3). Will need the observer
  pipeline on `SurfaceMetadataStore` that Phase 2 intentionally
  deferred.
- Claude session index + recovery UI (Phases 4 / 5).
- Delete the `CMUX_DISABLE_METADATA_PERSIST` rollback env var one
  release after Phase 2 is stable.

## Test plan

- [x] `xcodebuild -scheme cmux -configuration Debug` builds clean
  locally at `/tmp/cmux-metadata-persist`.
- [x] `xcodebuild -scheme cmux-unit build-for-testing` builds clean.
- [ ] CI runs `cmux-unit` + `tests_v2/test_metadata_persistence.py`
  (main) + extended M7 titlebar persist case.
- [ ] CI runs `tests_v2/test_metadata_persistence.py` with
  `CMUX_DISABLE_METADATA_PERSIST=1` set in the tagged app's launch env.
- [ ] Reviewer: verify commit structure (types → bridge →
  capture/restore → counter → debug-command → tests → docs) is
  followable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
