### PR TITLE
Sidebar: keep custom workspace color when selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Stage 11 Agentics builds infrastructure for the advanced hyper engineer: we buil
 
 More at [stage11.ai](https://stage11.ai).
 
+## Hiring
+
+A really good way to impress us at a job interview — before we even open your resume — is a really good PR into this repo.
+
+Feel free to get in touch at [build with us](https://stage11.ai/build-with-us).
+
 ## License
 
 AGPL-3.0-or-later, inherited from upstream. See [LICENSE](./LICENSE) and [NOTICE](./NOTICE) for the full text and a summary of fork modifications.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10704,7 +10704,8 @@ private struct TabItemView: View, Equatable {
         case .leftRail:
             return 0
         case .solidFill:
-            return isActive ? 1.0 : 0
+            guard isActive else { return 0 }
+            return hasActiveCustomColorFill ? 1.5 : 1.0
         }
     }
 
@@ -10714,12 +10715,20 @@ private struct TabItemView: View, Equatable {
         case .leftRail:
             return .clear
         case .solidFill:
-            return BrandColors.goldSwiftUI
+            return hasActiveCustomColorFill ? BrandColors.blackSwiftUI : BrandColors.goldSwiftUI
         }
     }
 
+    // When a workspace has a custom color and is selected in .solidFill mode,
+    // the fill stays the workspace color (subconsciously reinforcing which
+    // workspace you're in) and emphasis comes from a black outline instead of
+    // swapping the fill to black.
+    private var hasActiveCustomColorFill: Bool {
+        isActive && activeTabIndicatorStyle == .solidFill && resolvedCustomTabColor != nil
+    }
+
     private var usesInvertedActiveForeground: Bool {
-        isActive && activeTabIndicatorStyle == .solidFill
+        isActive && activeTabIndicatorStyle == .solidFill && !hasActiveCustomColorFill
     }
 
     private var activePrimaryTextColor: Color {
@@ -10915,7 +10924,12 @@ private struct TabItemView: View, Equatable {
                             .fill(activeUnreadBadgeFillColor)
                         Text("\(unreadCount)")
                             .font(.system(size: 9, weight: .semibold))
-                            .foregroundColor(usesInvertedActiveForeground ? BrandColors.blackSwiftUI : .white)
+                            // Badge fill is always gold (`activeUnreadBadgeFillColor`).
+                            // Use black on the gold circle whenever the tab is the
+                            // active selection in .solidFill — including custom-color
+                            // workspaces, where the broader text palette stays primary
+                            // but black-on-gold remains the only legible badge choice.
+                            .foregroundColor(isActive && activeTabIndicatorStyle == .solidFill ? BrandColors.blackSwiftUI : .white)
                     }
                     .frame(width: 16, height: 16)
                 }
@@ -11460,7 +11474,10 @@ private struct TabItemView: View, Equatable {
             if isMultiSelected { return cmuxAccentColor().opacity(0.25) }
             return Color.clear
         case .solidFill:
-            if isActive { return Color(nsColor: sidebarSelectedWorkspaceBackgroundNSColor(for: colorScheme)) }
+            if isActive {
+                if let custom = resolvedCustomTabColor { return custom }
+                return Color(nsColor: sidebarSelectedWorkspaceBackgroundNSColor(for: colorScheme))
+            }
             if let custom = resolvedCustomTabColor {
                 if isMultiSelected { return custom.opacity(0.35) }
                 return custom.opacity(0.7)


### PR DESCRIPTION
## Summary

When a workspace has a custom color (e.g. red) and is selected in the `.solidFill` tab indicator style, the sidebar tab used to replace the workspace hue with solid black + gold stroke + gold text. This change keeps the workspace color on the active state and conveys selection with a thicker **black outline** (1.5pt vs 1.0pt), so being "in the red workspace" stays subconsciously reinforced for the entire time you're in it.

- `.solidFill` + active + custom color → background stays the custom color, stroke is black, text reverts to primary/secondary so it reads on the hue.
- `.solidFill` + active + no custom color → unchanged (black bg + gold stroke + gold text).
- `.leftRail` style → unchanged.
- Unread badge text stays black whenever the tab is the active selection in `.solidFill`, including custom-color tabs — the badge circle is always gold, and black-on-gold is the legible choice.

## Review

Got a clear Claude + clear Codex review before committing. Claude approved. Codex flagged that the unread badge text flipped to white on gold for active custom-color tabs (~2.3:1 contrast) — fixed in the same commit by decoupling badge text color from the narrowed `usesInvertedActiveForeground` helper.

## Follow-ups (out of scope here)

- A color outline around the entire workspace content area (not just the sidebar tab), so the workspace hue frames everything you're working in. Natural next step if the sidebar reinforcement feels good.
- Luminance-adaptive primary/secondary text on custom-color fills — today `.primary` / `.secondary` is reused on top of the workspace hue, which is readable on the default palette but could get tight for very bright or very dark custom hues, especially in dark mode.

## Test plan
- [ ] Select a workspace with a custom color (e.g. Crimson/Navy) with `.solidFill` indicator — verify the tab fill stays the hue, with a black outline.
- [ ] Select a workspace **without** a custom color — verify it still shows the classic black bg + gold outline + gold text.
- [ ] Switch the indicator style to `.leftRail` — verify no change from before.
- [ ] Selected custom-color tab with unread notifications — verify the badge count is black on the gold circle (not white).
- [ ] Toggle light / dark mode and re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)