### PR TITLE
M9: port TextBox Input from alumican/cmux-tb fork

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		A5001540 /* PortScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001541 /* PortScanner.swift */; };
 		A5001542 /* SurfaceMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001543 /* SurfaceMetadataStore.swift */; };
 		A5001544 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* AgentDetector.swift */; };
+		A5001700 /* TextBoxInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001701 /* TextBoxInput.swift */; };
+		A5001702 /* TextBoxInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001703 /* TextBoxInputTests.swift */; };
 		A5008F11 /* SurfaceTitleBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F12 /* SurfaceTitleBarView.swift */; };
 		A5008F21 /* TitleFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008F22 /* TitleFormatting.swift */; };
 			A5001006 /* GhosttyKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5001016 /* GhosttyKit.xcframework */; };
@@ -198,6 +200,8 @@
 		A5001541 /* PortScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScanner.swift; sourceTree = "<group>"; };
 		A5001543 /* SurfaceMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetadataStore.swift; sourceTree = "<group>"; };
 		A5001545 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
+		A5001701 /* TextBoxInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInput.swift; sourceTree = "<group>"; };
+		A5001703 /* TextBoxInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInputTests.swift; sourceTree = "<group>"; };
 		A5008F12 /* SurfaceTitleBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarView.swift; sourceTree = "<group>"; };
 		A5008F22 /* TitleFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleFormatting.swift; sourceTree = "<group>"; };
 			A5001016 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
@@ -440,6 +444,7 @@
 				A5001541 /* PortScanner.swift */,
 				A5001543 /* SurfaceMetadataStore.swift */,
 				A5001545 /* AgentDetector.swift */,
+				A5001701 /* TextBoxInput.swift */,
 				A5008F12 /* SurfaceTitleBarView.swift */,
 				A5008F22 /* TitleFormatting.swift */,
 				A5001225 /* SocketControlSettings.swift */,
@@ -547,6 +552,7 @@
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
+					A5001703 /* TextBoxInputTests.swift */,
 					F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
 					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
@@ -743,6 +749,7 @@
 				A5001540 /* PortScanner.swift in Sources */,
 				A5001542 /* SurfaceMetadataStore.swift in Sources */,
 				A5001544 /* AgentDetector.swift in Sources */,
+			A5001700 /* TextBoxInput.swift in Sources */,
 				A5008F11 /* SurfaceTitleBarView.swift in Sources */,
 				A5008F21 /* TitleFormatting.swift in Sources */,
 				A5001226 /* SocketControlSettings.swift in Sources */,
@@ -817,6 +824,7 @@
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */,
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
+					A5001702 /* TextBoxInputTests.swift in Sources */,
 					F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -115,210 +115,6 @@
         }
       }
     },
-    "cli.claude-teams.usage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Usage: cmux claude-teams [claude-args...]\n\nLaunch Claude Code with agent teams enabled.\n\nThis command:\n  - defaults Claude teammate mode to auto\n  - sets a tmux-like environment so Claude auto mode uses cmux splits\n  - sets CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1\n  - prepends a private tmux shim to PATH\n  - forwards all remaining arguments to claude\n\nThe tmux shim translates supported tmux window/pane commands into cmux\nworkspace and split operations in the current cmux session.\n\nExamples:\n  cmux claude-teams\n  cmux claude-teams --continue\n  cmux claude-teams --model sonnet"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使い方: cmux claude-teams [claude-args...]\n\nエージェントチームを有効にした状態で Claude Code を起動します。\n\nこのコマンドは次を行います:\n  - Claude の teammate mode を auto に設定\n  - Claude の auto mode が cmux の split を使うよう tmux 風の環境を設定\n  - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 を設定\n  - 専用の tmux shim を PATH の先頭に追加\n  - 残りの引数をそのまま claude に渡す\n\ntmux shim は、対応している tmux の window/pane コマンドを、現在の cmux セッション内の workspace と split 操作に変換します。\n\n例:\n  cmux claude-teams\n  cmux claude-teams --continue\n  cmux claude-teams --model sonnet"
-          }
-        }
-      }
-    },
-    "applescript.error.disabled": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "AppleScript is disabled by the macos-applescript configuration."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "macos-applescript の設定で AppleScript は無効になっています。"
-          }
-        }
-      }
-    },
-    "applescript.error.failedToCreateSplit": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to create split."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分割の作成に失敗しました。"
-          }
-        }
-      }
-    },
-    "applescript.error.failedToCreateWindow": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to create window."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウインドウの作成に失敗しました。"
-          }
-        }
-      }
-    },
-    "applescript.error.failedToCreateWorkspace": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed to create workspace."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースの作成に失敗しました。"
-          }
-        }
-      }
-    },
-    "applescript.error.missingAction": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing action string."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "アクション文字列がありません。"
-          }
-        }
-      }
-    },
-    "applescript.error.missingInputText": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing input text."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "入力するテキストがありません。"
-          }
-        }
-      }
-    },
-    "applescript.error.missingSplitDirection": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing or unknown split direction."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分割方向がないか、不明です。"
-          }
-        }
-      }
-    },
-    "applescript.error.missingTerminalTarget": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing terminal target."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "対象のターミナルがありません。"
-          }
-        }
-      }
-    },
-    "applescript.error.terminalUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Terminal is no longer available."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ターミナルはもう利用できません。"
-          }
-        }
-      }
-    },
-    "applescript.error.windowUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Window is no longer available."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ウインドウはもう利用できません。"
-          }
-        }
-      }
-    },
-    "applescript.error.workspaceUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Workspace is no longer available."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースはもう利用できません。"
-          }
-        }
-      }
-    },
     "about.build": {
       "extractionState": "manual",
       "localizations": {
@@ -767,822 +563,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Belgeler"
-          }
-        }
-      }
-    },
-    "debug.devBuildBanner.show": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Dev Build Banner"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "開発ビルドバナーを表示"
-          }
-        }
-      }
-    },
-    "debug.menu.openStressWorkspacesWithLoadedSurfaces": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open Stress Workspaces and Load All Terminals"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "負荷テスト用ワークスペースを開いてすべてのターミナルを読み込む"
-          }
-        }
-      }
-    },
-    "debug.menu.browserToolbarButtonSpacing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser Toolbar Button Spacing"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーツールバーのボタン間隔"
-          }
-        }
-      }
-    },
-    "debug.menu.browserProfilePopoverDebug": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser Profile Popover Debug…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザープロファイルポップオーバーのデバッグ…"
-          }
-        }
-      }
-    },
-    "debug.windows.browserProfilePopover.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser Profile Popover Debug"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザープロファイルポップオーバーのデバッグ"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.heading": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser Profile Popover"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザープロファイルポップオーバー"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.note": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tune the profile popover padding live while comparing it against the browser toolbar menu."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーツールバーのメニューと見比べながら、プロファイルポップオーバーの余白をライブで調整します。"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.group.padding": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Padding"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "余白"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.label.horizontal": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Horizontal"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "水平"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.label.vertical": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vertical"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "垂直"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.group.preview": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Preview"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プレビュー"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.reset": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リセット"
-          }
-        }
-      }
-    },
-    "debug.browserProfilePopover.liveNote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changes apply live to the browser profile popover."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "変更はブラウザープロファイルポップオーバーにライブで反映されます。"
-          }
-        }
-      }
-    },
-    "debug.devBuildBanner.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "THIS IS A DEV BUILD"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "これは開発ビルドです"
-          }
-        }
-      }
-    },
-    "sidebar.help.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Help"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ヘルプ"
-          }
-        }
-      }
-    },
-    "sidebar.help.welcome": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Welcome to c11mux!"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "c11muxへようこそ！"
-          }
-        }
-      }
-    },
-    "sidebar.help.changelog": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Changelog"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "更新履歴"
-          }
-        }
-      }
-    },
-    "sidebar.help.discord": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discord"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discord"
-          }
-        }
-      }
-    },
-    "sidebar.help.githubIssues": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GitHub Issues"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GitHub Issues"
-          }
-        }
-      }
-    },
-    "sidebar.help.sendFeedback": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send Feedback"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバックを送信"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.attachImages": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attach Images"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像を添付"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.attachImages.prompt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attach"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "添付"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.attachImages.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Attach Images"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像を添付"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.attachmentsHint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Up to 10 images."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像は最大10枚まで添付できます。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンセル"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.connectionError": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't send feedback. Check your connection and try again."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバックを送信できませんでした。接続を確認して、もう一度お試しください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.done": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Done"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "完了"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.email": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your Email"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メールアドレス"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.emailPlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "you@example.com"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "you@example.com"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.emptyMessage": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter a message before sending."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "送信する前にメッセージを入力してください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.endpointError": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feedback is unavailable right now. Email founders@manaflow.com instead."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在フィードバックを送信できません。代わりに founders@manaflow.com までメールしてください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.genericError": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couldn't send feedback. Please try again."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバックを送信できませんでした。もう一度お試しください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.imageTooLarge": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Each image must be 4 MB or smaller."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "各画像は 4 MB 以下にしてください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.invalidEmail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enter a valid email address."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効なメールアドレスを入力してください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.invalidImageSelection": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "One of the selected files could not be attached."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択したファイルのうち1つを添付できませんでした。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Message"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メッセージ"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.messagePlaceholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Share feedback, feature requests, or issues."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバック、機能要望、不具合をお知らせください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.messageTooLong": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Your message is too long."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メッセージが長すぎます。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.note": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can also reach us at founders@manaflow.com."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.rateLimited": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Too many feedback attempts. Please try again later."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバックの送信回数が多すぎます。しばらくしてからもう一度お試しください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.removeAttachment": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Remove"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "削除"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.send": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "送信"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.successBody": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can also reach us at founders@manaflow.com."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.successTitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thanks for the feedback."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバックありがとうございます。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Send Feedback"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィードバックを送信"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.tooManyImages": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can attach up to 10 images."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "画像は最大10枚まで添付できます。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.totalImagesTooLarge": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "These images are too large to send together. Remove a few and try again."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "これらの画像はまとめて送信するには大きすぎます。いくつか削除してもう一度お試しください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.feedback.validationError": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Check your message and attachments, then try again."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "メッセージと添付ファイルを確認して、もう一度お試しください。"
           }
         }
       }
@@ -4525,6 +3505,193 @@
         }
       }
     },
+    "applescript.error.disabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "AppleScript is disabled by the macos-applescript configuration."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macos-applescript の設定で AppleScript は無効になっています。"
+          }
+        }
+      }
+    },
+    "applescript.error.failedToCreateSplit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create split."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分割の作成に失敗しました。"
+          }
+        }
+      }
+    },
+    "applescript.error.failedToCreateWindow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create window."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウインドウの作成に失敗しました。"
+          }
+        }
+      }
+    },
+    "applescript.error.failedToCreateWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed to create workspace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースの作成に失敗しました。"
+          }
+        }
+      }
+    },
+    "applescript.error.missingAction": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing action string."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクション文字列がありません。"
+          }
+        }
+      }
+    },
+    "applescript.error.missingInputText": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing input text."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力するテキストがありません。"
+          }
+        }
+      }
+    },
+    "applescript.error.missingSplitDirection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing or unknown split direction."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分割方向がないか、不明です。"
+          }
+        }
+      }
+    },
+    "applescript.error.missingTerminalTarget": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing terminal target."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対象のターミナルがありません。"
+          }
+        }
+      }
+    },
+    "applescript.error.terminalUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal is no longer available."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルはもう利用できません。"
+          }
+        }
+      }
+    },
+    "applescript.error.windowUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Window is no longer available."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウインドウはもう利用できません。"
+          }
+        }
+      }
+    },
+    "applescript.error.workspaceUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace is no longer available."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースはもう利用できません。"
+          }
+        }
+      }
+    },
     "browser.action.newTab": {
       "extractionState": "manual",
       "localizations": {
@@ -4747,1451 +3914,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Arayın veya URL girin"
-          }
-        }
-      }
-    },
-    "browser.profile.buttonHelp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser Profile: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザープロファイル: %@"
-          }
-        }
-      }
-    },
-    "browser.profile.default": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Default"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デフォルト"
-          }
-        }
-      }
-    },
-    "browser.profile.menu.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profiles"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロファイル"
-          }
-        }
-      }
-    },
-    "browser.profile.new": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Profile..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新しいプロファイル..."
-          }
-        }
-      }
-    },
-    "browser.profile.new.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create a separate browser profile for cookies, history, and local storage."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cookie、履歴、ローカルストレージを分けるためのブラウザープロファイルを作成します。"
-          }
-        }
-      }
-    },
-    "browser.profile.new.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profile name"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロファイル名"
-          }
-        }
-      }
-    },
-    "browser.profile.new.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "New Browser Profile"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新しいブラウザープロファイル"
-          }
-        }
-      }
-    },
-    "browser.profile.rename": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rename Current Profile..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在のプロファイル名を変更..."
-          }
-        }
-      }
-    },
-    "browser.profile.rename.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose a new name for this browser profile."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このブラウザープロファイルの新しい名前を入力します。"
-          }
-        }
-      }
-    },
-    "browser.profile.rename.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Rename Browser Profile"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザープロファイル名を変更"
-          }
-        }
-      }
-    },
-    "browser.import.additionalData.note": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bookmarks, settings, and extensions are not available yet."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブックマーク、設定、拡張機能はまだ利用できません。"
-          }
-        }
-      }
-    },
-    "browser.import.additionalData": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Additional data (bookmarks, settings, extensions)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "追加データ（ブックマーク、設定、拡張機能）"
-          }
-        }
-      }
-    },
-    "browser.import.back": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Back"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "戻る"
-          }
-        }
-      }
-    },
-    "browser.import.complete.browser": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザー: %@"
-          }
-        }
-      }
-    },
-    "browser.import.complete.createdProfiles": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Created c11mux profiles: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作成した c11mux プロファイル: %@"
-          }
-        }
-      }
-    },
-    "browser.import.complete.destinationProfile": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Destination profile: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存先プロファイル: %@"
-          }
-        }
-      }
-    },
-    "browser.import.complete.domainFilter": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Domain filter: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドメインフィルタ: %@"
-          }
-        }
-      }
-    },
-    "browser.import.complete.profileMapping": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ -> %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$@ -> %2$@"
-          }
-        }
-      }
-    },
-    "browser.import.complete.profileMappings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profile mappings:"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロファイル対応:"
-          }
-        }
-      }
-    },
-    "browser.import.complete.importedCookies": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Imported cookies: %ld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートしたCookie: %ld"
-          }
-        }
-      }
-    },
-    "browser.import.complete.importedHistory": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Imported history entries: %ld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートした履歴件数: %ld"
-          }
-        }
-      }
-    },
-    "browser.import.complete.scope": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Scope: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "対象: %@"
-          }
-        }
-      }
-    },
-    "browser.import.complete.skippedCookies": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skipped cookies: %ld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "スキップしたCookie: %ld"
-          }
-        }
-      }
-    },
-    "browser.import.complete.sourceProfiles": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Source profiles: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "元プロファイル: %@"
-          }
-        }
-      }
-    },
-    "browser.import.complete.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser data import complete"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータのインポートが完了しました"
-          }
-        }
-      }
-    },
-    "browser.import.complete.warnings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Warnings:"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "警告:"
-          }
-        }
-      }
-    },
-    "browser.import.cookies": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cookies (site sign-ins)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cookie（サイトのログイン状態）"
-          }
-        }
-      }
-    },
-    "browser.import.destination.cmux": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Destination"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "保存先"
-          }
-        }
-      }
-    },
-    "browser.import.destinationProfile": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import into"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポート先"
-          }
-        }
-      }
-    },
-    "browser.import.destinationProfile.create": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create \"%@\""
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "\"%@\" を作成"
-          }
-        }
-      }
-    },
-    "browser.import.destinationProfile.help": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Imported data goes into the selected cmux profile."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートしたデータは、選択した cmux プロファイルに保存されます。"
-          }
-        }
-      }
-    },
-    "browser.import.destinationProfile.mergeHelp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "All selected source profiles go into one c11mux profile."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択した元プロファイルは、1つの c11mux プロファイルにまとめて取り込まれます。"
-          }
-        }
-      }
-    },
-    "browser.import.destinationProfile.separateHelp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Missing c11mux profiles are created on import."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "不足している c11mux プロファイルは、インポート時に作成されます。"
-          }
-        }
-      }
-    },
-    "browser.import.destinationMode.merge": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Merge into one"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1つにまとめる"
-          }
-        }
-      }
-    },
-    "browser.import.destinationMode.separate": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Separate profiles"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "分けて取り込む"
-          }
-        }
-      }
-    },
-    "browser.import.detected.all": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detected: %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検出済み: %@。"
-          }
-        }
-      }
-    },
-    "browser.import.detected.more.one": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detected: %@, +1 more."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検出済み: %@、ほか1件。"
-          }
-        }
-      }
-    },
-    "browser.import.detected.more.other": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Detected: %@, +%ld more."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "検出済み: %@、ほか%ld件。"
-          }
-        }
-      }
-    },
-    "browser.import.detected.none": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No supported browsers detected."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "対応しているブラウザーが見つかりませんでした。"
-          }
-        }
-      }
-    },
-    "browser.import.domain": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Domains"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ドメイン"
-          }
-        }
-      }
-    },
-    "browser.import.domain.placeholder": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Optional domains, comma-separated"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "任意のドメインをカンマ区切りで指定"
-          }
-        }
-      }
-    },
-    "browser.import.error.destinationCreateFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "c11mux could not create the destination profile \"%@\"."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "c11mux は保存先プロファイル「%@」を作成できませんでした。"
-          }
-        }
-      }
-    },
-    "browser.import.error.destinationMissing": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The selected c11mux browser profile no longer exists. Pick a destination profile again."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択した c11mux ブラウザープロファイルが見つかりません。保存先プロファイルを選び直してください。"
-          }
-        }
-      }
-    },
-    "browser.import.error.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import could not start"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートを開始できませんでした"
-          }
-        }
-      }
-    },
-    "browser.import.history": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History (visited pages)"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴（訪問したページ）"
-          }
-        }
-      }
-    },
-    "browser.import.next": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Next"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "次へ"
-          }
-        }
-      }
-    },
-    "browser.import.noBrowsers.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "c11mux could not find browser profiles to import from on this Mac."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "このMacでインポート元にできるブラウザープロファイルが見つかりませんでした。"
-          }
-        }
-      }
-    },
-    "browser.import.noBrowsers.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No importable browsers found"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートできるブラウザーが見つかりません"
-          }
-        }
-      }
-    },
-    "browser.import.progress.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importing %@ from %@…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%2$@ から %1$@ をインポート中…"
-          }
-        }
-      }
-    },
-    "browser.import.progress.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This can take a few seconds for large profiles."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロファイルが大きい場合は数秒かかることがあります。"
-          }
-        }
-      }
-    },
-    "browser.import.progress.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Importing Browser Data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータをインポート中"
-          }
-        }
-      }
-    },
-    "browser.import.scope.cookiesAndHistory": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cookies + history"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cookie + 履歴"
-          }
-        }
-      }
-    },
-    "browser.import.scope.cookiesOnly": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cookies only"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cookieのみ"
-          }
-        }
-      }
-    },
-    "browser.import.scope.everything": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Everything"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "すべて"
-          }
-        }
-      }
-    },
-    "browser.import.scope.historyOnly": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "History only"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "履歴のみ"
-          }
-        }
-      }
-    },
-    "browser.import.source": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザー"
-          }
-        }
-      }
-    },
-    "browser.import.sourceProfile.fallback": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profile %ld"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロファイル%ld"
-          }
-        }
-      }
-    },
-    "browser.import.sourceProfiles": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Profiles"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロファイル"
-          }
-        }
-      }
-    },
-    "browser.import.sourceProfiles.help": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select one or more profiles."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1つ以上のプロファイルを選択してください。"
-          }
-        }
-      }
-    },
-    "browser.import.sourceProfiles.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No source profiles detected for %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ の元プロファイルが見つかりません。"
-          }
-        }
-      }
-    },
-    "browser.import.start": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Start Import"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポート開始"
-          }
-        }
-      }
-    },
-    "browser.import.step.dataTypes": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Step 3 of 3"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "3 / 3"
-          }
-        }
-      }
-    },
-    "browser.import.step.source": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Step 1 of 3"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "1 / 3"
-          }
-        }
-      }
-    },
-    "browser.import.step.sourceProfiles": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Step 2 of 3"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "2 / 3"
-          }
-        }
-      }
-    },
-    "browser.import.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import Browser Data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータをインポート"
-          }
-        }
-      }
-    },
-    "browser.import.hint.dismiss": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide Hint"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ヒントを隠す"
-          }
-        }
-      }
-    },
-    "browser.import.hint.import": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポート…"
-          }
-        }
-      }
-    },
-    "browser.import.hint.settings": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser Settings"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザー設定"
-          }
-        }
-      }
-    },
-    "browser.import.hint.settingsFootnote": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "You can always find this in Settings > Browser."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "あとでいつでも「設定 > ブラウザー」で見つけられます。"
-          }
-        }
-      }
-    },
-    "browser.import.hint.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import browser data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータをインポート"
-          }
-        }
-      }
-    },
-    "browser.import.hint.toolbar": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポート"
-          }
-        }
-      }
-    },
-    "browser.import.hint.toolbar.help": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import browser data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータをインポート"
-          }
-        }
-      }
-    },
-    "browser.import.validation.scope": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Select Cookies, History, or both before starting import."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートを始める前に、Cookie、履歴、またはその両方を選択してください。"
-          }
-        }
-      }
-    },
-    "browser.import.validation.sourceProfiles": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose at least one source profile to import."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インポートする元プロファイルを少なくとも1つ選択してください。"
-          }
-        }
-      }
-    },
-    "browser.import.warning.additionalDataUnavailable": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Bookmarks, settings, and extensions import are not available yet. Imported cookies and history only."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブックマーク、設定、拡張機能のインポートにはまだ対応していません。Cookieと履歴のみを取り込みました。"
-          }
-        }
-      }
-    },
-    "browser.import.warning.browserCookiesReadFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed reading %@ cookies at %@: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ のCookieを %@ から読み込めませんでした: %@"
-          }
-        }
-      }
-    },
-    "browser.import.warning.browserHistoryReadFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed reading %@ history at %@: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ の履歴を %@ から読み込めませんでした: %@"
-          }
-        }
-      }
-    },
-    "browser.import.warning.cookieImportUnsupported": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ cookie import is not implemented yet."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ のCookieインポートにはまだ対応していません。"
-          }
-        }
-      }
-    },
-    "browser.import.warning.encryptedCookiesSkipped": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skipped %ld encrypted cookies that require Keychain decryption."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keychainでの復号が必要な暗号化Cookieを%ld件スキップしました。"
-          }
-        }
-      }
-    },
-    "browser.import.warning.keychainDecryptFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Skipped %ld encrypted %@ cookies because %@ could not be unlocked from Keychain."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keychain から %3$@ を開けなかったため、暗号化された %2$@ のCookieを%1$ld件スキップしました。"
-          }
-        }
-      }
-    },
-    "browser.import.warning.firefoxCookiesReadFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed reading Firefox cookies at %@: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Firefox のCookieを %@ から読み込めませんでした: %@"
-          }
-        }
-      }
-    },
-    "browser.import.warning.firefoxHistoryReadFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Failed reading Firefox history at %@: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Firefox の履歴を %@ から読み込めませんでした: %@"
-          }
-        }
-      }
-    },
-    "browser.import.warning.noHistoryDatabase": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No history database found for %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ の履歴データベースが見つかりませんでした。"
-          }
-        }
-      }
-    },
-    "browser.import.warning.safariCookiesUnsupported": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Safari cookies are stored in Cookies.binarycookies and are not yet supported by this importer."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Safari のCookieは Cookies.binarycookies に保存されており、このインポーターではまだ対応していません。"
-          }
-        }
-      }
-    },
-    "browser.theme.buttonHelp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Browser Theme: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーテーマ: %@"
           }
         }
       }
@@ -8682,6 +6404,1264 @@
         }
       }
     },
+    "browser.import.additionalData": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Additional data (bookmarks, settings, extensions)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "追加データ（ブックマーク、設定、拡張機能）"
+          }
+        }
+      }
+    },
+    "browser.import.additionalData.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bookmarks, settings, and extensions are not available yet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブックマーク、設定、拡張機能はまだ利用できません。"
+          }
+        }
+      }
+    },
+    "browser.import.back": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "戻る"
+          }
+        }
+      }
+    },
+    "browser.import.complete.browser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザー: %@"
+          }
+        }
+      }
+    },
+    "browser.import.complete.createdProfiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Created c11mux profiles: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成した c11mux プロファイル: %@"
+          }
+        }
+      }
+    },
+    "browser.import.complete.destinationProfile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destination profile: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存先プロファイル: %@"
+          }
+        }
+      }
+    },
+    "browser.import.complete.domainFilter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain filter: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメインフィルタ: %@"
+          }
+        }
+      }
+    },
+    "browser.import.complete.importedCookies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported cookies: %ld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートしたCookie: %ld"
+          }
+        }
+      }
+    },
+    "browser.import.complete.importedHistory": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported history entries: %ld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートした履歴件数: %ld"
+          }
+        }
+      }
+    },
+    "browser.import.complete.profileMapping": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ -> %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ -> %2$@"
+          }
+        }
+      }
+    },
+    "browser.import.complete.profileMappings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile mappings:"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイル対応:"
+          }
+        }
+      }
+    },
+    "browser.import.complete.scope": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scope: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対象: %@"
+          }
+        }
+      }
+    },
+    "browser.import.complete.skippedCookies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skipped cookies: %ld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキップしたCookie: %ld"
+          }
+        }
+      }
+    },
+    "browser.import.complete.sourceProfiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source profiles: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "元プロファイル: %@"
+          }
+        }
+      }
+    },
+    "browser.import.complete.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser data import complete"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータのインポートが完了しました"
+          }
+        }
+      }
+    },
+    "browser.import.complete.warnings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warnings:"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "警告:"
+          }
+        }
+      }
+    },
+    "browser.import.cookies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookies (site sign-ins)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookie（サイトのログイン状態）"
+          }
+        }
+      }
+    },
+    "browser.import.destination.cmux": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Destination"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存先"
+          }
+        }
+      }
+    },
+    "browser.import.destinationMode.merge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Merge into one"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1つにまとめる"
+          }
+        }
+      }
+    },
+    "browser.import.destinationMode.separate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Separate profiles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "分けて取り込む"
+          }
+        }
+      }
+    },
+    "browser.import.destinationProfile": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import into"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポート先"
+          }
+        }
+      }
+    },
+    "browser.import.destinationProfile.create": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create \"%@\""
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" を作成"
+          }
+        }
+      }
+    },
+    "browser.import.destinationProfile.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Imported data goes into the selected cmux profile."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートしたデータは、選択した cmux プロファイルに保存されます。"
+          }
+        }
+      }
+    },
+    "browser.import.destinationProfile.mergeHelp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All selected source profiles go into one c11mux profile."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した元プロファイルは、1つの c11mux プロファイルにまとめて取り込まれます。"
+          }
+        }
+      }
+    },
+    "browser.import.destinationProfile.separateHelp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Missing c11mux profiles are created on import."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不足している c11mux プロファイルは、インポート時に作成されます。"
+          }
+        }
+      }
+    },
+    "browser.import.detected.all": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detected: %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検出済み: %@。"
+          }
+        }
+      }
+    },
+    "browser.import.detected.more.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detected: %@, +1 more."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検出済み: %@、ほか1件。"
+          }
+        }
+      }
+    },
+    "browser.import.detected.more.other": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detected: %@, +%ld more."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検出済み: %@、ほか%ld件。"
+          }
+        }
+      }
+    },
+    "browser.import.detected.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No supported browsers detected."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対応しているブラウザーが見つかりませんでした。"
+          }
+        }
+      }
+    },
+    "browser.import.domain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domains"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン"
+          }
+        }
+      }
+    },
+    "browser.import.domain.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional domains, comma-separated"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意のドメインをカンマ区切りで指定"
+          }
+        }
+      }
+    },
+    "browser.import.error.destinationCreateFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11mux could not create the destination profile \"%@\"."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11mux は保存先プロファイル「%@」を作成できませんでした。"
+          }
+        }
+      }
+    },
+    "browser.import.error.destinationMissing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The selected c11mux browser profile no longer exists. Pick a destination profile again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択した c11mux ブラウザープロファイルが見つかりません。保存先プロファイルを選び直してください。"
+          }
+        }
+      }
+    },
+    "browser.import.error.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import could not start"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートを開始できませんでした"
+          }
+        }
+      }
+    },
+    "browser.import.hint.dismiss": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Hint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヒントを隠す"
+          }
+        }
+      }
+    },
+    "browser.import.hint.import": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポート…"
+          }
+        }
+      }
+    },
+    "browser.import.hint.settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザー設定"
+          }
+        }
+      }
+    },
+    "browser.import.hint.settingsFootnote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can always find this in Settings > Browser."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "あとでいつでも「設定 > ブラウザー」で見つけられます。"
+          }
+        }
+      }
+    },
+    "browser.import.hint.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import browser data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータをインポート"
+          }
+        }
+      }
+    },
+    "browser.import.hint.toolbar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポート"
+          }
+        }
+      }
+    },
+    "browser.import.hint.toolbar.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import browser data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータをインポート"
+          }
+        }
+      }
+    },
+    "browser.import.history": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History (visited pages)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴（訪問したページ）"
+          }
+        }
+      }
+    },
+    "browser.import.next": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次へ"
+          }
+        }
+      }
+    },
+    "browser.import.noBrowsers.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11mux could not find browser profiles to import from on this Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このMacでインポート元にできるブラウザープロファイルが見つかりませんでした。"
+          }
+        }
+      }
+    },
+    "browser.import.noBrowsers.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No importable browsers found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートできるブラウザーが見つかりません"
+          }
+        }
+      }
+    },
+    "browser.import.progress.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importing %@ from %@…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ から %1$@ をインポート中…"
+          }
+        }
+      }
+    },
+    "browser.import.progress.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This can take a few seconds for large profiles."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイルが大きい場合は数秒かかることがあります。"
+          }
+        }
+      }
+    },
+    "browser.import.progress.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Importing Browser Data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータをインポート中"
+          }
+        }
+      }
+    },
+    "browser.import.scope.cookiesAndHistory": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookies + history"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookie + 履歴"
+          }
+        }
+      }
+    },
+    "browser.import.scope.cookiesOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookies only"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookieのみ"
+          }
+        }
+      }
+    },
+    "browser.import.scope.everything": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Everything"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべて"
+          }
+        }
+      }
+    },
+    "browser.import.scope.historyOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "History only"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴のみ"
+          }
+        }
+      }
+    },
+    "browser.import.source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザー"
+          }
+        }
+      }
+    },
+    "browser.import.sourceProfile.fallback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile %ld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイル%ld"
+          }
+        }
+      }
+    },
+    "browser.import.sourceProfiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profiles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイル"
+          }
+        }
+      }
+    },
+    "browser.import.sourceProfiles.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No source profiles detected for %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の元プロファイルが見つかりません。"
+          }
+        }
+      }
+    },
+    "browser.import.sourceProfiles.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select one or more profiles."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1つ以上のプロファイルを選択してください。"
+          }
+        }
+      }
+    },
+    "browser.import.start": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start Import"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポート開始"
+          }
+        }
+      }
+    },
+    "browser.import.step.dataTypes": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step 3 of 3"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "3 / 3"
+          }
+        }
+      }
+    },
+    "browser.import.step.source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step 1 of 3"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 / 3"
+          }
+        }
+      }
+    },
+    "browser.import.step.sourceProfiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Step 2 of 3"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 / 3"
+          }
+        }
+      }
+    },
+    "browser.import.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Browser Data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータをインポート"
+          }
+        }
+      }
+    },
+    "browser.import.validation.scope": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select Cookies, History, or both before starting import."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートを始める前に、Cookie、履歴、またはその両方を選択してください。"
+          }
+        }
+      }
+    },
+    "browser.import.validation.sourceProfiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose at least one source profile to import."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インポートする元プロファイルを少なくとも1つ選択してください。"
+          }
+        }
+      }
+    },
+    "browser.import.warning.additionalDataUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bookmarks, settings, and extensions import are not available yet. Imported cookies and history only."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブックマーク、設定、拡張機能のインポートにはまだ対応していません。Cookieと履歴のみを取り込みました。"
+          }
+        }
+      }
+    },
+    "browser.import.warning.browserCookiesReadFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed reading %@ cookies at %@: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のCookieを %@ から読み込めませんでした: %@"
+          }
+        }
+      }
+    },
+    "browser.import.warning.browserHistoryReadFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed reading %@ history at %@: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の履歴を %@ から読み込めませんでした: %@"
+          }
+        }
+      }
+    },
+    "browser.import.warning.cookieImportUnsupported": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ cookie import is not implemented yet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のCookieインポートにはまだ対応していません。"
+          }
+        }
+      }
+    },
+    "browser.import.warning.encryptedCookiesSkipped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skipped %ld encrypted cookies that require Keychain decryption."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keychainでの復号が必要な暗号化Cookieを%ld件スキップしました。"
+          }
+        }
+      }
+    },
+    "browser.import.warning.firefoxCookiesReadFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed reading Firefox cookies at %@: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Firefox のCookieを %@ から読み込めませんでした: %@"
+          }
+        }
+      }
+    },
+    "browser.import.warning.firefoxHistoryReadFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Failed reading Firefox history at %@: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Firefox の履歴を %@ から読み込めませんでした: %@"
+          }
+        }
+      }
+    },
+    "browser.import.warning.keychainDecryptFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skipped %ld encrypted %@ cookies because %@ could not be unlocked from Keychain."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keychain から %3$@ を開けなかったため、暗号化された %2$@ のCookieを%1$ld件スキップしました。"
+          }
+        }
+      }
+    },
+    "browser.import.warning.noHistoryDatabase": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No history database found for %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の履歴データベースが見つかりませんでした。"
+          }
+        }
+      }
+    },
+    "browser.import.warning.safariCookiesUnsupported": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safari cookies are stored in Cookies.binarycookies and are not yet supported by this importer."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Safari のCookieは Cookies.binarycookies に保存されており、このインポーターではまだ対応していません。"
+          }
+        }
+      }
+    },
     "browser.newTab": {
       "extractionState": "manual",
       "localizations": {
@@ -9034,6 +8014,176 @@
           "stringUnit": {
             "state": "translated",
             "value": "cmux'ta devam et"
+          }
+        }
+      }
+    },
+    "browser.profile.buttonHelp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Profile: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイル: %@"
+          }
+        }
+      }
+    },
+    "browser.profile.default": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        }
+      }
+    },
+    "browser.profile.menu.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profiles"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイル"
+          }
+        }
+      }
+    },
+    "browser.profile.new": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Profile..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいプロファイル..."
+          }
+        }
+      }
+    },
+    "browser.profile.new.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create a separate browser profile for cookies, history, and local storage."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookie、履歴、ローカルストレージを分けるためのブラウザープロファイルを作成します。"
+          }
+        }
+      }
+    },
+    "browser.profile.new.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイル名"
+          }
+        }
+      }
+    },
+    "browser.profile.new.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Browser Profile"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいブラウザープロファイル"
+          }
+        }
+      }
+    },
+    "browser.profile.rename": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Current Profile..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のプロファイル名を変更..."
+          }
+        }
+      }
+    },
+    "browser.profile.rename.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a new name for this browser profile."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このブラウザープロファイルの新しい名前を入力します。"
+          }
+        }
+      }
+    },
+    "browser.profile.rename.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Browser Profile"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイル名を変更"
           }
         }
       }
@@ -9490,6 +8640,23 @@
         }
       }
     },
+    "browser.theme.buttonHelp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Theme: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーテーマ: %@"
+          }
+        }
+      }
+    },
     "browser.toggleDevTools": {
       "extractionState": "manual",
       "localizations": {
@@ -9599,6 +8766,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Geliştirici Araçlarını Aç/Kapat"
+          }
+        }
+      }
+    },
+    "cli.claude-teams.usage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usage: cmux claude-teams [claude-args...]\n\nLaunch Claude Code with agent teams enabled.\n\nThis command:\n  - defaults Claude teammate mode to auto\n  - sets a tmux-like environment so Claude auto mode uses cmux splits\n  - sets CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1\n  - prepends a private tmux shim to PATH\n  - forwards all remaining arguments to claude\n\nThe tmux shim translates supported tmux window/pane commands into cmux\nworkspace and split operations in the current cmux session.\n\nExamples:\n  cmux claude-teams\n  cmux claude-teams --continue\n  cmux claude-teams --model sonnet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使い方: cmux claude-teams [claude-args...]\n\nエージェントチームを有効にした状態で Claude Code を起動します。\n\nこのコマンドは次を行います:\n  - Claude の teammate mode を auto に設定\n  - Claude の auto mode が cmux の split を使うよう tmux 風の環境を設定\n  - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 を設定\n  - 専用の tmux shim を PATH の先頭に追加\n  - 残りの引数をそのまま claude に渡す\n\ntmux shim は、対応している tmux の window/pane コマンドを、現在の cmux セッション内の workspace と split 操作に変換します。\n\n例:\n  cmux claude-teams\n  cmux claude-teams --continue\n  cmux claude-teams --model sonnet"
           }
         }
       }
@@ -10616,6 +9800,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "cmux CLI Kaldırıldı"
+          }
+        }
+      }
+    },
+    "clipboard.sshError.item": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld. %@ (%@): %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld. %@ (%@): %@"
+          }
+        }
+      }
+    },
+    "clipboard.sshError.single": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH error (%@): %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH エラー (%@): %@"
           }
         }
       }
@@ -14236,6 +13454,40 @@
         }
       }
     },
+    "command.disableMinimalMode.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable Minimal Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミニマルモードを無効にする"
+          }
+        }
+      }
+    },
+    "command.enableMinimalMode.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable Minimal Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミニマルモードを有効にする"
+          }
+        }
+      }
+    },
     "command.equalizeSplits.title": {
       "extractionState": "manual",
       "localizations": {
@@ -14345,40 +13597,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bölmeleri Eşitle"
-          }
-        }
-      }
-    },
-    "command.enableMinimalMode.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Enable Minimal Mode"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ミニマルモードを有効にする"
-          }
-        }
-      }
-    },
-    "command.disableMinimalMode.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disable Minimal Mode"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ミニマルモードを無効にする"
           }
         }
       }
@@ -24638,23 +23856,6 @@
         }
       }
     },
-    "common.create": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Create"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "作成"
-          }
-        }
-      }
-    },
     "common.close": {
       "extractionState": "manual",
       "localizations": {
@@ -24877,6 +24078,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ayrıntıları Kopyala"
+          }
+        }
+      }
+    },
+    "common.create": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成"
           }
         }
       }
@@ -26802,6 +26020,57 @@
         }
       }
     },
+    "contextMenu.copyError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラーをコピー"
+          }
+        }
+      }
+    },
+    "contextMenu.copyErrors": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Errors"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラーをコピー"
+          }
+        }
+      }
+    },
+    "contextMenu.copySshError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy SSH Error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHエラーをコピー"
+          }
+        }
+      }
+    },
     "contextMenu.markWorkspaceRead": {
       "extractionState": "manual",
       "localizations": {
@@ -27250,91 +26519,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Çalışma Alanlarını Okunmadı Olarak İşaretle"
-          }
-        }
-      }
-    },
-    "contextMenu.copyError": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Error"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エラーをコピー"
-          }
-        }
-      }
-    },
-    "contextMenu.copyErrors": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Errors"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エラーをコピー"
-          }
-        }
-      }
-    },
-    "clipboard.sshError.item": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld. %@ (%@): %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%lld. %@ (%@): %@"
-          }
-        }
-      }
-    },
-    "clipboard.sshError.single": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH error (%@): %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH エラー (%@): %@"
-          }
-        }
-      }
-    },
-    "contextMenu.copySshError": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy SSH Error"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSHエラーをコピー"
           }
         }
       }
@@ -28808,6 +27992,244 @@
         }
       }
     },
+    "debug.browserProfilePopover.group.padding": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padding"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "余白"
+          }
+        }
+      }
+    },
+    "debug.browserProfilePopover.group.preview": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preview"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレビュー"
+          }
+        }
+      }
+    },
+    "debug.browserProfilePopover.heading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Profile Popover"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイルポップオーバー"
+          }
+        }
+      }
+    },
+    "debug.browserProfilePopover.label.horizontal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Horizontal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "水平"
+          }
+        }
+      }
+    },
+    "debug.browserProfilePopover.label.vertical": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vertical"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "垂直"
+          }
+        }
+      }
+    },
+    "debug.browserProfilePopover.liveNote": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changes apply live to the browser profile popover."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更はブラウザープロファイルポップオーバーにライブで反映されます。"
+          }
+        }
+      }
+    },
+    "debug.browserProfilePopover.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tune the profile popover padding live while comparing it against the browser toolbar menu."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーツールバーのメニューと見比べながら、プロファイルポップオーバーの余白をライブで調整します。"
+          }
+        }
+      }
+    },
+    "debug.browserProfilePopover.reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        }
+      }
+    },
+    "debug.devBuildBanner.show": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Dev Build Banner"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開発ビルドバナーを表示"
+          }
+        }
+      }
+    },
+    "debug.devBuildBanner.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "THIS IS A DEV BUILD"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これは開発ビルドです"
+          }
+        }
+      }
+    },
+    "debug.menu.browserProfilePopoverDebug": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Profile Popover Debug…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイルポップオーバーのデバッグ…"
+          }
+        }
+      }
+    },
+    "debug.menu.browserToolbarButtonSpacing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Toolbar Button Spacing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーツールバーのボタン間隔"
+          }
+        }
+      }
+    },
+    "debug.menu.openStressWorkspacesWithLoadedSurfaces": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Stress Workspaces and Load All Terminals"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "負荷テスト用ワークスペースを開いてすべてのターミナルを読み込む"
+          }
+        }
+      }
+    },
+    "debug.windows.browserProfilePopover.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Profile Popover Debug"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザープロファイルポップオーバーのデバッグ"
+          }
+        }
+      }
+    },
     "dialog.closeLastTabWindow.message": {
       "extractionState": "manual",
       "localizations": {
@@ -29373,6 +28795,23 @@
         }
       }
     },
+    "dialog.closeTab.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        }
+      }
+    },
     "dialog.closeTab.close": {
       "extractionState": "manual",
       "localizations": {
@@ -29482,23 +28921,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kapat"
-          }
-        }
-      }
-    },
-    "dialog.closeTab.cancel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cancel"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "キャンセル"
           }
         }
       }
@@ -29763,57 +29185,6 @@
         }
       }
     },
-    "dialog.closeWorkspaces.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This will close %1$lld workspaces and all of their panels:\n%2$@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%1$lld 個のワークスペースと、それぞれのすべてのパネルを閉じます:\n%2$@"
-          }
-        }
-      }
-    },
-    "dialog.closeWorkspaces.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Close workspaces?"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースを閉じますか？"
-          }
-        }
-      }
-    },
-    "dialog.closeWorkspacesWindow.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "This will close the current window, its %1$lld workspaces, and all of their panels:\n%2$@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在のウィンドウと、その %1$lld 個のワークスペースと、それぞれのすべてのパネルを閉じます:\n%2$@"
-          }
-        }
-      }
-    },
     "dialog.closeWorkspace.message": {
       "extractionState": "manual",
       "localizations": {
@@ -30036,6 +29407,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Çalışma alanı kapatılsın mı?"
+          }
+        }
+      }
+    },
+    "dialog.closeWorkspaces.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will close %1$lld workspaces and all of their panels:\n%2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld 個のワークスペースと、それぞれのすべてのパネルを閉じます:\n%2$@"
+          }
+        }
+      }
+    },
+    "dialog.closeWorkspaces.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close workspaces?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを閉じますか？"
+          }
+        }
+      }
+    },
+    "dialog.closeWorkspacesWindow.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This will close the current window, its %1$lld workspaces, and all of their panels:\n%2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在のウィンドウと、その %1$lld 個のワークスペースと、それぞれのすべてのパネルを閉じます:\n%2$@"
           }
         }
       }
@@ -32635,6 +32057,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sistem"
+          }
+        }
+      }
+    },
+    "markdown.fileUnavailable.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The file may have been moved or deleted."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルが移動または削除された可能性があります。"
+          }
+        }
+      }
+    },
+    "markdown.fileUnavailable.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを利用できません"
+          }
+        }
+      }
+    },
+    "markdown.mermaid.installHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install @mermaid-js/mermaid-cli for diagram rendering"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "@mermaid-js/mermaid-cli をインストールすると図が表示されます"
           }
         }
       }
@@ -38306,23 +37779,6 @@
         }
       }
     },
-    "menu.view.importFromBrowser": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import Browser Data…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータを取り込む…"
-          }
-        }
-      }
-    },
     "menu.view.forward": {
       "extractionState": "manual",
       "localizations": {
@@ -38432,6 +37888,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "İleri"
+          }
+        }
+      }
+    },
+    "menu.view.importFromBrowser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Browser Data…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータを取り込む…"
           }
         }
       }
@@ -40131,6 +39604,23 @@
         }
       }
     },
+    "menu.view.toggleTextBoxInput": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle TextBox Input"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストボックス入力を切り替え"
+          }
+        }
+      }
+    },
     "menu.view.workspace": {
       "extractionState": "manual",
       "localizations": {
@@ -41617,6 +41107,74 @@
         }
       }
     },
+    "remote.status.connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続済み"
+          }
+        }
+      }
+    },
+    "remote.status.connecting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connecting"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続中"
+          }
+        }
+      }
+    },
+    "remote.status.disconnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disconnected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "切断済み"
+          }
+        }
+      }
+    },
+    "remote.status.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー"
+          }
+        }
+      }
+    },
     "search.close.help": {
       "extractionState": "manual",
       "localizations": {
@@ -42295,6 +41853,108 @@
         }
       }
     },
+    "settings.app.closeWorkspaceOnLastSurfaceShortcut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep Workspace Open When Closing Last Surface"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最後のサーフェスを閉じてもワークスペースを残す"
+          }
+        }
+      }
+    },
+    "settings.app.closeWorkspaceOnLastSurfaceShortcut.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut also closes the workspace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つなら、サーフェスを閉じるショートカットはワークスペースも閉じます。"
+          }
+        }
+      }
+    },
+    "settings.app.closeWorkspaceOnLastSurfaceShortcut.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut closes only the surface and keeps the workspace open. Use the close-workspace shortcut to close the workspace explicitly."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つでも、サーフェスを閉じるショートカットはサーフェスだけを閉じ、ワークスペースは残します。ワークスペースを閉じるショートカットを使うと明示的に閉じられます。"
+          }
+        }
+      }
+    },
+    "settings.app.commandPaletteSearchAllSurfaces": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Command Palette Searches All Surfaces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドパレットですべてのサーフェスを検索"
+          }
+        }
+      }
+    },
+    "settings.app.commandPaletteSearchAllSurfaces.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+P matches workspace rows only."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+Pはワークスペース行だけを対象にします。"
+          }
+        }
+      }
+    },
+    "settings.app.commandPaletteSearchAllSurfaces.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+P also matches terminal, browser, and markdown surfaces across workspaces."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+Pでワークスペースをまたいだターミナル、ブラウザ、Markdownのサーフェスも検索できます。"
+          }
+        }
+      }
+    },
     "settings.app.dockBadge": {
       "extractionState": "manual",
       "localizations": {
@@ -42521,36 +42181,104 @@
         }
       }
     },
-    "settings.app.showInMenuBar": {
+    "settings.app.fadeButtons": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show in Menu Bar"
+            "value": "Fade Buttons"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "メニューバーに表示"
+            "value": "ボタンをフェード表示"
           }
         }
       }
     },
-    "settings.app.showInMenuBar.subtitle": {
+    "settings.app.fadeButtons.subtitleOff": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keep c11mux in the menu bar for unread notifications and quick actions."
+            "value": "Keep action buttons always visible."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "未読通知の確認やクイック操作のために、c11muxをメニューバーに表示します。"
+            "value": "操作ボタンを常に表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.fadeButtons.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show action buttons only on hover."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "操作ボタンはホバー時のみ表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.hideAllSidebarDetails": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide All Sidebar Details"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーの詳細をすべて隠す"
+          }
+        }
+      }
+    },
+    "settings.app.hideAllSidebarDetails.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show secondary workspace details as controlled by the toggles below."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下のトグル設定に従って、ワークスペースの補助情報を表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.hideAllSidebarDetails.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show only the workspace title row. Overrides the detail toggles below."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースのタイトル行だけを表示します。下の詳細トグルより優先されます。"
           }
         }
       }
@@ -43120,6 +42848,57 @@
         }
       }
     },
+    "settings.app.minimalMode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ミニマルモード"
+          }
+        }
+      }
+    },
+    "settings.app.minimalMode.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use the standard workspace title bar and controls."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準のワークスペースタイトルバーと操作を使います。"
+          }
+        }
+      }
+    },
+    "settings.app.minimalMode.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide the workspace title bar and move workspace controls into the sidebar."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースのタイトルバーを隠し、ワークスペース操作をサイドバーに移動します。"
+          }
+        }
+      }
+    },
     "settings.app.newWorkspacePlacement": {
       "extractionState": "manual",
       "localizations": {
@@ -43229,108 +43008,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Yeni Çalışma Alanı Konumu"
-          }
-        }
-      }
-    },
-    "settings.app.commandPaletteSearchAllSurfaces": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Command Palette Searches All Surfaces"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コマンドパレットですべてのサーフェスを検索"
-          }
-        }
-      }
-    },
-    "settings.app.commandPaletteSearchAllSurfaces.subtitleOff": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cmd+P matches workspace rows only."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cmd+Pはワークスペース行だけを対象にします。"
-          }
-        }
-      }
-    },
-    "settings.app.commandPaletteSearchAllSurfaces.subtitleOn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cmd+P also matches terminal, browser, and markdown surfaces across workspaces."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cmd+Pでワークスペースをまたいだターミナル、ブラウザ、Markdownのサーフェスも検索できます。"
-          }
-        }
-      }
-    },
-    "settings.app.closeWorkspaceOnLastSurfaceShortcut": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep Workspace Open When Closing Last Surface"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "最後のサーフェスを閉じてもワークスペースを残す"
-          }
-        }
-      }
-    },
-    "settings.app.closeWorkspaceOnLastSurfaceShortcut.subtitleOff": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut also closes the workspace."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つなら、サーフェスを閉じるショートカットはワークスペースも閉じます。"
-          }
-        }
-      }
-    },
-    "settings.app.closeWorkspaceOnLastSurfaceShortcut.subtitleOn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut closes only the surface and keeps the workspace open. Use the close-workspace shortcut to close the workspace explicitly."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つでも、サーフェスを閉じるショートカットはサーフェスだけを閉じ、ワークスペースは残します。ワークスペースを閉じるショートカットを使うと明示的に閉じられます。"
           }
         }
       }
@@ -43670,57 +43347,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tıklamalar cmux tarayıcısında açılır."
-          }
-        }
-      }
-    },
-    "settings.app.hideAllSidebarDetails": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide All Sidebar Details"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイドバーの詳細をすべて隠す"
-          }
-        }
-      }
-    },
-    "settings.app.hideAllSidebarDetails.subtitleOff": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show secondary workspace details as controlled by the toggles below."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "下のトグル設定に従って、ワークスペースの補助情報を表示します。"
-          }
-        }
-      }
-    },
-    "settings.app.hideAllSidebarDetails.subtitleOn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show only the workspace title row. Overrides the detail toggles below."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースのタイトル行だけを表示します。下の詳細トグルより優先されます。"
           }
         }
       }
@@ -44516,6 +44142,40 @@
         }
       }
     },
+    "settings.app.showInMenuBar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show in Menu Bar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メニューバーに表示"
+          }
+        }
+      }
+    },
+    "settings.app.showInMenuBar.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep c11mux in the menu bar for unread notifications and quick actions."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未読通知の確認やクイック操作のために、c11muxをメニューバーに表示します。"
+          }
+        }
+      }
+    },
     "settings.app.showLog": {
       "extractionState": "manual",
       "localizations": {
@@ -45115,40 +44775,6 @@
         }
       }
     },
-    "settings.app.showSSH": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show SSH in Sidebar"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイドバーにSSHを表示"
-          }
-        }
-      }
-    },
-    "settings.app.showSSH.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Display the SSH target for remote workspaces in its own row."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リモートワークスペースのSSHターゲットを専用の行に表示します。"
-          }
-        }
-      }
-    },
     "settings.app.showPorts.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -45488,159 +45114,6 @@
         }
       }
     },
-    "settings.app.showWorkspaceTitlebar": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show Workspace Title Bar"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースのタイトルバーを表示"
-          }
-        }
-      }
-    },
-    "settings.app.showWorkspaceTitlebar.subtitleOff": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide the folder and active title above pane tabs."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペインタブの上にあるフォルダ名と現在のタイトルを隠します。"
-          }
-        }
-      }
-    },
-    "settings.app.showWorkspaceTitlebar.subtitleOn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show the folder and active title above pane tabs."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペインタブの上にフォルダ名と現在のタイトルを表示します。"
-          }
-        }
-      }
-    },
-    "settings.app.fadeButtons": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fade Buttons"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ボタンをフェード表示"
-          }
-        }
-      }
-    },
-    "settings.app.fadeButtons.subtitleOff": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Keep action buttons always visible."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "操作ボタンを常に表示します。"
-          }
-        }
-      }
-    },
-    "settings.app.fadeButtons.subtitleOn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show action buttons only on hover."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "操作ボタンはホバー時のみ表示します。"
-          }
-        }
-      }
-    },
-    "settings.app.minimalMode": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Minimal Mode"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ミニマルモード"
-          }
-        }
-      }
-    },
-    "settings.app.minimalMode.subtitleOff": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Use the standard workspace title bar and controls."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "標準のワークスペースタイトルバーと操作を使います。"
-          }
-        }
-      }
-    },
-    "settings.app.minimalMode.subtitleOn": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hide the workspace title bar and move workspace controls into the sidebar."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ワークスペースのタイトルバーを隠し、ワークスペース操作をサイドバーに移動します。"
-          }
-        }
-      }
-    },
     "settings.app.showPullRequests": {
       "extractionState": "manual",
       "localizations": {
@@ -45863,6 +45336,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "Durum, numara ve tıklanabilir bağlantıyla inceleme öğelerini (PR/MR/vb.) göster."
+          }
+        }
+      }
+    },
+    "settings.app.showSSH": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show SSH in Sidebar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーにSSHを表示"
+          }
+        }
+      }
+    },
+    "settings.app.showSSH.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Display the SSH target for remote workspaces in its own row."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートワークスペースのSSHターゲットを専用の行に表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.showWorkspaceTitlebar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Workspace Title Bar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースのタイトルバーを表示"
+          }
+        }
+      }
+    },
+    "settings.app.showWorkspaceTitlebar.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide the folder and active title above pane tabs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインタブの上にあるフォルダ名と現在のタイトルを隠します。"
+          }
+        }
+      }
+    },
+    "settings.app.showWorkspaceTitlebar.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the folder and active title above pane tabs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインタブの上にフォルダ名と現在のタイトルを表示します。"
           }
         }
       }
@@ -47219,312 +46777,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cmd+Q ile çıkmadan önce onay göster."
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.choose.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose..."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択..."
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.choose.prompt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.choose.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose Notification Sound"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知サウンドを選択"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.clear.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Clear"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クリア"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.error.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Custom Notification Sound Error"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "カスタム通知サウンドのエラー"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.file.none": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "No file selected"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイル未選択"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.status.empty": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose a custom audio file first."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "先にカスタム音声ファイルを選択してください。"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.status.missingExtensionPrefix": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File needs an extension: "
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "拡張子が必要です: "
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.status.missingFilePrefix": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File not found: "
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルが見つかりません: "
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.status.prepareFailed": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Could not prepare this file for notifications. Try WAV, AIFF, or CAF."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知用にこのファイルを準備できませんでした。WAV、AIFF、またはCAFを試してください。"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.status.ready": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ready for notifications."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知用の準備ができました。"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.custom.status.readyConverted": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prepared for notifications (converted to CAF)."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知用に準備しました（CAFに変換）。"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sound played when a notification arrives."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知を受信したときに再生するサウンドです。"
-          }
-        }
-      }
-    },
-    "settings.notifications.paneRing.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show a blue ring around panes with unread notifications."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未読の通知があるペインの周囲に青いリングを表示します。"
-          }
-        }
-      }
-    },
-    "settings.notifications.paneFlash.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Briefly flash a blue outline when c11mux highlights a pane."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "c11mux がペインを強調表示するときに短い青いアウトラインを表示します。"
-          }
-        }
-      }
-    },
-    "settings.notifications.paneFlash.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Pane Flash"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ペインフラッシュ"
-          }
-        }
-      }
-    },
-    "settings.notifications.paneRing.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Unread Pane Ring"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "未読ペインリング"
-          }
-        }
-      }
-    },
-    "settings.notifications.sound.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Notification Sound"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "通知サウンド"
           }
         }
       }
@@ -51032,6 +50284,40 @@
         }
       }
     },
+    "settings.browser.emptyImport.choose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose What to Import…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取り込む項目を選ぶ…"
+          }
+        }
+      }
+    },
+    "settings.browser.emptyImport.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import browser data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータを取り込む"
+          }
+        }
+      }
+    },
     "settings.browser.externalPatterns": {
       "extractionState": "manual",
       "localizations": {
@@ -51258,40 +50544,6 @@
         }
       }
     },
-    "settings.browser.emptyImport.choose": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose What to Import…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "取り込む項目を選ぶ…"
-          }
-        }
-      }
-    },
-    "settings.browser.emptyImport.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import browser data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータを取り込む"
-          }
-        }
-      }
-    },
     "settings.browser.history": {
       "extractionState": "manual",
       "localizations": {
@@ -51401,125 +50653,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tarama Geçmişi"
-          }
-        }
-      }
-    },
-    "settings.browser.import": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Import Browser Data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ブラウザーデータを取り込む"
-          }
-        }
-      }
-    },
-    "settings.browser.import.choose": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Choose…"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "選択…"
-          }
-        }
-      }
-    },
-    "settings.browser.import.refresh": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Refresh"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "再読み込み"
-          }
-        }
-      }
-    },
-    "settings.browser.import.hint.note.hidden": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The blank-tab import hint is hidden. Turn it back on here any time."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "空タブのインポート案内は非表示です。ここでいつでも再表示できます。"
-          }
-        }
-      }
-    },
-    "settings.browser.import.hint.note.settingsOnly": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Blank tabs are currently using Settings only mode from the debug window."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "現在、空タブはデバッグウィンドウの「設定のみ」モードになっています。"
-          }
-        }
-      }
-    },
-    "settings.browser.import.hint.note.visible": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Blank browser tabs can show this import suggestion. Hide or re-enable it here."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "空のブラウザータブにこのインポート案内を表示できます。ここで非表示や再表示を切り替えられます。"
-          }
-        }
-      }
-    },
-    "settings.browser.import.hint.show": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Show import hint on blank browser tabs"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "空のブラウザータブにインポート案内を表示"
           }
         }
       }
@@ -53102,6 +52235,125 @@
           "stringUnit": {
             "state": "translated",
             "value": "Kaydet"
+          }
+        }
+      }
+    },
+    "settings.browser.import": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Browser Data"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザーデータを取り込む"
+          }
+        }
+      }
+    },
+    "settings.browser.import.choose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択…"
+          }
+        }
+      }
+    },
+    "settings.browser.import.hint.note.hidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The blank-tab import hint is hidden. Turn it back on here any time."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空タブのインポート案内は非表示です。ここでいつでも再表示できます。"
+          }
+        }
+      }
+    },
+    "settings.browser.import.hint.note.settingsOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blank tabs are currently using Settings only mode from the debug window."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在、空タブはデバッグウィンドウの「設定のみ」モードになっています。"
+          }
+        }
+      }
+    },
+    "settings.browser.import.hint.note.visible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blank browser tabs can show this import suggestion. Hide or re-enable it here."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空のブラウザータブにこのインポート案内を表示できます。ここで非表示や再表示を切り替えられます。"
+          }
+        }
+      }
+    },
+    "settings.browser.import.hint.show": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show import hint on blank browser tabs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空のブラウザータブにインポート案内を表示"
+          }
+        }
+      }
+    },
+    "settings.browser.import.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再読み込み"
           }
         }
       }
@@ -55705,6 +54957,312 @@
         }
       }
     },
+    "settings.notifications.paneFlash.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Briefly flash a blue outline when c11mux highlights a pane."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11mux がペインを強調表示するときに短い青いアウトラインを表示します。"
+          }
+        }
+      }
+    },
+    "settings.notifications.paneFlash.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pane Flash"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインフラッシュ"
+          }
+        }
+      }
+    },
+    "settings.notifications.paneRing.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show a blue ring around panes with unread notifications."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未読の通知があるペインの周囲に青いリングを表示します。"
+          }
+        }
+      }
+    },
+    "settings.notifications.paneRing.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unread Pane Ring"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未読ペインリング"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.choose.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択..."
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.choose.prompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.choose.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Notification Sound"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知サウンドを選択"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.clear.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリア"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.error.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom Notification Sound Error"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム通知サウンドのエラー"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.file.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No file selected"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル未選択"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.status.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a custom audio file first."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "先にカスタム音声ファイルを選択してください。"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.status.missingExtensionPrefix": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File needs an extension: "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拡張子が必要です: "
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.status.missingFilePrefix": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File not found: "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルが見つかりません: "
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.status.prepareFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not prepare this file for notifications. Try WAV, AIFF, or CAF."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知用にこのファイルを準備できませんでした。WAV、AIFF、またはCAFを試してください。"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.status.ready": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ready for notifications."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知用の準備ができました。"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.custom.status.readyConverted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prepared for notifications (converted to CAF)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知用に準備しました（CAFに変換）。"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sound played when a notification arrives."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知を受信したときに再生するサウンドです。"
+          }
+        }
+      }
+    },
+    "settings.notifications.sound.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notification Sound"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通知サウンド"
+          }
+        }
+      }
+    },
     "settings.preset.hudGlass": {
       "extractionState": "manual",
       "localizations": {
@@ -57061,6 +56619,136 @@
         }
       }
     },
+    "settings.section.sidebarAppearance": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar Appearance"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーの外観"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "侧边栏外观"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "側邊欄外觀"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 모양"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleisten-Erscheinungsbild"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apariencia de la barra lateral"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apparence de la barre latérale"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aspetto barra laterale"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebjælkeudseende"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wygląd paska bocznego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Внешний вид боковой панели"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Izgled bočne trake"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مظهر الشريط الجانبي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidefelts utseende"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aparência da Barra Lateral"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รูปลักษณ์แถบด้านข้าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kenar Çubuğu Görünümü"
+          }
+        }
+      }
+    },
+    "settings.section.textBoxInput": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "TextBox Input"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストボックス入力"
+          }
+        }
+      }
+    },
     "settings.section.workspaceColors": {
       "extractionState": "manual",
       "localizations": {
@@ -57626,6 +57314,1362 @@
         }
       }
     },
+    "settings.sidebarAppearance.defaultLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predeterminado"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Par défaut"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Predefinito"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślny"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadano"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "افتراضي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Padrão"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ค่าเริ่มต้น"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsayılan"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.reset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Sidebar Tint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのティントをリセット"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置侧边栏色调"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置側邊欄色調"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 색조 초기화"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleisten-Farbton zurücksetzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer tinte de la barra lateral"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser la teinte de la barre latérale"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina tinta barra laterale"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nulstil sidebjælkens farvetone"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj odcień paska bocznego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить оттенок боковой панели"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj nijansu bočne trake"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين لون الشريط الجانبي"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilbakestill sidefelts fargetone"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redefinir Tonalidade da Barra Lateral"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ตโทนสีแถบด้านข้าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kenar Çubuğu Renk Tonunu Sıfırla"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.reset.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リセット"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "초기화"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zurücksetzen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restablecer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Réinitialiser"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nulstil"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعادة تعيين"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tilbakestill"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Redefinir"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเซ็ต"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sıfırla"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.reset.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore default sidebar appearance."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーの外観をデフォルトに戻す。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复默认侧边栏外观。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復預設側邊欄外觀。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 모양을 기본값으로 복원합니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard-Seitenleisten-Erscheinungsbild wiederherstellen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar la apariencia predeterminada de la barra lateral."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurer l'apparence par défaut de la barre latérale."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripristina l'aspetto predefinito della barra laterale."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gendan standardudseendet for sidebjælken."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przywróć domyślny wygląd paska bocznego."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Восстановить внешний вид боковой панели по умолчанию."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vrati zadani izgled bočne trake."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "استعادة مظهر الشريط الجانبي الافتراضي."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gjenopprett standard sidefelts utseende."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restaurar aparência padrão da barra lateral."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คืนค่ารูปลักษณ์แถบด้านข้างเป็นค่าเริ่มต้น"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Varsayılan kenar çubuğu görünümünü geri yükle."
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintColorDark": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark Mode Tint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークモードのティント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色模式色调"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色模式色調"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 모드 색조"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbton im dunklen Modus"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinte del modo oscuro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teinte du mode sombre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinta modalità scura"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mørk tilstand farvetone"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odcień trybu ciemnego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оттенок тёмного режима"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nijansa tamnog načina"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون الوضع الداكن"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fargetone for mørk modus"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tonalidade do Modo Escuro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โทนสีโหมดมืด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koyu Mod Renk Tonu"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintColorDark.picker": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark tint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダークティント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色色调"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "深色色調"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 색조"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dunkler Farbton"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinte oscuro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teinte sombre"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinta scura"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mørk farvetone"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciemny odcień"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тёмный оттенок"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tamna nijansa"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون داكن"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mørk fargetone"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tonalidade escura"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โทนมืด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koyu ton"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintColorDark.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar tint color when using dark appearance."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダーク表示時のサイドバーのティントカラー。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用深色外观时侧边栏的色调颜色。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用深色外觀時側邊欄的色調顏色。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다크 모양 사용 시 사이드바 색조 색상."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleisten-Farbton bei dunklem Erscheinungsbild."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de tinte de la barra lateral en apariencia oscura."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur de teinte de la barre latérale en apparence sombre."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore tinta della barra laterale in modalità scura."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebjælkens farvetone ved mørkt udseende."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kolor odcienia paska bocznego w ciemnym wyglądzie."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цвет оттенка боковой панели в тёмном режиме."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Boja nijanse bočne trake pri tamnom izgledu."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون تلوين الشريط الجانبي عند استخدام المظهر الداكن."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fargetone for sidefeltet med mørkt utseende."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor de tonalidade da barra lateral na aparência escura."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สีโทนของแถบด้านข้างเมื่อใช้รูปลักษณ์มืด"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koyu görünüm kullanılırken kenar çubuğu renk tonu."
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintColorLight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light Mode Tint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライトモードのティント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色模式色调"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "淺色模式色調"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이트 모드 색조"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbton im hellen Modus"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinte del modo claro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teinte du mode clair"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinta modalità chiara"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lys tilstand farvetone"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odcień trybu jasnego"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оттенок светлого режима"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nijansa svijetlog načina"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون الوضع الفاتح"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fargetone for lys modus"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tonalidade do Modo Claro"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โทนสีโหมดสว่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açık Mod Renk Tonu"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintColorLight.picker": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light tint"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライトティント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浅色色调"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "淺色色調"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이트 색조"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heller Farbton"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinte claro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Teinte claire"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tinta chiara"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lys farvetone"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jasny odcień"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Светлый оттенок"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Svijetla nijansa"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون فاتح"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lys fargetone"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tonalidade clara"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โทนสว่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açık ton"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintColorLight.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar tint color when using light appearance."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライト表示時のサイドバーのティントカラー。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用浅色外观时侧边栏的色调颜色。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用淺色外觀時側邊欄的色調顏色。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라이트 모양 사용 시 사이드바 색조 색상."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seitenleisten-Farbton bei hellem Erscheinungsbild."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color de tinte de la barra lateral en apariencia clara."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couleur de teinte de la barre latérale en apparence claire."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colore tinta della barra laterale in modalità chiara."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebjælkens farvetone ved lyst udseende."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kolor odcienia paska bocznego w jasnym wyglądzie."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Цвет оттенка боковой панели в светлом режиме."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Boja nijanse bočne trake pri svijetlom izgledu."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لون تلوين الشريط الجانبي عند استخدام المظهر الفاتح."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fargetone for sidefeltet med lyst utseende."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cor de tonalidade da barra lateral na aparência clara."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "สีโทนของแถบด้านข้างเมื่อใช้รูปลักษณ์สว่าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Açık görünüm kullanılırken kenar çubuğu renk tonu."
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintOpacity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tint Opacity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ティントの不透明度"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色调不透明度"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色調不透明度"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "색조 불투명도"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farbton-Deckkraft"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opacidad del tinte"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opacité de la teinte"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opacità tinta"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Farvetone gennemsigtighed"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Krycie odcienia"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Непрозрачность оттенка"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prozirnost nijanse"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "شفافية اللون"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fargetone-opasitet"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opacidade da Tonalidade"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความทึบของโทนสี"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renk Tonu Opaklığı"
+          }
+        }
+      }
+    },
+    "settings.sidebarAppearance.tintOpacity.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How strongly the tint color shows over the sidebar material."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーの素材上にティントカラーがどの程度表示されるか。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色调颜色在侧边栏材质上的显示强度。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "色調顏色在側邊欄材質上的顯示強度。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바 재질 위에 색조 색상이 표시되는 강도."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wie stark der Farbton über dem Seitenleisten-Material sichtbar ist."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intensidad del color de tinte sobre el material de la barra lateral."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intensité de la teinte sur le matériau de la barre latérale."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intensità della tinta sul materiale della barra laterale."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hvor stærkt farvetonen vises over sidebjælkens materiale."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak silnie kolor odcienia jest widoczny na materiale paska bocznego."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Насколько сильно оттенок виден на материале боковой панели."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koliko jako se boja nijanse prikazuje preko materijala bočne trake."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مدى قوة ظهور لون التلوين فوق مادة الشريط الجانبي."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hvor sterkt fargetonen vises over sidefelts materiale."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intensidade da cor de tonalidade sobre o material da barra lateral."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ความเข้มของสีโทนที่แสดงบนวัสดุแถบด้านข้าง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Renk tonunun kenar çubuğu materyali üzerinde ne kadar güçlü göründüğü."
+          }
+        }
+      }
+    },
     "settings.state.active": {
       "extractionState": "manual",
       "localizations": {
@@ -57961,6 +59005,164 @@
           "stringUnit": {
             "state": "translated",
             "value": "Etkin Değil"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.enableMode": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Enable Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストボックスを有効化"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.enableMode.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Add a text box for terminal input. Supports standard editing, IME, and clipboard shortcuts."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル入力のためのテキストボックスを追加します。標準的な編集、IME、クリップボードのショートカットに対応しています。"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.escapeBehavior": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Escape Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Escapeキー"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.escapeBehavior.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Action when pressing Escape in the TextBox."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストボックスでEscapeキーを押したときの動作"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.sendOnReturn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Send on Return"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enterで送信"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.sendOnReturn.off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Return = Newline"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.sendOnReturn.on": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Return = Send"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.sendOnReturn.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Insert new line with Shift+Return"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shift+Enterで改行"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.shortcutBehavior": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Keyboard Shortcut (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キーボードショートカット（%@）"
+          }
+        }
+      }
+    },
+    "settings.textBoxInput.shortcutBehavior.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Shortcut key can be changed in Keyboard Shortcuts settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカット設定からキーを変更可能"
           }
         }
       }
@@ -62485,6 +63687,57 @@
         }
       }
     },
+    "shortcut.toggleTextBoxInput.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle TextBox Input"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テキストボックス入力を切り替え"
+          }
+        }
+      }
+    },
+    "sidebar.activeTabIndicator.leftRail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Left Rail"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左レール"
+          }
+        }
+      }
+    },
+    "sidebar.activeTabIndicator.solidFill": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Solid Fill"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "塗りつぶし"
+          }
+        }
+      }
+    },
     "sidebar.closeWorkspace.tooltip": {
       "extractionState": "manual",
       "localizations": {
@@ -62707,6 +63960,584 @@
           "stringUnit": {
             "state": "translated",
             "value": "Finder'da veya başka bir uygulamada açmak için sürükleyin"
+          }
+        }
+      }
+    },
+    "sidebar.help.button": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Help"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ヘルプ"
+          }
+        }
+      }
+    },
+    "sidebar.help.changelog": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Changelog"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新履歴"
+          }
+        }
+      }
+    },
+    "sidebar.help.discord": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discord"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Discord"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.attachImages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attach Images"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像を添付"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.attachImages.prompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attach"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添付"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.attachImages.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Attach Images"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像を添付"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.attachmentsHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Up to 10 images."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像は最大10枚まで添付できます。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.connectionError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't send feedback. Check your connection and try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックを送信できませんでした。接続を確認して、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.done": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Done"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "完了"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.email": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Email"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メールアドレス"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.emailPlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "you@example.com"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "you@example.com"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.emptyMessage": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a message before sending."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信する前にメッセージを入力してください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.endpointError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feedback is unavailable right now. Email founders@manaflow.com instead."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在フィードバックを送信できません。代わりに founders@manaflow.com までメールしてください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.genericError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't send feedback. Please try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックを送信できませんでした。もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.imageTooLarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Each image must be 4 MB or smaller."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各画像は 4 MB 以下にしてください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.invalidEmail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a valid email address."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なメールアドレスを入力してください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.invalidImageSelection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "One of the selected files could not be attached."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択したファイルのうち1つを添付できませんでした。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Message"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージ"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.messagePlaceholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share feedback, feature requests, or issues."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバック、機能要望、不具合をお知らせください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.messageTooLong": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your message is too long."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージが長すぎます。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can also reach us at founders@manaflow.com."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.rateLimited": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Too many feedback attempts. Please try again later."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックの送信回数が多すぎます。しばらくしてからもう一度お試しください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.removeAttachment": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.send": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "送信"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.successBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can also reach us at founders@manaflow.com."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "founders@manaflow.com 宛てに直接ご連絡いただくこともできます。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.successTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thanks for the feedback."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックありがとうございます。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Feedback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックを送信"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.tooManyImages": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "You can attach up to 10 images."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像は最大10枚まで添付できます。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.totalImagesTooLarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These images are too large to send together. Remove a few and try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これらの画像はまとめて送信するには大きすぎます。いくつか削除してもう一度お試しください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.feedback.validationError": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check your message and attachments, then try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "メッセージと添付ファイルを確認して、もう一度お試しください。"
+          }
+        }
+      }
+    },
+    "sidebar.help.githubIssues": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Issues"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Issues"
+          }
+        }
+      }
+    },
+    "sidebar.help.sendFeedback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Send Feedback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フィードバックを送信"
+          }
+        }
+      }
+    },
+    "sidebar.help.welcome": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Welcome to c11mux!"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11muxへようこそ！"
           }
         }
       }
@@ -63954,6 +65785,159 @@
         }
       }
     },
+    "sidebar.remote.badge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH"
+          }
+        }
+      }
+    },
+    "sidebar.remote.help.connected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH connected to %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH は %@ に接続済み"
+          }
+        }
+      }
+    },
+    "sidebar.remote.help.connecting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH connecting to %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH は %@ に接続中"
+          }
+        }
+      }
+    },
+    "sidebar.remote.help.disconnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH disconnected from %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH は %@ から切断済み"
+          }
+        }
+      }
+    },
+    "sidebar.remote.help.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH error for %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の SSH エラー"
+          }
+        }
+      }
+    },
+    "sidebar.remote.help.errorWithDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH error for %@: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の SSH エラー: %@"
+          }
+        }
+      }
+    },
+    "sidebar.remote.help.targetFallback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "remote host"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートホスト"
+          }
+        }
+      }
+    },
+    "sidebar.remote.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH • %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH • %@"
+          }
+        }
+      }
+    },
+    "sidebar.remote.subtitleFallback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH ワークスペース"
+          }
+        }
+      }
+    },
     "sidebar.workspace.accessibilityHint": {
       "extractionState": "manual",
       "localizations": {
@@ -64063,261 +66047,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Bu çalışma alanına odaklanmak için etkinleştirin. Yeniden sıralamak için sürükleyin veya Yukarı Taşı ve Aşağı Taşı eylemlerini kullanın."
-          }
-        }
-      }
-    },
-    "sidebar.remote.badge": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH"
-          }
-        }
-      }
-    },
-    "remote.status.connected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connected"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続済み"
-          }
-        }
-      }
-    },
-    "remote.status.connecting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Connecting"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "接続中"
-          }
-        }
-      }
-    },
-    "remote.status.disconnected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Disconnected"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "切断済み"
-          }
-        }
-      }
-    },
-    "remote.status.error": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Error"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "エラー"
-          }
-        }
-      }
-    },
-    "sidebar.remote.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH • %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH • %@"
-          }
-        }
-      }
-    },
-    "sidebar.remote.subtitleFallback": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH workspace"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH ワークスペース"
-          }
-        }
-      }
-    },
-    "sidebar.remote.help.connected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH connected to %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH は %@ に接続済み"
-          }
-        }
-      }
-    },
-    "sidebar.remote.help.connecting": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH connecting to %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH は %@ に接続中"
-          }
-        }
-      }
-    },
-    "sidebar.remote.help.error": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH error for %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ の SSH エラー"
-          }
-        }
-      }
-    },
-    "sidebar.remote.help.errorWithDetail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH error for %@: %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "%@ の SSH エラー: %@"
-          }
-        }
-      }
-    },
-    "sidebar.remote.help.disconnected": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH disconnected from %@"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "SSH は %@ から切断済み"
-          }
-        }
-      }
-    },
-    "sidebar.remote.help.targetFallback": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "remote host"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リモートホスト"
-          }
-        }
-      }
-    },
-    "sidebar.activeTabIndicator.leftRail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Left Rail"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "左レール"
-          }
-        }
-      }
-    },
-    "sidebar.activeTabIndicator.solidFill": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Solid Fill"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "塗りつぶし"
           }
         }
       }
@@ -66917,6 +68646,83 @@
           "stringUnit": {
             "state": "translated",
             "value": "Adsız Sekme"
+          }
+        }
+      }
+    },
+    "textbox.escapeBehavior.focusTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Focus Terminal"
+          }
+        }
+      }
+    },
+    "textbox.escapeBehavior.sendEscape": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Send ESC Key"
+          }
+        }
+      }
+    },
+    "textbox.placeholder.enterToNewline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Commands or prompts here… Shift+Return to send"
+          }
+        }
+      }
+    },
+    "textbox.placeholder.enterToSend": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Commands or prompts here… Shift+Return for newline"
+          }
+        }
+      }
+    },
+    "textbox.send.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Send"
+          }
+        }
+      }
+    },
+    "textbox.shortcutBehavior.toggleDisplay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Display"
+          }
+        }
+      }
+    },
+    "textbox.shortcutBehavior.toggleFocus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Toggle Focus"
           }
         }
       }
@@ -76008,1526 +77814,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sağa Böl"
-          }
-        }
-      }
-    },
-    "markdown.fileUnavailable.message": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The file may have been moved or deleted."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルが移動または削除された可能性があります。"
-          }
-        }
-      }
-    },
-    "markdown.mermaid.installHint": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Install @mermaid-js/mermaid-cli for diagram rendering"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "@mermaid-js/mermaid-cli をインストールすると図が表示されます"
-          }
-        }
-      }
-    },
-    "markdown.fileUnavailable.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "File unavailable"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ファイルを利用できません"
-          }
-        }
-      }
-    },
-    "settings.section.sidebarAppearance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sidebar Appearance"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイドバーの外観"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "侧边栏外观"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "側邊欄外觀"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사이드바 모양"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenleisten-Erscheinungsbild"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apariencia de la barra lateral"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apparence de la barre latérale"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspetto barra laterale"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sidebjælkeudseende"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wygląd paska bocznego"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Внешний вид боковой панели"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Izgled bočne trake"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مظهر الشريط الجانبي"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sidefelts utseende"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aparência da Barra Lateral"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รูปลักษณ์แถบด้านข้าง"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kenar Çubuğu Görünümü"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintColorLight": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Light Mode Tint"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライトモードのティント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "浅色模式色调"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "淺色模式色調"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "라이트 모드 색조"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Farbton im hellen Modus"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinte del modo claro"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teinte du mode clair"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinta modalità chiara"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lys tilstand farvetone"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Odcień trybu jasnego"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Оттенок светлого режима"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nijansa svijetlog načina"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لون الوضع الفاتح"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fargetone for lys modus"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tonalidade do Modo Claro"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โทนสีโหมดสว่าง"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Açık Mod Renk Tonu"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintColorLight.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sidebar tint color when using light appearance."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライト表示時のサイドバーのティントカラー。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用浅色外观时侧边栏的色调颜色。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用淺色外觀時側邊欄的色調顏色。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "라이트 모양 사용 시 사이드바 색조 색상."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenleisten-Farbton bei hellem Erscheinungsbild."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Color de tinte de la barra lateral en apariencia clara."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couleur de teinte de la barre latérale en apparence claire."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Colore tinta della barra laterale in modalità chiara."
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sidebjælkens farvetone ved lyst udseende."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kolor odcienia paska bocznego w jasnym wyglądzie."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Цвет оттенка боковой панели в светлом режиме."
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Boja nijanse bočne trake pri svijetlom izgledu."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لون تلوين الشريط الجانبي عند استخدام المظهر الفاتح."
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fargetone for sidefeltet med lyst utseende."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cor de tonalidade da barra lateral na aparência clara."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สีโทนของแถบด้านข้างเมื่อใช้รูปลักษณ์สว่าง"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Açık görünüm kullanılırken kenar çubuğu renk tonu."
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintColorLight.picker": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Light tint"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ライトティント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "浅色色调"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "淺色色調"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "라이트 색조"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Heller Farbton"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinte claro"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teinte claire"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinta chiara"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lys farvetone"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jasny odcień"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Светлый оттенок"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Svijetla nijansa"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لون فاتح"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Lys fargetone"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tonalidade clara"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โทนสว่าง"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Açık ton"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintColorDark": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dark Mode Tint"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダークモードのティント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "深色模式色调"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "深色模式色調"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다크 모드 색조"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Farbton im dunklen Modus"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinte del modo oscuro"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teinte du mode sombre"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinta modalità scura"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mørk tilstand farvetone"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Odcień trybu ciemnego"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Оттенок тёмного режима"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nijansa tamnog načina"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لون الوضع الداكن"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fargetone for mørk modus"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tonalidade do Modo Escuro"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โทนสีโหมดมืด"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koyu Mod Renk Tonu"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintColorDark.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sidebar tint color when using dark appearance."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダーク表示時のサイドバーのティントカラー。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用深色外观时侧边栏的色调颜色。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "使用深色外觀時側邊欄的色調顏色。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다크 모양 사용 시 사이드바 색조 색상."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenleisten-Farbton bei dunklem Erscheinungsbild."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Color de tinte de la barra lateral en apariencia oscura."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Couleur de teinte de la barre latérale en apparence sombre."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Colore tinta della barra laterale in modalità scura."
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sidebjælkens farvetone ved mørkt udseende."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kolor odcienia paska bocznego w ciemnym wyglądzie."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Цвет оттенка боковой панели в тёмном режиме."
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Boja nijanse bočne trake pri tamnom izgledu."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لون تلوين الشريط الجانبي عند استخدام المظهر الداكن."
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fargetone for sidefeltet med mørkt utseende."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cor de tonalidade da barra lateral na aparência escura."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "สีโทนของแถบด้านข้างเมื่อใช้รูปลักษณ์มืด"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koyu görünüm kullanılırken kenar çubuğu renk tonu."
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintColorDark.picker": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dark tint"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ダークティント"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "深色色调"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "深色色調"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "다크 색조"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Dunkler Farbton"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinte oscuro"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Teinte sombre"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tinta scura"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mørk farvetone"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ciemny odcień"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Тёмный оттенок"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tamna nijansa"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "لون داكن"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Mørk fargetone"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tonalidade escura"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "โทนมืด"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koyu ton"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintOpacity": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tint Opacity"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ティントの不透明度"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "色调不透明度"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "色調不透明度"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "색조 불투명도"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Farbton-Deckkraft"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opacidad del tinte"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opacité de la teinte"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opacità tinta"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Farvetone gennemsigtighed"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Krycie odcienia"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Непрозрачность оттенка"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Prozirnost nijanse"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "شفافية اللون"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fargetone-opasitet"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Opacidade da Tonalidade"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ความทึบของโทนสี"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renk Tonu Opaklığı"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.tintOpacity.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "How strongly the tint color shows over the sidebar material."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイドバーの素材上にティントカラーがどの程度表示されるか。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "色调颜色在侧边栏材质上的显示强度。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "色調顏色在側邊欄材質上的顯示強度。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사이드바 재질 위에 색조 색상이 표시되는 강도."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Wie stark der Farbton über dem Seitenleisten-Material sichtbar ist."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensidad del color de tinte sobre el material de la barra lateral."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensité de la teinte sur le matériau de la barre latérale."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensità della tinta sul materiale della barra laterale."
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hvor stærkt farvetonen vises over sidebjælkens materiale."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Jak silnie kolor odcienia jest widoczny na materiale paska bocznego."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Насколько сильно оттенок виден на материале боковой панели."
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Koliko jako se boja nijanse prikazuje preko materijala bočne trake."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "مدى قوة ظهور لون التلوين فوق مادة الشريط الجانبي."
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Hvor sterkt fargetonen vises over sidefelts materiale."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Intensidade da cor de tonalidade sobre o material da barra lateral."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ความเข้มของสีโทนที่แสดงบนวัสดุแถบด้านข้าง"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Renk tonunun kenar çubuğu materyali üzerinde ne kadar güçlü göründüğü."
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.reset": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset Sidebar Tint"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイドバーのティントをリセット"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置侧边栏色调"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置側邊欄色調"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사이드바 색조 초기화"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Seitenleisten-Farbton zurücksetzen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer tinte de la barra lateral"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinitialiser la teinte de la barre latérale"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ripristina tinta barra laterale"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nulstil sidebjælkens farvetone"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetuj odcień paska bocznego"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сбросить оттенок боковой панели"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetuj nijansu bočne trake"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إعادة تعيين لون الشريط الجانبي"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tilbakestill sidefelts fargetone"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redefinir Tonalidade da Barra Lateral"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รีเซ็ตโทนสีแถบด้านข้าง"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Kenar Çubuğu Renk Tonunu Sıfırla"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.reset.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restore default sidebar appearance."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "サイドバーの外観をデフォルトに戻す。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恢复默认侧边栏外观。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "恢復預設側邊欄外觀。"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "사이드바 모양을 기본값으로 복원합니다."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard-Seitenleisten-Erscheinungsbild wiederherstellen."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restaurar la apariencia predeterminada de la barra lateral."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restaurer l'apparence par défaut de la barre latérale."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ripristina l'aspetto predefinito della barra laterale."
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gendan standardudseendet for sidebjælken."
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Przywróć domyślny wygląd paska bocznego."
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Восстановить внешний вид боковой панели по умолчанию."
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Vrati zadani izgled bočne trake."
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "استعادة مظهر الشريط الجانبي الافتراضي."
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Gjenopprett standard sidefelts utseende."
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restaurar aparência padrão da barra lateral."
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "คืนค่ารูปลักษณ์แถบด้านข้างเป็นค่าเริ่มต้น"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Varsayılan kenar çubuğu görünümünü geri yükle."
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.reset.button": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Reset"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "リセット"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "重置"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "초기화"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zurücksetzen"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restablecer"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Réinitialiser"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Ripristina"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Nulstil"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetuj"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Сбросить"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Resetuj"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "إعادة تعيين"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Tilbakestill"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Redefinir"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "รีเซ็ต"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sıfırla"
-          }
-        }
-      }
-    },
-    "settings.sidebarAppearance.defaultLabel": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Default"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "デフォルト"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "默认"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "預設"
-          }
-        },
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "기본값"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Predeterminado"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Par défaut"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Predefinito"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Domyślny"
-          }
-        },
-        "ru": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "По умолчанию"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Zadano"
-          }
-        },
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "افتراضي"
-          }
-        },
-        "nb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Standard"
-          }
-        },
-        "pt-BR": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Padrão"
-          }
-        },
-        "th": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ค่าเริ่มต้น"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Varsayılan"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59009,40 +59009,6 @@
         }
       }
     },
-    "settings.textBoxInput.enableMode": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Enable Mode"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "テキストボックスを有効化"
-          }
-        }
-      }
-    },
-    "settings.textBoxInput.enableMode.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "new",
-            "value": "Add a text box for terminal input. Supports standard editing, IME, and clipboard shortcuts."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "ターミナル入力のためのテキストボックスを追加します。標準的な編集、IME、クリップボードのショートカットに対応しています。"
-          }
-        }
-      }
-    },
     "settings.textBoxInput.escapeBehavior": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9511,6 +9511,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        // [TextBox] Cmd+Option+B — toggle TextBox Input (plan §4.6).
+        // The default chord was chosen to avoid the Cmd+Option+T
+        // collision with close-other-tabs above. Behavior is gated by
+        // `TextBoxInputSettings.shortcutBehavior` (toggleDisplay vs.
+        // toggleFocus), resolved inside `Workspace.toggleTextBoxMode`.
+        if matchShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: .toggleTextBoxInput)) {
+            let targetWindow = event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            if let terminalContext = focusedTerminalShortcutContext(preferredWindow: targetWindow),
+               let workspace = terminalContext.tabManager.tabs.first(where: { $0.id == terminalContext.workspaceId }) {
+                workspace.toggleTextBoxMode(.default)
+            }
+            return true
+        }
+
         // Cmd+W must close the focused panel even if first-responder momentarily lags on a
         // browser NSTextView during split focus transitions.
         if matchShortcut(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -448,6 +448,10 @@ final class FileDropOverlayView: NSView {
     /// The WKWebView currently receiving forwarded drag events, so we can
     /// synthesize draggingExited/draggingEntered as the cursor moves.
     private weak var activeDragWebView: WKWebView?
+    /// [TextBox] InputTextView under the cursor during an active drag, if any.
+    /// Set by `updateDragTarget` during `draggingUpdated` so `performDragOperation`
+    /// can route the drop without re-hit-testing. Plan §4.9.
+    private weak var activeDragTextBox: InputTextView?
     private var lastHitTestLogSignature: String?
     private var lastDragRouteLogSignatureByPhase: [String: String] = [:]
 
@@ -617,6 +621,9 @@ final class FileDropOverlayView: NSView {
             prev.draggingExited(sender)
             activeDragWebView = nil
         }
+        // [TextBox] No per-step notification needed — InputTextView does not
+        // maintain cross-event drag state. Just drop our reference.
+        activeDragTextBox = nil
     }
 
     override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
@@ -628,6 +635,9 @@ final class FileDropOverlayView: NSView {
         )
         let webView = activeDragWebView
         activeDragWebView = nil
+        // [TextBox] Capture the TextBox target before resetting it.
+        let textBox = activeDragTextBox
+        activeDragTextBox = nil
         let terminal = terminalUnderPoint(sender.draggingLocation)
         let hasTerminalTarget = terminal != nil
 #if DEBUG
@@ -642,6 +652,18 @@ final class FileDropOverlayView: NSView {
         guard shouldCapture else { return false }
         if let webView {
             return webView.performDragOperation(sender)
+        }
+        // [TextBox] TextBox wins over terminal when the cursor is over one
+        // (TextBox sits below the terminal view, so they do not overlap; this
+        // branch fires when the drop lands inside the bordered text field).
+        if let textBox {
+            let urls = (sender.draggingPasteboard.readObjects(
+                forClasses: [NSURL.self],
+                options: [.urlReadingFileURLsOnly: true]
+            ) as? [URL]) ?? []
+            guard !urls.isEmpty else { return false }
+            textBox.insertDroppedFilePaths(urls)
+            return true
         }
         guard let terminal else { return false }
         return terminal.performDragOperation(sender)
@@ -663,12 +685,22 @@ final class FileDropOverlayView: NSView {
         }
 
         if let webView {
+            // [TextBox] Browser beats TextBox when the browser pane owns the point.
+            activeDragTextBox = nil
             if activeDragWebView !== webView {
                 activeDragWebView = webView
                 return webView.draggingEntered(sender)
             }
             return webView.draggingUpdated(sender)
         }
+
+        // [TextBox] After browser has had its turn, check whether the cursor is
+        // over an InputTextView. Return `.copy` so macOS shows the green `+`
+        // badge — otherwise users see the reject cursor over a target that
+        // will actually accept the drop. Plan §4.9.
+        let textBox = shouldCapture ? textBoxUnderPoint(loc) : nil
+        activeDragTextBox = textBox
+        if textBox != nil { return .copy }
 
         let hasTerminalTarget = terminalUnderPoint(loc) != nil
 #if DEBUG
@@ -682,6 +714,23 @@ final class FileDropOverlayView: NSView {
 #endif
         guard shouldCapture, hasTerminalTarget else { return [] }
         return .copy
+    }
+
+    /// [TextBox] Hit-test the window for an `InputTextView` (TextBox field)
+    /// at the given window point. Mirrors `webViewUnderPoint` but walks the
+    /// hit view's ancestor chain for the custom NSTextView subclass.
+    private func textBoxUnderPoint(_ windowPoint: NSPoint) -> InputTextView? {
+        guard let window, let contentView = window.contentView else { return nil }
+        isHidden = true
+        defer { isHidden = false }
+        let point = contentView.convert(windowPoint, from: nil)
+        guard let hitView = contentView.hitTest(point) else { return nil }
+        var current: NSView? = hitView
+        while let view = current {
+            if let inputView = view as? InputTextView { return inputView }
+            current = view.superview
+        }
+        return nil
     }
 
     private func debugPasteboardTypes(_ types: [NSPasteboard.PasteboardType]?) -> String {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7765,6 +7765,20 @@ final class GhosttySurfaceScrollView: NSView {
             }
             window.makeKeyAndOrderFront(nil)
         }
+        // [TextBox] Do not steal focus from an active TextBox. ensureFocus
+        // runs on tab switches, socket focus commands, and session restore.
+        // If the user has moved focus into a panel's TextBox we must respect
+        // that intent — the explicit Cmd+Option+B shortcut is the supported
+        // way to move focus back to the terminal. See plan §4.8 F11.
+        if window.firstResponder is InputTextView {
+#if DEBUG
+            dlog(
+                "focus.ensure.skip surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") " +
+                "reason=textBoxFocused"
+            )
+#endif
+            return
+        }
         let result = window.makeFirstResponder(surfaceView)
 #if DEBUG
         dlog(
@@ -7898,6 +7912,16 @@ final class GhosttySurfaceScrollView: NSView {
         if let fr = window.firstResponder, isSearchOverlayOrDescendant(fr) {
 #if DEBUG
             dlog("find.applyFirstResponder SKIP surface=\(surfaceShort) reason=searchOverlayFocused")
+#endif
+            return
+        }
+        // [TextBox] Same rule as ensureFocus: the automatic apply path
+        // (didBecomeKey, viewDidMoveToWindow, setActive, setVisibleInUI,
+        // etc.) must not reclaim focus while the user is composing in a
+        // TextBox. See plan §4.8 F11.
+        if window.firstResponder is InputTextView {
+#if DEBUG
+            dlog("find.applyFirstResponder SKIP surface=\(surfaceShort) reason=textBoxFocused")
 #endif
             return
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -846,6 +846,10 @@ class GhosttyApp {
     private(set) var config: ghostty_config_t?
     private(set) var defaultBackgroundColor: NSColor = .windowBackgroundColor
     private(set) var defaultBackgroundOpacity: Double = 1.0
+    /// [TextBox] Foreground color derived from the active Ghostty theme.
+    /// Mirrors `defaultBackgroundColor`; consumed by `TextBoxInputContainer`
+    /// for text/border/insertion-point styling that matches the terminal.
+    private(set) var defaultForegroundColor: NSColor = .textColor
     private static func resolveBackgroundLogURL(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL {
@@ -1678,6 +1682,19 @@ class GhosttyApp {
                 red: CGFloat(color.r) / 255,
                 green: CGFloat(color.g) / 255,
                 blue: CGFloat(color.b) / 255,
+                alpha: 1.0
+            )
+        }
+
+        // [TextBox] Pick up the theme foreground alongside the background so
+        // TextBoxInputContainer can mirror the terminal's text color.
+        var fgColor = ghostty_config_color_s()
+        let fgKey = "foreground"
+        if ghostty_config_get(config, &fgColor, fgKey, UInt(fgKey.lengthOfBytes(using: .utf8))) {
+            defaultForegroundColor = NSColor(
+                red: CGFloat(fgColor.r) / 255,
+                green: CGFloat(fgColor.g) / 255,
+                blue: CGFloat(fgColor.b) / 255,
                 alpha: 1.0
             )
         }
@@ -3507,6 +3524,78 @@ final class TerminalSurface: Identifiable, ObservableObject {
             return
         }
         writeTextData(data, to: surface)
+    }
+
+    // MARK: - [TextBox] TextBoxInput integration helpers
+    //
+    // The TextBoxInputContainer needs to move first-responder back to the
+    // terminal view, forward raw NSEvents, and send synthetic key events
+    // (Return, arrows, Tab, Backspace, Escape) when key routing decides
+    // the keystroke belongs to the terminal instead of the TextBox. These
+    // helpers are additive — they do not touch `forceRefresh` or any
+    // other typing-latency-sensitive hot path.
+
+    /// Move keyboard focus back to the terminal surface view.
+    func focusTerminalView() {
+        let view = surfaceView
+        guard let window = view.window else { return }
+        DispatchQueue.main.async {
+            window.makeFirstResponder(view)
+        }
+    }
+
+    /// Build a synthetic `NSEvent` for a named key and deliver it to the
+    /// terminal surface the same way AppKit would route a real keystroke.
+    func sendSyntheticKey(
+        characters: String,
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags = []
+    ) {
+        let view = surfaceView
+        guard let window = view.window else { return }
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: modifiers,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        ) else { return }
+        view.keyDown(with: event)
+    }
+
+    /// Named-key wrapper used by `TextBoxInputContainer` when routing
+    /// decides a keystroke belongs to the terminal (Rule 5/9) or when
+    /// submitting via bracket-paste (`TextBoxSubmit`).
+    func sendKey(_ key: TextBoxKeyRouting.TerminalKey) {
+        sendSyntheticKey(characters: key.characters, keyCode: key.keyCode)
+    }
+
+    /// Pass-through for a fully-formed NSEvent (Rule 2 `forwardControl`).
+    func forwardKeyEvent(_ event: NSEvent) {
+        surfaceView.keyDown(with: event)
+    }
+
+    /// Whether the user has scrolled up to review scrollback. Used by
+    /// `TextBoxInputContainer` to decide whether to restore scroll
+    /// position after the TextBox resizes (which triggers SIGWINCH).
+    var isScrolledUp: Bool {
+        hostedView.isUserScrolledAwayFromBottom
+    }
+
+    /// Current scrollbar offset (row index), if Ghostty has reported one.
+    var scrollbarOffset: UInt64? {
+        hostedView.currentScrollbarOffset
+    }
+
+    /// Scroll the terminal back to a saved row. Used to preserve scroll
+    /// position across TextBox height changes.
+    func scrollToRow(_ row: UInt64) {
+        _ = performBindingAction("scroll_to_row:\(row)")
     }
 
     func requestBackgroundSurfaceStartIfNeeded() {
@@ -6148,6 +6237,10 @@ final class GhosttySurfaceScrollView: NSView {
     /// When true, auto-scroll should be suspended to prevent the "doomscroll" bug
     /// where the terminal fights the user's scroll position.
     private var userScrolledAwayFromBottom = false
+    /// [TextBox] Read-only accessor used by `TerminalSurface.isScrolledUp`.
+    var isUserScrolledAwayFromBottom: Bool { userScrolledAwayFromBottom }
+    /// [TextBox] Read-only accessor used by `TerminalSurface.scrollbarOffset`.
+    var currentScrollbarOffset: UInt64? { surfaceView.scrollbar?.offset }
     /// Threshold in points from bottom to consider "at bottom" (allows for minor float drift)
     private static let scrollToBottomThreshold: CGFloat = 5.0
     private var isActive = true

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -45,6 +45,9 @@ enum KeyboardShortcutSettings {
         case toggleBrowserDeveloperTools
         case showBrowserJavaScriptConsole
 
+        // Input
+        case toggleTextBoxInput
+
         var id: String { rawValue }
 
         var label: String {
@@ -79,6 +82,7 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return String(localized: "shortcut.openBrowser.label", defaultValue: "Open Browser")
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
+            case .toggleTextBoxInput: return String(localized: "shortcut.toggleTextBoxInput.label", defaultValue: "Toggle TextBox Input")
             }
         }
 
@@ -114,6 +118,7 @@ enum KeyboardShortcutSettings {
             case .openBrowser: return "shortcut.openBrowser"
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
+            case .toggleTextBoxInput: return "shortcut.toggleTextBoxInput"
             }
         }
 
@@ -181,6 +186,12 @@ enum KeyboardShortcutSettings {
             case .showBrowserJavaScriptConsole:
                 // Safari default: Show JavaScript Console.
                 return StoredShortcut(key: "c", command: true, shift: false, option: true, control: false)
+            case .toggleTextBoxInput:
+                // Cmd+Option+T is already bound in AppDelegate to close-other-tabs
+                // (see AppDelegateShortcutRoutingTests); the upstream fork author's
+                // own source comment calls out Cmd+Option+B as the conflict-free
+                // choice. See plan §4.5.
+                return StoredShortcut(key: "b", command: true, shift: false, option: true, control: false)
             }
         }
 

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -45,9 +45,9 @@ final class TerminalPanel: Panel, ObservableObject {
     // flags let SwiftUI react to toggle changes; the input view is a
     // non-published `weak` so view lifecycle does not churn observers.
 
-    /// Whether the TextBox is mounted for this panel. On by default;
-    /// Cmd+Option+B toggles visibility per panel.
-    @Published var isTextBoxActive: Bool = true
+    /// Whether the TextBox is mounted for this panel. Hidden by default;
+    /// Cmd+Option+B summons and dismisses it per panel.
+    @Published var isTextBoxActive: Bool = false
 
     /// Draft text currently held in the TextBox. Preserved across tab
     /// switches so users do not lose in-flight prompts.

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -36,6 +36,27 @@ final class TerminalPanel: Panel, ObservableObject {
     /// (hostedView.window == nil) until the user switches workspaces.
     @Published var viewReattachToken: UInt64 = 0
 
+    // MARK: - [TextBox] Per-panel TextBoxInput state
+    //
+    // Each terminal panel owns its own TextBox visibility flag, draft
+    // content buffer, and a weak reference to the live InputTextView so
+    // the workspace can swap focus between the TextBox and the terminal
+    // without walking the AppKit responder chain. The `@Published`
+    // flags let SwiftUI react to toggle changes; the input view is a
+    // non-published `weak` so view lifecycle does not churn observers.
+
+    /// Whether the TextBox is mounted for this panel. Seeded from the
+    /// global "Enable Mode" setting; workspace-level toggles update it.
+    @Published var isTextBoxActive: Bool = TextBoxInputSettings.isEnabled()
+
+    /// Draft text currently held in the TextBox. Preserved across tab
+    /// switches so users do not lose in-flight prompts.
+    @Published var textBoxContent: String = ""
+
+    /// Live InputTextView for this panel (when mounted). Used by
+    /// `Workspace.toggleTextBoxMode` to detect and move focus.
+    weak var inputTextView: InputTextView?
+
     private var cancellables = Set<AnyCancellable>()
 
     var displayTitle: String {

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -45,9 +45,9 @@ final class TerminalPanel: Panel, ObservableObject {
     // flags let SwiftUI react to toggle changes; the input view is a
     // non-published `weak` so view lifecycle does not churn observers.
 
-    /// Whether the TextBox is mounted for this panel. Seeded from the
-    /// global "Enable Mode" setting; workspace-level toggles update it.
-    @Published var isTextBoxActive: Bool = TextBoxInputSettings.isEnabled()
+    /// Whether the TextBox is mounted for this panel. On by default;
+    /// Cmd+Option+B toggles visibility per panel.
+    @Published var isTextBoxActive: Bool = true
 
     /// Draft text currently held in the TextBox. Preserved across tab
     /// switches so users do not lose in-flight prompts.

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -7,6 +7,13 @@ struct TerminalPanelView: View {
     @ObservedObject var panel: TerminalPanel
     @AppStorage(NotificationPaneRingSettings.enabledKey)
     private var notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
+    // [TextBox] TextBox Input settings (plan §4.3)
+    @AppStorage(TextBoxInputSettings.enabledKey)
+    private var textBoxEnabled = TextBoxInputSettings.defaultEnabled
+    @AppStorage(TextBoxInputSettings.enterToSendKey)
+    private var textBoxEnterToSend = TextBoxInputSettings.defaultEnterToSend
+    @AppStorage(TextBoxInputSettings.shortcutBehaviorKey)
+    private var textBoxShortcutBehavior = TextBoxInputSettings.defaultShortcutBehavior.rawValue
     let isFocused: Bool
     let isVisibleInUI: Bool
     let portalPriority: Int
@@ -16,23 +23,78 @@ struct TerminalPanelView: View {
     let onFocus: () -> Void
     let onTriggerFlash: () -> Void
 
+    /// Whether the TextBox should be mounted for this panel right now.
+    /// Global setting AND per-panel flag both must be on.
+    private var showTextBox: Bool {
+        textBoxEnabled && panel.isTextBoxActive
+    }
+
+    /// Resolve the terminal type from SurfaceMetadataStore (set by
+    /// AgentDetector). Returns `nil` until the detector has classified
+    /// the surface; `TextBoxAppDetection` falls back to title regex in
+    /// that case.
+    private var terminalTypeFromMetadata: String? {
+        let snapshot = SurfaceMetadataStore.shared.getMetadata(
+            workspaceId: panel.workspaceId, surfaceId: panel.id
+        )
+        return snapshot.metadata[MetadataKey.terminalType] as? String
+    }
+
+    /// Font to use for the TextBox. Matches the active Ghostty config
+    /// size when available; falls back to the system monospaced default.
+    private var terminalFont: NSFont {
+        NSFont.monospacedSystemFont(
+            ofSize: GhosttyConfig.load().fontSize,
+            weight: .regular
+        )
+    }
+
     var body: some View {
         // Layering contract: terminal find UI is mounted in GhosttySurfaceScrollView (AppKit portal layer)
         // via `searchState`. Rendering `SurfaceSearchOverlay` in this SwiftUI container can hide it.
-        GhosttyTerminalView(
-            terminalSurface: panel.surface,
-            isActive: isFocused,
-            isVisibleInUI: isVisibleInUI,
-            portalZPriority: portalPriority,
-            showsInactiveOverlay: isSplit && !isFocused,
-            showsUnreadNotificationRing: hasUnreadNotification && notificationPaneRingEnabled,
-            inactiveOverlayColor: appearance.unfocusedOverlayNSColor,
-            inactiveOverlayOpacity: appearance.unfocusedOverlayOpacity,
-            searchState: panel.searchState,
-            reattachToken: panel.viewReattachToken,
-            onFocus: { _ in onFocus() },
-            onTriggerFlash: onTriggerFlash
-        )
+        // The TextBox mounts BELOW the terminal view in a SwiftUI VStack — the search overlay stays in
+        // the AppKit portal layer (unchanged) and is unaffected by this wrapper.
+        VStack(spacing: 0) {
+            GhosttyTerminalView(
+                terminalSurface: panel.surface,
+                isActive: isFocused,
+                isVisibleInUI: isVisibleInUI,
+                portalZPriority: portalPriority,
+                showsInactiveOverlay: isSplit && !isFocused,
+                showsUnreadNotificationRing: hasUnreadNotification && notificationPaneRingEnabled,
+                inactiveOverlayColor: appearance.unfocusedOverlayNSColor,
+                inactiveOverlayOpacity: appearance.unfocusedOverlayOpacity,
+                searchState: panel.searchState,
+                reattachToken: panel.viewReattachToken,
+                onFocus: { _ in onFocus() },
+                onTriggerFlash: onTriggerFlash
+            )
+
+            if showTextBox {
+                TextBoxInputContainer(
+                    text: $panel.textBoxContent,
+                    enterToSend: textBoxEnterToSend,
+                    surface: panel.surface,
+                    terminalBackgroundColor: GhosttyApp.shared.defaultBackgroundColor
+                        .withAlphaComponent(GhosttyApp.shared.defaultBackgroundOpacity),
+                    terminalForegroundColor: GhosttyApp.shared.defaultForegroundColor,
+                    terminalFont: terminalFont,
+                    terminalTitle: panel.title,
+                    terminalType: terminalTypeFromMetadata,
+                    onInputTextViewCreated: { [weak panel] view in
+                        panel?.inputTextView = view
+                    }
+                )
+            }
+        }
+        // [TextBox] When the user flips "Enable Mode" on, force the panel's
+        // runtime flag to match so the TextBox appears immediately without
+        // needing the user to press Cmd+Option+B first.
+        .onChange(of: textBoxEnabled) { newValue in
+            if newValue {
+                panel.isTextBoxActive = true
+            }
+        }
         // Keep the NSViewRepresentable identity stable across bonsplit structural updates.
         // This prevents transient teardown/recreate that can momentarily detach the hosted terminal view.
         .id(panel.id)

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -8,8 +8,6 @@ struct TerminalPanelView: View {
     @AppStorage(NotificationPaneRingSettings.enabledKey)
     private var notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
     // [TextBox] TextBox Input settings (plan §4.3)
-    @AppStorage(TextBoxInputSettings.enabledKey)
-    private var textBoxEnabled = TextBoxInputSettings.defaultEnabled
     @AppStorage(TextBoxInputSettings.enterToSendKey)
     private var textBoxEnterToSend = TextBoxInputSettings.defaultEnterToSend
     @AppStorage(TextBoxInputSettings.shortcutBehaviorKey)
@@ -24,9 +22,9 @@ struct TerminalPanelView: View {
     let onTriggerFlash: () -> Void
 
     /// Whether the TextBox should be mounted for this panel right now.
-    /// Global setting AND per-panel flag both must be on.
+    /// Per-panel toggle is the only gate; Cmd+Option+B flips it.
     private var showTextBox: Bool {
-        textBoxEnabled && panel.isTextBoxActive
+        panel.isTextBoxActive
     }
 
     /// Resolve the terminal type from SurfaceMetadataStore (set by
@@ -85,14 +83,6 @@ struct TerminalPanelView: View {
                         panel?.inputTextView = view
                     }
                 )
-            }
-        }
-        // [TextBox] When the user flips "Enable Mode" on, force the panel's
-        // runtime flag to match so the TextBox appears immediately without
-        // needing the user to press Cmd+Option+B first.
-        .onChange(of: textBoxEnabled) { newValue in
-            if newValue {
-                panel.isTextBoxActive = true
             }
         }
         // Keep the NSViewRepresentable identity stable across bonsplit structural updates.

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -88,8 +88,8 @@ inputTextView reference. Switching tabs preserves TextBox state.
 
 ## Settings (Settings > TextBox Input)
 
-TextBox is on by default for every terminal pane; Cmd+Option+B toggles
-visibility per panel.
+TextBox is hidden by default; Cmd+Option+B summons and dismisses it per
+panel (the only toggle — there is no global "Enable Mode" setting).
 
 - **Send on Return**: On = Return sends / Shift+Enter inserts newline,
   Off = Enter inserts newline / Shift+Enter sends (default: on)
@@ -178,7 +178,7 @@ visibility per panel.
 - [ ] T9.4  Cmd+Opt+B moves focus to terminal when TextBox focused (toggleFocus mode)
 - [ ] T9.5  Toggle applies to all tabs simultaneously
 - [ ] T9.6  Custom shortcut key works after changing in Settings
-- [ ] T9.7  New terminal panes have TextBox visible by default
+- [ ] T9.7  New terminal panes start with the TextBox hidden; Cmd+Opt+B summons it
 
 ### T10. Drag & Drop (F8)
 - [ ] T10.1  Drop single file → shell-escaped path inserted
@@ -213,7 +213,7 @@ visibility per panel.
 ### T14. Per-panel State (F14)
 - [ ] T14.1  Switching tabs preserves TextBox content
 - [ ] T14.2  Toggle applies to all tabs simultaneously (global, not per-tab)
-- [ ] T14.3  New tab starts with TextBox visible (isTextBoxActive=true)
+- [ ] T14.3  New tab starts with TextBox hidden (isTextBoxActive=false)
 - [ ] T14.4  Split panes each have their own TextBox
 
 ### T15. Placeholder & Send Button (F9, F10)

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1,0 +1,1293 @@
+/*
+TextBoxInput.swift
+
+# TextBox Input Mode
+
+Provides a native text editing experience for terminal input that
+terminal emulators typically struggle with.
+
+## Rationale
+
+ghostty (libghostty)'s key input path has limitations with IME,
+macOS standard keybindings, and system clipboard operations. TextBox
+handles these natively via AppKit and sends only committed text to the
+terminal. Shell history, tab completion, and Ctrl+key commands are
+transparently forwarded while keeping focus in the TextBox, so users
+get a seamless experience without being aware of two input modes.
+
+## Features
+
+### F1. Native Text Editing
+Full macOS standard operations: Cmd+A (select all), Cmd+C/V/X (copy/paste/cut),
+Cmd+Z/Shift+Cmd+Z (undo/redo), Option+Arrow (word navigation), mouse selection,
+double-click word select, triple-click line select.
+
+### F2. IME Support
+Input methods (Japanese, Chinese, Korean, etc.) work correctly via NSTextView's
+built-in marked text handling. Composition is not interrupted by terminal updates.
+
+### F3. Multi-line Input
+Insert newlines for multi-line text submission.
+Default: Enter = send, Shift+Enter = newline (reversible in settings).
+
+### F4. Auto-grow
+Text box grows with content (1–8 visible lines), then scrolls internally.
+Shrinks back to minimum after submit.
+
+### F5. Key Routing
+All rules are defined in `TextBoxKeyRouting` as a centralized table.
+See the rule table above that enum for the full specification.
+- Rule 1: Emacs editing (Ctrl+A/E/F/B/N/P/K/H) — handled by NSTextView
+- Rule 2: Ctrl+other — forwarded to terminal (keep focus)
+- Rule 3: "/" prefix — forwarded to terminal + focus terminal (empty, Claude Code/Codex)
+- Rule 4: "@" prefix — forwarded to terminal + focus terminal (empty, Claude Code/Codex)
+- Rule 5: "?" key — forwarded as raw event (empty, Claude Code/Codex, keep focus)
+- Rule 6/7: Return/Shift+Return — submit or newline (setting-dependent)
+- Rule 8: Escape — focus terminal or send ESC (setting-dependent)
+- Rule 9: ↑ ↓ ← → Tab Backspace — forwarded to terminal when empty (keep focus)
+- Rule 10: Fallback — default TextBox text input
+
+### F6. Theme Sync
+Matches terminal background/foreground colors (via Ghostty runtime config),
+font size, background-opacity, and selection colors (inverted fg/bg).
+
+### F7. Toggle Shortcut
+Cmd+Option+B to toggle display or focus (configurable in Settings).
+Default behavior: Toggle Focus (keep TextBox visible, swap focus).
+Scope: all tabs toggle simultaneously.
+
+### F8. Drag & Drop
+Drop files/folders from Finder onto the TextBox to insert shell-escaped paths.
+Multiple files are space-separated. Dropped text is selected for easy review.
+
+### F9. Placeholder
+Shows dynamic hint text when empty ("Commands or prompts here…")
+with the current send key (Return or Shift+Return) based on settings.
+
+### F10. Send Button
+Paperplane icon button with hover/press highlight. Submits TextBox content.
+
+### F11. Focus Guards
+Terminal focus-restore mechanisms (ensureFocus, applyFirstResponder) skip
+stealing focus when an InputTextView is the current first responder.
+
+### F12. App Detection
+Detects Claude Code and Codex by matching terminal tab title (regex,
+case-insensitive). Claude Code is also detected when the title starts
+with "✱" or "✳" (icon prefix) or "⠂" (thinking indicator).
+Used to enable prefix/key forwarding (Rules 3–5).
+
+### F13. Bracket Paste Submission
+Text is sent via PTY bracket paste, then Return is sent as a separate
+synthetic key event after a 200ms delay. This ensures apps using bracket
+paste mode (zsh, Claude CLI) process the paste before receiving Return.
+
+### F14. Per-panel State
+Each TerminalPanel has independent isTextBoxActive, textBoxContent, and
+inputTextView reference. Switching tabs preserves TextBox state.
+
+## Settings (Settings > TextBox Input)
+
+- **Enable Mode**: Toggle TextBox on/off (default: off)
+- **Send on Return**: On = Return sends / Shift+Enter inserts newline,
+  Off = Enter inserts newline / Shift+Enter sends (default: on)
+- **Escape Key**: Send ESC Key or Focus Terminal (default: Send ESC Key)
+- **Keyboard Shortcut (Cmd+Option+B)**: Toggle Display or Toggle Focus
+  (default: Toggle Focus). Key is customizable in Keyboard Shortcuts settings.
+
+## Test Plan
+
+### T1. Settings
+- [ ] T1.1  Default values: enabled=false, enterToSend=true, escape=sendEscape, shortcut=toggleFocus
+- [ ] T1.2  Toggle each setting and verify it persists across app restart
+- [ ] T1.3  Reset All restores all settings to defaults
+- [ ] T1.4  Settings rows are dimmed/disabled when Enable Mode is off
+
+### T2. Basic Text Editing (F1)
+- [ ] T2.1  Type text and verify it appears in the TextBox
+- [ ] T2.2  Cmd+A selects all text
+- [ ] T2.3  Cmd+C/V/X copy, paste, cut
+- [ ] T2.4  Cmd+Z undo, Shift+Cmd+Z redo
+- [ ] T2.5  Option+Left/Right moves by word
+- [ ] T2.6  Mouse click positions cursor
+- [ ] T2.7  Mouse drag selects text
+- [ ] T2.8  Double-click selects word, triple-click selects line
+
+### T3. IME (F2)
+- [ ] T3.1  Japanese input (Hiragana → Kanji conversion) completes correctly
+- [ ] T3.2  Chinese pinyin input works
+- [ ] T3.3  Korean input works
+- [ ] T3.4  IME composition is not interrupted by terminal title updates
+
+### T4. Multi-line & Auto-grow (F3, F4)
+- [ ] T4.1  Shift+Return inserts newline (enterToSend=on)
+- [ ] T4.2  Return inserts newline (enterToSend=off)
+- [ ] T4.3  TextBox height grows from 2 lines up to 8 lines
+- [ ] T4.4  Beyond 8 lines, content scrolls internally
+- [ ] T4.5  After submit, TextBox shrinks back to minimum height
+
+### T5. Key Routing — Emacs (F5, Rule 1)
+- [ ] T5.1  Ctrl+A moves to beginning of line
+- [ ] T5.2  Ctrl+E moves to end of line
+- [ ] T5.3  Ctrl+F moves forward, Ctrl+B moves backward
+- [ ] T5.4  Ctrl+N moves down, Ctrl+P moves up (multi-line)
+- [ ] T5.5  Ctrl+K kills to end of line
+- [ ] T5.6  Ctrl+H deletes backward
+
+### T6. Key Routing — Terminal Forwarding (F5, Rules 2–5, 9)
+- [ ] T6.1  Ctrl+C sends SIGINT to terminal (focus stays in TextBox)
+- [ ] T6.2  Ctrl+D sends EOF to terminal
+- [ ] T6.3  Ctrl+Z sends SIGTSTP to terminal
+- [ ] T6.4  Ctrl+L clears terminal screen
+- [ ] T6.5  "/" in empty TextBox + Claude Code → forwarded, focus moves to terminal
+- [ ] T6.6  "/" in non-empty TextBox → typed as text
+- [ ] T6.7  "/" in empty TextBox + plain shell → typed as text
+- [ ] T6.8  "@" in empty TextBox + Claude Code → forwarded, focus moves to terminal
+- [ ] T6.9  "@" in empty TextBox + Codex → forwarded, focus moves to terminal
+- [ ] T6.10 "?" in empty TextBox + Claude Code → forwarded as key event, focus stays
+- [ ] T6.11 "?" in non-empty TextBox → typed as text
+- [ ] T6.12 Arrow Up/Down in empty TextBox → shell history navigation
+- [ ] T6.13 Tab in empty TextBox → tab completion in terminal
+- [ ] T6.14 Backspace in empty TextBox → forwarded to terminal
+- [ ] T6.15 Arrow keys in non-empty TextBox → cursor movement within TextBox
+
+### T7. Submit & Escape (F5, Rules 6–8)
+- [ ] T7.1  Return submits text (enterToSend=on)
+- [ ] T7.2  Shift+Return submits text (enterToSend=off)
+- [ ] T7.3  Submitted text appears in terminal with command execution
+- [ ] T7.4  TextBox is cleared after submit
+- [ ] T7.5  Empty submit sends just Return to terminal
+- [ ] T7.6  Escape sends ESC key to terminal (escape=sendEscape)
+- [ ] T7.7  Escape moves focus to terminal (escape=focusTerminal)
+- [ ] T7.8  Multi-line text is sent correctly via bracket paste
+
+### T8. Theme Sync (F6)
+- [ ] T8.1  TextBox background matches terminal background color
+- [ ] T8.2  TextBox text color matches terminal foreground color
+- [ ] T8.3  TextBox respects background-opacity setting
+- [ ] T8.4  Selection color is inverted (fg on bg)
+- [ ] T8.5  Font size matches terminal font size
+- [ ] T8.6  Cursor (insertion point) color matches foreground
+- [ ] T8.7  Theme changes are reflected immediately
+
+### T9. Toggle Shortcut (F7)
+- [ ] T9.1  Cmd+Opt+B shows TextBox when hidden (toggleDisplay mode)
+- [ ] T9.2  Cmd+Opt+B hides TextBox when shown (toggleDisplay mode)
+- [ ] T9.3  Cmd+Opt+B moves focus to TextBox when unfocused (toggleFocus mode)
+- [ ] T9.4  Cmd+Opt+B moves focus to terminal when TextBox focused (toggleFocus mode)
+- [ ] T9.5  Toggle applies to all tabs simultaneously
+- [ ] T9.6  Custom shortcut key works after changing in Settings
+- [ ] T9.7  Enabling "Enable Mode" setting forces TextBox visible
+
+### T10. Drag & Drop (F8)
+- [ ] T10.1  Drop single file → shell-escaped path inserted
+- [ ] T10.2  Drop multiple files → space-separated escaped paths
+- [ ] T10.3  Drop folder → folder path inserted
+- [ ] T10.4  Paths with spaces/special chars are properly escaped
+- [ ] T10.5  Green "+" badge appears when dragging over TextBox
+- [ ] T10.6  Dropped text is selected for review
+- [ ] T10.7  Drop onto terminal area still works normally
+
+### T11. Focus Guards (F11)
+- [ ] T11.1  Terminal ensureFocus does not steal focus from TextBox
+- [ ] T11.2  Find panel close does not steal focus from TextBox
+- [ ] T11.3  Clicking TextBox gives it focus
+- [ ] T11.4  Border brightens when focused, dims when unfocused
+
+### T12. App Detection (F12)
+- [ ] T12.1  "Claude Code" in title → detected
+- [ ] T12.2  "✱ Claude Code" or "✳ Claude Code" (with icon) → detected
+- [ ] T12.2b Title starting with "✳" (e.g. "✳ Japanese greeting conversation") → detected as Claude Code
+- [ ] T12.2c Title starting with "⠂" (e.g. "⠂ New coding session") → detected as Claude Code
+- [ ] T12.3  "Codex" in title → detected
+- [ ] T12.4  "zsh" or "bash" → not detected
+- [ ] T12.5  Detection is case-insensitive
+
+### T13. Bracket Paste & Timing (F13)
+- [ ] T13.1  Pasted text arrives in terminal correctly
+- [ ] T13.2  Return is sent after 200ms delay (not inside bracket paste)
+- [ ] T13.3  Shell (zsh) executes pasted commands correctly
+- [ ] T13.4  Claude CLI receives pasted prompts correctly
+
+### T14. Per-panel State (F14)
+- [ ] T14.1  Switching tabs preserves TextBox content
+- [ ] T14.2  Toggle applies to all tabs simultaneously (global, not per-tab)
+- [ ] T14.3  New tab inherits global Enable Mode setting
+- [ ] T14.4  Split panes each have their own TextBox
+
+### T15. Placeholder & Send Button (F9, F10)
+- [ ] T15.1  Placeholder text shows when TextBox is empty
+- [ ] T15.2  Placeholder disappears when text is entered
+- [ ] T15.3  Placeholder reflects current send key setting
+- [ ] T15.4  Send button submits text on click
+- [ ] T15.5  Send button shows hover highlight
+- [ ] T15.6  Send button shows press state
+
+## Upstream Impact
+
+Code added to upstream (manaflow-ai/cmux) files is marked with `[TextBox]`.
+Run `grep -r '\[TextBox\]' Sources/` to list all locations.
+*/
+
+import AppKit
+import SwiftUI
+
+// MARK: - Constants
+
+/// Layout constants for the TextBox bar (outer container with padding, button, spacing).
+private enum TextBoxLayout {
+    /// Font size of the send button icon.
+    static let sendButtonSize: CGFloat = 18
+    /// Spacing between the text view and the send button.
+    static let contentSpacing: CGFloat = 4
+    /// Left padding of the entire TextBox bar.
+    static let leftPadding: CGFloat = 8
+    /// Right padding of the entire TextBox bar.
+    static let rightPadding: CGFloat = 8
+    /// Top padding of the entire TextBox bar.
+    static let topPadding: CGFloat = 8
+    /// Bottom padding of the entire TextBox bar.
+    static let bottomPadding: CGFloat = 8
+}
+
+/// Layout constants for the internal NSTextView (font, sizing, border, insets).
+private enum TextBoxInputViewLayout {
+    /// Minimum number of visible lines.
+    static let minLines: Int = 2
+    /// Maximum number of visible lines before the text view starts scrolling internally.
+    static let maxLines: Int = 8
+    /// Added to the terminal font size for the TextBox font (slightly larger for readability).
+    static let fontSizeOffset: CGFloat = 1
+    /// Extra spacing between lines in multi-line input.
+    static let lineSpacing: CGFloat = 4
+    /// Inset between the text and the text view's border (width=horizontal, height=vertical).
+    static let textInset = NSSize(width: 2, height: 6)
+    /// Border stroke width around the text view container.
+    static let borderWidth: CGFloat = 1
+    /// Border color opacity when unfocused (fraction of the terminal foreground color).
+    static let borderOpacity: CGFloat = 0.25
+    /// Border color opacity when focused (caret is in the text view).
+    static let focusedBorderOpacity: CGFloat = 0.45
+    /// Corner radius of the text view container.
+    static let cornerRadius: CGFloat = 6
+    /// Opacity of the placeholder text (fraction of the terminal foreground color).
+    static let placeholderOpacity: CGFloat = 0.35
+    /// Placeholder text shown when the TextBox is empty.
+    /// The send key name changes based on the Enter-to-Send setting.
+    static func placeholderText(enterToSend: Bool) -> String {
+        if enterToSend {
+            return String(localized: "textbox.placeholder.enterToSend", defaultValue: "Commands or prompts here… Shift+Return for newline")
+        } else {
+            return String(localized: "textbox.placeholder.enterToNewline", defaultValue: "Commands or prompts here… Shift+Return to send")
+        }
+    }
+}
+
+/// Behavioral constants for TextBox (timing, thresholds, etc.).
+private enum TextBoxBehavior {
+    /// Delay (ms) between sending pasted text and the Return key.
+    /// Apps using bracket paste mode (zsh, Claude CLI) need time to process
+    /// the paste before receiving Return. 50ms/100ms are insufficient;
+    /// 200ms is the minimum reliable value. See `TextBoxSubmit` for details.
+    /// Set to 0 to send Return immediately after the paste.
+    static let returnKeyDelayMs: Int = 200
+    /// Delay (ms) before sending Return when the TextBox is empty (no paste).
+    /// Set to 0 to send Return immediately (default).
+    static let emptyReturnKeyDelayMs: Int = 0
+    /// Scope of the Cmd+Opt+B toggle shortcut.
+    /// `.active` = only the focused tab, `.all` = all tabs simultaneously.
+    static let toggleScope: TextBoxToggleTarget = .all
+}
+
+// MARK: - Toggle Scope
+
+/// Scope of the TextBox toggle shortcut (Cmd+Opt+B).
+enum TextBoxToggleTarget {
+    /// Toggle only the currently active (focused or TextBox-focused) panel.
+    case active
+    /// Toggle all terminal panels simultaneously.
+    case all
+
+    /// The configured default scope, read from TextBoxBehavior.
+    static var `default`: TextBoxToggleTarget { TextBoxBehavior.toggleScope }
+}
+
+// MARK: - App Detection
+
+/// Terminal apps detected for TextBox key-routing decisions.
+///
+/// Detection is metadata-first: if the caller supplies a canonical
+/// `terminalType` string from `SurfaceMetadataStore` (set by c11mux's
+/// `AgentDetector` from M1/M2), that is authoritative. When metadata is
+/// absent or unknown we fall back to the title regex that the upstream
+/// fork uses. This keeps the feature working before `AgentDetector` has
+/// classified a surface and in any environment where metadata is missing.
+enum TextBoxAppDetection: CaseIterable {
+    case claudeCode
+    case codex
+
+    /// Canonical `SurfaceMetadataStore.terminal_type` values. Kept in sync
+    /// with `AgentDetector.classify(...)`.
+    private var metadataTerminalTypes: Set<String> {
+        switch self {
+        case .claudeCode: return ["claude-code"]
+        case .codex:      return ["codex"]
+        }
+    }
+
+    /// Regex pattern matched (case-insensitive) against the terminal tab title.
+    /// Claude Code detection: matches "Claude Code" anywhere in the title,
+    /// or a title starting with "✱ " / "✳ " (idle/active icon) or "⠂ " (thinking indicator).
+    private var tabTitlePattern: String {
+        switch self {
+        case .claudeCode: return "Claude Code|^[✱✳⠂] "
+        case .codex:      return "Codex"
+        }
+    }
+
+    /// Metadata-first match: use `terminalType` when present, otherwise
+    /// fall back to the title regex.
+    func matches(terminalType: String?, terminalTitle: String) -> Bool {
+        if let type = terminalType, !type.isEmpty {
+            return metadataTerminalTypes.contains(type)
+        }
+        return terminalTitle.range(
+            of: tabTitlePattern,
+            options: [.caseInsensitive, .regularExpression]
+        ) != nil
+    }
+
+    /// Title-only match, retained for tests and callers without metadata access.
+    func matches(terminalTitle: String) -> Bool {
+        matches(terminalType: nil, terminalTitle: terminalTitle)
+    }
+}
+
+// MARK: - Focus State
+
+/// The three observable states of the TextBox, used to decide what the
+/// toggle shortcut (Cmd+Opt+B) should do.
+///
+/// Transitions on shortcut press:
+///   hidden           → show TextBox + focus it
+///   visibleUnfocused → focus TextBox (don't hide it)
+///   visibleFocused   → hide TextBox + focus terminal
+enum TextBoxFocusState {
+    /// TextBox is not displayed.
+    case hidden
+    /// TextBox is displayed but the terminal (or another view) has focus.
+    case visibleUnfocused
+    /// TextBox is displayed and has keyboard focus.
+    case visibleFocused
+
+    /// Determine the current state from panel and window state.
+    static func current(isTextBoxActive: Bool, window: NSWindow?) -> TextBoxFocusState {
+        guard isTextBoxActive else { return .hidden }
+        guard let firstResponder = window?.firstResponder else { return .visibleUnfocused }
+        if firstResponder is InputTextView {
+            return .visibleFocused
+        }
+        return .visibleUnfocused
+    }
+
+}
+
+// MARK: - Key Routing
+//
+// All TextBox key handling is governed by the rule table below.
+// Rules are evaluated top-down; the first match wins. Unmatched
+// keys fall through to default TextBox text input.
+//
+// Rules are evaluated within each input path (keyDown / insertText /
+// doCommand). Groups never overlap because each NSTextView interception
+// point produces a distinct input type.
+//
+// | # | Modifier | Key              | TextBox | App              | Action                                |
+// |---|----------|------------------|---------|------------------|---------------------------------------|
+// | 1  | Ctrl     | A E F B N P K H  | any     | any              | Emacs editing (handled by NSTextView) |
+// | 2  | Ctrl     | * (other)        | any     | any              | Forward to terminal (keep focus)      |
+// | 3  |          | /                | empty   | claudeCode,codex | Forward prefix + focus terminal       |
+// | 4  |          | @                | empty   | claudeCode,codex | Forward prefix + focus terminal       |
+// | 5  |          | ?                | empty   | claudeCode,codex | Forward key event to terminal (keep focus) |
+// | 6  |          | Return           | any     | any              | Submit or newline (setting)           |
+// | 7  | Shift    | Return           | any     | any              | Newline or submit (inverse of 6)      |
+// | 8  |          | Escape           | any     | any              | Focus terminal or send ESC (setting)  |
+// | 9  |          | ↑ ↓ ← → Tab BS   | empty   | any              | Forward key to terminal (keep focus)  |
+// | 10 | *        | *                | any     | any              | TextBox text input (fallback)         |
+
+/// Normalized input from the three NSTextView interception points.
+enum TextBoxKeyInput {
+    /// From keyDown(): Ctrl + character key.
+    case ctrl(String)
+    /// From keyDown(): unmodified character key (no Ctrl/Cmd/Option).
+    case key(String)
+    /// From insertText(): committed text character.
+    case text(String)
+    /// From doCommand(): AppKit-interpreted command selector.
+    case command(Selector, shifted: Bool)
+}
+
+/// Routing result — tells the caller what action to take.
+enum TextBoxKeyAction {
+    /// Rule 1: Pass to NSTextView for Emacs-style editing.
+    case emacsEdit
+    /// Rule 2: Forward raw Ctrl+key event to terminal (keep focus).
+    case forwardControl
+    /// Rule 3/4: Forward prefix character to terminal and move focus.
+    case forwardPrefix(String)
+    /// Rule 5: Forward raw key event to terminal (keep focus).
+    case forwardKeyEvent
+    /// Rule 6/7: Send TextBox content to terminal.
+    case submit
+    /// Rule 6/7: Insert newline into TextBox.
+    case insertNewline
+    /// Rule 8: Escape action (setting-dependent).
+    case escape
+    /// Rule 9: Forward interpreted key to terminal (keep focus).
+    case forwardKey(TextBoxKeyRouting.TerminalKey)
+    /// Fallback: Default TextBox text input.
+    case textInput
+}
+
+/// Centralized key routing for TextBox. All routing decisions are made here;
+/// each NSTextView interception point (`keyDown`, `insertText`, `doCommand`)
+/// converts its input to `TextBoxKeyInput` and calls `route()`.
+///
+/// All key definitions are collected in this enum so new rules can be added
+/// in one place without touching the interception points.
+enum TextBoxKeyRouting {
+
+    // MARK: Key Definitions
+
+    /// Named keys that TextBox forwards to the terminal via synthetic NSEvents.
+    enum TerminalKey {
+        case returnKey, arrowUp, arrowDown, arrowLeft, arrowRight, tab, backspace, escape
+
+        var characters: String {
+            switch self {
+            case .returnKey: return "\r"
+            case .arrowUp:   return "\u{F700}"
+            case .arrowDown: return "\u{F701}"
+            case .arrowLeft: return "\u{F702}"
+            case .arrowRight: return "\u{F703}"
+            case .tab:       return "\t"
+            case .backspace: return "\u{7F}"
+            case .escape:    return "\u{1B}"
+            }
+        }
+
+        var keyCode: UInt16 {
+            switch self {
+            case .returnKey: return 36
+            case .arrowUp:   return 126
+            case .arrowDown: return 125
+            case .arrowLeft: return 123
+            case .arrowRight: return 124
+            case .tab:       return 48
+            case .backspace: return 51
+            case .escape:    return 53
+            }
+        }
+    }
+
+    /// Rule 1: Emacs editing keys — Ctrl+key handled locally by NSTextView.
+    private static let emacsEditingKeys: Set<String> = [
+        "a",  // moveToBeginningOfLine:
+        "e",  // moveToEndOfLine:
+        "f",  // moveForward:
+        "b",  // moveBackward:
+        "n",  // moveDown:
+        "p",  // moveUp:
+        "k",  // deleteToEndOfLine: (via killLine:)
+        "h",  // deleteBackward:
+    ]
+
+    /// Rules 3, 4: Prefixes forwarded to terminal when TextBox is empty (+ focus terminal).
+    private static let prefixForwardKeys: [TextBoxAppDetection: [String]] = [
+        .claudeCode: ["/", "@"],
+        .codex:      ["/", "@"],
+    ]
+
+    /// Rule 5: Text forwarded to terminal when TextBox is empty (keep focus).
+    private static let textForwardKeys: [TextBoxAppDetection: [String]] = [
+        .claudeCode: ["?"],
+        .codex:      ["?"],
+    ]
+
+    /// Rule 7: Selectors forwarded to terminal when TextBox is empty.
+    private static let emptyStateSelectors: [Selector: TerminalKey] = [
+        #selector(NSResponder.moveUp(_:)):         .arrowUp,
+        #selector(NSResponder.moveDown(_:)):       .arrowDown,
+        #selector(NSResponder.moveLeft(_:)):       .arrowLeft,
+        #selector(NSResponder.moveRight(_:)):      .arrowRight,
+        #selector(NSResponder.insertTab(_:)):      .tab,
+        #selector(NSResponder.deleteBackward(_:)): .backspace,
+    ]
+
+    // MARK: Routing
+
+    /// Single entry point for all key routing decisions.
+    ///
+    /// `terminalType` is the canonical `SurfaceMetadataStore.terminal_type`
+    /// value (e.g. "claude-code", "codex"); when present it takes
+    /// precedence over `terminalTitle`. Defaults to `nil` so legacy
+    /// callers and tests that only thread a title still work.
+    static func route(
+        _ input: TextBoxKeyInput,
+        isEmpty: Bool,
+        terminalTitle: String,
+        terminalType: String? = nil,
+        enterToSend: Bool
+    ) -> TextBoxKeyAction {
+        switch input {
+
+        // Rules 1, 2: Ctrl+key
+        case .ctrl(let char):
+            if emacsEditingKeys.contains(char) { return .emacsEdit }      // Rule 1
+            return .forwardControl                                        // Rule 2
+
+        // Rule 5: Unmodified key forwarded as raw event (keep focus)
+        case .key(let char):
+            if isEmpty {
+                for (app, keys) in textForwardKeys
+                    where keys.contains(char)
+                        && app.matches(terminalType: terminalType, terminalTitle: terminalTitle) {
+                    return .forwardKeyEvent                               // Rule 5
+                }
+            }
+            return .textInput                                             // Rule 10 (Fallback)
+
+        // Rules 3, 4, fallback: Inserted text
+        case .text(let str):
+            if isEmpty {
+                for (app, keys) in prefixForwardKeys
+                    where keys.contains(str)
+                        && app.matches(terminalType: terminalType, terminalTitle: terminalTitle) {
+                    return .forwardPrefix(str)                            // Rule 3, 4
+                }
+            }
+            return .textInput                                             // Rule 10 (Fallback)
+
+        // Rules 6, 7, 8, 9: Command selectors
+        case .command(let selector, let shifted):
+            // Rule 6, 7: Return
+            if selector == #selector(NSResponder.insertNewline(_:)) ||
+               selector == #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)) {
+                let shouldSend = enterToSend ? !shifted : shifted
+                return shouldSend ? .submit : .insertNewline
+            }
+            // Rule 8: Escape
+            if selector == #selector(NSResponder.cancelOperation(_:)) {
+                return .escape
+            }
+            // Rule 9: Empty-state navigation
+            if isEmpty, let key = emptyStateSelectors[selector] {
+                return .forwardKey(key)
+            }
+            return .textInput                                             // Rule 10 (Fallback)
+        }
+    }
+}
+
+// MARK: - Key Events
+
+/// Events dispatched from the TextBox to its parent for terminal forwarding.
+enum TextBoxKeyEvent {
+    /// User pressed Return/Shift+Return to submit text.
+    case submit
+    /// User pressed Escape.
+    case escape
+    /// A named key to forward to the terminal (arrows, Tab, Backspace).
+    case key(TextBoxKeyRouting.TerminalKey)
+    /// A Ctrl+key combination to forward as a raw NSEvent.
+    case control(NSEvent)
+}
+
+// MARK: - Settings
+
+/// Settings for TextBox Input Mode
+enum TextBoxInputSettings {
+    static let enabledKey = "textBoxEnabled"
+    static let enterToSendKey = "textBoxEnterToSend"
+    static let escapeBehaviorKey = "textBoxEscapeBehavior"
+    static let shortcutBehaviorKey = "textBoxShortcutBehavior"
+
+    static let defaultEnabled = false // [TextBox] Off by default; users opt in via Settings
+    static let defaultEnterToSend = true
+    static let defaultEscapeBehavior = TextBoxEscapeBehavior.sendEscape
+    static let defaultShortcutBehavior = TextBoxShortcutBehavior.toggleFocus
+
+    /// Opacity applied to settings rows when TextBox is disabled.
+    static let disabledSettingsOpacity: Double = 0.5
+
+    /// Reset all TextBox settings to defaults via UserDefaults.
+    static func resetAll() {
+        UserDefaults.standard.removeObject(forKey: enabledKey)
+        UserDefaults.standard.removeObject(forKey: enterToSendKey)
+        UserDefaults.standard.removeObject(forKey: escapeBehaviorKey)
+        UserDefaults.standard.removeObject(forKey: shortcutBehaviorKey)
+    }
+
+    private static func bool(forKey key: String, default defaultValue: Bool) -> Bool {
+        UserDefaults.standard.object(forKey: key) == nil
+            ? defaultValue
+            : UserDefaults.standard.bool(forKey: key)
+    }
+
+    static func isEnabled() -> Bool {
+        bool(forKey: enabledKey, default: defaultEnabled)
+    }
+
+    static func isEnterToSend() -> Bool {
+        bool(forKey: enterToSendKey, default: defaultEnterToSend)
+    }
+
+    static func escapeBehavior() -> TextBoxEscapeBehavior {
+        guard let raw = UserDefaults.standard.string(forKey: escapeBehaviorKey),
+              let value = TextBoxEscapeBehavior(rawValue: raw) else {
+            return defaultEscapeBehavior
+        }
+        return value
+    }
+
+    static func shortcutBehavior() -> TextBoxShortcutBehavior {
+        guard let raw = UserDefaults.standard.string(forKey: shortcutBehaviorKey),
+              let value = TextBoxShortcutBehavior(rawValue: raw) else {
+            return defaultShortcutBehavior
+        }
+        return value
+    }
+}
+
+/// What the keyboard shortcut (Cmd+Opt+B) does.
+enum TextBoxShortcutBehavior: String, CaseIterable, Identifiable {
+    /// Toggle TextBox visibility (show/hide).
+    case toggleDisplay = "toggleDisplay"
+    /// Keep TextBox always visible, toggle focus between TextBox and terminal.
+    case toggleFocus = "toggleFocus"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .toggleDisplay:
+            return String(localized: "textbox.shortcutBehavior.toggleDisplay", defaultValue: "Toggle Display")
+        case .toggleFocus:
+            return String(localized: "textbox.shortcutBehavior.toggleFocus", defaultValue: "Toggle Focus")
+        }
+    }
+}
+
+/// What happens when the user presses Escape in the TextBox.
+enum TextBoxEscapeBehavior: String, CaseIterable, Identifiable {
+    /// Send the ESC key to the terminal and keep focus in the TextBox.
+    case sendEscape = "sendEscape"
+    /// Move focus back to the terminal without sending ESC.
+    case focusTerminal = "focusTerminal"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .sendEscape:
+            return String(localized: "textbox.escapeBehavior.sendEscape", defaultValue: "Send ESC Key")
+        case .focusTerminal:
+            return String(localized: "textbox.escapeBehavior.focusTerminal", defaultValue: "Focus Terminal")
+        }
+    }
+}
+
+// MARK: - Text Submission
+
+/// Send text through TextBox: writes to PTY via bracket paste, then
+/// sends Return as a separate synthetic key event after a delay.
+///
+/// **Why not `sendText(text + "\r")` or `sendText(text + "\n")`?**
+/// `sendText` wraps content in bracket paste (`\x1b[200~…\x1b[201~`).
+/// Applications that enable bracket paste mode (zsh, Claude CLI, etc.)
+/// treat `\r`/`\n` inside the paste as literal characters, not as
+/// command execution. Return must be sent as a separate synthetic key
+/// event *outside* the paste sequence.
+/// Note: `sendText(text + "\n")` does work for apps that don't use
+/// bracket paste (e.g., node REPL), but fails for shell and Claude CLI.
+///
+/// **Why 200ms delay?**
+/// Claude CLI shows "pasting text…" while processing bracket paste
+/// (~100ms). If Return arrives before processing finishes, it is
+/// silently ignored. 50ms and 100ms were tested and are insufficient.
+/// 200ms is the minimum reliable value.
+enum TextBoxSubmit {
+    static func send(_ text: String, via surface: TerminalSurface) {
+        let trimmed = text.trimmingCharacters(in: .newlines)
+        let delayMs = TextBoxBehavior.returnKeyDelayMs
+        if !trimmed.isEmpty {
+            surface.sendText(trimmed)
+        }
+        let effectiveDelayMs = trimmed.isEmpty
+            ? TextBoxBehavior.emptyReturnKeyDelayMs
+            : delayMs
+        if effectiveDelayMs <= 0 {
+            surface.sendKey(.returnKey)
+        } else {
+            let delay = TimeInterval(effectiveDelayMs) / 1000.0
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak surface] in
+                surface?.sendKey(.returnKey)
+            }
+        }
+    }
+}
+
+// MARK: - Container View
+
+/// Inline text input that sits flush at the bottom of the terminal.
+///
+/// Styled as a thin single-line field with the terminal's own colors so it looks
+/// like the prompt's caret area was replaced by a native text field.
+///
+/// Accepts a `TerminalSurface` directly so that all key forwarding and
+/// text submission logic stays inside TextBoxInput.swift, minimizing
+/// TextBox-specific code in upstream files.
+struct TextBoxInputContainer: View {
+    @Binding var text: String
+    let enterToSend: Bool
+    let surface: TerminalSurface
+    let terminalBackgroundColor: NSColor
+    let terminalForegroundColor: NSColor
+    let terminalFont: NSFont
+    let terminalTitle: String
+    /// Canonical `SurfaceMetadataStore.terminal_type` (e.g. "claude-code").
+    /// `nil` / empty means metadata is unset — routing falls back to the
+    /// title regex via `TextBoxAppDetection.matches`.
+    let terminalType: String?
+    /// Called when the InputTextView is created, so the panel can store a direct
+    /// reference for focus management across multiple tabs.
+    let onInputTextViewCreated: ((InputTextView) -> Void)?
+    @State private var textViewHeight: CGFloat = 0
+
+    /// Computes the height for a given number of lines using the current font.
+    private func heightForLines(_ count: Int) -> CGFloat {
+        let fontSize = max(1, terminalFont.pointSize + TextBoxInputViewLayout.fontSizeOffset)
+        let font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        let lineHeight = font.ascender - font.descender + font.leading
+            + TextBoxInputViewLayout.lineSpacing
+        return lineHeight * CGFloat(count) + TextBoxInputViewLayout.textInset.height * 2
+    }
+
+    var body: some View {
+        let minH = heightForLines(TextBoxInputViewLayout.minLines)
+        let maxH = heightForLines(TextBoxInputViewLayout.maxLines)
+        let clampedHeight = max(minH, min(maxH, textViewHeight))
+
+        HStack(alignment: .bottom, spacing: TextBoxLayout.contentSpacing) {
+            TextBoxInputView(
+                text: $text,
+                enterToSend: enterToSend,
+                textViewHeight: $textViewHeight,
+                onKeyEvent: { event in
+                    switch event {
+                    case .submit:
+                        submit()
+                    case .escape:
+                        switch TextBoxInputSettings.escapeBehavior() {
+                        case .focusTerminal:
+                            surface.focusTerminalView()
+                        case .sendEscape:
+                            surface.sendKey(.escape)
+                        }
+                    case .key(let key):
+                        surface.sendKey(key)
+                    case .control(let nsEvent):
+                        surface.forwardKeyEvent(nsEvent)
+                    }
+                },
+                onPrefixForward: { prefix in
+                    surface.sendText(prefix)
+                    surface.focusTerminalView()
+                },
+                onInputTextViewCreated: onInputTextViewCreated,
+                terminalBackgroundColor: terminalBackgroundColor,
+                terminalForegroundColor: terminalForegroundColor,
+                terminalFont: terminalFont,
+                terminalTitle: terminalTitle,
+                terminalType: terminalType
+            )
+            .frame(height: clampedHeight)
+
+            Button(action: submit) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: TextBoxLayout.sendButtonSize))
+            }
+            .buttonStyle(TextBoxSendButtonStyle(foregroundColor: Color(nsColor: terminalForegroundColor)))
+            .help(String(localized: "textbox.send.tooltip", defaultValue: "Send"))
+        }
+        .padding(.leading, TextBoxLayout.leftPadding)
+        .padding(.trailing, TextBoxLayout.rightPadding)
+        .padding(.top, TextBoxLayout.topPadding)
+        .padding(.bottom, TextBoxLayout.bottomPadding)
+        .background(Color(nsColor: terminalBackgroundColor))
+        // [TextBox] Restore terminal scroll position after TextBox height changes.
+        // When the VStack resizes the terminal, ghostty sends SIGWINCH which causes
+        // TUI apps like Claude Code to re-render and snap to the bottom. We save the
+        // scroll offset before the resize and restore it after a short delay.
+        .onChange(of: clampedHeight) { [clampedHeight] _ in
+            guard clampedHeight > 0 else { return }
+            guard surface.isScrolledUp,
+                  let savedOffset = surface.scrollbarOffset else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                surface.scrollToRow(savedOffset)
+            }
+        }
+    }
+
+    private func submit() {
+        let content = text
+        TextBoxSubmit.send(content, via: surface)
+        text = ""
+        // Reset height to minimum so the TextBox shrinks after sending
+        // multi-line content. The binding update (text = "") triggers
+        // updateNSView which calls recalcHeight, but the layout pass
+        // may not run soon enough for the frame to shrink visually.
+        textViewHeight = 0
+    }
+}
+
+// MARK: - NSViewRepresentable
+
+/// NSViewRepresentable that wraps NSTextView for inline terminal input.
+///
+/// Styled to blend with the terminal: same background/foreground colors, monospace font,
+/// with a subtle border to indicate it is a native editable field.
+struct TextBoxInputView: NSViewRepresentable {
+    @Binding var text: String
+    let enterToSend: Bool
+    @Binding var textViewHeight: CGFloat
+    let onKeyEvent: (TextBoxKeyEvent) -> Void
+    let onPrefixForward: (String) -> Void
+    let onInputTextViewCreated: ((InputTextView) -> Void)?
+    let terminalBackgroundColor: NSColor
+    let terminalForegroundColor: NSColor
+    let terminalFont: NSFont
+    let terminalTitle: String
+    let terminalType: String?
+
+    private var adjustedFont: NSFont {
+        let size = max(1, terminalFont.pointSize + TextBoxInputViewLayout.fontSizeOffset)
+        return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+    }
+
+    private func makeParagraphStyle() -> NSMutableParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = TextBoxInputViewLayout.lineSpacing
+        return style
+    }
+
+    private func makeTypingAttributes() -> [NSAttributedString.Key: Any] {
+        [
+            .font: adjustedFont,
+            .foregroundColor: terminalForegroundColor,
+            .paragraphStyle: makeParagraphStyle(),
+        ]
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        // Border is on a container NSView, not on the NSScrollView directly.
+        // Setting `wantsLayer = true` + `layer?.borderWidth` on NSScrollView
+        // does not render a border (its layer management conflicts with
+        // direct layer property access). A plain NSView wrapper works reliably.
+        let container = NSView()
+        container.wantsLayer = true
+        container.layer?.borderWidth = TextBoxInputViewLayout.borderWidth
+        container.layer?.borderColor = terminalForegroundColor.withAlphaComponent(TextBoxInputViewLayout.borderOpacity).cgColor
+        container.layer?.cornerRadius = TextBoxInputViewLayout.cornerRadius
+        container.layer?.masksToBounds = true
+
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        let textView = InputTextView()
+
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.usesFindPanel = false
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        // Ensure the text view resizes horizontally with the scroll view's
+        // content area. Without this, the text container width may stay at 0
+        // on macOS Sonoma/Sequoia, making typed text invisible. (#6)
+        textView.autoresizingMask = [.width]
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainerInset = TextBoxInputViewLayout.textInset
+        textView.delegate = context.coordinator
+        textView.inputCoordinator = context.coordinator
+        textView.enterToSend = enterToSend
+        textView.terminalTitle = terminalTitle
+        textView.terminalType = terminalType
+
+        // Match terminal appearance — background is drawn by the outer
+        // SwiftUI .background() to avoid double-compositing when the
+        // terminal uses background-opacity < 1.
+        textView.drawsBackground = false
+        textView.insertionPointColor = terminalForegroundColor
+        textView.textColor = terminalForegroundColor
+        // Match terminal selection colors: foreground on background inverted.
+        textView.selectedTextAttributes = [
+            .backgroundColor: terminalForegroundColor,
+            .foregroundColor: terminalBackgroundColor.withAlphaComponent(1.0),
+        ]
+        textView.font = adjustedFont
+        textView.typingAttributes = makeTypingAttributes()
+        textView.defaultParagraphStyle = makeParagraphStyle()
+
+        if let textContainer = textView.textContainer {
+            textContainer.widthTracksTextView = true
+            textContainer.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        }
+
+        scrollView.documentView = textView
+        context.coordinator.textView = textView
+        context.coordinator.container = container
+
+        container.addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: container.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+
+        // Register this InputTextView with the panel for direct focus management
+        onInputTextViewCreated?(textView)
+
+        // Auto-focus the text view and calculate initial height.
+        // Only auto-focus if nothing else currently has focus (i.e. the
+        // window has no first responder yet). When toggling all tabs at once,
+        // the active tab's terminal already has focus and must not be stolen.
+        DispatchQueue.main.async {
+            if textView.window?.firstResponder == textView.window {
+                textView.window?.makeFirstResponder(textView)
+            }
+            context.coordinator.recalcHeight(textView)
+        }
+
+        return container
+    }
+
+    func updateNSView(_ container: NSView, context: Context) {
+        guard let scrollView = container.subviews.first as? NSScrollView,
+              let textView = scrollView.documentView as? InputTextView else { return }
+        context.coordinator.parent = self
+        // Skip text sync during IME composition: textView.string includes marked
+        // (uncommitted) text while the binding only has committed text. Overwriting
+        // here would disrupt the active input method session.
+        if !textView.hasMarkedText(), textView.string != text {
+            textView.string = text
+            context.coordinator.recalcHeight(textView)
+        }
+        // Keep enterToSend, colors, and terminal identity in sync
+        textView.enterToSend = enterToSend
+        textView.terminalTitle = terminalTitle
+        textView.terminalType = terminalType
+        textView.insertionPointColor = terminalForegroundColor
+        textView.textColor = terminalForegroundColor
+        textView.selectedTextAttributes = [
+            .backgroundColor: terminalForegroundColor,
+            .foregroundColor: terminalBackgroundColor.withAlphaComponent(1.0),
+        ]
+        textView.typingAttributes = makeTypingAttributes()
+        let isFocused = textView.window?.firstResponder === textView
+        let opacity = isFocused
+            ? TextBoxInputViewLayout.focusedBorderOpacity
+            : TextBoxInputViewLayout.borderOpacity
+        container.layer?.borderColor = terminalForegroundColor.withAlphaComponent(opacity).cgColor
+    }
+
+    // MARK: Coordinator
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: TextBoxInputView
+        weak var textView: NSTextView?
+        weak var container: NSView?
+
+        init(_ parent: TextBoxInputView) {
+            self.parent = parent
+        }
+
+        func updateBorderOpacity(focused: Bool) {
+            let opacity = focused
+                ? TextBoxInputViewLayout.focusedBorderOpacity
+                : TextBoxInputViewLayout.borderOpacity
+            container?.layer?.borderColor = parent.terminalForegroundColor
+                .withAlphaComponent(opacity).cgColor
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.text = textView.string
+            recalcHeight(textView)
+        }
+
+        func recalcHeight(_ textView: NSTextView) {
+            guard let layoutManager = textView.layoutManager,
+                  let textContainer = textView.textContainer else { return }
+            layoutManager.ensureLayout(for: textContainer)
+            let contentHeight = layoutManager.usedRect(for: textContainer).height
+                + textView.textContainerInset.height * 2
+            parent.textViewHeight = contentHeight
+        }
+
+    }
+}
+
+// MARK: - Send Button Style
+
+/// Button style with hover/press highlight for the TextBox send button.
+private struct TextBoxSendButtonStyle: ButtonStyle {
+    let foregroundColor: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        TextBoxSendButtonBody(configuration: configuration, foregroundColor: foregroundColor)
+    }
+}
+
+private struct TextBoxSendButtonBody: View {
+    let configuration: TextBoxSendButtonStyle.Configuration
+    let foregroundColor: Color
+    @State private var isHovered = false
+
+    private var backgroundOpacity: Double {
+        if configuration.isPressed { return 0.16 }
+        if isHovered { return 0.08 }
+        return 0.0
+    }
+
+    var body: some View {
+        configuration.label
+            .foregroundColor(foregroundColor)
+            .padding(4)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(foregroundColor.opacity(backgroundOpacity))
+            )
+            .onHover { hovering in
+                isHovered = hovering
+            }
+            .animation(.easeOut(duration: 0.12), value: isHovered)
+            .animation(.easeOut(duration: 0.08), value: configuration.isPressed)
+    }
+}
+
+// MARK: - InputTextView
+
+/// Custom NSTextView subclass that routes key events to the coordinator.
+///
+/// Two separate interception layers are used intentionally:
+///
+/// 1. **`keyDown`** — intercepts Ctrl+key *before* AppKit interprets them.
+///    Ctrl+C, Ctrl+D, etc. must always reach the terminal regardless of
+///    TextBox content. If we waited for `doCommandBySelector`, AppKit
+///    would convert them into selectors and they wouldn't reach the
+///    terminal correctly.
+///
+/// 2. **`doCommandBySelector`** — handles interpreted commands (arrows,
+///    Tab, Backspace, Enter, Escape). These are forwarded to the terminal
+///    only when the TextBox is empty (except Enter/Escape which are always
+///    handled). Using `doCommandBySelector` instead of raw `keyDown`
+///    forwarding avoids `^^` garbage characters that appear when
+///    forwarding raw NSEvents.
+final class InputTextView: NSTextView {
+    weak var inputCoordinator: TextBoxInputView.Coordinator?
+    var enterToSend: Bool = false
+    /// Current terminal process title, used for app detection fallback.
+    var terminalTitle: String = ""
+    /// Canonical `SurfaceMetadataStore.terminal_type` for metadata-first app detection.
+    var terminalType: String? = nil
+
+    /// Set by keyDown when a key event was already forwarded to the terminal,
+    /// so insertText can skip the duplicate insertion that the input method
+    /// system triggers in parallel.
+    private var keyEventAlreadyForwarded = false
+
+    // Shell-escape characters matching terminal drag-and-drop behavior.
+    private static let shellEscapeCharacters = "\\ ()[]{}<>\"'`!#$&;|*?\t"
+
+    private static func escapeForShell(_ value: String) -> String {
+        var result = value
+        for char in shellEscapeCharacters {
+            result = result.replacingOccurrences(of: String(char), with: "\\\(char)")
+        }
+        return result
+    }
+
+    /// Insert shell-escaped file paths, focus the TextBox, and select the
+    /// inserted text. Called from FileDropOverlayView when a Finder file drag
+    /// is dropped over the TextBox area.
+    ///
+    /// Uses asyncAfter(0.05s) because the drop is routed through
+    /// FileDropOverlayView's performDragOperation, and synchronous text
+    /// insertion during a drag session stalls until the next mouse event.
+    func insertDroppedFilePaths(_ urls: [URL]) {
+        let escaped = urls
+            .map { Self.escapeForShell($0.path) }
+            .joined(separator: " ")
+
+        let capturedWindow = window
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { [weak self] in
+            guard let self else { return }
+            let range = capturedWindow?.firstResponder === self
+                ? self.selectedRange()
+                : NSRange(location: self.string.count, length: 0)
+            let insertionPoint = range.location
+            capturedWindow?.makeFirstResponder(self)
+            self.insertText(escaped, replacementRange: range)
+            self.setSelectedRange(NSRange(location: insertionPoint, length: (escaped as NSString).length))
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        if string.isEmpty {
+            let placeholder = TextBoxInputViewLayout.placeholderText(enterToSend: enterToSend)
+            let color = (insertionPointColor ?? .white)
+                .withAlphaComponent(TextBoxInputViewLayout.placeholderOpacity)
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: font ?? NSFont.systemFont(ofSize: 13),
+                .foregroundColor: color,
+            ]
+            let inset = textContainerInset
+            let origin = NSPoint(
+                x: inset.width + (textContainer?.lineFragmentPadding ?? 0),
+                y: inset.height
+            )
+            NSString(string: placeholder).draw(at: origin, withAttributes: attrs)
+        }
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+        super.mouseDown(with: event)
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result { inputCoordinator?.updateBorderOpacity(focused: true) }
+        return result
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let result = super.resignFirstResponder()
+        if result { inputCoordinator?.updateBorderOpacity(focused: false) }
+        return result
+    }
+
+    override func insertText(_ string: Any, replacementRange: NSRange) {
+        // If keyDown already forwarded this key event to the terminal,
+        // skip the text insertion that the input method system triggers.
+        if keyEventAlreadyForwarded {
+            keyEventAlreadyForwarded = false
+            return
+        }
+        if let str = string as? String {
+            let action = TextBoxKeyRouting.route(
+                .text(str), isEmpty: self.string.isEmpty,
+                terminalTitle: terminalTitle, terminalType: terminalType,
+                enterToSend: enterToSend)
+            switch action {
+            case .forwardPrefix(let prefix):
+                inputCoordinator?.parent.onPrefixForward(prefix)
+                return
+            case .textInput:
+                break  // fall through to super
+            default:
+                break
+            }
+        }
+        super.insertText(string, replacementRange: replacementRange)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        if flags.contains(.control),
+           let chars = event.charactersIgnoringModifiers {
+            let action = TextBoxKeyRouting.route(
+                .ctrl(chars), isEmpty: string.isEmpty,
+                terminalTitle: terminalTitle, terminalType: terminalType,
+                enterToSend: enterToSend)
+            switch action {
+            case .emacsEdit:
+                super.keyDown(with: event)
+            case .forwardControl:
+                inputCoordinator?.parent.onKeyEvent(.control(event))
+            default:
+                break
+            }
+            return
+        }
+
+        // Rule 5: Check for unmodified keys that should be forwarded as raw events.
+        // Use `characters` (not `charactersIgnoringModifiers`) because "?" is
+        // Shift+"/" and we need the actual typed character.
+        if let chars = event.characters {
+            let action = TextBoxKeyRouting.route(
+                .key(chars), isEmpty: string.isEmpty,
+                terminalTitle: terminalTitle, terminalType: terminalType,
+                enterToSend: enterToSend)
+            if case .forwardKeyEvent = action {
+                keyEventAlreadyForwarded = true
+                inputCoordinator?.parent.onKeyEvent(.control(event))
+                return
+            }
+        }
+
+        super.keyDown(with: event)
+    }
+
+    override func doCommand(by selector: Selector) {
+        let shifted = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
+        let action = TextBoxKeyRouting.route(
+            .command(selector, shifted: shifted), isEmpty: string.isEmpty,
+            terminalTitle: terminalTitle, terminalType: terminalType,
+            enterToSend: enterToSend)
+        switch action {
+        case .submit:
+            inputCoordinator?.parent.onKeyEvent(.submit)
+        case .insertNewline:
+            insertNewlineIgnoringFieldEditor(nil)
+        case .escape:
+            inputCoordinator?.parent.onKeyEvent(.escape)
+        case .forwardKey(let key):
+            inputCoordinator?.parent.onKeyEvent(.key(key))
+        case .textInput:
+            super.doCommand(by: selector)
+        default:
+            super.doCommand(by: selector)
+        }
+    }
+}
+
+// MARK: - Settings View Modifier
+
+extension View {
+    /// Dims and disables a settings row when TextBox is not enabled.
+    func textBoxSettingsDisabled(_ isDisabled: Bool) -> some View {
+        self
+            .disabled(isDisabled)
+            .opacity(isDisabled ? TextBoxInputSettings.disabledSettingsOpacity : 1.0)
+    }
+}

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -614,7 +614,7 @@ enum TextBoxInputSettings {
 
     static let defaultEnterToSend = true
     static let defaultEscapeBehavior = TextBoxEscapeBehavior.sendEscape
-    static let defaultShortcutBehavior = TextBoxShortcutBehavior.toggleFocus
+    static let defaultShortcutBehavior = TextBoxShortcutBehavior.toggleDisplay
 
     /// Reset all TextBox settings to defaults via UserDefaults.
     static func resetAll() {

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -44,7 +44,9 @@ See the rule table above that enum for the full specification.
 - Rule 5: "?" key — forwarded as raw event (empty, Claude Code/Codex, keep focus)
 - Rule 6/7: Return/Shift+Return — submit or newline (setting-dependent)
 - Rule 8: Escape — focus terminal or send ESC (setting-dependent)
-- Rule 9: ↑ ↓ ← → Tab Backspace — forwarded to terminal when empty (keep focus)
+- Rule 9: Tab, Backspace — forwarded to terminal when empty (keep focus).
+  Arrow keys are *not* forwarded; they always drive NSTextView cursor
+  movement, even when the TextBox is empty (Option B decision).
 - Rule 10: Fallback — default TextBox text input
 
 ### F6. Theme Sync
@@ -147,10 +149,10 @@ panel (the only toggle — there is no global "Enable Mode" setting).
 - [ ] T6.9  "@" in empty TextBox + Codex → forwarded, focus moves to terminal
 - [ ] T6.10 "?" in empty TextBox + Claude Code → forwarded as key event, focus stays
 - [ ] T6.11 "?" in non-empty TextBox → typed as text
-- [ ] T6.12 Arrow Up/Down in empty TextBox → shell history navigation
+- [ ] T6.12 Arrow Up/Down in empty TextBox → cursor stays in TextBox (Option B: no shell-history forwarding)
 - [ ] T6.13 Tab in empty TextBox → tab completion in terminal
 - [ ] T6.14 Backspace in empty TextBox → forwarded to terminal
-- [ ] T6.15 Arrow keys in non-empty TextBox → cursor movement within TextBox
+- [ ] T6.15 Arrow keys in non-empty TextBox → cursor movement within TextBox (same as empty; no forwarding)
 
 ### T7. Submit & Escape (F5, Rules 6–8)
 - [ ] T7.1  Return submits text (enterToSend=on)
@@ -515,12 +517,10 @@ enum TextBoxKeyRouting {
         .codex:      ["?"],
     ]
 
-    /// Rule 7: Selectors forwarded to terminal when TextBox is empty.
+    /// Rule 9: Selectors forwarded to terminal when TextBox is empty.
+    /// Arrow keys intentionally stay in the TextBox (Option B) so they always
+    /// drive NSTextView cursor movement, never shell history navigation.
     private static let emptyStateSelectors: [Selector: TerminalKey] = [
-        #selector(NSResponder.moveUp(_:)):         .arrowUp,
-        #selector(NSResponder.moveDown(_:)):       .arrowDown,
-        #selector(NSResponder.moveLeft(_:)):       .arrowLeft,
-        #selector(NSResponder.moveRight(_:)):      .arrowRight,
         #selector(NSResponder.insertTab(_:)):      .tab,
         #selector(NSResponder.deleteBackward(_:)): .backspace,
     ]

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -88,7 +88,9 @@ inputTextView reference. Switching tabs preserves TextBox state.
 
 ## Settings (Settings > TextBox Input)
 
-- **Enable Mode**: Toggle TextBox on/off (default: off)
+TextBox is on by default for every terminal pane; Cmd+Option+B toggles
+visibility per panel.
+
 - **Send on Return**: On = Return sends / Shift+Enter inserts newline,
   Off = Enter inserts newline / Shift+Enter sends (default: on)
 - **Escape Key**: Send ESC Key or Focus Terminal (default: Send ESC Key)
@@ -98,10 +100,9 @@ inputTextView reference. Switching tabs preserves TextBox state.
 ## Test Plan
 
 ### T1. Settings
-- [ ] T1.1  Default values: enabled=false, enterToSend=true, escape=sendEscape, shortcut=toggleFocus
+- [ ] T1.1  Default values: enterToSend=true, escape=sendEscape, shortcut=toggleFocus
 - [ ] T1.2  Toggle each setting and verify it persists across app restart
 - [ ] T1.3  Reset All restores all settings to defaults
-- [ ] T1.4  Settings rows are dimmed/disabled when Enable Mode is off
 
 ### T2. Basic Text Editing (F1)
 - [ ] T2.1  Type text and verify it appears in the TextBox
@@ -177,7 +178,7 @@ inputTextView reference. Switching tabs preserves TextBox state.
 - [ ] T9.4  Cmd+Opt+B moves focus to terminal when TextBox focused (toggleFocus mode)
 - [ ] T9.5  Toggle applies to all tabs simultaneously
 - [ ] T9.6  Custom shortcut key works after changing in Settings
-- [ ] T9.7  Enabling "Enable Mode" setting forces TextBox visible
+- [ ] T9.7  New terminal panes have TextBox visible by default
 
 ### T10. Drag & Drop (F8)
 - [ ] T10.1  Drop single file → shell-escaped path inserted
@@ -212,7 +213,7 @@ inputTextView reference. Switching tabs preserves TextBox state.
 ### T14. Per-panel State (F14)
 - [ ] T14.1  Switching tabs preserves TextBox content
 - [ ] T14.2  Toggle applies to all tabs simultaneously (global, not per-tab)
-- [ ] T14.3  New tab inherits global Enable Mode setting
+- [ ] T14.3  New tab starts with TextBox visible (isTextBoxActive=true)
 - [ ] T14.4  Split panes each have their own TextBox
 
 ### T15. Placeholder & Send Button (F9, F10)
@@ -607,22 +608,16 @@ enum TextBoxKeyEvent {
 
 /// Settings for TextBox Input Mode
 enum TextBoxInputSettings {
-    static let enabledKey = "textBoxEnabled"
     static let enterToSendKey = "textBoxEnterToSend"
     static let escapeBehaviorKey = "textBoxEscapeBehavior"
     static let shortcutBehaviorKey = "textBoxShortcutBehavior"
 
-    static let defaultEnabled = false // [TextBox] Off by default; users opt in via Settings
     static let defaultEnterToSend = true
     static let defaultEscapeBehavior = TextBoxEscapeBehavior.sendEscape
     static let defaultShortcutBehavior = TextBoxShortcutBehavior.toggleFocus
 
-    /// Opacity applied to settings rows when TextBox is disabled.
-    static let disabledSettingsOpacity: Double = 0.5
-
     /// Reset all TextBox settings to defaults via UserDefaults.
     static func resetAll() {
-        UserDefaults.standard.removeObject(forKey: enabledKey)
         UserDefaults.standard.removeObject(forKey: enterToSendKey)
         UserDefaults.standard.removeObject(forKey: escapeBehaviorKey)
         UserDefaults.standard.removeObject(forKey: shortcutBehaviorKey)
@@ -632,10 +627,6 @@ enum TextBoxInputSettings {
         UserDefaults.standard.object(forKey: key) == nil
             ? defaultValue
             : UserDefaults.standard.bool(forKey: key)
-    }
-
-    static func isEnabled() -> Bool {
-        bool(forKey: enabledKey, default: defaultEnabled)
     }
 
     static func isEnterToSend() -> Bool {
@@ -1281,13 +1272,3 @@ final class InputTextView: NSTextView {
     }
 }
 
-// MARK: - Settings View Modifier
-
-extension View {
-    /// Dims and disables a settings row when TextBox is not enabled.
-    func textBoxSettingsDisabled(_ isDisabled: Bool) -> some View {
-        self
-            .disabled(isDisabled)
-            .opacity(isDisabled ? TextBoxInputSettings.disabledSettingsOpacity : 1.0)
-    }
-}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5892,6 +5892,13 @@ final class Workspace: Identifiable, ObservableObject {
                 title: TitleFormatting.sidebarLabel(from: resolvedTitle),
                 hasCustomTitle: panelCustomTitles[panelId] != nil
             )
+            // [TextBox] Keep TerminalPanel.title in sync so TextBox key
+            // routing can detect running apps (Claude Code, Codex) via
+            // the title regex when `SurfaceMetadataStore.terminal_type`
+            // has not yet been classified. See plan §4.4 (title-sync hook).
+            if let terminalPanel = panel as? TerminalPanel {
+                terminalPanel.updateTitle(trimmed)
+            }
         }
 
         // If this is the only panel and no custom title, update workspace title
@@ -5906,6 +5913,119 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         return didMutate
+    }
+
+    // MARK: - [TextBox] TextBox Input toggle (plan §4.4)
+
+    /// Toggle the TextBox Input for this workspace's terminal panels.
+    ///
+    /// `scope` decides whether we operate on the focused panel only or
+    /// on every terminal panel in this workspace (§8 Q9 locked:
+    /// "current workspace"). Behavior within each panel depends on the
+    /// user's `TextBoxInputSettings.shortcutBehavior`:
+    ///
+    /// - `.toggleDisplay`: flip `panel.isTextBoxActive` (show ⇄ hide).
+    /// - `.toggleFocus`: keep the TextBox visible, swap first responder
+    ///   between the InputTextView and the terminal surface.
+    ///
+    /// Focus changes are dispatched with `DispatchQueue.main.async` to
+    /// avoid reentering first-responder machinery mid-event.
+    func toggleTextBoxMode(_ scope: TextBoxToggleTarget) {
+        let terminalPanels = panels.values.compactMap { $0 as? TerminalPanel }
+        guard !terminalPanels.isEmpty else { return }
+
+        let behavior = TextBoxInputSettings.shortcutBehavior()
+        let targets: [TerminalPanel]
+
+        switch scope {
+        case .all:
+            targets = terminalPanels
+        case .active:
+            if let focusedId = focusedPanelIdForTextBoxToggle(),
+               let panel = panels[focusedId] as? TerminalPanel {
+                targets = [panel]
+            } else {
+                targets = terminalPanels
+            }
+        }
+
+        switch behavior {
+        case .toggleDisplay:
+            let shouldShow = !targets.allSatisfy { $0.isTextBoxActive }
+            for panel in targets {
+                panel.isTextBoxActive = shouldShow
+            }
+            if shouldShow {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self else { return }
+                    if let active = self.firstResponderTextBox() {
+                        _ = active
+                        return
+                    }
+                    if let firstTarget = targets.first,
+                       let view = firstTarget.inputTextView {
+                        view.window?.makeFirstResponder(view)
+                    }
+                }
+            }
+        case .toggleFocus:
+            // Keep the box visible; swap focus between TextBox and terminal.
+            for panel in targets where !panel.isTextBoxActive {
+                panel.isTextBoxActive = true
+            }
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                if let active = self.firstResponderTextBox() {
+                    // Focus is in a TextBox — move it back to that panel's terminal.
+                    let panel = targets.first { $0.inputTextView === active }
+                        ?? terminalPanels.first { $0.inputTextView === active }
+                    panel?.surface.focusTerminalView()
+                } else {
+                    // Focus is in the terminal (or elsewhere) — move it into the TextBox.
+                    guard let firstTarget = targets.first,
+                          let view = firstTarget.inputTextView else { return }
+                    view.window?.makeFirstResponder(view)
+                }
+            }
+        }
+    }
+
+    /// Returns the focused panel ID if it belongs to this workspace and
+    /// is a TerminalPanel. Resolved by walking the current main window's
+    /// first responder back to a GhosttyNSView, matching the pattern used
+    /// by `AppDelegate.focusedTerminalShortcutContext`.
+    private func focusedPanelIdForTextBoxToggle() -> UUID? {
+        let targetWindow = NSApp.keyWindow ?? NSApp.mainWindow
+        guard let responder = targetWindow?.firstResponder else { return nil }
+        // If the first responder is an InputTextView, walk its panel back via inputTextView.
+        if let inputView = responder as? InputTextView {
+            for (panelId, panel) in panels {
+                if let terminalPanel = panel as? TerminalPanel,
+                   terminalPanel.inputTextView === inputView {
+                    return panelId
+                }
+            }
+            return nil
+        }
+        // Otherwise try the terminal surface responder chain.
+        var node: NSResponder? = responder
+        while let current = node {
+            if let view = current as? NSView,
+               let surfaceView = view as? GhosttyNSView,
+               let surfaceId = surfaceView.terminalSurface?.id,
+               panels[surfaceId] is TerminalPanel {
+                return surfaceId
+            }
+            node = current.nextResponder
+        }
+        return nil
+    }
+
+    /// Returns the InputTextView currently holding first responder in
+    /// this workspace's key window, if any.
+    private func firstResponderTextBox() -> InputTextView? {
+        let window = NSApp.keyWindow ?? NSApp.mainWindow
+        return window?.firstResponder as? InputTextView
     }
 
     // MARK: - M7 title bar integration

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5956,35 +5956,53 @@ final class Workspace: Identifiable, ObservableObject {
                 panel.isTextBoxActive = shouldShow
             }
             if shouldShow {
+                focusInputTextView(in: targets, retriesRemaining: 4)
+            }
+        case .toggleFocus:
+            // Keep the box visible; swap focus between TextBox and terminal.
+            let wasAllVisible = targets.allSatisfy { $0.isTextBoxActive }
+            for panel in targets where !panel.isTextBoxActive {
+                panel.isTextBoxActive = true
+            }
+            if !wasAllVisible {
+                // First press summoned the TextBox from hidden — focus it, don't
+                // swap back to the terminal (the InputTextView may not be mounted
+                // yet, so retry briefly until SwiftUI wires it up).
+                focusInputTextView(in: targets, retriesRemaining: 4)
+            } else {
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
                     if let active = self.firstResponderTextBox() {
-                        _ = active
-                        return
-                    }
-                    if let firstTarget = targets.first,
-                       let view = firstTarget.inputTextView {
+                        // Focus is in a TextBox — move it back to that panel's terminal.
+                        let panel = targets.first { $0.inputTextView === active }
+                            ?? terminalPanels.first { $0.inputTextView === active }
+                        panel?.surface.focusTerminalView()
+                    } else {
+                        // Focus is in the terminal (or elsewhere) — move it into the TextBox.
+                        guard let firstTarget = targets.first,
+                              let view = firstTarget.inputTextView else { return }
                         view.window?.makeFirstResponder(view)
                     }
                 }
             }
-        case .toggleFocus:
-            // Keep the box visible; swap focus between TextBox and terminal.
-            for panel in targets where !panel.isTextBoxActive {
-                panel.isTextBoxActive = true
+        }
+    }
+
+    /// Move first responder into the first target panel's InputTextView, retrying
+    /// briefly if SwiftUI has not yet mounted the container. Used after showing
+    /// the TextBox from hidden, where `inputTextView` is nil until the next
+    /// render pass wires it up via `onInputTextViewCreated`.
+    private func focusInputTextView(in targets: [TerminalPanel], retriesRemaining: Int) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if self.firstResponderTextBox() != nil { return }
+            if let firstTarget = targets.first, let view = firstTarget.inputTextView {
+                view.window?.makeFirstResponder(view)
+                return
             }
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                if let active = self.firstResponderTextBox() {
-                    // Focus is in a TextBox — move it back to that panel's terminal.
-                    let panel = targets.first { $0.inputTextView === active }
-                        ?? terminalPanels.first { $0.inputTextView === active }
-                    panel?.surface.focusTerminalView()
-                } else {
-                    // Focus is in the terminal (or elsewhere) — move it into the TextBox.
-                    guard let firstTarget = targets.first,
-                          let view = firstTarget.inputTextView else { return }
-                    view.window?.makeFirstResponder(view)
+            if retriesRemaining > 0 {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.025) { [weak self] in
+                    self?.focusInputTextView(in: targets, retriesRemaining: retriesRemaining - 1)
                 }
             }
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5327,14 +5327,15 @@ struct SettingsView: View {
                         }
                     }
 
-                    // [TextBox] TextBox Input settings (plan §4.7)
+                    // [TextBox] TextBox Input settings (plan §4.7). Keys match
+                    // the upstream fork so Japanese translations carry over.
                     SettingsSectionHeader(title: String(localized: "settings.section.textBoxInput", defaultValue: "TextBox Input"))
                         .id(SettingsNavigationTarget.textBoxInput)
                         .accessibilityIdentifier("SettingsTextBoxInputSection")
                     SettingsCard {
                         SettingsCardRow(
-                            String(localized: "settings.textBoxInput.enable", defaultValue: "Enable Mode"),
-                            subtitle: String(localized: "settings.textBoxInput.enable.subtitle", defaultValue: "Show a native text box below each terminal for composing multi-line input and AI prompts.")
+                            String(localized: "settings.textBoxInput.enableMode", defaultValue: "Enable Mode"),
+                            subtitle: String(localized: "settings.textBoxInput.enableMode.subtitle", defaultValue: "Add a text box for terminal input. Supports standard editing, IME, and clipboard shortcuts.")
                         ) {
                             Toggle("", isOn: $textBoxEnabled)
                                 .labelsHidden()
@@ -5345,21 +5346,21 @@ struct SettingsView: View {
                         SettingsCardDivider()
 
                         SettingsPickerRow(
-                            String(localized: "settings.textBoxInput.enterToSend", defaultValue: "Send on Return"),
-                            subtitle: String(localized: "settings.textBoxInput.enterToSend.subtitle", defaultValue: "When on, Return submits and Shift+Return inserts a newline. When off, the keys are reversed."),
+                            String(localized: "settings.textBoxInput.sendOnReturn", defaultValue: "Send on Return"),
+                            subtitle: String(localized: "settings.textBoxInput.sendOnReturn.subtitle", defaultValue: "Insert new line with Shift+Return"),
                             controlWidth: pickerColumnWidth,
                             selection: $textBoxEnterToSend
                         ) {
-                            Text(String(localized: "settings.textBoxInput.enterToSend.on", defaultValue: "Return = Send")).tag(true)
-                            Text(String(localized: "settings.textBoxInput.enterToSend.off", defaultValue: "Return = Newline")).tag(false)
+                            Text(String(localized: "settings.textBoxInput.sendOnReturn.on", defaultValue: "Return = Send")).tag(true)
+                            Text(String(localized: "settings.textBoxInput.sendOnReturn.off", defaultValue: "Return = Newline")).tag(false)
                         }
                         .textBoxSettingsDisabled(!textBoxEnabled)
 
                         SettingsCardDivider()
 
                         SettingsPickerRow(
-                            String(localized: "settings.textBoxInput.escape", defaultValue: "Escape Key"),
-                            subtitle: String(localized: "settings.textBoxInput.escape.subtitle", defaultValue: "What the Escape key does while focus is in the TextBox."),
+                            String(localized: "settings.textBoxInput.escapeBehavior", defaultValue: "Escape Key"),
+                            subtitle: String(localized: "settings.textBoxInput.escapeBehavior.subtitle", defaultValue: "Action when pressing Escape in the TextBox."),
                             controlWidth: pickerColumnWidth,
                             selection: $textBoxEscapeBehavior
                         ) {
@@ -5372,8 +5373,11 @@ struct SettingsView: View {
                         SettingsCardDivider()
 
                         SettingsPickerRow(
-                            String(localized: "settings.textBoxInput.shortcutBehavior", defaultValue: "Shortcut Behavior"),
-                            subtitle: String(localized: "settings.textBoxInput.shortcutBehavior.subtitle", defaultValue: "What the Toggle TextBox Input shortcut does. Display toggles visibility; Focus keeps the box visible and swaps focus."),
+                            String(
+                                format: String(localized: "settings.textBoxInput.shortcutBehavior", defaultValue: "Keyboard Shortcut (%@)"),
+                                KeyboardShortcutSettings.shortcut(for: .toggleTextBoxInput).displayString
+                            ),
+                            subtitle: String(localized: "settings.textBoxInput.shortcutBehavior.subtitle", defaultValue: "Shortcut key can be changed in Keyboard Shortcuts settings."),
                             controlWidth: pickerColumnWidth,
                             selection: $textBoxShortcutBehavior
                         ) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3902,7 +3902,6 @@ struct SettingsView: View {
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
 
     // [TextBox] TextBox Input settings (plan §4.7)
-    @AppStorage(TextBoxInputSettings.enabledKey) private var textBoxEnabled = TextBoxInputSettings.defaultEnabled
     @AppStorage(TextBoxInputSettings.enterToSendKey) private var textBoxEnterToSend = TextBoxInputSettings.defaultEnterToSend
     @AppStorage(TextBoxInputSettings.escapeBehaviorKey) private var textBoxEscapeBehavior = TextBoxInputSettings.defaultEscapeBehavior.rawValue
     @AppStorage(TextBoxInputSettings.shortcutBehaviorKey) private var textBoxShortcutBehavior = TextBoxInputSettings.defaultShortcutBehavior.rawValue
@@ -5333,18 +5332,6 @@ struct SettingsView: View {
                         .id(SettingsNavigationTarget.textBoxInput)
                         .accessibilityIdentifier("SettingsTextBoxInputSection")
                     SettingsCard {
-                        SettingsCardRow(
-                            String(localized: "settings.textBoxInput.enableMode", defaultValue: "Enable Mode"),
-                            subtitle: String(localized: "settings.textBoxInput.enableMode.subtitle", defaultValue: "Add a text box for terminal input. Supports standard editing, IME, and clipboard shortcuts.")
-                        ) {
-                            Toggle("", isOn: $textBoxEnabled)
-                                .labelsHidden()
-                                .controlSize(.small)
-                                .accessibilityIdentifier("TextBoxEnableToggle")
-                        }
-
-                        SettingsCardDivider()
-
                         SettingsPickerRow(
                             String(localized: "settings.textBoxInput.sendOnReturn", defaultValue: "Send on Return"),
                             subtitle: String(localized: "settings.textBoxInput.sendOnReturn.subtitle", defaultValue: "Insert new line with Shift+Return"),
@@ -5354,7 +5341,6 @@ struct SettingsView: View {
                             Text(String(localized: "settings.textBoxInput.sendOnReturn.on", defaultValue: "Return = Send")).tag(true)
                             Text(String(localized: "settings.textBoxInput.sendOnReturn.off", defaultValue: "Return = Newline")).tag(false)
                         }
-                        .textBoxSettingsDisabled(!textBoxEnabled)
 
                         SettingsCardDivider()
 
@@ -5368,7 +5354,6 @@ struct SettingsView: View {
                                 Text(option.displayName).tag(option.rawValue)
                             }
                         }
-                        .textBoxSettingsDisabled(!textBoxEnabled)
 
                         SettingsCardDivider()
 
@@ -5385,7 +5370,6 @@ struct SettingsView: View {
                                 Text(option.displayName).tag(option.rawValue)
                             }
                         }
-                        .textBoxSettingsDisabled(!textBoxEnabled)
                     }
 
                     SettingsSectionHeader(title: String(localized: "settings.section.keyboardShortcuts", defaultValue: "Keyboard Shortcuts"))
@@ -5692,7 +5676,6 @@ struct SettingsView: View {
         KeyboardShortcutSettings.resetAll()
         // [TextBox] Also reset TextBox Input defaults when Reset All runs.
         TextBoxInputSettings.resetAll()
-        textBoxEnabled = TextBoxInputSettings.defaultEnabled
         textBoxEnterToSend = TextBoxInputSettings.defaultEnterToSend
         textBoxEscapeBehavior = TextBoxInputSettings.defaultEscapeBehavior.rawValue
         textBoxShortcutBehavior = TextBoxInputSettings.defaultShortcutBehavior.rawValue

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2711,6 +2711,7 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
 enum SettingsNavigationTarget: String {
     case browser
     case browserImport
+    case textBoxInput
     case keyboardShortcuts
 }
 
@@ -3899,6 +3900,12 @@ struct SettingsView: View {
     @AppStorage("sidebarTintHexLight") private var sidebarTintHexLight: String?
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
+
+    // [TextBox] TextBox Input settings (plan §4.7)
+    @AppStorage(TextBoxInputSettings.enabledKey) private var textBoxEnabled = TextBoxInputSettings.defaultEnabled
+    @AppStorage(TextBoxInputSettings.enterToSendKey) private var textBoxEnterToSend = TextBoxInputSettings.defaultEnterToSend
+    @AppStorage(TextBoxInputSettings.escapeBehaviorKey) private var textBoxEscapeBehavior = TextBoxInputSettings.defaultEscapeBehavior.rawValue
+    @AppStorage(TextBoxInputSettings.shortcutBehaviorKey) private var textBoxShortcutBehavior = TextBoxInputSettings.defaultShortcutBehavior.rawValue
 
     @ObservedObject private var notificationStore = TerminalNotificationStore.shared
     @State private var shortcutResetToken = UUID()
@@ -5320,6 +5327,63 @@ struct SettingsView: View {
                         }
                     }
 
+                    // [TextBox] TextBox Input settings (plan §4.7)
+                    SettingsSectionHeader(title: String(localized: "settings.section.textBoxInput", defaultValue: "TextBox Input"))
+                        .id(SettingsNavigationTarget.textBoxInput)
+                        .accessibilityIdentifier("SettingsTextBoxInputSection")
+                    SettingsCard {
+                        SettingsCardRow(
+                            String(localized: "settings.textBoxInput.enable", defaultValue: "Enable Mode"),
+                            subtitle: String(localized: "settings.textBoxInput.enable.subtitle", defaultValue: "Show a native text box below each terminal for composing multi-line input and AI prompts.")
+                        ) {
+                            Toggle("", isOn: $textBoxEnabled)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityIdentifier("TextBoxEnableToggle")
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.textBoxInput.enterToSend", defaultValue: "Send on Return"),
+                            subtitle: String(localized: "settings.textBoxInput.enterToSend.subtitle", defaultValue: "When on, Return submits and Shift+Return inserts a newline. When off, the keys are reversed."),
+                            controlWidth: pickerColumnWidth,
+                            selection: $textBoxEnterToSend
+                        ) {
+                            Text(String(localized: "settings.textBoxInput.enterToSend.on", defaultValue: "Return = Send")).tag(true)
+                            Text(String(localized: "settings.textBoxInput.enterToSend.off", defaultValue: "Return = Newline")).tag(false)
+                        }
+                        .textBoxSettingsDisabled(!textBoxEnabled)
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.textBoxInput.escape", defaultValue: "Escape Key"),
+                            subtitle: String(localized: "settings.textBoxInput.escape.subtitle", defaultValue: "What the Escape key does while focus is in the TextBox."),
+                            controlWidth: pickerColumnWidth,
+                            selection: $textBoxEscapeBehavior
+                        ) {
+                            ForEach(TextBoxEscapeBehavior.allCases) { option in
+                                Text(option.displayName).tag(option.rawValue)
+                            }
+                        }
+                        .textBoxSettingsDisabled(!textBoxEnabled)
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            String(localized: "settings.textBoxInput.shortcutBehavior", defaultValue: "Shortcut Behavior"),
+                            subtitle: String(localized: "settings.textBoxInput.shortcutBehavior.subtitle", defaultValue: "What the Toggle TextBox Input shortcut does. Display toggles visibility; Focus keeps the box visible and swaps focus."),
+                            controlWidth: pickerColumnWidth,
+                            selection: $textBoxShortcutBehavior
+                        ) {
+                            ForEach(TextBoxShortcutBehavior.allCases) { option in
+                                Text(option.displayName).tag(option.rawValue)
+                            }
+                        }
+                        .textBoxSettingsDisabled(!textBoxEnabled)
+                    }
+
                     SettingsSectionHeader(title: String(localized: "settings.section.keyboardShortcuts", defaultValue: "Keyboard Shortcuts"))
                         .id(SettingsNavigationTarget.keyboardShortcuts)
                         .accessibilityIdentifier("SettingsKeyboardShortcutsSection")
@@ -5622,6 +5686,12 @@ struct SettingsView: View {
         socketPasswordStatusIsError = false
         refreshDetectedImportBrowsers()
         KeyboardShortcutSettings.resetAll()
+        // [TextBox] Also reset TextBox Input defaults when Reset All runs.
+        TextBoxInputSettings.resetAll()
+        textBoxEnabled = TextBoxInputSettings.defaultEnabled
+        textBoxEnterToSend = TextBoxInputSettings.defaultEnterToSend
+        textBoxEscapeBehavior = TextBoxInputSettings.defaultEscapeBehavior.rawValue
+        textBoxShortcutBehavior = TextBoxInputSettings.defaultShortcutBehavior.rawValue
         WorkspaceTabColorSettings.reset()
         reloadWorkspaceTabColorSettings()
         shortcutResetToken = UUID()

--- a/cmuxTests/TextBoxInputTests.swift
+++ b/cmuxTests/TextBoxInputTests.swift
@@ -21,17 +21,8 @@ final class TextBoxInputSettingsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDefaultEnabledIsFalse() {
-        XCTAssertFalse(TextBoxInputSettings.isEnabled())
-    }
-
     func testDefaultEnterToSendIsTrue() {
         XCTAssertTrue(TextBoxInputSettings.isEnterToSend())
-    }
-
-    func testSetEnabledTrue() {
-        UserDefaults.standard.set(true, forKey: TextBoxInputSettings.enabledKey)
-        XCTAssertTrue(TextBoxInputSettings.isEnabled())
     }
 
     func testSetEnterToSendFalse() {

--- a/cmuxTests/TextBoxInputTests.swift
+++ b/cmuxTests/TextBoxInputTests.swift
@@ -1,0 +1,402 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// MARK: - TextBoxInputSettings Tests
+
+final class TextBoxInputSettingsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        TextBoxInputSettings.resetAll()
+    }
+
+    override func tearDown() {
+        TextBoxInputSettings.resetAll()
+        super.tearDown()
+    }
+
+    func testDefaultEnabledIsFalse() {
+        XCTAssertFalse(TextBoxInputSettings.isEnabled())
+    }
+
+    func testDefaultEnterToSendIsTrue() {
+        XCTAssertTrue(TextBoxInputSettings.isEnterToSend())
+    }
+
+    func testSetEnabledTrue() {
+        UserDefaults.standard.set(true, forKey: TextBoxInputSettings.enabledKey)
+        XCTAssertTrue(TextBoxInputSettings.isEnabled())
+    }
+
+    func testSetEnterToSendFalse() {
+        UserDefaults.standard.set(false, forKey: TextBoxInputSettings.enterToSendKey)
+        XCTAssertFalse(TextBoxInputSettings.isEnterToSend())
+    }
+}
+
+// MARK: - KeyboardShortcutSettings Integration Tests
+
+final class TextBoxShortcutTests: XCTestCase {
+
+    override func tearDown() {
+        KeyboardShortcutSettings.resetShortcut(for: .toggleTextBoxInput)
+        super.tearDown()
+    }
+
+    func testToggleTextBoxInputDefaultShortcut() {
+        let shortcut = KeyboardShortcutSettings.Action.toggleTextBoxInput.defaultShortcut
+        XCTAssertEqual(shortcut.key, "b")
+        XCTAssertTrue(shortcut.command)
+        XCTAssertFalse(shortcut.shift)
+        XCTAssertTrue(shortcut.option)
+        XCTAssertFalse(shortcut.control)
+    }
+
+    func testToggleTextBoxInputDefaultsKey() {
+        XCTAssertEqual(
+            KeyboardShortcutSettings.Action.toggleTextBoxInput.defaultsKey,
+            "shortcut.toggleTextBoxInput"
+        )
+    }
+
+    func testToggleTextBoxInputLabel() {
+        let label = KeyboardShortcutSettings.Action.toggleTextBoxInput.label
+        XCTAssertEqual(label, "Toggle TextBox Input")
+    }
+
+    func testCustomShortcutPersistence() {
+        let custom = StoredShortcut(key: "j", command: true, shift: false, option: false, control: false)
+        KeyboardShortcutSettings.setShortcut(custom, for: .toggleTextBoxInput)
+
+        let loaded = KeyboardShortcutSettings.shortcut(for: .toggleTextBoxInput)
+        XCTAssertEqual(loaded, custom)
+    }
+
+    func testResetShortcutRestoresDefault() {
+        let custom = StoredShortcut(key: "j", command: true, shift: false, option: false, control: false)
+        KeyboardShortcutSettings.setShortcut(custom, for: .toggleTextBoxInput)
+        KeyboardShortcutSettings.resetShortcut(for: .toggleTextBoxInput)
+
+        let loaded = KeyboardShortcutSettings.shortcut(for: .toggleTextBoxInput)
+        XCTAssertEqual(loaded, KeyboardShortcutSettings.Action.toggleTextBoxInput.defaultShortcut)
+    }
+}
+
+// MARK: - TextBoxKeyRouting Tests
+
+final class TextBoxKeyRoutingTests: XCTestCase {
+
+    // Helper to call route() with common defaults.
+    private func route(
+        _ input: TextBoxKeyInput,
+        isEmpty: Bool = false,
+        terminalTitle: String = "",
+        enterToSend: Bool = true
+    ) -> TextBoxKeyAction {
+        TextBoxKeyRouting.route(input, isEmpty: isEmpty, terminalTitle: terminalTitle, enterToSend: enterToSend)
+    }
+
+    // MARK: Rule 1 — Emacs editing (Ctrl + A/E/F/B/N/P/K/H)
+
+    func testCtrlEmacsKeysReturnEmacsEdit() {
+        for key in ["a", "e", "f", "b", "n", "p", "k", "h"] {
+            let action = route(.ctrl(key))
+            guard case .emacsEdit = action else {
+                XCTFail("Ctrl+\(key) should be .emacsEdit, got \(action)")
+                return
+            }
+        }
+    }
+
+    // MARK: Rule 2 — Ctrl+other → forward to terminal
+
+    func testCtrlNonEmacsKeysReturnForwardControl() {
+        for key in ["c", "z", "d", "l", "r"] {
+            let action = route(.ctrl(key))
+            guard case .forwardControl = action else {
+                XCTFail("Ctrl+\(key) should be .forwardControl, got \(action)")
+                return
+            }
+        }
+    }
+
+    // MARK: Rule 3 — "/" prefix forwarding (empty + app detected)
+
+    func testSlashForwardWhenEmptyAndClaudeCodeRunning() {
+        let action = route(.text("/"), isEmpty: true, terminalTitle: "Claude Code")
+        guard case .forwardPrefix("/") = action else {
+            XCTFail("Expected .forwardPrefix(\"/\"), got \(action)")
+            return
+        }
+    }
+
+    func testSlashForwardWhenEmptyAndCodexRunning() {
+        let action = route(.text("/"), isEmpty: true, terminalTitle: "Codex")
+        guard case .forwardPrefix("/") = action else {
+            XCTFail("Expected .forwardPrefix(\"/\"), got \(action)")
+            return
+        }
+    }
+
+    func testSlashNotForwardedWhenNotEmpty() {
+        let action = route(.text("/"), isEmpty: false, terminalTitle: "Claude Code")
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput, got \(action)")
+            return
+        }
+    }
+
+    func testSlashNotForwardedWhenNoAppDetected() {
+        let action = route(.text("/"), isEmpty: true, terminalTitle: "zsh")
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput, got \(action)")
+            return
+        }
+    }
+
+    // MARK: Rule 4 — "@" prefix forwarding (empty + app detected)
+
+    func testAtForwardWhenEmptyAndClaudeCodeRunning() {
+        let action = route(.text("@"), isEmpty: true, terminalTitle: "Claude Code")
+        guard case .forwardPrefix("@") = action else {
+            XCTFail("Expected .forwardPrefix(\"@\"), got \(action)")
+            return
+        }
+    }
+
+    func testAtForwardWhenEmptyAndCodexRunning() {
+        let action = route(.text("@"), isEmpty: true, terminalTitle: "Codex")
+        guard case .forwardPrefix("@") = action else {
+            XCTFail("Expected .forwardPrefix(\"@\") for Codex, got \(action)")
+            return
+        }
+    }
+
+    func testAtNotForwardedWhenNotEmpty() {
+        let action = route(.text("@"), isEmpty: false, terminalTitle: "Claude Code")
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput, got \(action)")
+            return
+        }
+    }
+
+    // MARK: Rule 5 — "?" key event forwarding (empty + app detected, keep focus)
+
+    func testQuestionMarkForwardWhenEmptyAndClaudeCodeRunning() {
+        let action = route(.key("?"), isEmpty: true, terminalTitle: "Claude Code")
+        guard case .forwardKeyEvent = action else {
+            XCTFail("Expected .forwardKeyEvent, got \(action)")
+            return
+        }
+    }
+
+    func testQuestionMarkForwardWhenEmptyAndCodexRunning() {
+        let action = route(.key("?"), isEmpty: true, terminalTitle: "Codex")
+        guard case .forwardKeyEvent = action else {
+            XCTFail("Expected .forwardKeyEvent, got \(action)")
+            return
+        }
+    }
+
+    func testQuestionMarkNotForwardedWhenNotEmpty() {
+        let action = route(.key("?"), isEmpty: false, terminalTitle: "Claude Code")
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput, got \(action)")
+            return
+        }
+    }
+
+    func testQuestionMarkNotForwardedWhenNoAppDetected() {
+        let action = route(.key("?"), isEmpty: true, terminalTitle: "zsh")
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput, got \(action)")
+            return
+        }
+    }
+
+    // MARK: Rule 6/7 — Return (setting-dependent)
+
+    func testReturnSubmitsWhenEnterToSendAndNotShifted() {
+        let action = route(.command(#selector(NSResponder.insertNewline(_:)), shifted: false), enterToSend: true)
+        guard case .submit = action else {
+            XCTFail("Expected .submit, got \(action)")
+            return
+        }
+    }
+
+    func testShiftReturnInsertsNewlineWhenEnterToSend() {
+        let action = route(.command(#selector(NSResponder.insertNewline(_:)), shifted: true), enterToSend: true)
+        guard case .insertNewline = action else {
+            XCTFail("Expected .insertNewline, got \(action)")
+            return
+        }
+    }
+
+    func testReturnInsertsNewlineWhenNotEnterToSend() {
+        let action = route(.command(#selector(NSResponder.insertNewline(_:)), shifted: false), enterToSend: false)
+        guard case .insertNewline = action else {
+            XCTFail("Expected .insertNewline, got \(action)")
+            return
+        }
+    }
+
+    func testShiftReturnSubmitsWhenNotEnterToSend() {
+        let action = route(.command(#selector(NSResponder.insertNewline(_:)), shifted: true), enterToSend: false)
+        guard case .submit = action else {
+            XCTFail("Expected .submit, got \(action)")
+            return
+        }
+    }
+
+    // MARK: Rule 8 — Escape
+
+    func testEscapeReturnsEscape() {
+        let action = route(.command(#selector(NSResponder.cancelOperation(_:)), shifted: false))
+        guard case .escape = action else {
+            XCTFail("Expected .escape, got \(action)")
+            return
+        }
+    }
+
+    // MARK: Rule 9 — Empty-state navigation forwarding
+
+    func testArrowUpForwardedWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.moveUp(_:)), shifted: false), isEmpty: true)
+        guard case .forwardKey(.arrowUp) = action else {
+            XCTFail("Expected .forwardKey(.arrowUp), got \(action)")
+            return
+        }
+    }
+
+    func testArrowDownForwardedWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.moveDown(_:)), shifted: false), isEmpty: true)
+        guard case .forwardKey(.arrowDown) = action else {
+            XCTFail("Expected .forwardKey(.arrowDown), got \(action)")
+            return
+        }
+    }
+
+    func testTabForwardedWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.insertTab(_:)), shifted: false), isEmpty: true)
+        guard case .forwardKey(.tab) = action else {
+            XCTFail("Expected .forwardKey(.tab), got \(action)")
+            return
+        }
+    }
+
+    func testBackspaceForwardedWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.deleteBackward(_:)), shifted: false), isEmpty: true)
+        guard case .forwardKey(.backspace) = action else {
+            XCTFail("Expected .forwardKey(.backspace), got \(action)")
+            return
+        }
+    }
+
+    func testArrowUpNotForwardedWhenNotEmpty() {
+        let action = route(.command(#selector(NSResponder.moveUp(_:)), shifted: false), isEmpty: false)
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput when not empty, got \(action)")
+            return
+        }
+    }
+
+    // MARK: Rule 10 — Fallback (textInput)
+
+    func testRegularTextReturnsTextInput() {
+        let action = route(.text("a"), isEmpty: false)
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput, got \(action)")
+            return
+        }
+    }
+
+    func testUnknownSelectorReturnsTextInput() {
+        let action = route(.command(#selector(NSResponder.selectAll(_:)), shifted: false))
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput for unknown selector, got \(action)")
+            return
+        }
+    }
+}
+
+// MARK: - TextBoxAppDetection Tests
+
+final class TextBoxAppDetectionTests: XCTestCase {
+
+    func testClaudeCodeDetected() {
+        XCTAssertTrue(TextBoxAppDetection.claudeCode.matches(terminalTitle: "Claude Code"))
+    }
+
+    func testClaudeCodeDetectedWithIcon() {
+        XCTAssertTrue(TextBoxAppDetection.claudeCode.matches(terminalTitle: "✱ Claude Code"))
+    }
+
+    func testClaudeCodeDetectedWithAltIcon() {
+        XCTAssertTrue(TextBoxAppDetection.claudeCode.matches(terminalTitle: "✳ Claude Code"))
+    }
+
+    func testClaudeCodeDetectedWithThinkingIndicator() {
+        XCTAssertTrue(TextBoxAppDetection.claudeCode.matches(terminalTitle: "⠂ New coding session"))
+    }
+
+    func testClaudeCodeDetectedWithIconAndSessionTitle() {
+        XCTAssertTrue(TextBoxAppDetection.claudeCode.matches(terminalTitle: "✳ Japanese greeting conversation"))
+    }
+
+    func testCodexDetected() {
+        XCTAssertTrue(TextBoxAppDetection.codex.matches(terminalTitle: "Codex"))
+    }
+
+    func testPlainShellNotDetected() {
+        XCTAssertFalse(TextBoxAppDetection.claudeCode.matches(terminalTitle: "zsh"))
+        XCTAssertFalse(TextBoxAppDetection.codex.matches(terminalTitle: "zsh"))
+    }
+
+    // MARK: Metadata-first detection (c11mux SurfaceMetadataStore)
+
+    func testMetadataClaudeCodeDetectedRegardlessOfTitle() {
+        XCTAssertTrue(
+            TextBoxAppDetection.claudeCode.matches(
+                terminalType: "claude-code", terminalTitle: "zsh")
+        )
+    }
+
+    func testMetadataCodexDetectedRegardlessOfTitle() {
+        XCTAssertTrue(
+            TextBoxAppDetection.codex.matches(
+                terminalType: "codex", terminalTitle: "zsh")
+        )
+    }
+
+    func testMetadataShellSuppressesClaudeCodeDetection() {
+        // Metadata says shell; title happens to say "Claude Code". Metadata wins.
+        XCTAssertFalse(
+            TextBoxAppDetection.claudeCode.matches(
+                terminalType: "shell", terminalTitle: "Claude Code")
+        )
+    }
+
+    func testNilMetadataFallsBackToTitleRegex() {
+        XCTAssertTrue(
+            TextBoxAppDetection.claudeCode.matches(
+                terminalType: nil, terminalTitle: "Claude Code")
+        )
+        XCTAssertFalse(
+            TextBoxAppDetection.claudeCode.matches(
+                terminalType: nil, terminalTitle: "zsh")
+        )
+    }
+
+    func testEmptyMetadataFallsBackToTitleRegex() {
+        XCTAssertTrue(
+            TextBoxAppDetection.claudeCode.matches(
+                terminalType: "", terminalTitle: "Claude Code")
+        )
+    }
+}

--- a/cmuxTests/TextBoxInputTests.swift
+++ b/cmuxTests/TextBoxInputTests.swift
@@ -256,22 +256,10 @@ final class TextBoxKeyRoutingTests: XCTestCase {
     }
 
     // MARK: Rule 9 — Empty-state navigation forwarding
-
-    func testArrowUpForwardedWhenEmpty() {
-        let action = route(.command(#selector(NSResponder.moveUp(_:)), shifted: false), isEmpty: true)
-        guard case .forwardKey(.arrowUp) = action else {
-            XCTFail("Expected .forwardKey(.arrowUp), got \(action)")
-            return
-        }
-    }
-
-    func testArrowDownForwardedWhenEmpty() {
-        let action = route(.command(#selector(NSResponder.moveDown(_:)), shifted: false), isEmpty: true)
-        guard case .forwardKey(.arrowDown) = action else {
-            XCTFail("Expected .forwardKey(.arrowDown), got \(action)")
-            return
-        }
-    }
+    //
+    // Option B: arrow keys are never forwarded to the terminal. They always
+    // drive NSTextView cursor movement (.textInput), whether the TextBox is
+    // empty or not. Only Tab and Backspace still forward in the empty state.
 
     func testTabForwardedWhenEmpty() {
         let action = route(.command(#selector(NSResponder.insertTab(_:)), shifted: false), isEmpty: true)
@@ -285,6 +273,46 @@ final class TextBoxKeyRoutingTests: XCTestCase {
         let action = route(.command(#selector(NSResponder.deleteBackward(_:)), shifted: false), isEmpty: true)
         guard case .forwardKey(.backspace) = action else {
             XCTFail("Expected .forwardKey(.backspace), got \(action)")
+            return
+        }
+    }
+
+    func testTabNotForwardedWhenNotEmpty() {
+        let action = route(.command(#selector(NSResponder.insertTab(_:)), shifted: false), isEmpty: false)
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput when not empty, got \(action)")
+            return
+        }
+    }
+
+    func testArrowUpStaysInTextBoxWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.moveUp(_:)), shifted: false), isEmpty: true)
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput (arrows never forward — Option B), got \(action)")
+            return
+        }
+    }
+
+    func testArrowDownStaysInTextBoxWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.moveDown(_:)), shifted: false), isEmpty: true)
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput (arrows never forward — Option B), got \(action)")
+            return
+        }
+    }
+
+    func testArrowLeftStaysInTextBoxWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.moveLeft(_:)), shifted: false), isEmpty: true)
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput (arrows never forward — Option B), got \(action)")
+            return
+        }
+    }
+
+    func testArrowRightStaysInTextBoxWhenEmpty() {
+        let action = route(.command(#selector(NSResponder.moveRight(_:)), shifted: false), isEmpty: true)
+        guard case .textInput = action else {
+            XCTFail("Expected .textInput (arrows never forward — Option B), got \(action)")
             return
         }
     }


### PR DESCRIPTION
## Summary

Port the TextBox Input feature from the
[alumican/cmux-tb](https://github.com/alumican/cmux-tb) fork into c11mux.
Adds a native macOS `NSTextView` that can be summoned below any terminal pane
so users — and AI agents — can compose multi-line input, leverage IME
correctly, and drop files that auto-expand to shell-escaped paths.

- **Hidden by default per terminal pane.** `Cmd+Option+B` summons and
  dismisses it on each press (`toggleDisplay`). Showing by default lost
  to the simpler summon-on-demand model after a brief round-trip in the
  amendments.
- **Toggle shortcut:** `Cmd+Option+B` (plan §4.5 — `Cmd+Option+T` is
  already bound to close-other-tabs in AppDelegate; the fork author's
  own source comment calls out B as the conflict-free choice).
- **Arrow keys always stay in the TextBox.** The fork forwarded arrows
  to the terminal when empty; we dropped that per user decision ("Option B").
  Tab and Backspace still forward to the shell when empty.
- **Agent detection is metadata-first.** Reads
  `SurfaceMetadataStore.terminal_type` written by c11mux's `AgentDetector`
  (M1/M2) before falling back to the fork's title-regex.
- Authoritative plan doc:
  [`docs/c11mux-textbox-port-plan.md`](docs/c11mux-textbox-port-plan.md)
  (v2, post-Trident review).
- Trident review pack (8 reviews + 3 syntheses):
  [`docs/c11mux-textbox-port-plan-review-pack-2026-04-18T1255/`](docs/c11mux-textbox-port-plan-review-pack-2026-04-18T1255/).

## Known regression shipped with the feature

**Up/Down cursor movement in a multi-line TextBox does not work.**
Left/Right move the cursor character-by-character as expected; Up/Down
silently do nothing. Evidence captured via dlog instrumentation in the
M9 session: `moveUp:` selector never arrives at `InputTextView.doCommand`,
despite the text view being first responder and `moveLeft:` / `moveRight:`
arriving fine. This rules out our routing — the arrow keys are being
intercepted upstream (probably a parent NSScrollView or the Bonsplit
split-pane host) before they reach the NSTextView. Filed as a follow-up
in `C11MUX_TODO.md` with a ~1h investigation recipe. Not a merge blocker
— `Shift+Return` inserts blank lines and Left/Right still navigate.

## Locked decisions (plan §8)

| # | Decision | Applied value |
|---|---|---|
| Q1 | Rename TextBoxInput → ComposeSurface? | **No** — keep `TextBoxInput`. |
| Q2 | Default enabled state | ~~`false`~~ → `true` → **Default-hidden per pane; `Cmd+Option+B` summons** (two amendments settled on summon-on-demand). |
| Q3 | Default shortcut | **`Cmd+Option+B`** (not Cmd+Option+T — collision). |
| Q4 | Agent detection | **Metadata-first (`SurfaceMetadataStore.terminal_type`) with title-regex fallback.** |
| Q5 | Number of settings | ~~Ship 4~~ → **Ship 3** (Send-on-Return, Escape, Shortcut Behavior) after Enable Mode was removed. |
| Q6 | PR shape | **Single PR** with the 9-phase commit history preserved, plus 3 amendment commits on top. |
| Q9 | `.all` scope semantics | **Current workspace only.** |
| Q10 | Latency pass criterion | **≤1ms p95 keystroke-to-paint delta** (TextBox visible-but-unfocused vs. baseline). |
| Q11 | VoiceOver | **Not a merge blocker** — file follow-up if users hit issues. |
| Arrow keys | "Option B" — always stay in TextBox | Arrow forwarding removed; Tab/Backspace empty-state forwarding retained. |
| Shortcut default | `.toggleFocus` → `.toggleDisplay` | Shortcut now summons/dismisses instead of only swapping focus. Focus-swap mode still available in Settings. |

## Commit history (11 commits)

Phase commits:

| # | Commit | Summary |
|---|---|---|
| 1 | `1423d1ea` | Drop `TextBoxInput.swift` scaffolding (1260 LOC, 3 edits from fork) + `TerminalSurface`/`GhosttyApp` extensions (absorbed from planned Phase 3 due to compile-order dependency). |
| 2 | `888fc69a` | `TerminalPanel` per-panel state (`isTextBoxActive`, `textBoxContent`, weak `inputTextView`); `KeyboardShortcutSettings.toggleTextBoxInput` case at `Cmd+Option+B`; Settings → TextBox Input section + Reset hook. |
| 3 | `9593de98` | Focus guards: `ensureFocus` and `applyFirstResponderIfNeeded` defer to an active TextBox. |
| 4 | `d5eeec27` | Mount `TextBoxInputContainer` under each terminal, threaded with theme colors, font, and metadata-derived `terminalType`. |
| 5 | `fa3883ca` | AppDelegate `Cmd+Option+B` dispatch → `Workspace.toggleTextBoxMode`; title-sync hook in `Workspace.updatePanelTitle`. |
| 6 | `718c69a9` | Drag-routing lifecycle: shell-escaped file drops land in the TextBox with green `+` badge; browser and terminal paths preserved. |
| 7 | `cfdb1ea7` | 20 new `Resources/Localizable.xcstrings` keys (11 EN+JA from fork, 9 EN-only for c11mux-specific additions). |

Amendment commits (user-driven revisions during manual testing):

| # | Commit | Summary |
|---|---|---|
| 8 | `d84c47b4` | **Amendment 1**: TextBox default-on; `enabledKey` / `defaultEnabled` / `isEnabled()` removed, Enable Mode row removed, `textBoxSettingsDisabled` helper dropped (only caller was the deleted row), `isTextBoxActive` seeds to `true`. Settings section reduces 4 → 3 rows. |
| 9 | `88b5283b` | **Amendment 2 / Change 1**: `isTextBoxActive` default flipped back to `false` (summon-on-demand). Added `focusInputTextView(in:retriesRemaining:)` helper in `Workspace.toggleTextBoxMode` — first-press needs a retry loop because SwiftUI may not have mounted the InputTextView when `DispatchQueue.main.async` fires; 4× 25ms retry. |
| 10 | `e28377fb` | **Amendment 2 / Change 2**: Arrow keys removed from `emptyStateSelectors` (Option B). Arrows always return `.textInput` from the router — Tab and Backspace still forward to the terminal when empty. Test suite updated. |
| 11 | `81094365` | **Amendment 3**: `defaultShortcutBehavior = .toggleDisplay`. Shortcut now summons (first press) and hides (second press). The `.toggleFocus` focus-swap mode is still available in Settings → TextBox Input → Keyboard Shortcut. |

Two-commit regression-test pattern **does not apply** here — this is a
feature port, not a bug fix (plan §4.1).

## Typing-latency validation

Hard floor: ≤1ms p95 keystroke-to-paint delta with TextBox visible-but-
unfocused vs. TextBox-hidden baseline. **Not blocked by the code
changes in this PR**:

- `TerminalSurface.forceRefresh(reason:)` — **NOT modified**.
- `GhosttyNSView.hitTest()` / `WindowTerminalHostView.hitTest()` —
  **NOT modified**.
- `TabItemView` (with `.equatable()`) — **NOT modified**.
- `applyDefaultBackground` scope-guard path — **NOT modified**. The
  `defaultForegroundColor` read in `updateDefaultBackground` runs
  during config reload, not on keystrokes.
- `GhosttyScrollView.scrollWheel` was intentionally **NOT** guarded for
  TextBox — scroll-over-terminal is an explicit focus request.

Numerical measurement on the user's primary machine is deferred to the
manual validation checklist below and should run before merge.
Baseline = TextBox hidden via `Cmd+Option+B` (the default state now);
comparison = TextBox visible-but-unfocused.

## Phase 8 validation (automated)

- Tagged debug app launches cleanly: `./scripts/reload.sh --tag m9-textbox` → `c11mux DEV m9-textbox.app`.
- 1900+ log lines emitted with **zero** errors, warnings, or crash indicators.
- Every phase + amendment passed compile with the tagged derivedDataPath:
  ```
  xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux \
    -configuration Debug -destination 'platform=macOS' \
    -derivedDataPath /tmp/cmux-m9-textbox build
  → BUILD SUCCEEDED
  ```

## Test plan (manual)

- [ ] Fresh terminal pane does **not** show a TextBox by default.
- [ ] `Cmd+Option+B` summons the TextBox and focuses it. Second press hides it.
      (Default `.toggleDisplay` mode.)
- [ ] Settings panel: TextBox Input section appears between Browser and
      Keyboard Shortcuts with exactly **3** rows — `Send on Return`,
      `Escape Key`, `Keyboard Shortcut (…)`. No `Enable Mode` row, no
      dimmed/disabled rows. Reset All reverts the three TextBox settings.
- [ ] Switch shortcut behavior to `.toggleFocus` in Settings: focus
      ping-pongs between TextBox and terminal without hiding the TextBox.
- [ ] `Cmd+Option+T` still closes-other-tabs (regression check for the
      shortcut collision documented in `AppDelegateShortcutRoutingTests`).
- [ ] Submit single-line + multi-line via Return / Shift+Return; verify
      bracket-paste + delayed Return in `zsh`, `claude`, and `codex`.
- [ ] Arrow keys in TextBox: Left/Right move cursor; Up/Down **silently
      broken** — known regression, do not flag as a new bug.
- [ ] IME: Japanese (Kotoeri) — required; Chinese (Pinyin), Korean — nice-to-have.
- [ ] Drag-drop: drop files onto TextBox (shell-escaped paths with `+`
      badge), onto web pane (existing behavior preserved), onto terminal
      (existing behavior preserved).
- [ ] Claude Code / Codex agent detection: `/`, `@`, `?` route correctly
      with metadata present (AgentDetector) and with metadata absent
      (title-regex fallback).
- [ ] Numerical typing-latency measurement: p95 delta < 1ms with TextBox
      visible-but-unfocused vs. TextBox-hidden baseline (plan §8 Q10).
- [ ] VoiceOver: navigate into TextBox, compose, submit. File follow-up
      issue if broken — **not a merge blocker** per §8 Q11.

## Coordination notes

- **Up/Down cursor bug** tracked in `C11MUX_TODO.md` with reproduction
  notes, evidence, and a ~1h follow-up recipe.
- **Tier-1 persistence plan** (`docs/c11mux-tier1-persistence-plan.md`)
  touches per-panel state; `isTextBoxActive` and `textBoxContent` are
  candidates for future persistence. No direct conflict today — coordinate
  before both land on `main`.
- **Help menu** URL edits from the fork are deliberately NOT ported — they
  pointed at the fork repository.
- **Sparkle `SUFeedURL`** change from the fork is deliberately NOT ported —
  it would hijack c11mux's auto-update channel.
- **Orphaned `UserDefaults` key `textBoxEnabled`:** the default-on
  amendment removed the key; the default-hidden amendment did not
  re-introduce it. Any pre-existing value in a user's plist is silently
  ignored. No migration code shipped — matches c11mux conventions for
  default-schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)