### PR TITLE
CMUX-11 Phase 1: PaneMetadataStore (in-memory)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */; };
 		D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
 		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
+		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
+		D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
 		D7006BF0A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */; };
 		D7007BF0A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */; };
 		D7008BF0A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */; };
@@ -215,6 +217,8 @@
 		D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataKeys.swift; sourceTree = "<group>"; };
 		D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
 		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
+		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
+		D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStoreTests.swift; sourceTree = "<group>"; };
 		D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceRoundTripTests.swift; sourceTree = "<group>"; };
 		D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistencePrecedenceTests.swift; sourceTree = "<group>"; };
 		D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceUncoercibleTests.swift; sourceTree = "<group>"; };
@@ -471,6 +475,7 @@
 				A5001543 /* SurfaceMetadataStore.swift */,
 				D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */,
 				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
+				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
 				A5001545 /* AgentDetector.swift */,
 				A5001701 /* TextBoxInput.swift */,
 				A5008F12 /* SurfaceTitleBarView.swift */,
@@ -616,6 +621,7 @@
 					D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */,
 					D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */,
 					D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */,
+					D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -789,6 +795,7 @@
 				A5001542 /* SurfaceMetadataStore.swift in Sources */,
 				D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */,
 				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
+				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
 				A5001544 /* AgentDetector.swift in Sources */,
 			A5001700 /* TextBoxInput.swift in Sources */,
 				A5008F11 /* SurfaceTitleBarView.swift in Sources */,
@@ -901,6 +908,7 @@
 					D7007BF0A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift in Sources */,
 					D7008BF0A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift in Sources */,
 					D7009BF0A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift in Sources */,
+					D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/PaneMetadataStore.swift
+++ b/Sources/PaneMetadataStore.swift
@@ -1,0 +1,327 @@
+import Foundation
+#if DEBUG
+import Bonsplit
+#endif
+
+/// Per-pane JSON metadata store (CMUX-11 Phase 1).
+///
+/// Mirrors `SurfaceMetadataStore` but keys by `(workspaceId, paneId)` instead
+/// of `(workspaceId, surfaceId)`. The first consumer is a free-form pane
+/// title carrying lineage (`Parent :: Child :: Grandchild`); the store is
+/// built for parity so future pane-level metadata (status/role/progress) can
+/// land without a second migration.
+///
+/// Source precedence reuses the surface store's `MetadataSource` chain
+/// (`explicit > declare > osc > heuristic`). In practice only `.explicit`
+/// writes flow through this store today (agents and operators); the OSC and
+/// heuristic layers don't apply to panes in v1.
+///
+/// In-memory only in Phase 1. Phase 3 wires persistence through the existing
+/// `PersistedJSONValue` / `PersistedMetadataSource` rails introduced for
+/// surfaces by Tier 1 Phase 2.
+final class PaneMetadataStore: @unchecked Sendable {
+    static let shared = PaneMetadataStore()
+
+    // MARK: - Constants
+
+    /// Same 64 KiB per-pane cap used for surfaces.
+    static let payloadCapBytes: Int = SurfaceMetadataStore.payloadCapBytes
+
+    /// Reserved canonical keys recognised at the pane layer. Title and
+    /// description start; the rest of the surface canonical set is allowed
+    /// for future use without a schema bump and validates against the same
+    /// rules. Keys outside this set accept any JSON value.
+    static let reservedKeys: Set<String> = SurfaceMetadataStore.reservedKeys
+
+    typealias SourceRecord = SurfaceMetadataStore.SourceRecord
+    typealias WriteError = SurfaceMetadataStore.WriteError
+    typealias WriteMode = SurfaceMetadataStore.WriteMode
+    typealias WriteResult = SurfaceMetadataStore.WriteResult
+
+    // MARK: - State
+
+    private let queue = DispatchQueue(label: "com.cmux.pane-metadata", qos: .userInitiated)
+
+    /// `[workspaceId: [paneId: blob]]`.
+    private var metadata: [UUID: [UUID: [String: Any]]] = [:]
+
+    /// Parallel `(source, ts)` sidecar.
+    private var sources: [UUID: [UUID: [String: SourceRecord]]] = [:]
+
+    /// Monotonic revision counter — same contract as the surface store. Bumped
+    /// on every mutation that changes state, never on idempotent writes or
+    /// rejected lower-precedence writes. Read by the autosave fingerprint so
+    /// metadata-only mutations between 8 s ticks still trigger a write.
+    private var paneMetadataStoreRevision: UInt64 = 0
+
+    // MARK: - Public API
+
+    func setMetadata(
+        workspaceId: UUID,
+        paneId: UUID,
+        partial: [String: Any],
+        mode: WriteMode,
+        source: MetadataSource
+    ) throws -> WriteResult {
+        return try queue.sync {
+            try setMetadataLocked(
+                workspaceId: workspaceId,
+                paneId: paneId,
+                partial: partial,
+                mode: mode,
+                source: source
+            )
+        }
+    }
+
+    func getMetadata(workspaceId: UUID, paneId: UUID) -> (metadata: [String: Any], sources: [String: [String: Any]]) {
+        return queue.sync {
+            let md = metadata[workspaceId]?[paneId] ?? [:]
+            let src = sources[workspaceId]?[paneId]
+                .map { m in m.mapValues { $0.toJSON() } } ?? [:]
+            return (md, src)
+        }
+    }
+
+    /// Read the monotonic revision counter. Mirrors
+    /// `SurfaceMetadataStore.currentRevision()` so the autosave fingerprint
+    /// can fold pane-metadata churn into the same tick decision.
+    func currentRevision() -> UInt64 {
+        return queue.sync { paneMetadataStoreRevision }
+    }
+
+    func getSource(workspaceId: UUID, paneId: UUID, key: String) -> MetadataSource? {
+        return queue.sync {
+            return sources[workspaceId]?[paneId]?[key]?.source
+        }
+    }
+
+    /// Clear specific keys (or the whole blob when `keys == nil`).
+    /// `keys == nil` requires `source == .explicit`, mirroring surfaces.
+    func clearMetadata(
+        workspaceId: UUID,
+        paneId: UUID,
+        keys: [String]?,
+        source: MetadataSource
+    ) throws -> WriteResult {
+        return try queue.sync {
+            var result = WriteResult()
+            if keys == nil {
+                guard source == .explicit else {
+                    throw WriteError.replaceRequiresExplicit
+                }
+                let existing = metadata[workspaceId]?[paneId] ?? [:]
+                let existingSrc = sources[workspaceId]?[paneId] ?? [:]
+                metadata[workspaceId]?[paneId] = [:]
+                sources[workspaceId]?[paneId] = [:]
+                result.metadata = [:]
+                result.sources = [:]
+                if !existing.isEmpty || !existingSrc.isEmpty {
+                    paneMetadataStoreRevision &+= 1
+                }
+                return result
+            }
+
+            var blob = metadata[workspaceId]?[paneId] ?? [:]
+            var sblob = sources[workspaceId]?[paneId] ?? [:]
+            var removedAny = false
+
+            for key in keys! {
+                if let cur = sblob[key] {
+                    if source.precedence < cur.source.precedence {
+                        result.applied[key] = false
+                        result.reasons[key] = "lower_precedence"
+                        continue
+                    }
+                }
+                let hadValue = blob.removeValue(forKey: key) != nil
+                let hadSource = sblob.removeValue(forKey: key) != nil
+                if hadValue || hadSource { removedAny = true }
+                result.applied[key] = true
+            }
+
+            metadata[workspaceId, default: [:]][paneId] = blob
+            sources[workspaceId, default: [:]][paneId] = sblob
+            result.metadata = blob
+            result.sources = sblob.mapValues { $0.toJSON() }
+            if removedAny { paneMetadataStoreRevision &+= 1 }
+            return result
+        }
+    }
+
+    /// Restore a pane's metadata from a session snapshot. Bypasses the
+    /// precedence chain — the snapshot is the prior session's source of
+    /// truth — but post-restore writes still respect precedence against the
+    /// restored record. Same contract as `SurfaceMetadataStore`.
+    func restoreFromSnapshot(
+        workspaceId: UUID,
+        paneId: UUID,
+        values: [String: Any],
+        sources: [String: SourceRecord]
+    ) {
+        queue.sync {
+            metadata[workspaceId, default: [:]][paneId] = values
+            self.sources[workspaceId, default: [:]][paneId] = sources
+            paneMetadataStoreRevision &+= 1
+        }
+    }
+
+    /// Drop a single pane's metadata. Called when a pane closes for good.
+    func removePane(workspaceId: UUID, paneId: UUID) {
+        queue.async { [self] in
+            metadata[workspaceId]?.removeValue(forKey: paneId)
+            sources[workspaceId]?.removeValue(forKey: paneId)
+        }
+    }
+
+    /// Prune any panes not in `validPaneIds`. Called from workspace cleanup
+    /// the way `SurfaceMetadataStore.pruneWorkspace` is.
+    func pruneWorkspace(workspaceId: UUID, validPaneIds: Set<UUID>) {
+        queue.async { [self] in
+            if var wsMetadata = metadata[workspaceId] {
+                wsMetadata = wsMetadata.filter { validPaneIds.contains($0.key) }
+                metadata[workspaceId] = wsMetadata
+            }
+            if var wsSources = sources[workspaceId] {
+                wsSources = wsSources.filter { validPaneIds.contains($0.key) }
+                sources[workspaceId] = wsSources
+            }
+        }
+    }
+
+    /// Drop all pane metadata for a workspace.
+    func removeWorkspace(workspaceId: UUID) {
+        queue.async { [self] in
+            metadata.removeValue(forKey: workspaceId)
+            sources.removeValue(forKey: workspaceId)
+        }
+    }
+
+    /// Single-key write with precedence gating. Mirrors
+    /// `SurfaceMetadataStore.setInternal` for symmetry; pane callers will
+    /// almost always use `setMetadata` directly with `source: .explicit`.
+    @discardableResult
+    func setInternal(
+        workspaceId: UUID,
+        paneId: UUID,
+        key: String,
+        value: Any,
+        source: MetadataSource
+    ) -> Bool {
+        return queue.sync {
+            var blob = metadata[workspaceId]?[paneId] ?? [:]
+            var sblob = sources[workspaceId]?[paneId] ?? [:]
+
+            if let cur = sblob[key], source.precedence < cur.source.precedence {
+                return false
+            }
+            if SurfaceMetadataStore.validateReservedKey(key, value) != nil {
+                return false
+            }
+            if let existing = blob[key], sameJSONValue(existing, value), sblob[key]?.source == source {
+                return false
+            }
+            blob[key] = value
+            sblob[key] = SourceRecord(source: source, ts: Date().timeIntervalSince1970)
+
+            if let encoded = try? JSONSerialization.data(withJSONObject: blob, options: []),
+               encoded.count > PaneMetadataStore.payloadCapBytes {
+                return false
+            }
+
+            metadata[workspaceId, default: [:]][paneId] = blob
+            sources[workspaceId, default: [:]][paneId] = sblob
+            paneMetadataStoreRevision &+= 1
+            return true
+        }
+    }
+
+    // MARK: - Locked merge helper
+
+    private func setMetadataLocked(
+        workspaceId: UUID,
+        paneId: UUID,
+        partial: [String: Any],
+        mode: WriteMode,
+        source: MetadataSource
+    ) throws -> WriteResult {
+        if mode == .replace, source != .explicit {
+            throw WriteError.replaceRequiresExplicit
+        }
+
+        for (k, v) in partial {
+            if SurfaceMetadataStore.reservedKeys.contains(k) {
+                if let err = SurfaceMetadataStore.validateReservedKey(k, v) {
+                    throw err
+                }
+            }
+        }
+
+        var blob: [String: Any]
+        var sblob: [String: SourceRecord]
+        var result = WriteResult()
+
+        if mode == .replace {
+            blob = [:]
+            sblob = [:]
+        } else {
+            blob = metadata[workspaceId]?[paneId] ?? [:]
+            sblob = sources[workspaceId]?[paneId] ?? [:]
+        }
+
+        let ts = Date().timeIntervalSince1970
+        var mutated = false
+
+        if mode == .replace {
+            let priorBlob = metadata[workspaceId]?[paneId] ?? [:]
+            let priorSrc = sources[workspaceId]?[paneId] ?? [:]
+            if !priorBlob.isEmpty || !priorSrc.isEmpty { mutated = true }
+        }
+
+        for (k, v) in partial {
+            if mode == .merge, let cur = sblob[k], source.precedence < cur.source.precedence {
+                result.applied[k] = false
+                result.reasons[k] = "lower_precedence"
+                continue
+            }
+            let existing = blob[k]
+            let existingSource = sblob[k]?.source
+            let isSameWrite = existing.map { sameJSONValue($0, v) } ?? false
+                && existingSource == source
+            if isSameWrite {
+                result.applied[k] = true
+                continue
+            }
+            blob[k] = v
+            sblob[k] = SourceRecord(source: source, ts: ts)
+            result.applied[k] = true
+            mutated = true
+        }
+
+        guard let encoded = try? JSONSerialization.data(withJSONObject: blob, options: []) else {
+            throw WriteError.encodeFailed
+        }
+        if encoded.count > PaneMetadataStore.payloadCapBytes {
+            throw WriteError.payloadTooLarge
+        }
+
+        metadata[workspaceId, default: [:]][paneId] = blob
+        sources[workspaceId, default: [:]][paneId] = sblob
+
+        result.metadata = blob
+        result.sources = sblob.mapValues { $0.toJSON() }
+        if mutated { paneMetadataStoreRevision &+= 1 }
+        return result
+    }
+
+    // MARK: - Value equality for dedupe
+
+    private func sameJSONValue(_ a: Any, _ b: Any) -> Bool {
+        if let sa = a as? String, let sb = b as? String { return sa == sb }
+        if let na = a as? NSNumber, let nb = b as? NSNumber { return na == nb }
+        if let ba = a as? Bool, let bb = b as? Bool { return ba == bb }
+        let da = try? JSONSerialization.data(withJSONObject: ["v": a], options: [.sortedKeys])
+        let db = try? JSONSerialization.data(withJSONObject: ["v": b], options: [.sortedKeys])
+        return da == db
+    }
+}

--- a/cmuxTests/PaneMetadataStoreTests.swift
+++ b/cmuxTests/PaneMetadataStoreTests.swift
@@ -1,0 +1,507 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// CMUX-11 Phase 1: `PaneMetadataStore` parity tests. Mirrors the surface
+/// store's coverage — set/get/clear, source precedence, cap enforcement,
+/// revision counter, and persistence round-trip via `PersistedJSONValue`.
+/// OSC/heuristic-specific tests are omitted; those sources don't apply to
+/// panes in v1, but the precedence chain is still exercised end-to-end.
+final class PaneMetadataStoreTests: XCTestCase {
+    private func makeStoreAndPane() -> (PaneMetadataStore, UUID, UUID) {
+        // Shared singleton with fresh UUIDs so parallel tests don't collide.
+        return (PaneMetadataStore.shared, UUID(), UUID())
+    }
+
+    // MARK: - set / get
+
+    func testSetMergeStoresValueAndSource() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        let result = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Login Button"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertEqual(result.applied["title"], true)
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "Login Button")
+        XCTAssertEqual(store.getSource(workspaceId: wsId, paneId: paneId, key: "title"), .explicit)
+    }
+
+    func testMergePreservesOtherKeys() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Parent :: Child"],
+            mode: .merge,
+            source: .explicit
+        )
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["description": "review notes"],
+            mode: .merge,
+            source: .explicit
+        )
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "Parent :: Child")
+        XCTAssertEqual(snap.metadata["description"] as? String, "review notes")
+    }
+
+    func testReplaceWipesOtherKeys() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Old", "description": "gone"],
+            mode: .merge,
+            source: .explicit
+        )
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "New"],
+            mode: .replace,
+            source: .explicit
+        )
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "New")
+        XCTAssertNil(snap.metadata["description"])
+    }
+
+    func testReplaceRejectsNonExplicitSource() {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        XCTAssertThrowsError(
+            try store.setMetadata(
+                workspaceId: wsId,
+                paneId: paneId,
+                partial: ["title": "X"],
+                mode: .replace,
+                source: .declare
+            )
+        )
+    }
+
+    // MARK: - precedence
+
+    func testLowerPrecedenceMergeIsRejected() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Explicit"],
+            mode: .merge,
+            source: .explicit
+        )
+        let result = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Declared"],
+            mode: .merge,
+            source: .declare
+        )
+        XCTAssertEqual(result.applied["title"], false)
+        XCTAssertEqual(result.reasons["title"], "lower_precedence")
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "Explicit")
+    }
+
+    func testHigherPrecedenceMergeWins() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Declared"],
+            mode: .merge,
+            source: .declare
+        )
+        let result = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Explicit"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertEqual(result.applied["title"], true)
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "Explicit")
+        XCTAssertEqual(store.getSource(workspaceId: wsId, paneId: paneId, key: "title"), .explicit)
+    }
+
+    // MARK: - clear
+
+    func testClearSpecificKeyRemovesValue() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "T", "description": "D"],
+            mode: .merge,
+            source: .explicit
+        )
+        _ = try store.clearMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            keys: ["title"],
+            source: .explicit
+        )
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertNil(snap.metadata["title"])
+        XCTAssertEqual(snap.metadata["description"] as? String, "D")
+    }
+
+    func testClearAllRequiresExplicit() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "T"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertThrowsError(
+            try store.clearMetadata(
+                workspaceId: wsId,
+                paneId: paneId,
+                keys: nil,
+                source: .declare
+            )
+        )
+    }
+
+    // MARK: - cap enforcement
+
+    func testOverCapWriteIsRejected() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        let big = String(repeating: "x", count: PaneMetadataStore.payloadCapBytes + 128)
+        XCTAssertThrowsError(
+            try store.setMetadata(
+                workspaceId: wsId,
+                paneId: paneId,
+                partial: ["blob": big],
+                mode: .merge,
+                source: .explicit
+            )
+        )
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertNil(snap.metadata["blob"], "Rejected over-cap write must not land")
+    }
+
+    // MARK: - revision counter
+
+    func testSetMetadataBumpsRevisionOnce() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        let before = store.currentRevision()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "v1"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before &+ 1)
+    }
+
+    func testIdempotentWriteDoesNotBumpRevision() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "v"],
+            mode: .merge,
+            source: .explicit
+        )
+        let before = store.currentRevision()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "v"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before)
+    }
+
+    func testRejectedLowerPrecedenceDoesNotBump() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Explicit"],
+            mode: .merge,
+            source: .explicit
+        )
+        let before = store.currentRevision()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Declared"],
+            mode: .merge,
+            source: .declare
+        )
+        XCTAssertEqual(store.currentRevision(), before)
+    }
+
+    func testClearNonexistentKeyDoesNotBump() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        let before = store.currentRevision()
+        _ = try store.clearMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            keys: ["never-set"],
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before)
+    }
+
+    func testClearExistingKeyBumpsRevision() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "T"],
+            mode: .merge,
+            source: .explicit
+        )
+        let before = store.currentRevision()
+        _ = try store.clearMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            keys: ["title"],
+            source: .explicit
+        )
+        XCTAssertEqual(store.currentRevision(), before &+ 1)
+    }
+
+    func testRestoreFromSnapshotBumpsRevision() {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        let before = store.currentRevision()
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            paneId: paneId,
+            values: ["title": "Restored"],
+            sources: [
+                "title": PaneMetadataStore.SourceRecord(source: .explicit, ts: 1.0)
+            ]
+        )
+        XCTAssertEqual(store.currentRevision(), before &+ 1)
+    }
+
+    // MARK: - restore precedence
+
+    func testRestoreInstallsSnapshotAboveExistingWrite() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Newly Declared"],
+            mode: .merge,
+            source: .declare
+        )
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            paneId: paneId,
+            values: ["title": "From Snapshot"],
+            sources: [
+                "title": PaneMetadataStore.SourceRecord(source: .explicit, ts: 123.0)
+            ]
+        )
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "From Snapshot")
+        XCTAssertEqual(store.getSource(workspaceId: wsId, paneId: paneId, key: "title"), .explicit)
+    }
+
+    func testPostRestoreLowerPrecedenceCannotOverwrite() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            paneId: paneId,
+            values: ["title": "Explicit Title"],
+            sources: [
+                "title": PaneMetadataStore.SourceRecord(source: .explicit, ts: 100.0)
+            ]
+        )
+        let result = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "Declared Title"],
+            mode: .merge,
+            source: .declare
+        )
+        XCTAssertEqual(result.applied["title"], false)
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertEqual(snap.metadata["title"] as? String, "Explicit Title")
+    }
+
+    // MARK: - pane / workspace lifecycle
+
+    func testRemovePaneDropsMetadata() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: ["title": "T"],
+            mode: .merge,
+            source: .explicit
+        )
+        store.removePane(workspaceId: wsId, paneId: paneId)
+        // removePane is async; drain the store's queue by issuing a sync read.
+        _ = store.currentRevision()
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        XCTAssertTrue(snap.metadata.isEmpty)
+    }
+
+    func testPruneWorkspaceKeepsValidPanes() throws {
+        let store = PaneMetadataStore.shared
+        let wsId = UUID()
+        let keep = UUID()
+        let drop = UUID()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: keep,
+            partial: ["title": "Keep"],
+            mode: .merge,
+            source: .explicit
+        )
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: drop,
+            partial: ["title": "Drop"],
+            mode: .merge,
+            source: .explicit
+        )
+        store.pruneWorkspace(workspaceId: wsId, validPaneIds: [keep])
+        _ = store.currentRevision()
+        XCTAssertEqual(
+            store.getMetadata(workspaceId: wsId, paneId: keep).metadata["title"] as? String,
+            "Keep"
+        )
+        XCTAssertTrue(store.getMetadata(workspaceId: wsId, paneId: drop).metadata.isEmpty)
+    }
+
+    // MARK: - persistence round-trip
+
+    /// Tier 1 Phase 2's persistence rails (`PersistedJSONValue` /
+    /// `PersistedMetadataSource`) are reused for panes in Phase 3. Round-trip
+    /// through the bridge here so the scaffolding ships with confidence the
+    /// Phase 3 decode path will work.
+    func testSnapshotRoundTripViaPersistedJSONBridge() throws {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = try store.setMetadata(
+            workspaceId: wsId,
+            paneId: paneId,
+            partial: [
+                "title": "Login :: Review",
+                "description": "breadcrumb"
+            ],
+            mode: .merge,
+            source: .explicit
+        )
+        let snap = store.getMetadata(workspaceId: wsId, paneId: paneId)
+        let encodedValues = PersistedMetadataBridge.encodeValues(snap.metadata)
+        let encodedSources = PersistedMetadataBridge.encodeSources(snap.sources)
+
+        let valuesData = try JSONEncoder().encode(encodedValues)
+        let sourcesData = try JSONEncoder().encode(encodedSources)
+        let decodedValues = try JSONDecoder().decode(
+            [String: PersistedJSONValue].self, from: valuesData
+        )
+        let decodedSources = try JSONDecoder().decode(
+            [String: PersistedMetadataSource].self, from: sourcesData
+        )
+
+        // Install into a fresh pane via the restore path.
+        let restoredPane = UUID()
+        store.restoreFromSnapshot(
+            workspaceId: wsId,
+            paneId: restoredPane,
+            values: PersistedMetadataBridge.decodeValues(decodedValues),
+            sources: PersistedMetadataBridge.decodeSources(decodedSources)
+        )
+        let restored = store.getMetadata(workspaceId: wsId, paneId: restoredPane)
+        XCTAssertEqual(restored.metadata["title"] as? String, "Login :: Review")
+        XCTAssertEqual(restored.metadata["description"] as? String, "breadcrumb")
+        XCTAssertEqual(
+            store.getSource(workspaceId: wsId, paneId: restoredPane, key: "title"),
+            .explicit
+        )
+    }
+
+    // MARK: - setInternal
+
+    func testSetInternalBumpsOnNewKey() {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        let before = store.currentRevision()
+        let applied = store.setInternal(
+            workspaceId: wsId,
+            paneId: paneId,
+            key: "role",
+            value: "sub-agent",
+            source: .declare
+        )
+        XCTAssertTrue(applied)
+        XCTAssertEqual(store.currentRevision(), before &+ 1)
+    }
+
+    func testSetInternalDoesNotBumpOnIdempotentWrite() {
+        let (store, wsId, paneId) = makeStoreAndPane()
+        _ = store.setInternal(
+            workspaceId: wsId,
+            paneId: paneId,
+            key: "role",
+            value: "sub-agent",
+            source: .declare
+        )
+        let before = store.currentRevision()
+        _ = store.setInternal(
+            workspaceId: wsId,
+            paneId: paneId,
+            key: "role",
+            value: "sub-agent",
+            source: .declare
+        )
+        XCTAssertEqual(store.currentRevision(), before)
+    }
+
+    // MARK: - concurrency
+
+    func testConcurrentMutationsYieldMonotonicCounter() {
+        let store = PaneMetadataStore.shared
+        let before = store.currentRevision()
+
+        let totalWrites = 200
+        let group = DispatchGroup()
+        let queues: [DispatchQueue] = (0..<4).map {
+            DispatchQueue(label: "test.pane.metadata.revision.\($0)", attributes: .concurrent)
+        }
+        let perQueue = totalWrites / queues.count
+        for q in queues {
+            for i in 0..<perQueue {
+                group.enter()
+                q.async {
+                    _ = store.setInternal(
+                        workspaceId: UUID(),
+                        paneId: UUID(),
+                        key: "k\(i)",
+                        value: "v\(i)",
+                        source: .declare
+                    )
+                    group.leave()
+                }
+            }
+        }
+        group.wait()
+        let after = store.currentRevision()
+        XCTAssertEqual(
+            after, before &+ UInt64(totalWrites),
+            "Concurrent mutations must all be accounted for in the counter"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of CMUX-11 nameable panes — adds the `PaneMetadataStore` scaffolding so panes can carry first-class metadata (initial consumer: a free-form title with `::` lineage). Mirrors `SurfaceMetadataStore` exactly: same JSON value fidelity, source-precedence chain, 64 KiB cap, and monotonic revision counter that folds into the existing autosave fingerprint.

**Scaffolding only — no live consumers.** Phase 2 wires socket RPCs (`pane.set_metadata` / `.get` / `.clear`) and CLI; Phase 3 plumbs persistence via `SessionPaneSnapshot`; Phase 4 lands the skill cross-reference.

## Design notes

- **\"It's text. Trust the LLM.\"** Pane title is a single string. `::` is a convention, not a system delimiter — no auto-copy at split time, no merge rules, no close-time snapshotting. Per `docs/c11mux-pane-naming-plan.md` KEY DECISIONS, all non-negotiable.
- **Type aliasing over duplication.** `SourceRecord`, `WriteError`, `WriteMode`, `WriteResult` are aliased from `SurfaceMetadataStore` rather than re-declared. Future validation tightening flows automatically.
- **Reserved key set borrowed wholesale.** Title and description are the immediate consumers, but the full canonical surface key set is allowed so future pane-level metadata (status/role/progress) lands without a schema bump.
- **No window parity.** Out of scope per the plan — windows don't split, simpler case, defer.

## Tests

`cmuxTests/PaneMetadataStoreTests.swift` (21 tests):
- set/get/clear (merge, replace, replace-requires-explicit)
- source precedence (lower rejected, higher wins)
- cap enforcement
- revision counter (bump on mutation, no-bump on idempotent / rejected / clear-empty)
- restore-from-snapshot bypasses precedence; post-restore writes still respect it
- pane / workspace lifecycle (`removePane`, `pruneWorkspace`)
- round-trip through `PersistedJSONValue` / `PersistedMetadataSource` bridge — verifies Phase 3 persistence rails work today
- concurrent mutation monotonicity

OSC- and heuristic-specific tests are omitted: those sources don't apply to panes in v1. The precedence chain is still exercised end-to-end via `.declare`.

## Test plan
- [ ] CI Debug build passes
- [ ] CI unit tests pass (`PaneMetadataStoreTests`)
- [ ] No regressions in existing `MetadataStoreRevisionCounterTests` / `MetadataPersistencePrecedenceTests` / `MetadataPersistenceRoundTripTests`

## Lattice

CMUX-11 (`task_01KPHENJCMVS1FFH0HDJ6V3PN8`). Plan doc: `docs/c11mux-pane-naming-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)