### PR TITLE
m10/fixes: land 3 critical + 4 medium + 4 nit review fixes

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A5C101A1 /* PaneInteractionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B1 /* PaneInteractionCardView.swift */; };
 		A5C101A2 /* PaneInteractionOverlayHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B2 /* PaneInteractionOverlayHost.swift */; };
 		A5C102A0 /* PaneInteractionRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C102B0 /* PaneInteractionRuntimeTests.swift */; };
+		A5C103A1 /* PaneInteractionAcceptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C103B1 /* PaneInteractionAcceptTests.swift */; };
 		A58689DE /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C229 /* MermaidRenderer.swift */; };
 		A58689DF /* FencedCodeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C22A /* FencedCodeRenderer.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
@@ -228,6 +229,7 @@
 		A5C101B1 /* PaneInteractionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteractionCardView.swift; sourceTree = "<group>"; };
 		A5C101B2 /* PaneInteractionOverlayHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteractionOverlayHost.swift; sourceTree = "<group>"; };
 		A5C102B0 /* PaneInteractionRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInteractionRuntimeTests.swift; sourceTree = "<group>"; };
+		A5C103B1 /* PaneInteractionAcceptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInteractionAcceptTests.swift; sourceTree = "<group>"; };
 		A537C229 /* MermaidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MermaidRenderer.swift; sourceTree = "<group>"; };
 		A537C22A /* FencedCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FencedCodeRenderer.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
@@ -580,6 +582,7 @@
 					D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 					42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
 					A5C102B0 /* PaneInteractionRuntimeTests.swift */,
+					A5C103B1 /* PaneInteractionAcceptTests.swift */,
 					14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */,
 					1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
 					EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */,
@@ -856,6 +859,7 @@
 					734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
 					B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
 					A5C102A0 /* PaneInteractionRuntimeTests.swift in Sources */,
+					A5C103A1 /* PaneInteractionAcceptTests.swift in Sources */,
 					DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
 					0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */,
 					CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9036,7 +9036,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // key window's portal/SwiftUI hierarchy. Gate the same shortcuts here so the
         // overlay sees the Cmd+D accept and other app shortcuts stay suppressed while
         // a dialog is visible (plan §4.8).
-        let paneInteractionActive = tabManager?.hasActivePaneInteraction ?? false
+        //
+        // Resolve the active TabManager via `NSApp.keyWindow` so secondary windows
+        // (Cmd+N / "New Window") route through their OWN interaction runtime.
+        // `self.tabManager` IS updated on `didBecomeKeyNotification`
+        // (`setActiveMainWindow`), but a race can put the local monitor's event
+        // slightly ahead of that update. Looking up the context by key window
+        // inside the dispatcher itself removes that race.
+        let activeTabManager: TabManager? = {
+            if let keyWindow = NSApp.keyWindow,
+               let ctx = contextForMainTerminalWindow(keyWindow, reindex: false) {
+                return ctx.tabManager
+            }
+            return self.tabManager
+        }()
+        let paneInteractionActive = activeTabManager?.hasActivePaneInteraction ?? false
 
         if let closeConfirmationPanel {
             // Special-case: Cmd+D should confirm destructive close on alerts.
@@ -9065,7 +9079,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if matchShortcut(
                 event: event,
                 shortcut: StoredShortcut(key: "d", command: true, shift: false, option: false, control: false)
-            ), tabManager?.acceptActivePaneInteractionInKeyWorkspace() == true {
+            ), activeTabManager?.acceptActivePaneInteractionInKeyWorkspace() == true {
                 return true
             }
             return false

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5729,6 +5729,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return nil
     }
 
+    /// Resolve the `TabManager` whose workspace owns the event's intended
+    /// target main terminal window. Used by `handleCustomShortcut` to
+    /// dispatch Cmd+D (and other shortcuts gated on an active pane
+    /// interaction) to the correct window across multi-window setups.
+    ///
+    /// Resolution order:
+    ///   1. Event-window routing via `mainWindowContext(forShortcutEvent:)`
+    ///      (`event.window`, then `event.windowNumber`). Handles command
+    ///      palette, inspectors, and any surface that forwards key events
+    ///      to a main terminal window.
+    ///   2. SheetParent walk on `keyWindow`. Covers the "sheet over
+    ///      secondary" case: the sheet is keyWindow, its `sheetParent` is
+    ///      the main terminal window whose pane dialog is visible.
+    ///   3. Bare `keyWindow` lookup via `contextForMainTerminalWindow`
+    ///      (covered by the same call thanks to `sheetParent ?? keyWindow`).
+    ///   4. Return `nil` — do NOT fall back to `self.tabManager`. That
+    ///      fallback silently routed shortcuts to the primary window's
+    ///      TabManager whenever keyWindow was non-terminal (palette, sheet
+    ///      on secondary, inspector), which is the exact Trident
+    ///      Important #1 anti-pattern. Returning nil lets the dispatcher
+    ///      treat "no active interaction" correctly and fall through to
+    ///      the normal shortcut path.
+    @MainActor
+    func resolveActiveTabManagerForShortcut(
+        event: NSEvent?,
+        keyWindow: NSWindow?
+    ) -> TabManager? {
+        if let event,
+           let ctx = mainWindowContext(forShortcutEvent: event, debugSource: "custom_shortcut") {
+            return ctx.tabManager
+        }
+        let targetWindow = keyWindow?.sheetParent ?? keyWindow
+        if let targetWindow,
+           let ctx = contextForMainTerminalWindow(targetWindow, reindex: false) {
+            return ctx.tabManager
+        }
+        return nil
+    }
+
     private func preferredMainWindowContextForShortcutRouting(event: NSEvent) -> MainWindowContext? {
         if let context = mainWindowContext(forShortcutEvent: event, debugSource: "shortcut.routing") {
             return context
@@ -9037,19 +9076,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // overlay sees the Cmd+D accept and other app shortcuts stay suppressed while
         // a dialog is visible (plan §4.8).
         //
-        // Resolve the active TabManager via `NSApp.keyWindow` so secondary windows
-        // (Cmd+N / "New Window") route through their OWN interaction runtime.
-        // `self.tabManager` IS updated on `didBecomeKeyNotification`
-        // (`setActiveMainWindow`), but a race can put the local monitor's event
-        // slightly ahead of that update. Looking up the context by key window
-        // inside the dispatcher itself removes that race.
-        let activeTabManager: TabManager? = {
-            if let keyWindow = NSApp.keyWindow,
-               let ctx = contextForMainTerminalWindow(keyWindow, reindex: false) {
-                return ctx.tabManager
-            }
-            return self.tabManager
-        }()
+        // Routing rules live in `resolveActiveTabManagerForShortcut`: event-window
+        // first, then sheetParent-walk on keyWindow, then nil. Important #1: no
+        // silent fallback to `self.tabManager` — that routed Cmd+D to the primary
+        // window whenever keyWindow was non-terminal (sheet, palette, inspector).
+        let activeTabManager = resolveActiveTabManagerForShortcut(
+            event: event,
+            keyWindow: NSApp.keyWindow
+        )
         let paneInteractionActive = activeTabManager?.hasActivePaneInteraction ?? false
 
         if let closeConfirmationPanel {
@@ -10515,6 +10549,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // synthetic NSEvents.
     func debugHandleCustomShortcut(event: NSEvent) -> Bool {
         handleCustomShortcut(event: event)
+    }
+
+    // Debug/test hook: direct access to the shortcut dispatcher's TabManager
+    // resolver. Tests can pass their own `keyWindow` because unit-test focus
+    // behavior (NSApp.keyWindow / makeKey) is platform- and runner-dependent.
+    func debugResolveActiveTabManagerForShortcut(
+        event: NSEvent?,
+        keyWindow: NSWindow?
+    ) -> TabManager? {
+        resolveActiveTabManagerForShortcut(event: event, keyWindow: keyWindow)
     }
 
     // Debug/test hook: mirrors local monitor routing (keyDown + keyUp lifecycle).

--- a/Sources/Panels/PaneInteraction.swift
+++ b/Sources/Panels/PaneInteraction.swift
@@ -108,7 +108,10 @@ public enum ConfirmResult: Equatable {
     case confirmed
     /// Explicit user cancel (Cancel button, Esc, etc.).
     case cancelled
-    /// Panel closed, workspace closed, or runtime cleared. Distinguished from user cancel.
+    /// Panel closed, workspace closed, or runtime cleared. Also used when
+    /// `present` is called with a dedupe token that's already registered —
+    /// the duplicate caller resolves immediately with `.dismissed` so its
+    /// continuation doesn't hang. Distinguished from user cancel.
     case dismissed
 }
 
@@ -317,7 +320,10 @@ public final class PaneInteractionRuntime: ObservableObject {
 
     /// Clear every panel. Called from workspace teardown.
     public func clearAll() {
-        for panelId in Array(active.keys) + Array(queues.keys) {
+        // Union active + queues keys so a panel present in both isn't
+        // double-processed. `clear` is idempotent (second call is a no-op
+        // on cleared state) so the prior `+` concat was safe, just wasteful.
+        for panelId in Set(active.keys).union(queues.keys) {
             clear(panelId: panelId)
         }
     }

--- a/Sources/Panels/PaneInteraction.swift
+++ b/Sources/Panels/PaneInteraction.swift
@@ -197,29 +197,29 @@ public final class PaneInteractionRuntime: ObservableObject {
 
     public func resolveConfirm(panelId: UUID, result: ConfirmResult) {
         guard case .confirm(let c)? = active[panelId] else { return }
-        // Null active BEFORE firing completion so a reentrant resolve call
-        // on the same panel can't find the same interaction and double-resume.
-        active[panelId] = nil
+        // Advance state BEFORE firing completion. A completion that calls
+        // `present()` synchronously must see a correctly-advanced runtime —
+        // otherwise `drain`/`advance` would fire after the reentrant present
+        // and overwrite its active slot (losing that interaction's
+        // continuation) and wipe any dedupe token it just registered.
+        _ = drain(panelId: panelId)
         c.completion(result)
-        advance(panelId: panelId)
     }
 
     public func resolveTextInput(panelId: UUID, result: TextInputResult) {
         guard case .textInput(let t)? = active[panelId] else { return }
-        active[panelId] = nil
+        _ = drain(panelId: panelId)
         t.completion(result)
-        advance(panelId: panelId)
     }
 
     /// Generic cancel path (Esc/Cancel) that works across variants.
     public func cancelActive(panelId: UUID) {
         guard let interaction = active[panelId] else { return }
-        active[panelId] = nil
+        _ = drain(panelId: panelId)
         switch interaction {
         case .confirm(let c): c.completion(.cancelled)
         case .textInput(let t): t.completion(.cancelled)
         }
-        advance(panelId: panelId)
     }
 
     /// Cancel a specific interaction by id. Searches active and queued slots;
@@ -229,9 +229,8 @@ public final class PaneInteractionRuntime: ObservableObject {
     @discardableResult
     public func cancelInteraction(panelId: UUID, interactionId: UUID) -> Bool {
         if let current = active[panelId], current.id == interactionId {
-            active[panelId] = nil
+            _ = drain(panelId: panelId)
             dismissEvicted(current)
-            advance(panelId: panelId)
             return true
         }
         if var queue = queues[panelId],
@@ -253,34 +252,46 @@ public final class PaneInteractionRuntime: ObservableObject {
         guard let interaction = active[panelId] else { return false }
         switch interaction {
         case .confirm(let c):
-            active[panelId] = nil
+            _ = drain(panelId: panelId)
             c.completion(.confirmed)
         case .textInput(let t):
             let value = textInputValue ?? t.defaultValue
             if t.validate(value) != nil { return false }
-            active[panelId] = nil
+            _ = drain(panelId: panelId)
             t.completion(.submitted(value))
         }
-        advance(panelId: panelId)
         return true
     }
 
-    /// Expects `active[panelId]` to have already been set to nil by the caller
-    /// (see `resolveConfirm`/`resolveTextInput`/`cancelActive`/`acceptActive`).
-    /// Promotes the next queued interaction, or resets per-panel bookkeeping
-    /// (including `seenTokens`) if the panel is fully idle.
-    private func advance(panelId: UUID) {
+    /// Advance runtime state past the currently-active interaction:
+    /// null the active slot, promote the queue head if any, and clear
+    /// `seenTokens[panelId]` when the panel is fully idle. The previous
+    /// active interaction is returned so callers can inspect it; they are
+    /// expected to fire its completion AFTER this returns, not before.
+    ///
+    /// Running advance before firing completions is the invariant that keeps
+    /// reentrant `present()` calls from being silently overwritten (and their
+    /// dedupe-token registrations from being wiped). Pre-M10 rev this ran
+    /// after the completion and dropped reentrant presents on the floor.
+    @discardableResult
+    private func drain(panelId: UUID) -> PaneInteraction? {
+        let previous = active[panelId]
+        active[panelId] = nil
         if var queue = queues[panelId], !queue.isEmpty {
             active[panelId] = queue.removeFirst()
             queues[panelId] = queue.isEmpty ? nil : queue
         } else {
             queues[panelId] = nil
-            // Fully idle: let the next independent `present` with a previously
-            // seen dedupe token proceed (otherwise a stable per-panel token
-            // like `close_surface_cb.<id>` would silently suppress every
-            // subsequent close attempt for the life of the panel).
+        }
+        if active[panelId] == nil && queues[panelId] == nil {
+            // Fully idle: let the next independent `present` with a
+            // previously-seen dedupe token proceed (otherwise a stable
+            // per-panel token like `close_surface_cb.<id>` would silently
+            // suppress every subsequent close attempt for the life of the
+            // panel).
             seenTokens[panelId] = nil
         }
+        return previous
     }
 
     public func hasActive(panelId: UUID) -> Bool { active[panelId] != nil }

--- a/Sources/Panels/PaneInteraction.swift
+++ b/Sources/Panels/PaneInteraction.swift
@@ -171,7 +171,13 @@ public final class PaneInteractionRuntime: ObservableObject {
     public func present(panelId: UUID, interaction: PaneInteraction, dedupeToken: String? = nil) {
         if let token = dedupeToken {
             var tokens = seenTokens[panelId, default: []]
-            guard !tokens.contains(token) else { return }
+            if tokens.contains(token) {
+                // Duplicate: surface .dismissed to the incoming caller so its
+                // continuation resolves instead of hanging. The in-flight
+                // interaction is not disturbed.
+                dismissEvicted(interaction)
+                return
+            }
             tokens.insert(token)
             seenTokens[panelId] = tokens
         }
@@ -191,12 +197,16 @@ public final class PaneInteractionRuntime: ObservableObject {
 
     public func resolveConfirm(panelId: UUID, result: ConfirmResult) {
         guard case .confirm(let c)? = active[panelId] else { return }
+        // Null active BEFORE firing completion so a reentrant resolve call
+        // on the same panel can't find the same interaction and double-resume.
+        active[panelId] = nil
         c.completion(result)
         advance(panelId: panelId)
     }
 
     public func resolveTextInput(panelId: UUID, result: TextInputResult) {
         guard case .textInput(let t)? = active[panelId] else { return }
+        active[panelId] = nil
         t.completion(result)
         advance(panelId: panelId)
     }
@@ -204,11 +214,34 @@ public final class PaneInteractionRuntime: ObservableObject {
     /// Generic cancel path (Esc/Cancel) that works across variants.
     public func cancelActive(panelId: UUID) {
         guard let interaction = active[panelId] else { return }
+        active[panelId] = nil
         switch interaction {
         case .confirm(let c): c.completion(.cancelled)
         case .textInput(let t): t.completion(.cancelled)
         }
         advance(panelId: panelId)
+    }
+
+    /// Cancel a specific interaction by id. Searches active and queued slots;
+    /// if the target is active, fires `.dismissed` on its completion and
+    /// promotes the next queued interaction. If queued, removes it from the
+    /// queue and fires `.dismissed` on its completion. Returns true on hit.
+    @discardableResult
+    public func cancelInteraction(panelId: UUID, interactionId: UUID) -> Bool {
+        if let current = active[panelId], current.id == interactionId {
+            active[panelId] = nil
+            dismissEvicted(current)
+            advance(panelId: panelId)
+            return true
+        }
+        if var queue = queues[panelId],
+           let idx = queue.firstIndex(where: { $0.id == interactionId }) {
+            let removed = queue.remove(at: idx)
+            queues[panelId] = queue.isEmpty ? nil : queue
+            dismissEvicted(removed)
+            return true
+        }
+        return false
     }
 
     /// Typed accept for the currently active interaction on a panel. Used by Cmd+D
@@ -220,23 +253,33 @@ public final class PaneInteractionRuntime: ObservableObject {
         guard let interaction = active[panelId] else { return false }
         switch interaction {
         case .confirm(let c):
+            active[panelId] = nil
             c.completion(.confirmed)
         case .textInput(let t):
             let value = textInputValue ?? t.defaultValue
             if t.validate(value) != nil { return false }
+            active[panelId] = nil
             t.completion(.submitted(value))
         }
         advance(panelId: panelId)
         return true
     }
 
+    /// Expects `active[panelId]` to have already been set to nil by the caller
+    /// (see `resolveConfirm`/`resolveTextInput`/`cancelActive`/`acceptActive`).
+    /// Promotes the next queued interaction, or resets per-panel bookkeeping
+    /// (including `seenTokens`) if the panel is fully idle.
     private func advance(panelId: UUID) {
         if var queue = queues[panelId], !queue.isEmpty {
             active[panelId] = queue.removeFirst()
-            queues[panelId] = queue
+            queues[panelId] = queue.isEmpty ? nil : queue
         } else {
-            active[panelId] = nil
             queues[panelId] = nil
+            // Fully idle: let the next independent `present` with a previously
+            // seen dedupe token proceed (otherwise a stable per-panel token
+            // like `close_surface_cb.<id>` would silently suppress every
+            // subsequent close attempt for the life of the panel).
+            seenTokens[panelId] = nil
         }
     }
 
@@ -246,15 +289,19 @@ public final class PaneInteractionRuntime: ObservableObject {
 
     /// Panel/workspace teardown: resolve every pending (active + queued) with `.dismissed`.
     public func clear(panelId: UUID) {
-        if let interaction = active[panelId] {
-            dismissEvicted(interaction)
-        }
+        // Snapshot then null state BEFORE firing completions so any reentrant
+        // resolve/clear call sees a clean slate.
+        let snapshotActive = active[panelId]
+        let snapshotQueue = queues[panelId] ?? []
         active[panelId] = nil
-        if let queue = queues[panelId] {
-            for interaction in queue { dismissEvicted(interaction) }
-        }
         queues[panelId] = nil
         seenTokens[panelId] = nil
+        if let interaction = snapshotActive {
+            dismissEvicted(interaction)
+        }
+        for interaction in snapshotQueue {
+            dismissEvicted(interaction)
+        }
     }
 
     /// Clear every panel. Called from workspace teardown.

--- a/Sources/Panels/PaneInteractionCardView.swift
+++ b/Sources/Panels/PaneInteractionCardView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct PaneInteractionCardView: View {
     let panelId: UUID
     let interaction: PaneInteraction
-    @ObservedObject var runtime: PaneInteractionRuntime
+    let runtime: PaneInteractionRuntime
 
     var body: some View {
         ZStack {
@@ -44,7 +44,7 @@ struct PaneInteractionCardView: View {
 private struct ConfirmCard: View {
     let panelId: UUID
     let content: ConfirmContent
-    @ObservedObject var runtime: PaneInteractionRuntime
+    let runtime: PaneInteractionRuntime
 
     private enum Field: Hashable { case cancel, confirm }
     @FocusState private var focused: Field?
@@ -114,7 +114,7 @@ private struct ConfirmCard: View {
 private struct TextInputCard: View {
     let panelId: UUID
     let content: TextInputContent
-    @ObservedObject var runtime: PaneInteractionRuntime
+    let runtime: PaneInteractionRuntime
 
     @State private var value: String = ""
     @State private var errorText: String?

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -718,10 +718,17 @@ class TabManager: ObservableObject {
            runtime.hasActive(panelId: focusedPanelId) {
             return runtime.acceptActive(panelId: focusedPanelId)
         }
-        // Otherwise accept any active interaction — there's only ever one per panel,
-        // and multiple-panel-with-active-interaction is rare.
-        if let anyPanelId = runtime.activePanelIds.first {
-            return runtime.acceptActive(panelId: anyPanelId)
+        // Otherwise iterate panels in bonsplit pane/tab order and accept the
+        // first active one found. `Set.first` is nondeterministic; iterating
+        // the spatial layout makes the tiebreaker deterministic when two
+        // panels in the same workspace have active interactions.
+        for paneId in workspace.bonsplitController.allPaneIds {
+            for tab in workspace.bonsplitController.tabs(inPane: paneId) {
+                if let candidate = workspace.panelIdFromSurfaceId(tab.id),
+                   runtime.hasActive(panelId: candidate) {
+                    return runtime.acceptActive(panelId: candidate)
+                }
+            }
         }
         return false
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -718,16 +718,21 @@ class TabManager: ObservableObject {
            runtime.hasActive(panelId: focusedPanelId) {
             return runtime.acceptActive(panelId: focusedPanelId)
         }
-        // Otherwise iterate panels in bonsplit pane/tab order and accept the
-        // first active one found. `Set.first` is nondeterministic; iterating
-        // the spatial layout makes the tiebreaker deterministic when two
-        // panels in the same workspace have active interactions.
+        // Otherwise iterate panes in bonsplit spatial order. Restrict the
+        // fallback to each pane's SELECTED tab (Trident Important #2): the
+        // previous iteration walked every tab in every pane, selected or
+        // not, and happily accepted a dialog anchored on a non-selected
+        // (hidden) tab. If the hidden dialog was destructive, Cmd+D
+        // silently caused data loss. `selectedTab(inPane:)` only surfaces
+        // the tab the user is currently looking at in each pane — safe
+        // by construction.
         for paneId in workspace.bonsplitController.allPaneIds {
-            for tab in workspace.bonsplitController.tabs(inPane: paneId) {
-                if let candidate = workspace.panelIdFromSurfaceId(tab.id),
-                   runtime.hasActive(panelId: candidate) {
-                    return runtime.acceptActive(panelId: candidate)
-                }
+            guard let selected = workspace.bonsplitController.selectedTab(inPane: paneId),
+                  let candidate = workspace.panelIdFromSurfaceId(selected.id) else {
+                continue
+            }
+            if runtime.hasActive(panelId: candidate) {
+                return runtime.acceptActive(panelId: candidate)
             }
         }
         return false

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6904,6 +6904,22 @@ class TerminalController {
                 data: nil
             )
         }
+        // Feature-flag rollback must cover the socket entry-point too. Without
+        // this, `CMUX_PANE_DIALOG_DISABLED=1` still lets pane interactions
+        // fire via `pane.confirm` — defeating the rollback path.
+        //
+        // Order matters (Trident nit §B7): the flag check must run before
+        // TabManager resolve / param parsing so a rollback-validator probe
+        // gets `unavailable` regardless of whether the rest of the call
+        // would have been well-formed. Otherwise an invalid panel_id on a
+        // disabled build returns `invalid_params`, hiding the flag state.
+        guard PaneInteractionFeatureFlag.isEnabled else {
+            return .err(
+                code: "unavailable",
+                message: "Pane interactions are disabled (CMUX_PANE_DIALOG_DISABLED=1).",
+                data: nil
+            )
+        }
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
@@ -6913,16 +6929,6 @@ class TerminalController {
         guard let title = v2String(params, "title"), !title.isEmpty else {
             return .err(code: "invalid_params", message: "Missing or empty title", data: nil)
         }
-        // Feature-flag rollback must cover the socket entry-point too. Without
-        // this, `CMUX_PANE_DIALOG_DISABLED=1` still lets pane interactions
-        // fire via `pane.confirm` — defeating the rollback path.
-        guard PaneInteractionFeatureFlag.isEnabled else {
-            return .err(
-                code: "unavailable",
-                message: "Pane interactions are disabled (CMUX_PANE_DIALOG_DISABLED=1).",
-                data: nil
-            )
-        }
         let message = (v2String(params, "message") ?? "")
         let role: ConfirmContent.ConfirmRole
         switch v2String(params, "role") ?? "standard" {
@@ -6931,10 +6937,14 @@ class TerminalController {
         case "destructive":
             role = .destructive
         default:
+            // Echo the RAW role string (not the trimmed `v2String` output) so a
+            // caller sending whitespace-only input sees the exact payload they
+            // sent in the error data — keeps the debug signal intact (Trident
+            // nit §5).
             return .err(
                 code: "invalid_params",
                 message: "Invalid role (expected 'standard' or 'destructive')",
-                data: ["role": v2String(params, "role") ?? ""]
+                data: ["role": (params["role"] as? String) ?? ""]
             )
         }
         let timeoutSeconds = (params["timeout"] as? Double).map { max(0, $0) }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6914,6 +6914,10 @@ class TerminalController {
         }
         let holder = OutcomeHolder()
         var presented = false
+        // Track this call's interaction identity so a timeout cancels THIS
+        // interaction specifically — not whichever one happens to be active
+        // (which may be an earlier queued-in-front sibling).
+        var interactionId: UUID?
 
         v2MainSync {
             // Find the workspace that owns this panel. Iterate tabs across the
@@ -6933,6 +6937,7 @@ class TerminalController {
                     semaphore.signal()
                 }
             )
+            interactionId = content.id
             workspace.paneInteractionRuntime.present(
                 panelId: panelId,
                 interaction: .confirm(content)
@@ -6953,11 +6958,16 @@ class TerminalController {
         }
         let waitResult = semaphore.wait(timeout: waitDeadline)
         if waitResult == .timedOut {
-            // Cancel the active interaction for this panel so the card clears
-            // and any queued interactions advance.
+            // Cancel ONLY this call's interaction. If it was queued behind an
+            // earlier one, `cancelInteraction` removes it from the queue; the
+            // active interaction is untouched.
             v2MainSync {
-                if let workspace = tabManager.tabs.first(where: { $0.panels[panelId] != nil }) {
-                    workspace.paneInteractionRuntime.cancelActive(panelId: panelId)
+                if let workspace = tabManager.tabs.first(where: { $0.panels[panelId] != nil }),
+                   let id = interactionId {
+                    workspace.paneInteractionRuntime.cancelInteraction(
+                        panelId: panelId,
+                        interactionId: id
+                    )
                 }
             }
             return .ok(["result": "dismissed"])

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6890,6 +6890,17 @@ class TerminalController {
     ///   - "invalid_params" — missing panel_id or title
     ///   - "unknown_panel" — panel_id doesn't resolve to a panel in any workspace
     private func v2PaneConfirm(params: [String: Any]) -> V2CallResult {
+        // Socket callers must be off-main. `v2MainSync` is re-entry-safe (runs
+        // the body inline when already on main); combined with the semaphore
+        // wait below this produces a deadlock where the completion scheduled
+        // on main can never fire. Surface the misuse instead of hanging.
+        if Thread.isMainThread {
+            return .err(
+                code: "invalid_context",
+                message: "pane.confirm must not be invoked from the main thread; it blocks until user responds.",
+                data: nil
+            )
+        }
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
@@ -6910,8 +6921,19 @@ class TerminalController {
             )
         }
         let message = (v2String(params, "message") ?? "")
-        let roleStr = v2String(params, "role") ?? "standard"
-        let role: ConfirmContent.ConfirmRole = (roleStr == "destructive") ? .destructive : .standard
+        let role: ConfirmContent.ConfirmRole
+        switch v2String(params, "role") ?? "standard" {
+        case "standard":
+            role = .standard
+        case "destructive":
+            role = .destructive
+        default:
+            return .err(
+                code: "invalid_params",
+                message: "Invalid role (expected 'standard' or 'destructive')",
+                data: ["role": v2String(params, "role") ?? ""]
+            )
+        }
         let timeoutSeconds = (params["timeout"] as? Double).map { max(0, $0) }
         let clientId = (v2String(params, "_clientId")) ?? "socket"
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6886,8 +6886,11 @@ class TerminalController {
     /// Result: { "result": "ok" | "cancel" | "dismissed" }
     ///
     /// Errors:
-    ///   - "unavailable" — no TabManager
-    ///   - "invalid_params" — missing panel_id or title
+    ///   - "invalid_context" — invoked from the main thread (would deadlock)
+    ///   - "unavailable" — no TabManager, or pane interactions disabled via
+    ///     `CMUX_PANE_DIALOG_DISABLED=1` / the `cmux.paneDialog.enabled`
+    ///     default
+    ///   - "invalid_params" — missing panel_id, empty title, or invalid role
     ///   - "unknown_panel" — panel_id doesn't resolve to a panel in any workspace
     private func v2PaneConfirm(params: [String: Any]) -> V2CallResult {
         // Socket callers must be off-main. `v2MainSync` is re-entry-safe (runs
@@ -6988,30 +6991,56 @@ class TerminalController {
         } else {
             waitDeadline = .distantFuture
         }
-        let waitResult = semaphore.wait(timeout: waitDeadline)
-        if waitResult == .timedOut {
-            // Cancel ONLY this call's interaction. If it was queued behind an
-            // earlier one, `cancelInteraction` removes it from the queue; the
-            // active interaction is untouched.
-            v2MainSync {
-                if let workspace = tabManager.tabs.first(where: { $0.panels[panelId] != nil }),
-                   let id = interactionId {
-                    workspace.paneInteractionRuntime.cancelInteraction(
-                        panelId: panelId,
-                        interactionId: id
-                    )
+        let resultCode = TerminalController.v2PaneConfirmResolveOutcomeForTesting(
+            wait: { semaphore.wait(timeout: waitDeadline) },
+            onTimeout: {
+                // Cancel ONLY this call's interaction. If it was queued behind an
+                // earlier one, `cancelInteraction` removes it from the queue; the
+                // active interaction is untouched.
+                self.v2MainSync {
+                    if let workspace = tabManager.tabs.first(where: { $0.panels[panelId] != nil }),
+                       let id = interactionId {
+                        workspace.paneInteractionRuntime.cancelInteraction(
+                            panelId: panelId,
+                            interactionId: id
+                        )
+                    }
                 }
-            }
-            return .ok(["result": "dismissed"])
-        }
+            },
+            readOutcome: { holder.value }
+        )
+        return .ok(["result": resultCode])
+    }
 
-        switch holder.value {
-        case .confirmed:
-            return .ok(["result": "ok"])
-        case .cancelled:
-            return .ok(["result": "cancel"])
-        case .dismissed:
-            return .ok(["result": "dismissed"])
+    /// Blocker #1 invariant: resolve the v2PaneConfirm response code from the
+    /// blocking wait, the timeout-cancel side-effect, and a holder accessor.
+    ///
+    /// The subtle bug the old code had: after `wait(timeout:)` returned
+    /// `.timedOut`, the timeout branch hard-coded `"dismissed"`. But a user
+    /// click in the race window between wait-return and the cancel running
+    /// on main fires the completion, which populates `holder.value` with the
+    /// real outcome (often `.confirmed`) BEFORE this function is asked to
+    /// produce a response. Reading `holder.value` after `onTimeout` closes
+    /// the race — if the completion raced in, we honor its outcome instead
+    /// of silently dropping the user's answer.
+    ///
+    /// Exposed as `internal static` for `PaneInteractionRuntimeTests` to
+    /// exercise the race with deterministic closures. The live socket path
+    /// MUST route through this function so the test coverage stays load-bearing.
+    internal static func v2PaneConfirmResolveOutcomeForTesting(
+        wait: () -> DispatchTimeoutResult,
+        onTimeout: () -> Void,
+        readOutcome: () -> ConfirmResult
+    ) -> String {
+        if wait() == .timedOut {
+            onTimeout()
+            // Fall through to the outcome read — if the completion fired in
+            // the race window, `readOutcome` reflects the real user answer.
+        }
+        switch readOutcome() {
+        case .confirmed: return "ok"
+        case .cancelled: return "cancel"
+        case .dismissed: return "dismissed"
         }
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6899,6 +6899,16 @@ class TerminalController {
         guard let title = v2String(params, "title"), !title.isEmpty else {
             return .err(code: "invalid_params", message: "Missing or empty title", data: nil)
         }
+        // Feature-flag rollback must cover the socket entry-point too. Without
+        // this, `CMUX_PANE_DIALOG_DISABLED=1` still lets pane interactions
+        // fire via `pane.confirm` — defeating the rollback path.
+        guard PaneInteractionFeatureFlag.isEnabled else {
+            return .err(
+                code: "unavailable",
+                message: "Pane interactions are disabled (CMUX_PANE_DIALOG_DISABLED=1).",
+                data: nil
+            )
+        }
         let message = (v2String(params, "message") ?? "")
         let roleStr = v2String(params, "role") ?? "standard"
         let role: ConfirmContent.ConfirmRole = (roleStr == "destructive") ? .destructive : .standard

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7142,6 +7142,12 @@ final class Workspace: Identifiable, ObservableObject {
     /// Called before the workspace is removed from TabManager to ensure child
     /// processes receive SIGHUP even if ARC deallocation is delayed.
     func teardownAllPanels() {
+        // Resolve every in-flight pane interaction with `.dismissed` BEFORE
+        // we drop the panels. Without this, continuations awaiting the
+        // runtime (close-confirm, socket `pane.confirm`, text-input) hang
+        // indefinitely when a workspace is torn down wholesale.
+        paneInteractionRuntime.clearAll()
+
         let panelEntries = Array(panels)
         for (panelId, panel) in panelEntries {
             panelSubscriptions.removeValue(forKey: panelId)
@@ -9792,6 +9798,10 @@ extension Workspace: BonsplitDelegate {
 
         if !closedPanelIds.isEmpty {
             for panelId in closedPanelIds {
+                // Resolve any active/queued pane interactions for this panel
+                // with `.dismissed` before the panel is dropped. Mirrors the
+                // per-panel close path at :9592.
+                paneInteractionRuntime.clear(panelId: panelId)
                 panels[panelId]?.close()
                 panels.removeValue(forKey: panelId)
                 untrackRemoteTerminalSurface(panelId)

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3146,6 +3146,132 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             defaults.removeObject(forKey: key)
         }
     }
+
+    // MARK: - Important #1: multi-window Cmd+D dispatcher routing
+
+    func testShortcutActiveTabManagerWalksSheetParentToSecondaryWindow() throws {
+        // Trident Important #1: `contextForMainTerminalWindow(NSApp.keyWindow)`
+        // returns nil whenever keyWindow is not a main terminal window —
+        // command palette, an NSPanel float, or a sheet over a secondary
+        // window. The old fallback to `self.tabManager` silently routed Cmd+D
+        // to the primary window's TabManager while a pane dialog was open on
+        // secondary. Sheet-over-secondary is the canonical repro: attach a
+        // sheet (which takes keyWindow), stale the app-level pointer to
+        // primary, and assert resolution still lands on secondary via
+        // sheetParent walk.
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
+              let secondWindow = window(withId: secondWindowId) else {
+            XCTFail("Expected both window contexts to exist")
+            return
+        }
+        XCTAssertFalse(firstManager === secondManager)
+
+        secondWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        // Stale the app-level pointer to the primary's TabManager — this is
+        // the exact condition that made the old fallback silently wrong.
+        appDelegate.tabManager = firstManager
+        XCTAssertTrue(appDelegate.tabManager === firstManager)
+
+        // Present a sheet over secondary. The sheet becomes keyWindow; its
+        // `sheetParent` is the secondary main terminal window.
+        let sheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        sheet.isReleasedWhenClosed = false
+        secondWindow.beginSheet(sheet, completionHandler: nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        defer {
+            secondWindow.endSheet(sheet)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        }
+        XCTAssertTrue(secondWindow.attachedSheet === sheet,
+                      "Expected sheet to be attached to secondary window")
+
+        // Pass the sheet explicitly as keyWindow so the test doesn't rely on
+        // the runner making the sheet key (unit-test focus behavior can be
+        // platform-dependent). The resolver must walk sheetParent → second.
+#if DEBUG
+        let resolved = appDelegate.debugResolveActiveTabManagerForShortcut(
+            event: nil,
+            keyWindow: sheet
+        )
+#else
+        let resolved: TabManager? = nil
+        XCTFail("debugResolveActiveTabManagerForShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertTrue(resolved === secondManager,
+                      "Sheet over secondary must resolve via sheetParent to secondary's TabManager")
+        XCTAssertFalse(resolved === firstManager,
+                       "Fallback to primary's TabManager is the exact Important #1 anti-pattern")
+    }
+
+    func testShortcutActiveTabManagerReturnsNilForNonTerminalKeyWindow() throws {
+        // Important #1 companion: when keyWindow is not a main terminal
+        // window and has no sheetParent, resolution must return nil — not
+        // silently fall back to `self.tabManager`. Returning nil lets the
+        // dispatcher short-circuit cleanly and the shortcut falls through
+        // to normal dispatch, rather than accepting a pane dialog on an
+        // arbitrary window the user wasn't looking at.
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: firstWindowId) }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId) else {
+            XCTFail("Expected first window context")
+            return
+        }
+
+        // Stale the app-level pointer — if the resolver falls back to
+        // self.tabManager we'd get firstManager, which is the buggy outcome.
+        appDelegate.tabManager = firstManager
+
+        let floatingPanel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.titled, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        floatingPanel.isReleasedWhenClosed = false
+        defer { floatingPanel.close() }
+
+#if DEBUG
+        let resolved = appDelegate.debugResolveActiveTabManagerForShortcut(
+            event: nil,
+            keyWindow: floatingPanel
+        )
+#else
+        let resolved: TabManager? = firstManager
+        XCTFail("debugResolveActiveTabManagerForShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertNil(resolved,
+                     "Non-terminal key window must return nil — no silent fallback to self.tabManager. "
+                     + "Returning primary would let Cmd+D accept a pane dialog on the primary "
+                     + "while the user is looking at a floating panel / command palette.")
+    }
 }
 
 private final class CommandPaletteMarkedTextFieldEditor: NSTextView {

--- a/cmuxTests/PaneInteractionAcceptTests.swift
+++ b/cmuxTests/PaneInteractionAcceptTests.swift
@@ -95,6 +95,74 @@ final class PaneInteractionAcceptTests: XCTestCase {
         )
     }
 
+    // MARK: - T3: Workspace teardown integration
+
+    func testWorkspaceTeardownAllPanelsDismissesActiveInteraction() {
+        // T3 (Trident consensus): `Workspace.teardownAllPanels()` is the
+        // workspace-close path and must deliver `.dismissed` to every
+        // in-flight pane interaction's completion before freeing the
+        // panels. Without this, continuations awaiting the runtime hang
+        // indefinitely. Locks down R3 behavior at the Workspace boundary,
+        // not just the runtime boundary.
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected initial workspace with a focused panel")
+            return
+        }
+
+        // Present one confirm + one textInput + one queued confirm across
+        // two panels to exercise both the active and queued dismissal paths.
+        let secondPanel = workspace.createReplacementTerminalPanel()
+
+        var firstActive: ConfirmResult?
+        var firstQueued: ConfirmResult?
+        var secondActive: TextInputResult?
+
+        workspace.paneInteractionRuntime.present(
+            panelId: firstPanelId,
+            interaction: .confirm(ConfirmContent(
+                title: "A", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+                role: .standard, source: .local,
+                completion: { firstActive = $0 }
+            ))
+        )
+        workspace.paneInteractionRuntime.present(
+            panelId: firstPanelId,
+            interaction: .confirm(ConfirmContent(
+                title: "Q", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+                role: .standard, source: .local,
+                completion: { firstQueued = $0 }
+            ))
+        )
+        workspace.paneInteractionRuntime.present(
+            panelId: secondPanel.id,
+            interaction: .textInput(TextInputContent(
+                title: "Rename", message: nil, placeholder: nil,
+                defaultValue: "",
+                confirmLabel: "OK", cancelLabel: "Cancel",
+                validate: { _ in nil },
+                source: .local,
+                completion: { secondActive = $0 }
+            ))
+        )
+
+        XCTAssertTrue(workspace.paneInteractionRuntime.hasAnyActive)
+
+        workspace.teardownAllPanels()
+
+        XCTAssertEqual(firstActive, .dismissed,
+                       "Active interaction on panel 1 must be dismissed by teardown")
+        XCTAssertEqual(firstQueued, .dismissed,
+                       "Queued interaction on panel 1 must be dismissed by teardown")
+        XCTAssertEqual(secondActive, .dismissed,
+                       "Active interaction on panel 2 must be dismissed by teardown")
+        XCTAssertFalse(
+            workspace.paneInteractionRuntime.hasAnyActive,
+            "Runtime must be empty post-teardown"
+        )
+    }
+
     func testAcceptActiveOnVisibleTabStillWorks() {
         // Sanity: the happy path — dialog on the currently selected tab —
         // still accepts. Locks in that the selected-tab preference fix

--- a/cmuxTests/PaneInteractionAcceptTests.swift
+++ b/cmuxTests/PaneInteractionAcceptTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import AppKit
+import Bonsplit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests for `TabManager.acceptActivePaneInteractionInKeyWorkspace` —
+/// the Cmd+D dispatcher's accept path (plan §4.8).
+@MainActor
+final class PaneInteractionAcceptTests: XCTestCase {
+
+    // MARK: - Important #2: selected-tab preference (hidden-tab safety)
+
+    func testAcceptActiveRejectsDialogOnHiddenTab() {
+        // Trident Important #2: `tabs(inPane:)` returns every tab in a pane,
+        // selected or not. A dialog presented on a tab the user had focused —
+        // and then switched away from — stays anchored on its (now hidden)
+        // panel. The old iteration walked all tabs and accepted whichever
+        // active interaction came first. If the hidden dialog was
+        // destructive (e.g. "close without saving"), Cmd+D silently caused
+        // data loss.
+        //
+        // Fix: prefer `selectedTab(inPane:)` in the iteration — the hidden
+        // tab's dialog must not be accepted by Cmd+D on the active tab.
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId,
+              let firstSurfaceId = workspace.surfaceIdFromPanelId(firstPanelId) else {
+            XCTFail("Expected initial workspace with a focused panel")
+            return
+        }
+
+        // Add a second terminal tab in the same pane. createReplacementTerminalPanel
+        // creates the TerminalPanel + registers the surface-id → panel-id mapping
+        // + adds a bonsplit tab via `createTab` (which uses focusedPaneId →
+        // same pane as the first tab).
+        let secondPanel = workspace.createReplacementTerminalPanel()
+        guard let secondSurfaceId = workspace.surfaceIdFromPanelId(secondPanel.id) else {
+            XCTFail("Expected surface ID for second panel")
+            return
+        }
+
+        // Verify both tabs sit in a single pane.
+        XCTAssertEqual(workspace.bonsplitController.allPaneIds.count, 1,
+                       "Both tabs should share the same pane")
+        guard let paneId = workspace.bonsplitController.allPaneIds.first else {
+            XCTFail("Expected one pane")
+            return
+        }
+        let tabIds = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
+        XCTAssertEqual(Set(tabIds), Set([firstSurfaceId, secondSurfaceId]),
+                       "Pane must host both surface tabs")
+
+        // Explicitly select the FIRST tab so the second is hidden. Also
+        // ensure focusedPanelId is the first panel (no dialog on it).
+        workspace.bonsplitController.selectTab(firstSurfaceId)
+        workspace.focusPanel(firstPanelId)
+        XCTAssertEqual(workspace.focusedPanelId, firstPanelId)
+        XCTAssertEqual(workspace.bonsplitController.selectedTab(inPane: paneId)?.id,
+                       firstSurfaceId,
+                       "First tab must be the pane's selected tab")
+
+        // Present a destructive-looking confirm on the hidden (second) panel.
+        var hiddenResult: ConfirmResult?
+        let hiddenContent = ConfirmContent(
+            title: "Close?", message: nil,
+            confirmLabel: "Close", cancelLabel: "Cancel",
+            role: .destructive, source: .local,
+            completion: { hiddenResult = $0 }
+        )
+        workspace.paneInteractionRuntime.present(
+            panelId: secondPanel.id,
+            interaction: .confirm(hiddenContent)
+        )
+
+        // No dialog on the first (visible) panel.
+        XCTAssertFalse(workspace.paneInteractionRuntime.hasActive(panelId: firstPanelId))
+        XCTAssertTrue(workspace.paneInteractionRuntime.hasActive(panelId: secondPanel.id))
+
+        // Cmd+D must refuse to accept the hidden-tab dialog.
+        let accepted = manager.acceptActivePaneInteractionInKeyWorkspace()
+
+        XCTAssertFalse(accepted,
+                       "Cmd+D must not silently accept a dialog on a non-selected tab.")
+        XCTAssertNil(hiddenResult,
+                     "Hidden dialog's completion must not fire — it stays anchored "
+                     + "until the user explicitly surfaces the tab.")
+        XCTAssertTrue(
+            workspace.paneInteractionRuntime.hasActive(panelId: secondPanel.id),
+            "Hidden dialog must remain active — not resolved, not cancelled."
+        )
+    }
+
+    func testAcceptActiveOnVisibleTabStillWorks() {
+        // Sanity: the happy path — dialog on the currently selected tab —
+        // still accepts. Locks in that the selected-tab preference fix
+        // doesn't also break the common case.
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected initial workspace with a focused panel")
+            return
+        }
+
+        var result: ConfirmResult?
+        let content = ConfirmContent(
+            title: "Close?", message: nil,
+            confirmLabel: "Close", cancelLabel: "Cancel",
+            role: .destructive, source: .local,
+            completion: { result = $0 }
+        )
+        workspace.paneInteractionRuntime.present(
+            panelId: firstPanelId,
+            interaction: .confirm(content)
+        )
+
+        let accepted = manager.acceptActivePaneInteractionInKeyWorkspace()
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(result, .confirmed,
+                       "Dialog on the focused panel must still accept on Cmd+D")
+    }
+}

--- a/cmuxTests/PaneInteractionRuntimeTests.swift
+++ b/cmuxTests/PaneInteractionRuntimeTests.swift
@@ -399,6 +399,124 @@ final class PaneInteractionRuntimeTests: XCTestCase {
         XCTAssertFalse(runtime.acceptActive(panelId: UUID()))
     }
 
+    // MARK: - Reentrant present (Blocker #2 — advance-before-fire invariant)
+
+    func testResolveConfirmReentrantPresentPreservesQueueHead() {
+        // Blocker #2 regression: resolveConfirm must advance queue state BEFORE
+        // firing the completion. Otherwise a completion that synchronously
+        // calls `present()` installs its own active slot, then `advance()`
+        // fires afterwards and silently overwrites it with the queue head.
+        // The re-entrant interaction's continuation would never fire.
+        let runtime = PaneInteractionRuntime()
+        let panelId = UUID()
+
+        var aResult: ConfirmResult?
+        var bResult: ConfirmResult?
+        var cResult: ConfirmResult?
+
+        // C is presented synchronously from inside A's completion.
+        let c = ConfirmContent(
+            title: "C", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { cResult = $0 }
+        )
+        let b = ConfirmContent(
+            title: "B", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { bResult = $0 }
+        )
+        let a = ConfirmContent(
+            title: "A", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { [weak runtime] result in
+                aResult = result
+                // Re-enter while active[panelId] is supposedly nil — the bug
+                // would allow C to become active here, only to be wiped by
+                // a post-completion `advance` promoting B.
+                runtime?.present(panelId: panelId, interaction: .confirm(c))
+            }
+        )
+
+        runtime.present(panelId: panelId, interaction: .confirm(a))
+        runtime.present(panelId: panelId, interaction: .confirm(b))
+
+        runtime.resolveConfirm(panelId: panelId, result: .confirmed)
+
+        // A's completion fired.
+        XCTAssertEqual(aResult, .confirmed)
+        // Neither B nor C's completion has fired yet.
+        XCTAssertNil(bResult, "B must still be pending (either active or queued)")
+        XCTAssertNil(cResult, "C must still be pending — not overwritten, not lost")
+        XCTAssertTrue(runtime.hasActive(panelId: panelId))
+
+        // Drain: B is queue head, should promote before C. Without the fix,
+        // C would have been overwritten by B when advance fired after A's
+        // completion, so bResult would resolve here but cResult would never.
+        runtime.resolveConfirm(panelId: panelId, result: .cancelled)
+        XCTAssertEqual(bResult, .cancelled, "Queue head B must have been promoted, not lost")
+        XCTAssertNil(cResult)
+
+        runtime.resolveConfirm(panelId: panelId, result: .confirmed)
+        XCTAssertEqual(cResult, .confirmed,
+                       "C's continuation must fire — the reentrant present cannot be dropped")
+    }
+
+    func testResolveConfirmReentrantPresentPreservesDedupeToken() {
+        // Blocker #2 (Gemini variant): when the queue is empty at resolve
+        // time, advance also wipes `seenTokens[panelId]`. If the completion
+        // synchronously presents a new interaction with a dedupe token, the
+        // token registration happens BEFORE advance fires — and advance then
+        // nukes it. Subsequent duplicate presents would no longer be deduped.
+        let runtime = PaneInteractionRuntime()
+        let panelId = UUID()
+
+        var aResult: ConfirmResult?
+        var bResult: ConfirmResult?
+        var cResult: ConfirmResult?
+
+        let b = ConfirmContent(
+            title: "B", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { bResult = $0 }
+        )
+        let a = ConfirmContent(
+            title: "A", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { [weak runtime] result in
+                aResult = result
+                runtime?.present(
+                    panelId: panelId,
+                    interaction: .confirm(b),
+                    dedupeToken: "token-x"
+                )
+            }
+        )
+
+        runtime.present(panelId: panelId, interaction: .confirm(a))
+        // No queued entries behind A — advance's "fully idle" branch will run.
+        runtime.resolveConfirm(panelId: panelId, result: .confirmed)
+
+        XCTAssertEqual(aResult, .confirmed)
+        XCTAssertNil(bResult, "B must be active now, not resolved")
+        XCTAssertTrue(runtime.hasActive(panelId: panelId))
+
+        // Fresh present with the same token-x must be deduped — the token
+        // registered during the reentrant present inside A's completion must
+        // have survived the state transition.
+        let c = ConfirmContent(
+            title: "C", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { cResult = $0 }
+        )
+        runtime.present(panelId: panelId, interaction: .confirm(c), dedupeToken: "token-x")
+
+        XCTAssertEqual(cResult, .dismissed,
+                       "token-x must still be registered — advance must not wipe tokens "
+                       + "registered during a reentrant present in the completion")
+        XCTAssertNil(bResult, "B remains active; it was never disturbed")
+        XCTAssertTrue(runtime.hasActive(panelId: panelId))
+    }
+
     // MARK: - Fixtures
 
     private func makeConfirm(completion: @escaping (ConfirmResult) -> Void) -> ConfirmContent {

--- a/cmuxTests/PaneInteractionRuntimeTests.swift
+++ b/cmuxTests/PaneInteractionRuntimeTests.swift
@@ -125,6 +125,109 @@ final class PaneInteractionRuntimeTests: XCTestCase {
         XCTAssertFalse(runtime.hasAnyActive)
     }
 
+    // MARK: - T1: clearAll() + dedupe-token reset (consensus gap)
+
+    func testClearAllResetsSeenTokensAcrossPanels() {
+        // T1 (Trident consensus): `clearAll()` is the workspace-teardown
+        // path — it resolves active + queued interactions with `.dismissed`
+        // AND must reset each panel's `seenTokens` so a re-used stable
+        // token (e.g. `close_surface_cb.<id>`) on the NEXT present after
+        // teardown proceeds instead of being silently suppressed.
+        //
+        // `clear(panelId:)` already nulls seenTokens for one panel. This
+        // test locks in that `clearAll()` does it across every panel.
+        let runtime = PaneInteractionRuntime()
+        let panelA = UUID()
+        let panelB = UUID()
+        var aFirst: ConfirmResult?
+        var aDeduped: ConfirmResult?
+        var bFirst: ConfirmResult?
+        var bDeduped: ConfirmResult?
+        var aPostTeardown: ConfirmResult?
+        var bPostTeardown: ConfirmResult?
+
+        // Present with per-panel stable tokens; duplicates must be deduped.
+        runtime.present(panelId: panelA,
+                        interaction: .confirm(makeConfirm { aFirst = $0 }),
+                        dedupeToken: "close.A")
+        runtime.present(panelId: panelA,
+                        interaction: .confirm(makeConfirm { aDeduped = $0 }),
+                        dedupeToken: "close.A")
+        runtime.present(panelId: panelB,
+                        interaction: .confirm(makeConfirm { bFirst = $0 }),
+                        dedupeToken: "close.B")
+        runtime.present(panelId: panelB,
+                        interaction: .confirm(makeConfirm { bDeduped = $0 }),
+                        dedupeToken: "close.B")
+
+        XCTAssertEqual(aDeduped, .dismissed, "Duplicate on A must dedupe")
+        XCTAssertEqual(bDeduped, .dismissed, "Duplicate on B must dedupe")
+        XCTAssertNil(aFirst)
+        XCTAssertNil(bFirst)
+
+        runtime.clearAll()
+
+        XCTAssertEqual(aFirst, .dismissed, "clearAll must dismiss A's active")
+        XCTAssertEqual(bFirst, .dismissed, "clearAll must dismiss B's active")
+        XCTAssertFalse(runtime.hasAnyActive)
+
+        // Re-present with the SAME tokens on each panel. After teardown,
+        // seenTokens must be reset — these presents should become active,
+        // not fire immediately with `.dismissed`.
+        runtime.present(panelId: panelA,
+                        interaction: .confirm(makeConfirm { aPostTeardown = $0 }),
+                        dedupeToken: "close.A")
+        runtime.present(panelId: panelB,
+                        interaction: .confirm(makeConfirm { bPostTeardown = $0 }),
+                        dedupeToken: "close.B")
+
+        XCTAssertTrue(runtime.hasActive(panelId: panelA),
+                      "A's post-teardown present must become active — token reset")
+        XCTAssertTrue(runtime.hasActive(panelId: panelB),
+                      "B's post-teardown present must become active — token reset")
+        XCTAssertNil(aPostTeardown,
+                     "A's post-teardown interaction must NOT be dismissed as duplicate")
+        XCTAssertNil(bPostTeardown,
+                     "B's post-teardown interaction must NOT be dismissed as duplicate")
+    }
+
+    // MARK: - T2: Cross-panel cancelInteraction isolation (consensus gap)
+
+    func testCancelInteractionIsScopedToItsPanelId() {
+        // T2 (Trident consensus): cancelInteraction(panelId:interactionId:)
+        // scopes the id lookup to the supplied panelId. A caller holding
+        // an interaction id from panel B cannot pass it with `panelId: A`
+        // and have it resolve B's interaction — that would undermine the
+        // per-panel isolation contract the socket layer relies on.
+        let runtime = PaneInteractionRuntime()
+        let panelA = UUID()
+        let panelB = UUID()
+        var aResult: ConfirmResult?
+        var bResult: ConfirmResult?
+
+        let a = ConfirmContent(
+            title: "A", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { aResult = $0 }
+        )
+        let b = ConfirmContent(
+            title: "B", message: nil, confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { bResult = $0 }
+        )
+        runtime.present(panelId: panelA, interaction: .confirm(a))
+        runtime.present(panelId: panelB, interaction: .confirm(b))
+
+        // Ask panel A to cancel panel B's interaction id — must not hit.
+        let hit = runtime.cancelInteraction(panelId: panelA, interactionId: b.id)
+
+        XCTAssertFalse(hit, "Panel A must not resolve an interaction id that belongs to panel B")
+        XCTAssertNil(aResult, "Panel A's active must not fire")
+        XCTAssertNil(bResult, "Panel B's active must not fire")
+        XCTAssertTrue(runtime.hasActive(panelId: panelA))
+        XCTAssertTrue(runtime.hasActive(panelId: panelB))
+    }
+
     func testDismissedIsDistinctFromCancelled() {
         // Result type distinction — a panel torn down mid-dialog reports .dismissed,
         // not .cancelled. Callers rely on this to distinguish "user said no" from

--- a/cmuxTests/PaneInteractionRuntimeTests.swift
+++ b/cmuxTests/PaneInteractionRuntimeTests.swift
@@ -246,6 +246,76 @@ final class PaneInteractionRuntimeTests: XCTestCase {
         }
     }
 
+    // MARK: - cancelInteraction (targeted cancel by id)
+
+    func testCancelInteractionQueuedRemovesQueuedOnly() {
+        // Socket `pane.confirm` timeout must cancel ONLY the caller's own
+        // interaction. If the caller's interaction is queued behind an
+        // active one, the active must not be disturbed.
+        let runtime = PaneInteractionRuntime()
+        let panelId = UUID()
+        var activeResult: ConfirmResult?
+        var queuedResult: ConfirmResult?
+
+        let activeContent = ConfirmContent(
+            title: "A", message: nil,
+            confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { activeResult = $0 }
+        )
+        let queuedContent = ConfirmContent(
+            title: "B", message: nil,
+            confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { queuedResult = $0 }
+        )
+        runtime.present(panelId: panelId, interaction: .confirm(activeContent))
+        runtime.present(panelId: panelId, interaction: .confirm(queuedContent))
+
+        let hit = runtime.cancelInteraction(panelId: panelId, interactionId: queuedContent.id)
+
+        XCTAssertTrue(hit)
+        XCTAssertEqual(queuedResult, .dismissed, "Queued interaction must resolve with .dismissed")
+        XCTAssertNil(activeResult, "Active interaction must not be disturbed")
+        XCTAssertTrue(runtime.hasActive(panelId: panelId), "Active must stay active")
+    }
+
+    func testCancelInteractionActivePromotesNextQueued() {
+        let runtime = PaneInteractionRuntime()
+        let panelId = UUID()
+        var activeResult: ConfirmResult?
+        var queuedResult: ConfirmResult?
+
+        let activeContent = ConfirmContent(
+            title: "A", message: nil,
+            confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { activeResult = $0 }
+        )
+        let queuedContent = ConfirmContent(
+            title: "B", message: nil,
+            confirmLabel: "OK", cancelLabel: "Cancel",
+            role: .standard, source: .local,
+            completion: { queuedResult = $0 }
+        )
+        runtime.present(panelId: panelId, interaction: .confirm(activeContent))
+        runtime.present(panelId: panelId, interaction: .confirm(queuedContent))
+
+        let hit = runtime.cancelInteraction(panelId: panelId, interactionId: activeContent.id)
+
+        XCTAssertTrue(hit)
+        XCTAssertEqual(activeResult, .dismissed)
+        XCTAssertNil(queuedResult, "Queued must not yet resolve — it's promoted, not cancelled")
+        XCTAssertTrue(runtime.hasActive(panelId: panelId), "Queued was promoted to active")
+    }
+
+    func testCancelInteractionMissReturnsFalse() {
+        let runtime = PaneInteractionRuntime()
+        let panelId = UUID()
+        let hit = runtime.cancelInteraction(panelId: panelId, interactionId: UUID())
+        XCTAssertFalse(hit)
+    }
+
     // MARK: - Variant mismatch
 
     func testResolveConfirmOnTextInputDoesNotFire() {

--- a/cmuxTests/PaneInteractionRuntimeTests.swift
+++ b/cmuxTests/PaneInteractionRuntimeTests.swift
@@ -102,6 +102,29 @@ final class PaneInteractionRuntimeTests: XCTestCase {
         XCTAssertFalse(runtime.hasActive(panelId: panelId))
     }
 
+    func testClearAllResolvesEveryPanelWithDismissed() {
+        // Workspace teardown path: `clearAll()` must resolve every pending
+        // interaction across every panel with `.dismissed`, matching what
+        // `Workspace.teardownAllPanels()` relies on.
+        let runtime = PaneInteractionRuntime()
+        let panelA = UUID()
+        let panelB = UUID()
+        var resultA: ConfirmResult?
+        var queuedA: ConfirmResult?
+        var resultB: TextInputResult?
+
+        runtime.present(panelId: panelA, interaction: .confirm(makeConfirm { resultA = $0 }))
+        runtime.present(panelId: panelA, interaction: .confirm(makeConfirm { queuedA = $0 }))
+        runtime.present(panelId: panelB, interaction: .textInput(makeTextInput { resultB = $0 }))
+
+        runtime.clearAll()
+
+        XCTAssertEqual(resultA, .dismissed)
+        XCTAssertEqual(queuedA, .dismissed)
+        XCTAssertEqual(resultB, .dismissed)
+        XCTAssertFalse(runtime.hasAnyActive)
+    }
+
     func testDismissedIsDistinctFromCancelled() {
         // Result type distinction — a panel torn down mid-dialog reports .dismissed,
         // not .cancelled. Callers rely on this to distinguish "user said no" from

--- a/cmuxTests/PaneInteractionRuntimeTests.swift
+++ b/cmuxTests/PaneInteractionRuntimeTests.swift
@@ -119,7 +119,10 @@ final class PaneInteractionRuntimeTests: XCTestCase {
 
     // MARK: - Dedupe token
 
-    func testDedupeTokenSuppressesDuplicatePresent() {
+    func testDedupedPresentResolvesDuplicateWithDismissed() {
+        // A duplicate present (same dedupe token) must not drop the caller's
+        // continuation silently. The second caller's completion fires with
+        // .dismissed immediately; the in-flight interaction continues.
         let runtime = PaneInteractionRuntime()
         let panelId = UUID()
         var first: ConfirmResult?
@@ -132,11 +135,42 @@ final class PaneInteractionRuntimeTests: XCTestCase {
                         interaction: .confirm(makeConfirm { second = $0 }),
                         dedupeToken: "close_surface_cb.x")
 
-        runtime.resolveConfirm(panelId: panelId, result: .confirmed)
+        // Duplicate caller resolved immediately with .dismissed; first is still active.
+        XCTAssertEqual(second, .dismissed)
+        XCTAssertNil(first, "First present must remain active")
+        XCTAssertTrue(runtime.hasActive(panelId: panelId))
 
+        runtime.resolveConfirm(panelId: panelId, result: .confirmed)
         XCTAssertEqual(first, .confirmed)
-        XCTAssertNil(second, "Duplicate token must drop the second present entirely")
         XCTAssertFalse(runtime.hasActive(panelId: panelId))
+    }
+
+    func testSeenTokensResetAfterPanelBecomesIdle() {
+        // Stable per-panel tokens (e.g. `close_surface_cb.<id>`) must not
+        // permanently suppress future attempts once the panel is idle.
+        let runtime = PaneInteractionRuntime()
+        let panelId = UUID()
+        var first: ConfirmResult?
+        var second: ConfirmResult?
+
+        runtime.present(panelId: panelId,
+                        interaction: .confirm(makeConfirm { first = $0 }),
+                        dedupeToken: "close_surface_cb.x")
+        runtime.resolveConfirm(panelId: panelId, result: .cancelled)
+        XCTAssertEqual(first, .cancelled)
+        XCTAssertFalse(runtime.hasActive(panelId: panelId))
+
+        // Same token, panel is idle → should NOT be deduped.
+        runtime.present(panelId: panelId,
+                        interaction: .confirm(makeConfirm { second = $0 }),
+                        dedupeToken: "close_surface_cb.x")
+
+        XCTAssertTrue(runtime.hasActive(panelId: panelId),
+                      "Panel becoming idle must reset seenTokens so a re-used token presents normally")
+        XCTAssertNil(second, "Second present is active, not resolved yet")
+
+        runtime.resolveConfirm(panelId: panelId, result: .confirmed)
+        XCTAssertEqual(second, .confirmed)
     }
 
     func testDedupeTokenAllowsDifferentTokens() {

--- a/cmuxTests/PaneInteractionRuntimeTests.swift
+++ b/cmuxTests/PaneInteractionRuntimeTests.swift
@@ -399,6 +399,68 @@ final class PaneInteractionRuntimeTests: XCTestCase {
         XCTAssertFalse(runtime.acceptActive(panelId: UUID()))
     }
 
+    // MARK: - v2PaneConfirm timeout race (Blocker #1)
+
+    func testV2PaneConfirmTimeoutRaceHonorsLateCompletion() {
+        // Blocker #1: `semaphore.wait(timeout:)` returns `.timedOut`, but in the
+        // microseconds between that return and the timeout branch's cancel
+        // side-effect running on main, the user clicks Confirm. The completion
+        // fires on main, sets `holder.value = .confirmed`, and signals the
+        // semaphore (no-op — already timed out). The socket thread used to
+        // hard-code `"dismissed"` in the timeout branch, discarding the real
+        // user answer even though the side-effect tied to `.confirmed` already
+        // ran. Agent-facing protocol bug.
+        //
+        // This test pins the invariant by threading a mutable outcome through
+        // the resolver: `onTimeout` flips it to `.confirmed` (simulating the
+        // late completion), and the response must reflect `"ok"`, not
+        // `"dismissed"`.
+        var outcome: ConfirmResult = .dismissed
+        let result = TerminalController.v2PaneConfirmResolveOutcomeForTesting(
+            wait: { .timedOut },
+            onTimeout: {
+                // Completion fired in the race window between wait-return
+                // and cancel-run; holder was populated.
+                outcome = .confirmed
+            },
+            readOutcome: { outcome }
+        )
+        XCTAssertEqual(result, "ok",
+                       "Timeout branch must honor a late-firing completion's outcome, "
+                       + "not hard-code \"dismissed\".")
+    }
+
+    func testV2PaneConfirmTimeoutNonRacyReturnsDismissed() {
+        // Non-racy timeout: genuine deadline, no completion races in.
+        // `onTimeout` runs cancelInteraction which fires .dismissed on
+        // the completion, populating the holder with .dismissed. The
+        // response is "dismissed" — unchanged from pre-fix behavior.
+        var outcome: ConfirmResult = .dismissed
+        let result = TerminalController.v2PaneConfirmResolveOutcomeForTesting(
+            wait: { .timedOut },
+            onTimeout: {
+                // cancelInteraction fires .dismissed; holder is already at
+                // the default. Represent this by leaving outcome alone.
+                outcome = .dismissed
+            },
+            readOutcome: { outcome }
+        )
+        XCTAssertEqual(result, "dismissed")
+    }
+
+    func testV2PaneConfirmSuccessBranchDoesNotFireTimeout() {
+        // Signal arrived before deadline: wait returns `.success`, onTimeout
+        // must not run, and the outcome is whatever the completion wrote.
+        var timeoutFired = false
+        let result = TerminalController.v2PaneConfirmResolveOutcomeForTesting(
+            wait: { .success },
+            onTimeout: { timeoutFired = true },
+            readOutcome: { .cancelled }
+        )
+        XCTAssertFalse(timeoutFired)
+        XCTAssertEqual(result, "cancel")
+    }
+
     // MARK: - Reentrant present (Blocker #2 — advance-before-fire invariant)
 
     func testResolveConfirmReentrantPresentPreservesQueueHead() {


### PR DESCRIPTION
## Summary

Addresses the 9 findings from `/tmp/m10-self-review.md` (consolidated self-review + parallel `codex exec` adversarial review) against M10 Pane Interaction. Cut from `m10-pane-interaction@278ae98b` (Phase 6b.1) so the fixes are reviewable in isolation from the continuer agent's Phases 6b.2–10. Merges cleanly on top of the current `m10-pane-interaction` tip.

### 3 criticals
- **R1 (C1)** — Dedupe token leak + stranded `close_surface_cb.<id>`. Duplicate `present` now resolves the caller's continuation with `.dismissed`; `seenTokens[panelId]` is cleared when the panel becomes fully idle so subsequent close attempts work.
- **R3 (C2)** — `Workspace.teardownAllPanels` and `splitTabBar(_:didClosePane:)` fire `paneInteractionRuntime.clearAll()` / `clear(panelId:)` so awaiting continuations don't hang when a workspace or bonsplit pane is torn down.
- **R4 (C3)** — `v2PaneConfirm` timeout now cancels by interaction id (new `cancelInteraction(panelId:, interactionId:)` API on the runtime) instead of `cancelActive`, so a queued call's timeout cannot cancel an unrelated active interaction.

### 4 mediums
- **R5 (M3)** — Feature-flag gate added to `v2PaneConfirm`, completing the `CMUX_PANE_DIALOG_DISABLED=1` rollback story.
- **R6 (M4)** — Deterministic Cmd+D tiebreaker: iterate bonsplit pane/tab order instead of `Set.first`.
- **R10 (M2)** — Cmd+D dispatcher resolves the active `TabManager` via `NSApp.keyWindow` so secondary windows route through their own runtime, closing the `didBecomeKey` race.
- M1 (WebView overlay mount) is the continuer's Phase 2c — not in this PR.

### 4 nits
- **R2 (N2)** — `resolve*` / `cancelActive` / `acceptActive` / `clear` null `active[panelId]` BEFORE firing completions to eliminate reentrant double-resume risk. `advance` refactored accordingly.
- **R7 (N1)** — Strict `role` parsing in `pane.confirm`: unknown values return `invalid_params` instead of silently coercing to `.standard`.
- **R8 (N3)** — `v2PaneConfirm` rejects main-thread invocation up front to prevent the latent `v2MainSync` + `semaphore.wait` deadlock.
- **R9 (N4)** — Card views use `let runtime: PaneInteractionRuntime` instead of `@ObservedObject` (no `@Published` reads), eliminating redundant re-renders.

## Commits

Each fix is its own bisectable commit prefixed `m10/fixes: R<n> — <name>` (R1+R2, R7+R8 are bundled since they share files).

## Test plan

- [x] `xcodebuild -scheme cmux` Debug build clean
- [x] `xcodebuild -scheme cmux-unit build-for-testing` clean
- [x] New regression tests compile (`testDedupedPresentResolvesDuplicateWithDismissed`, `testSeenTokensResetAfterPanelBecomesIdle`, `testClearAllResolvesEveryPanelWithDismissed`, `testCancelInteractionQueuedRemovesQueuedOnly`, `testCancelInteractionActivePromotesNextQueued`, `testCancelInteractionMissReturnsFalse`)
- [ ] CI `cmux-unit` run
- [ ] Manual smoke once merged into `m10-pane-interaction` alongside continuer work

🤖 Generated with [Claude Code](https://claude.com/claude-code)