### PR TITLE
CMUX-15: Default pane grid sized to monitor class (3x3 / 2x3 / 2x2)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
 		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
 		D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
+		D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */; };
 		D7006BF0A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */; };
 		D7007BF0A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */; };
 		D7008BF0A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */; };
@@ -219,6 +220,7 @@
 		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
 		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
 		D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStoreTests.swift; sourceTree = "<group>"; };
+		D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGridSettingsTests.swift; sourceTree = "<group>"; };
 		D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceRoundTripTests.swift; sourceTree = "<group>"; };
 		D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistencePrecedenceTests.swift; sourceTree = "<group>"; };
 		D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceUncoercibleTests.swift; sourceTree = "<group>"; };
@@ -622,6 +624,7 @@
 					D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */,
 					D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */,
 					D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */,
+					D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -909,6 +912,7 @@
 					D7008BF0A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift in Sources */,
 					D7009BF0A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift in Sources */,
 					D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */,
+					D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5988,6 +5988,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+    func spawnDefaultGridWhenReady(to workspace: Workspace) {
+        let workspaceId = workspace.id
+        runWhenInitialTerminalReady(in: workspace) { [weak self] initialPanel in
+            // Resolve at dispatch time; the hosting window is typically not
+            // attached when addWorkspace returns.
+            let window = self?.mainWindowContainingWorkspace(workspaceId)
+            let screenFrame = DefaultGridSettings.resolvedScreenFrame(for: window)
+            DefaultGridSettings.performDefaultGrid(
+                on: workspace,
+                initialPanel: initialPanel,
+                screenFrame: screenFrame
+            )
+        }
+    }
+
     private func runWhenInitialTerminalReady(
         in workspace: Workspace,
         _ action: @escaping (TerminalPanel) -> Void

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1173,6 +1173,14 @@ class TabManager: ObservableObject {
             } else {
                 sendWelcomeWhenReady(to: newWorkspace)
             }
+        } else if autoWelcomeIfNeeded && select && DefaultGridSettings.isEnabled() {
+            // Welcome already ran (or is disabled): every subsequent new
+            // workspace gets the monitor-classed default grid when enabled.
+            if let appDelegate = AppDelegate.shared {
+                appDelegate.spawnDefaultGridWhenReady(to: newWorkspace)
+            } else {
+                spawnDefaultGridWhenReady(to: newWorkspace)
+            }
         }
         return newWorkspace
     }
@@ -1204,6 +1212,73 @@ class TabManager: ObservableObject {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 UserDefaults.standard.set(true, forKey: WelcomeSettings.shownKey)
                 WelcomeSettings.performQuadLayout(on: workspace, initialPanel: terminalPanel)
+            }
+        }
+
+        panelsCancellable = workspace.$panels
+            .map { _ in () }
+            .sink { _ in
+                Task { @MainActor in
+                    finishIfReady()
+                }
+            }
+        readyObserver = NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceDidBecomeReady,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let workspaceId = note.userInfo?["workspaceId"] as? UUID,
+                  workspaceId == workspace.id else { return }
+            Task { @MainActor in
+                finishIfReady()
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            Task { @MainActor in
+                if let readyObserver, !resolved {
+                    NotificationCenter.default.removeObserver(readyObserver)
+                }
+                if !resolved {
+                    panelsCancellable?.cancel()
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func spawnDefaultGridWhenReady(to workspace: Workspace) {
+        func performGrid(_ initialPanel: TerminalPanel) {
+            let screenFrame = DefaultGridSettings.resolvedScreenFrame(for: nil)
+            DefaultGridSettings.performDefaultGrid(
+                on: workspace,
+                initialPanel: initialPanel,
+                screenFrame: screenFrame
+            )
+        }
+
+        if let terminalPanel = workspace.focusedTerminalPanel,
+           terminalPanel.surface.surface != nil {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                performGrid(terminalPanel)
+            }
+            return
+        }
+
+        var resolved = false
+        var readyObserver: NSObjectProtocol?
+        var panelsCancellable: AnyCancellable?
+
+        func finishIfReady() {
+            guard !resolved,
+                  let terminalPanel = workspace.focusedTerminalPanel,
+                  terminalPanel.surface.surface != nil else { return }
+            resolved = true
+            if let readyObserver {
+                NotificationCenter.default.removeObserver(readyObserver)
+            }
+            panelsCancellable?.cancel()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                performGrid(terminalPanel)
             }
         }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3814,6 +3814,142 @@ enum WelcomeSettings {
     }
 }
 
+enum DefaultGridSettings {
+    static let enabledKey = "cmuxDefaultGridEnabled"
+    static let defaultEnabled = true
+
+    // Pixel-dimension thresholds (width × height) that classify the host screen
+    // into a default grid shape. Chosen on width primarily, matching typical
+    // desktop marketing resolutions (4K, QHD, and sub-QHD).
+    static let fourKMinWidth: CGFloat = 3840
+    static let fourKMinHeight: CGFloat = 2160
+    static let qhdMinWidth: CGFloat = 2560
+    static let qhdMinHeight: CGFloat = 1440
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    /// Pure function mapping a screen's pixel frame to a grid shape.
+    /// Degenerate or missing screens fall back to 1×1 (no splits).
+    static func classify(screenFrame: NSRect) -> (cols: Int, rows: Int) {
+        let width = screenFrame.width
+        let height = screenFrame.height
+        guard width > 0, height > 0 else { return (cols: 1, rows: 1) }
+        if width >= fourKMinWidth && height >= fourKMinHeight {
+            return (cols: 3, rows: 3)
+        }
+        if width >= qhdMinWidth && height >= qhdMinHeight {
+            return (cols: 2, rows: 3)
+        }
+        return (cols: 2, rows: 2)
+    }
+
+    /// Describes a single split operation inside a grid build: which column's
+    /// current bottom-most panel to split, and in what direction.
+    struct SplitOp: Equatable {
+        enum Direction: Equatable {
+            /// Split horizontally (side-by-side) to create a new column.
+            case horizontalToNewColumn
+            /// Split vertically (top-bottom) below the current column tail.
+            case verticalDownInColumn
+        }
+
+        let column: Int
+        let direction: Direction
+    }
+
+    /// Pure grid construction schedule. Phase 1 fans out `cols - 1` columns
+    /// to the right of the initial panel. Phase 2 walks each column and
+    /// stacks `rows - 1` additional panes vertically beneath the column head.
+    static func gridSplitOperations(cols: Int, rows: Int) -> [SplitOp] {
+        guard cols >= 1, rows >= 1 else { return [] }
+        var ops: [SplitOp] = []
+        for col in 1..<cols {
+            ops.append(SplitOp(column: col, direction: .horizontalToNewColumn))
+        }
+        for col in 0..<cols {
+            for _ in 1..<rows {
+                ops.append(SplitOp(column: col, direction: .verticalDownInColumn))
+            }
+        }
+        return ops
+    }
+
+    /// Resolves the pixel frame of the screen that best contains the given
+    /// window. Returns `.zero` if no screen can be resolved, which the
+    /// classifier treats as the 1×1 fallback (no grid).
+    static func resolvedScreenFrame(for window: NSWindow?) -> NSRect {
+        if let screen = window?.screen {
+            return screen.frame
+        }
+        if let window, let best = bestScreen(for: window) {
+            return best.frame
+        }
+        return NSScreen.main?.frame ?? .zero
+    }
+
+    private static func bestScreen(for window: NSWindow) -> NSScreen? {
+        let windowFrame = window.frame
+        return NSScreen.screens.max { lhs, rhs in
+            lhs.frame.intersection(windowFrame).area < rhs.frame.intersection(windowFrame).area
+        }
+    }
+
+    /// Auto-spawns a cols × rows terminal grid rooted at `initialPanel`. Silently
+    /// truncates the build if any split fails (partial grid is acceptable).
+    /// Callers decide when the initial panel's Ghostty surface is ready.
+    @MainActor
+    static func performDefaultGrid(
+        on workspace: Workspace,
+        initialPanel: TerminalPanel,
+        screenFrame: NSRect
+    ) {
+        let (cols, rows) = classify(screenFrame: screenFrame)
+        guard cols > 1 || rows > 1 else { return }
+
+        let ops = gridSplitOperations(cols: cols, rows: rows)
+
+        // columnTails[col] = the panel currently occupying the bottom of column col.
+        // Seeded with the initial panel in column 0; other columns are populated
+        // by the phase-1 horizontal splits before any vertical splits run.
+        var columnTails: [Int: TerminalPanel] = [0: initialPanel]
+
+        for op in ops {
+            switch op.direction {
+            case .horizontalToNewColumn:
+                // Chain off the previous column's head so columns march rightward.
+                let sourceColumn = op.column - 1
+                guard let source = columnTails[sourceColumn] else { return }
+                guard let newPanel = workspace.newTerminalSplit(
+                    from: source.id,
+                    orientation: .horizontal,
+                    insertFirst: false,
+                    focus: false
+                ) else { return }
+                columnTails[op.column] = newPanel
+
+            case .verticalDownInColumn:
+                guard let source = columnTails[op.column] else { return }
+                guard let newPanel = workspace.newTerminalSplit(
+                    from: source.id,
+                    orientation: .vertical,
+                    insertFirst: false,
+                    focus: false
+                ) else { return }
+                columnTails[op.column] = newPanel
+            }
+        }
+    }
+}
+
+private extension NSRect {
+    var area: CGFloat { width * height }
+}
+
 enum TelemetrySettings {
     static let sendAnonymousTelemetryKey = "sendAnonymousTelemetry"
     static let defaultSendAnonymousTelemetry = true

--- a/cmuxTests/DefaultGridSettingsTests.swift
+++ b/cmuxTests/DefaultGridSettingsTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Unit tests for `DefaultGridSettings` — the pure classification and
+/// grid-construction helpers that power the default monitor-sized pane grid.
+final class DefaultGridSettingsTests: XCTestCase {
+
+    // MARK: - classify()
+
+    func testClassify4KProducesThreeByThree() {
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 3840, height: 2160))
+        XCTAssertEqual(cols, 3)
+        XCTAssertEqual(rows, 3)
+    }
+
+    func testClassifyAboveFourKProducesThreeByThree() {
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 5120, height: 2880))
+        XCTAssertEqual(cols, 3)
+        XCTAssertEqual(rows, 3)
+    }
+
+    func testClassifyQHDProducesTwoByThree() {
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 2560, height: 1440))
+        XCTAssertEqual(cols, 2)
+        XCTAssertEqual(rows, 3)
+    }
+
+    func testClassifyBetweenQHDAndFourKProducesTwoByThree() {
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 3440, height: 1440))
+        XCTAssertEqual(cols, 2)
+        XCTAssertEqual(rows, 3)
+    }
+
+    func testClassifyLaptopProducesTwoByTwo() {
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 1920, height: 1080))
+        XCTAssertEqual(cols, 2)
+        XCTAssertEqual(rows, 2)
+    }
+
+    func testClassifySmallProducesTwoByTwo() {
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 1280, height: 800))
+        XCTAssertEqual(cols, 2)
+        XCTAssertEqual(rows, 2)
+    }
+
+    func testClassifyZeroRectProducesOneByOneFallback() {
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: .zero)
+        XCTAssertEqual(cols, 1)
+        XCTAssertEqual(rows, 1)
+    }
+
+    func testClassifyFourKWidthButSubQHDHeightFallsToQHDClass() {
+        // 3840 wide but only 1600 tall: width alone is insufficient — the
+        // height check gates the 4K bucket, so classification lands at QHD.
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 3840, height: 1600))
+        XCTAssertEqual(cols, 2)
+        XCTAssertEqual(rows, 3)
+    }
+
+    // MARK: - gridSplitOperations()
+
+    func testGridOpsOneByOneProducesNoSplits() {
+        XCTAssertEqual(DefaultGridSettings.gridSplitOperations(cols: 1, rows: 1), [])
+    }
+
+    func testGridOpsTwoByTwoProducesThreeSplits() {
+        let ops = DefaultGridSettings.gridSplitOperations(cols: 2, rows: 2)
+        XCTAssertEqual(ops.count, 3)
+        // Phase 1: one horizontal split to build column 1.
+        XCTAssertEqual(ops[0], DefaultGridSettings.SplitOp(column: 1, direction: .horizontalToNewColumn))
+        // Phase 2: one vertical split per column.
+        XCTAssertEqual(ops[1], DefaultGridSettings.SplitOp(column: 0, direction: .verticalDownInColumn))
+        XCTAssertEqual(ops[2], DefaultGridSettings.SplitOp(column: 1, direction: .verticalDownInColumn))
+    }
+
+    func testGridOpsTwoByThreeProducesFiveSplits() {
+        let ops = DefaultGridSettings.gridSplitOperations(cols: 2, rows: 3)
+        XCTAssertEqual(ops.count, 5)
+        XCTAssertEqual(ops[0], DefaultGridSettings.SplitOp(column: 1, direction: .horizontalToNewColumn))
+        // Column 0 gets two vertical splits, then column 1 gets two.
+        XCTAssertEqual(ops[1], DefaultGridSettings.SplitOp(column: 0, direction: .verticalDownInColumn))
+        XCTAssertEqual(ops[2], DefaultGridSettings.SplitOp(column: 0, direction: .verticalDownInColumn))
+        XCTAssertEqual(ops[3], DefaultGridSettings.SplitOp(column: 1, direction: .verticalDownInColumn))
+        XCTAssertEqual(ops[4], DefaultGridSettings.SplitOp(column: 1, direction: .verticalDownInColumn))
+    }
+
+    func testGridOpsThreeByThreeProducesEightSplits() {
+        let ops = DefaultGridSettings.gridSplitOperations(cols: 3, rows: 3)
+        XCTAssertEqual(ops.count, 8)
+        // Phase 1: two horizontal splits in column-order to build columns 1 and 2.
+        XCTAssertEqual(ops[0].direction, .horizontalToNewColumn)
+        XCTAssertEqual(ops[0].column, 1)
+        XCTAssertEqual(ops[1].direction, .horizontalToNewColumn)
+        XCTAssertEqual(ops[1].column, 2)
+        // Phase 2: six vertical splits, two per column.
+        let verticalOps = ops.dropFirst(2)
+        XCTAssertTrue(verticalOps.allSatisfy { $0.direction == .verticalDownInColumn })
+        let columnCounts = Dictionary(grouping: verticalOps, by: { $0.column }).mapValues { $0.count }
+        XCTAssertEqual(columnCounts[0], 2)
+        XCTAssertEqual(columnCounts[1], 2)
+        XCTAssertEqual(columnCounts[2], 2)
+    }
+
+    func testGridOpsTotalMatchesColsTimesRowsMinusOne() {
+        for cols in 1...4 {
+            for rows in 1...4 {
+                let ops = DefaultGridSettings.gridSplitOperations(cols: cols, rows: rows)
+                XCTAssertEqual(ops.count, cols * rows - 1, "cols=\(cols) rows=\(rows)")
+            }
+        }
+    }
+
+    // MARK: - isEnabled()
+
+    func testIsEnabledDefaultsTrueWhenKeyUnset() {
+        let defaults = UserDefaults(suiteName: "DefaultGridSettingsTests.\(UUID().uuidString)")!
+        defaults.removeObject(forKey: DefaultGridSettings.enabledKey)
+        XCTAssertTrue(DefaultGridSettings.isEnabled(defaults: defaults))
+    }
+
+    func testIsEnabledReturnsFalseWhenKeyFalse() {
+        let defaults = UserDefaults(suiteName: "DefaultGridSettingsTests.\(UUID().uuidString)")!
+        defaults.set(false, forKey: DefaultGridSettings.enabledKey)
+        XCTAssertFalse(DefaultGridSettings.isEnabled(defaults: defaults))
+    }
+
+    func testIsEnabledReturnsTrueWhenKeyTrue() {
+        let defaults = UserDefaults(suiteName: "DefaultGridSettingsTests.\(UUID().uuidString)")!
+        defaults.set(true, forKey: DefaultGridSettings.enabledKey)
+        XCTAssertTrue(DefaultGridSettings.isEnabled(defaults: defaults))
+    }
+}


### PR DESCRIPTION
## Summary

Auto-spawns a default terminal pane grid on new workspaces, sized to the host screen's pixel class:

| Resolution class                              | Grid (cols × rows) | Total panes |
|-----------------------------------------------|--------------------|-------------|
| ≥ 3840 × 2160 (4K, typical 32"+)              | 3 × 3              | 9           |
| ≥ 2560 × 1440 (QHD, typical 27")              | 2 × 3              | 6           |
| < 2560 × 1440 (laptop/small external)          | 2 × 2              | 4           |

Mirrors the welcome-quad pattern — runs after the initial Ghostty surface is ready, chains programmatic splits through `newTerminalSplit`, and silently bails on partial failure. Gated by `cmuxDefaultGridEnabled` UserDefaults (default: `true`). Welcome-quad still wins on first run; saved session layouts still win on restore.

Lattice ticket: [CMUX-15](./.lattice/tasks/task_01KPHHQ6T4K09KE9YF20KPT8VS.json)
Plan: [.lattice/plans/task_01KPHHQ6T4K09KE9YF20KPT8VS.md](./.lattice/plans/task_01KPHHQ6T4K09KE9YF20KPT8VS.md)

## Open questions — defaults I chose (needs sign-off)

The plan listed 7 open questions. I went with the proposed defaults rather than blocking. Flag any you want changed:

| # | Question | Default used |
|---|---|---|
| 1 | Ultra-wide monitors (5120×1440) | Classified by width/height independently; 5120×1440 → 2×3 (height gates 4K bucket). Defer special-case. |
| 2 | Opt-out UX | UserDefaults-only for MVP. No settings pane UI. `defaults write com.cmux.app cmuxDefaultGridEnabled -bool false` to disable. |
| 3 | First new workspace after welcome ran | Yes — default grid fires on all subsequent new workspaces. |
| 4 | Pane content | All terminals (no mixed surfaces like the welcome quad). |
| 5 | Pixel breakpoints | 3840×2160 and 2560×1440 as written in plan. |
| 6 | Ultra-portrait monitors | Fixed table, don't auto-rotate. |
| 7 | Workspace-scoped settings precedence | Out of MVP scope; defer. |

## Implementation

- `enum DefaultGridSettings` in `Sources/cmuxApp.swift` adjacent to `WelcomeSettings`. Owns:
  - `isEnabled()` — UserDefaults gate.
  - `classify(screenFrame:)` — pure pixel-dim → `(cols, rows)`.
  - `gridSplitOperations(cols:rows:)` — pure split schedule (testable without a running app).
  - `resolvedScreenFrame(for:)` — window → NSScreen.frame resolution with `.zero` fallback (no crash if no screen).
  - `performDefaultGrid(on:initialPanel:screenFrame:)` — applies the grid via `workspace.newTerminalSplit` calls.
- `AppDelegate.spawnDefaultGridWhenReady(to:)` — mirrors `sendWelcomeCommandWhenReady`, resolves screen at dispatch time.
- `TabManager.addWorkspace` — adds `else if` branch after the welcome check; gracefully falls back to TabManager's own surface-ready path when `AppDelegate.shared` is unavailable.

## Test plan

- [x] Unit tests on `DefaultGridSettings.classify` (7 threshold cases including zero rect) + `gridSplitOperations` (shape + algebraic `cols*rows-1` invariant) + `isEnabled` (3 defaults cases) — run on CI.
- [x] Build: `./scripts/reload.sh --tag cmux-15-default-grid` → BUILD SUCCEEDED.
- [ ] Manual: open a new workspace on primary display, verify grid matches classification. Deferred to reviewer — test execution runs on CI per project policy (`feedback_cmux_never_run_xcodebuild_test`).

## Not in scope

- Multi-monitor support (tracked separately as CMUX-16, sibling ticket).
- Reshuffling on monitor class change between sessions.
- Settings-pane UI toggle for `cmuxDefaultGridEnabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)