### PR TITLE
M10: multi-window dispatcher routing + hidden-tab accept safety

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		A5C101A1 /* PaneInteractionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B1 /* PaneInteractionCardView.swift */; };
 		A5C101A2 /* PaneInteractionOverlayHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B2 /* PaneInteractionOverlayHost.swift */; };
 		A5C102A0 /* PaneInteractionRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C102B0 /* PaneInteractionRuntimeTests.swift */; };
+		A5C103A1 /* PaneInteractionAcceptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C103B1 /* PaneInteractionAcceptTests.swift */; };
 		A58689DE /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C229 /* MermaidRenderer.swift */; };
 		A58689DF /* FencedCodeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C22A /* FencedCodeRenderer.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
@@ -246,6 +247,7 @@
 		A5C101B1 /* PaneInteractionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteractionCardView.swift; sourceTree = "<group>"; };
 		A5C101B2 /* PaneInteractionOverlayHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteractionOverlayHost.swift; sourceTree = "<group>"; };
 		A5C102B0 /* PaneInteractionRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInteractionRuntimeTests.swift; sourceTree = "<group>"; };
+		A5C103B1 /* PaneInteractionAcceptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInteractionAcceptTests.swift; sourceTree = "<group>"; };
 		A537C229 /* MermaidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MermaidRenderer.swift; sourceTree = "<group>"; };
 		A537C22A /* FencedCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FencedCodeRenderer.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
@@ -602,6 +604,7 @@
 					D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */,
 					42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
 					A5C102B0 /* PaneInteractionRuntimeTests.swift */,
+					A5C103B1 /* PaneInteractionAcceptTests.swift */,
 					14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */,
 					1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
 					EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */,
@@ -887,6 +890,7 @@
 					734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */,
 					B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
 					A5C102A0 /* PaneInteractionRuntimeTests.swift in Sources */,
+					A5C103A1 /* PaneInteractionAcceptTests.swift in Sources */,
 					DCC935C5F55C1DCB33E25521 /* WorkspacePullRequestSidebarTests.swift in Sources */,
 					0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */,
 					CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5801,6 +5801,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return nil
     }
 
+    /// Resolve the `TabManager` whose workspace owns the event's intended
+    /// target main terminal window. Used by `handleCustomShortcut` to
+    /// dispatch Cmd+D (and other shortcuts gated on an active pane
+    /// interaction) to the correct window across multi-window setups.
+    ///
+    /// Resolution order:
+    ///   1. Event-window routing via `mainWindowContext(forShortcutEvent:)`
+    ///      (`event.window`, then `event.windowNumber`). Handles command
+    ///      palette, inspectors, and any surface that forwards key events
+    ///      to a main terminal window.
+    ///   2. SheetParent walk on `keyWindow`. Covers the "sheet over
+    ///      secondary" case: the sheet is keyWindow, its `sheetParent` is
+    ///      the main terminal window whose pane dialog is visible.
+    ///   3. Bare `keyWindow` lookup via `contextForMainTerminalWindow`
+    ///      (covered by the same call thanks to `sheetParent ?? keyWindow`).
+    ///   4. Return `nil` — do NOT fall back to `self.tabManager`. That
+    ///      fallback silently routed shortcuts to the primary window's
+    ///      TabManager whenever keyWindow was non-terminal (palette, sheet
+    ///      on secondary, inspector), which is the exact Trident
+    ///      Important #1 anti-pattern. Returning nil lets the dispatcher
+    ///      treat "no active interaction" correctly and fall through to
+    ///      the normal shortcut path.
+    @MainActor
+    func resolveActiveTabManagerForShortcut(
+        event: NSEvent?,
+        keyWindow: NSWindow?
+    ) -> TabManager? {
+        if let event,
+           let ctx = mainWindowContext(forShortcutEvent: event, debugSource: "custom_shortcut") {
+            return ctx.tabManager
+        }
+        let targetWindow = keyWindow?.sheetParent ?? keyWindow
+        if let targetWindow,
+           let ctx = contextForMainTerminalWindow(targetWindow, reindex: false) {
+            return ctx.tabManager
+        }
+        return nil
+    }
+
     private func preferredMainWindowContextForShortcutRouting(event: NSEvent) -> MainWindowContext? {
         if let context = mainWindowContext(forShortcutEvent: event, debugSource: "shortcut.routing") {
             return context
@@ -9108,7 +9147,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // key window's portal/SwiftUI hierarchy. Gate the same shortcuts here so the
         // overlay sees the Cmd+D accept and other app shortcuts stay suppressed while
         // a dialog is visible (plan §4.8).
-        let paneInteractionActive = tabManager?.hasActivePaneInteraction ?? false
+        //
+        // Routing rules live in `resolveActiveTabManagerForShortcut`: event-window
+        // first, then sheetParent-walk on keyWindow, then nil. Important #1: no
+        // silent fallback to `self.tabManager` — that routed Cmd+D to the primary
+        // window whenever keyWindow was non-terminal (sheet, palette, inspector).
+        let activeTabManager = resolveActiveTabManagerForShortcut(
+            event: event,
+            keyWindow: NSApp.keyWindow
+        )
+        let paneInteractionActive = activeTabManager?.hasActivePaneInteraction ?? false
 
         if let closeConfirmationPanel {
             // Special-case: Cmd+D should confirm destructive close on alerts.
@@ -9147,7 +9195,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if matchShortcut(
                 event: event,
                 shortcut: StoredShortcut(key: "d", command: true, shift: false, option: false, control: false)
-            ), tabManager?.acceptActivePaneInteractionInKeyWorkspace() == true {
+            ), activeTabManager?.acceptActivePaneInteractionInKeyWorkspace() == true {
                 return true
             }
             let hasAppShortcutModifier = hasCommand || hasControl || hasOption
@@ -10598,6 +10646,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // synthetic NSEvents.
     func debugHandleCustomShortcut(event: NSEvent) -> Bool {
         handleCustomShortcut(event: event)
+    }
+
+    // Debug/test hook: direct access to the shortcut dispatcher's TabManager
+    // resolver. Tests can pass their own `keyWindow` because unit-test focus
+    // behavior (NSApp.keyWindow / makeKey) is platform- and runner-dependent.
+    func debugResolveActiveTabManagerForShortcut(
+        event: NSEvent?,
+        keyWindow: NSWindow?
+    ) -> TabManager? {
+        resolveActiveTabManagerForShortcut(event: event, keyWindow: keyWindow)
     }
 
     // Debug/test hook: mirrors local monitor routing (keyDown + keyUp lifecycle).

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -729,10 +729,22 @@ class TabManager: ObservableObject {
            runtime.hasActive(panelId: focusedPanelId) {
             return runtime.acceptActive(panelId: focusedPanelId)
         }
-        // Otherwise accept any active interaction — there's only ever one per panel,
-        // and multiple-panel-with-active-interaction is rare.
-        if let anyPanelId = runtime.activePanelIds.first {
-            return runtime.acceptActive(panelId: anyPanelId)
+        // Otherwise iterate panes in bonsplit spatial order. Restrict the
+        // fallback to each pane's SELECTED tab (Trident Important #2): the
+        // previous iteration used `runtime.activePanelIds.first` (and earlier
+        // `tabs(inPane:)`), both of which happily accept a dialog anchored on
+        // a non-selected (hidden) tab. If the hidden dialog is destructive,
+        // Cmd+D silently causes data loss. `selectedTab(inPane:)` only
+        // surfaces the tab the user is currently looking at in each pane —
+        // safe by construction.
+        for paneId in workspace.bonsplitController.allPaneIds {
+            guard let selected = workspace.bonsplitController.selectedTab(inPane: paneId),
+                  let candidate = workspace.panelIdFromSurfaceId(selected.id) else {
+                continue
+            }
+            if runtime.hasActive(panelId: candidate) {
+                return runtime.acceptActive(panelId: candidate)
+            }
         }
         return false
     }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3146,6 +3146,132 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             defaults.removeObject(forKey: key)
         }
     }
+
+    // MARK: - Important #1: multi-window Cmd+D dispatcher routing
+
+    func testShortcutActiveTabManagerWalksSheetParentToSecondaryWindow() throws {
+        // Trident Important #1: `contextForMainTerminalWindow(NSApp.keyWindow)`
+        // returns nil whenever keyWindow is not a main terminal window —
+        // command palette, an NSPanel float, or a sheet over a secondary
+        // window. The old fallback to `self.tabManager` silently routed Cmd+D
+        // to the primary window's TabManager while a pane dialog was open on
+        // secondary. Sheet-over-secondary is the canonical repro: attach a
+        // sheet (which takes keyWindow), stale the app-level pointer to
+        // primary, and assert resolution still lands on secondary via
+        // sheetParent walk.
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        let secondWindowId = appDelegate.createMainWindow()
+        defer {
+            closeWindow(withId: firstWindowId)
+            closeWindow(withId: secondWindowId)
+        }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId),
+              let secondManager = appDelegate.tabManagerFor(windowId: secondWindowId),
+              let secondWindow = window(withId: secondWindowId) else {
+            XCTFail("Expected both window contexts to exist")
+            return
+        }
+        XCTAssertFalse(firstManager === secondManager)
+
+        secondWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+        // Stale the app-level pointer to the primary's TabManager — this is
+        // the exact condition that made the old fallback silently wrong.
+        appDelegate.tabManager = firstManager
+        XCTAssertTrue(appDelegate.tabManager === firstManager)
+
+        // Present a sheet over secondary. The sheet becomes keyWindow; its
+        // `sheetParent` is the secondary main terminal window.
+        let sheet = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 240, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        sheet.isReleasedWhenClosed = false
+        secondWindow.beginSheet(sheet, completionHandler: nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        defer {
+            secondWindow.endSheet(sheet)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        }
+        XCTAssertTrue(secondWindow.attachedSheet === sheet,
+                      "Expected sheet to be attached to secondary window")
+
+        // Pass the sheet explicitly as keyWindow so the test doesn't rely on
+        // the runner making the sheet key (unit-test focus behavior can be
+        // platform-dependent). The resolver must walk sheetParent → second.
+#if DEBUG
+        let resolved = appDelegate.debugResolveActiveTabManagerForShortcut(
+            event: nil,
+            keyWindow: sheet
+        )
+#else
+        let resolved: TabManager? = nil
+        XCTFail("debugResolveActiveTabManagerForShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertTrue(resolved === secondManager,
+                      "Sheet over secondary must resolve via sheetParent to secondary's TabManager")
+        XCTAssertFalse(resolved === firstManager,
+                       "Fallback to primary's TabManager is the exact Important #1 anti-pattern")
+    }
+
+    func testShortcutActiveTabManagerReturnsNilForNonTerminalKeyWindow() throws {
+        // Important #1 companion: when keyWindow is not a main terminal
+        // window and has no sheetParent, resolution must return nil — not
+        // silently fall back to `self.tabManager`. Returning nil lets the
+        // dispatcher short-circuit cleanly and the shortcut falls through
+        // to normal dispatch, rather than accepting a pane dialog on an
+        // arbitrary window the user wasn't looking at.
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let firstWindowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: firstWindowId) }
+
+        guard let firstManager = appDelegate.tabManagerFor(windowId: firstWindowId) else {
+            XCTFail("Expected first window context")
+            return
+        }
+
+        // Stale the app-level pointer — if the resolver falls back to
+        // self.tabManager we'd get firstManager, which is the buggy outcome.
+        appDelegate.tabManager = firstManager
+
+        let floatingPanel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 200, height: 100),
+            styleMask: [.titled, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        floatingPanel.isReleasedWhenClosed = false
+        defer { floatingPanel.close() }
+
+#if DEBUG
+        let resolved = appDelegate.debugResolveActiveTabManagerForShortcut(
+            event: nil,
+            keyWindow: floatingPanel
+        )
+#else
+        let resolved: TabManager? = firstManager
+        XCTFail("debugResolveActiveTabManagerForShortcut is only available in DEBUG")
+#endif
+
+        XCTAssertNil(resolved,
+                     "Non-terminal key window must return nil — no silent fallback to self.tabManager. "
+                     + "Returning primary would let Cmd+D accept a pane dialog on the primary "
+                     + "while the user is looking at a floating panel / command palette.")
+    }
 }
 
 private final class CommandPaletteMarkedTextFieldEditor: NSTextView {

--- a/cmuxTests/PaneInteractionAcceptTests.swift
+++ b/cmuxTests/PaneInteractionAcceptTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+import AppKit
+import Bonsplit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Tests for `TabManager.acceptActivePaneInteractionInKeyWorkspace` —
+/// the Cmd+D dispatcher's accept path (plan §4.8).
+@MainActor
+final class PaneInteractionAcceptTests: XCTestCase {
+
+    // MARK: - Important #2: selected-tab preference (hidden-tab safety)
+
+    func testAcceptActiveRejectsDialogOnHiddenTab() {
+        // Trident Important #2: `tabs(inPane:)` returns every tab in a pane,
+        // selected or not. A dialog presented on a tab the user had focused —
+        // and then switched away from — stays anchored on its (now hidden)
+        // panel. The old iteration walked all tabs and accepted whichever
+        // active interaction came first. If the hidden dialog was
+        // destructive (e.g. "close without saving"), Cmd+D silently caused
+        // data loss.
+        //
+        // Fix: prefer `selectedTab(inPane:)` in the iteration — the hidden
+        // tab's dialog must not be accepted by Cmd+D on the active tab.
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId,
+              let firstSurfaceId = workspace.surfaceIdFromPanelId(firstPanelId) else {
+            XCTFail("Expected initial workspace with a focused panel")
+            return
+        }
+
+        // Add a second terminal tab in the same pane. createReplacementTerminalPanel
+        // creates the TerminalPanel + registers the surface-id → panel-id mapping
+        // + adds a bonsplit tab via `createTab` (which uses focusedPaneId →
+        // same pane as the first tab).
+        let secondPanel = workspace.createReplacementTerminalPanel()
+        guard let secondSurfaceId = workspace.surfaceIdFromPanelId(secondPanel.id) else {
+            XCTFail("Expected surface ID for second panel")
+            return
+        }
+
+        // Verify both tabs sit in a single pane.
+        XCTAssertEqual(workspace.bonsplitController.allPaneIds.count, 1,
+                       "Both tabs should share the same pane")
+        guard let paneId = workspace.bonsplitController.allPaneIds.first else {
+            XCTFail("Expected one pane")
+            return
+        }
+        let tabIds = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
+        XCTAssertEqual(Set(tabIds), Set([firstSurfaceId, secondSurfaceId]),
+                       "Pane must host both surface tabs")
+
+        // Explicitly select the FIRST tab so the second is hidden. Also
+        // ensure focusedPanelId is the first panel (no dialog on it).
+        workspace.bonsplitController.selectTab(firstSurfaceId)
+        workspace.focusPanel(firstPanelId)
+        XCTAssertEqual(workspace.focusedPanelId, firstPanelId)
+        XCTAssertEqual(workspace.bonsplitController.selectedTab(inPane: paneId)?.id,
+                       firstSurfaceId,
+                       "First tab must be the pane's selected tab")
+
+        // Present a destructive-looking confirm on the hidden (second) panel.
+        var hiddenResult: ConfirmResult?
+        let hiddenContent = ConfirmContent(
+            title: "Close?", message: nil,
+            confirmLabel: "Close", cancelLabel: "Cancel",
+            role: .destructive, source: .local,
+            completion: { hiddenResult = $0 }
+        )
+        workspace.paneInteractionRuntime.present(
+            panelId: secondPanel.id,
+            interaction: .confirm(hiddenContent)
+        )
+
+        // No dialog on the first (visible) panel.
+        XCTAssertFalse(workspace.paneInteractionRuntime.hasActive(panelId: firstPanelId))
+        XCTAssertTrue(workspace.paneInteractionRuntime.hasActive(panelId: secondPanel.id))
+
+        // Cmd+D must refuse to accept the hidden-tab dialog.
+        let accepted = manager.acceptActivePaneInteractionInKeyWorkspace()
+
+        XCTAssertFalse(accepted,
+                       "Cmd+D must not silently accept a dialog on a non-selected tab.")
+        XCTAssertNil(hiddenResult,
+                     "Hidden dialog's completion must not fire — it stays anchored "
+                     + "until the user explicitly surfaces the tab.")
+        XCTAssertTrue(
+            workspace.paneInteractionRuntime.hasActive(panelId: secondPanel.id),
+            "Hidden dialog must remain active — not resolved, not cancelled."
+        )
+    }
+
+    func testAcceptActiveOnVisibleTabStillWorks() {
+        // Sanity: the happy path — dialog on the currently selected tab —
+        // still accepts. Locks in that the selected-tab preference fix
+        // doesn't also break the common case.
+        let manager = TabManager()
+        guard let workspace = manager.selectedWorkspace,
+              let firstPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected initial workspace with a focused panel")
+            return
+        }
+
+        var result: ConfirmResult?
+        let content = ConfirmContent(
+            title: "Close?", message: nil,
+            confirmLabel: "Close", cancelLabel: "Cancel",
+            role: .destructive, source: .local,
+            completion: { result = $0 }
+        )
+        workspace.paneInteractionRuntime.present(
+            panelId: firstPanelId,
+            interaction: .confirm(content)
+        )
+
+        let accepted = manager.acceptActivePaneInteractionInKeyWorkspace()
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(result, .confirmed,
+                       "Dialog on the focused panel must still accept on Cmd+D")
+    }
+}


### PR DESCRIPTION
Two targeted safety fixes for the M10 pane-dialog dispatcher, carried over from a parallel Trident review pass (`notes/trident-review-m10-review-fixes-pack-20260418-1751/`) whose remaining Blocker/Important findings that weren't already addressed by the `m10-pane-interaction` trident-fix pass (`…m10-pane-interaction-pack-20260418-1754/`).

Supersedes #18 (closed). Every other finding in the m10-review-fixes pack was already fixed on this base by `533aa6bd`, `40f295eb`, `d0d8042c`, `2a7e0567`, `e3a3d1ae`, `fc5ac550` — a full superseded-by map is in #18's closing comment.

## What this PR lands

### Important #1 — multi-window shortcut dispatcher (`R-I1`)
`handleCustomShortcut` resolves the active `TabManager` from `self.tabManager`. Whenever `keyWindow` is a sheet over a secondary window, a floating `NSPanel`, or an inspector, `self.tabManager` may still point at the primary window — so `hasActivePaneInteraction` reads the wrong workspace and Cmd+D either silently falls through (hidden dialog on secondary) or accepts the wrong one.

New helper `resolveActiveTabManagerForShortcut(event:keyWindow:)`:
1. Event-window routing first via the existing `mainWindowContext(forShortcutEvent:)`.
2. SheetParent walk on keyWindow — lands on the hosting main terminal window.
3. Returns `nil` on miss; no silent fallback to `self.tabManager`.

Used at the pane-interaction gate for both `hasActivePaneInteraction` and `acceptActivePaneInteractionInKeyWorkspace`.

### Important #2 — hidden-tab dialog safety (`R-I2`)
`TabManager.acceptActivePaneInteractionInKeyWorkspace` currently uses `runtime.activePanelIds.first` in the fallback (and previously `tabs(inPane:)`). Both accept dialogs anchored on tabs that the user **switched away from** before resolving. If that hidden dialog is destructive (close-without-saving), Cmd+D causes invisible data loss.

Fallback now iterates panes in bonsplit spatial order and checks `bonsplitController.selectedTab(inPane:)` only — i.e., the tab the user is actually looking at in each pane. Happy-path (`focusedPanelId`) is unchanged.

### Regression tests
- `testShortcutActiveTabManagerWalksSheetParentToSecondaryWindow` — two TabManagers, sheet over secondary, stale `self.tabManager` → must resolve to secondary.
- `testShortcutActiveTabManagerReturnsNilForNonTerminalKeyWindow` — floating `NSPanel` keyWindow → must return nil, not silently route to primary.
- `testAcceptActiveRejectsDialogOnHiddenTab` — two tabs in one pane, destructive dialog on the non-selected tab → Cmd+D must not accept it, completion must not fire, dialog remains active.
- `testAcceptActiveOnVisibleTabStillWorks` — happy-path sanity.

All tests reference `AppDelegate.debugResolveActiveTabManagerForShortcut` — a `#if DEBUG` hook that lets tests pass `keyWindow` directly (NSApp.keyWindow behavior for programmatically-created sheets is runner-dependent).

## Commit structure
Test-before-fix per `CLAUDE.md` regression-test commit policy:
1. `T-I1` — failing tests for sheetParent + no-fallback (compile-red without R-I1).
2. `R-I1` — introduces resolver + debug hook, updates dispatcher.
3. `T-I2` — failing test for hidden-tab accept.
4. `R-I2` — prefers `selectedTab(inPane:)` in the fallback.

## Not in scope (separate observation)
While auditing upstream's v2PaneConfirm rewrite (`2a7e0567`), I noticed `PaneInteractionFeatureFlag.isEnabled` is checked from `ContentView.swift`, `Workspace.swift`, `TabManager.swift`, and `PaneInteraction.swift`, but **no longer from `TerminalController.v2PaneConfirm`**. `CMUX_PANE_DIALOG_DISABLED=1` therefore does NOT gate the socket entrypoint — `pane.confirm` presents a dialog even with the rollback flag set. Surfacing for a separate fix; not touched here to keep this PR focused.

## Validation
Tagged build green on `./scripts/reload.sh --tag m10-dispatcher-safety`. Tests deferred to CI per project policy.

## Links
- Trident pack for m10-review-fixes: `notes/trident-review-m10-review-fixes-pack-20260418-1751/`
- Trident pack for m10-pane-interaction: `notes/trident-review-m10-pane-interaction-pack-20260418-1754/` (on sibling worktree)