### PR TITLE
CMUX-11 Phase 2: pane metadata RPCs + CLI + --title seeding

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1714,9 +1714,10 @@ struct CMUXCLI {
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
             let (panelArg, rem1) = parseOption(rem0, name: "--panel")
             let (sfArg, rem2) = parseOption(rem1, name: "--surface")
+            let (titleArg, rem3) = parseOption(rem2, name: "--title")
             let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceRaw = sfArg ?? panelArg ?? (wsArg == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
-            guard let direction = rem2.first else {
+            guard let direction = rem3.first else {
                 throw CLIError(message: "new-split requires a direction")
             }
             var params: [String: Any] = ["direction": direction]
@@ -1724,6 +1725,7 @@ struct CMUXCLI {
             if let wsId { params["workspace_id"] = wsId }
             let sfId = try normalizeSurfaceHandle(surfaceRaw, client: client, workspaceHandle: wsId)
             if let sfId { params["surface_id"] = sfId }
+            if let titleArg, !titleArg.isEmpty { params["title"] = titleArg }
             let payload = try client.sendV2(method: "surface.split", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
 
@@ -1800,12 +1802,14 @@ struct CMUXCLI {
             let direction = optionValue(commandArgs, name: "--direction") ?? "right"
             let url = optionValue(commandArgs, name: "--url")
             let file = optionValue(commandArgs, name: "--file")
+            let title = optionValue(commandArgs, name: "--title")
             var params: [String: Any] = ["direction": direction]
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
             if let type { params["type"] = type }
             if let url { params["url"] = url }
             if let file { params["file"] = file }
+            if let title, !title.isEmpty { params["title"] = title }
             let payload = try client.sendV2(method: "pane.create", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
@@ -6676,10 +6680,12 @@ struct CMUXCLI {
               --workspace <id|ref>   Target workspace (default: $CMUX_WORKSPACE_ID)
               --surface <id|ref>     Surface to split from (default: $CMUX_SURFACE_ID)
               --panel <id|ref>       Alias for --surface
+              --title <text>         Seed the new pane's title metadata atomically with creation
 
             Example:
               cmux new-split right
               cmux new-split down --workspace workspace:1
+              cmux new-split right --title "Parent :: Code Review"
             """
         case "list-panes":
             return """
@@ -6776,11 +6782,13 @@ struct CMUXCLI {
               --workspace <id|ref>                Target workspace (default: $CMUX_WORKSPACE_ID)
               --url <url>                         URL for browser panes
               --file <path>                       File path for markdown panes
+              --title <text>                      Seed the new pane's title metadata atomically with creation
 
             Example:
               cmux new-pane
               cmux new-pane --type browser --direction down --url https://example.com
               cmux new-pane --type markdown --file ~/docs/README.md
+              cmux new-pane --title "Parent :: Code Review"
             """
         case "new-surface":
             return """
@@ -7409,13 +7417,14 @@ struct CMUXCLI {
             """
         case "set-metadata":
             return """
-            Usage: cmux set-metadata [--surface <id|ref>] [--workspace <id|ref>]
+            Usage: cmux set-metadata [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]
                                      (--json '{...}' | --key <K> --value <V> [--type string|number|bool|json])
                                      [--mode merge|replace] [--source explicit|declare|osc|heuristic]
                                      [--json]
 
-            Set one or more metadata keys on a surface via surface.set_metadata.
-            Defaults: mode=merge, source=explicit.
+            Set one or more metadata keys on a surface (surface.set_metadata) or
+            pane (pane.set_metadata). Defaults: mode=merge, source=explicit.
+            --surface and --pane are mutually exclusive.
 
             Flags:
               --json '{...}'           Full JSON object of keys/values
@@ -7424,51 +7433,59 @@ struct CMUXCLI {
               --mode <merge|replace>   Merge (default) or full replace (source=explicit only)
               --source <src>           Write source (default: explicit)
               --surface <id|ref>       Target surface (default: $CMUX_SURFACE_ID / focused)
+              --pane <id|ref>          Target pane (routes to pane.set_metadata)
               --workspace <id|ref>     Target workspace (default: $CMUX_WORKSPACE_ID)
 
             Examples:
               cmux set-metadata --key title --value "My Surface"
               cmux set-metadata --json '{"title":"x","role":"review"}'
               cmux set-metadata --key progress --value 0.5 --type number
+              cmux set-metadata --pane pane:2 --key title --value "Pane :: Child"
             """
         case "get-metadata":
             return """
-            Usage: cmux get-metadata [--surface <id|ref>] [--workspace <id|ref>]
+            Usage: cmux get-metadata [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]
                                      [--key <K> ...] [--sources] [--json]
 
-            Read metadata (and optional per-key sidecar) for a surface via
-            surface.get_metadata. Repeat --key to filter to specific keys.
+            Read metadata (and optional per-key sidecar) for a surface
+            (surface.get_metadata) or pane (pane.get_metadata). Repeat --key to
+            filter. --surface and --pane are mutually exclusive.
 
             Flags:
               --key <K>                Restrict to one key (repeatable)
               --sources                Include metadata_sources sidecar
               --surface <id|ref>       Target surface (default: $CMUX_SURFACE_ID / focused)
+              --pane <id|ref>          Target pane (routes to pane.get_metadata)
               --workspace <id|ref>     Target workspace (default: $CMUX_WORKSPACE_ID)
               --json                   Emit raw JSON result
 
             Examples:
               cmux get-metadata
               cmux get-metadata --key terminal_type --sources
+              cmux get-metadata --pane pane:2
             """
         case "clear-metadata":
             return """
-            Usage: cmux clear-metadata [--surface <id|ref>] [--workspace <id|ref>]
+            Usage: cmux clear-metadata [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]
                                        [--key <K> ...] [--source explicit|declare|osc|heuristic]
                                        [--json]
 
-            Clear keys from a surface's metadata via surface.clear_metadata. With no
-            --key flags, clears the entire blob (requires source=explicit).
+            Clear keys from a surface (surface.clear_metadata) or pane
+            (pane.clear_metadata). With no --key flags, clears the entire blob
+            (requires source=explicit). --surface and --pane are mutually exclusive.
 
             Flags:
               --key <K>                Key to clear (repeatable)
               --source <src>           Precedence source (default: explicit)
               --surface <id|ref>       Target surface (default: $CMUX_SURFACE_ID / focused)
+              --pane <id|ref>          Target pane (routes to pane.clear_metadata)
               --workspace <id|ref>     Target workspace (default: $CMUX_WORKSPACE_ID)
               --json                   Emit raw JSON result
 
             Examples:
               cmux clear-metadata --key terminal_type
               cmux clear-metadata --surface surface:2
+              cmux clear-metadata --pane pane:2 --key title
             """
         case "set-workspace-metadata":
             return """
@@ -8535,6 +8552,49 @@ struct CMUXCLI {
         return (workspaceId, surfaceId)
     }
 
+    /// Result of resolving a metadata command's target when either a pane or
+    /// a surface may be specified. `--surface` and `--pane` are mutually
+    /// exclusive; default (neither) routes to the caller's current surface
+    /// per existing behavior.
+    private enum MetadataCommandTarget {
+        case surface(workspaceId: String?, surfaceId: String?)
+        case pane(workspaceId: String?, paneId: String)
+    }
+
+    private func resolveMetadataCommandTarget(
+        commandArgs: [String],
+        client: SocketClient,
+        windowOverride: String?
+    ) throws -> MetadataCommandTarget {
+        let surfaceRaw = optionValue(commandArgs, name: "--surface")
+            ?? optionValue(commandArgs, name: "--panel")
+        let paneRaw = optionValue(commandArgs, name: "--pane")
+
+        if surfaceRaw != nil, paneRaw != nil {
+            throw CLIError(message: "usage: --surface and --pane are mutually exclusive")
+        }
+
+        if let paneRaw {
+            let workspaceRaw = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowOverride)
+            let workspaceId = try normalizeWorkspaceHandle(workspaceRaw, client: client)
+            guard let paneId = try normalizePaneHandle(
+                paneRaw,
+                client: client,
+                workspaceHandle: workspaceId
+            ) else {
+                throw CLIError(message: "Invalid pane handle: \(paneRaw)")
+            }
+            return .pane(workspaceId: workspaceId, paneId: paneId)
+        }
+
+        let (workspaceId, surfaceId) = try resolveMetadataTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        return .surface(workspaceId: workspaceId, surfaceId: surfaceId)
+    }
+
     /// `cmux set-agent` — M1 sugar over `surface.set_metadata { source: declare, mode: merge }`.
     private func runSetAgentCommand(
         commandArgs: [String],
@@ -8634,7 +8694,7 @@ struct CMUXCLI {
 
         let mode = (optionValue(commandArgs, name: "--mode") ?? "merge").lowercased()
         let source = (optionValue(commandArgs, name: "--source") ?? "explicit").lowercased()
-        let (workspaceId, surfaceId) = try resolveMetadataTarget(
+        let target = try resolveMetadataCommandTarget(
             commandArgs: commandArgs,
             client: client,
             windowOverride: windowOverride
@@ -8644,14 +8704,24 @@ struct CMUXCLI {
             "mode": mode,
             "source": source
         ]
-        if let workspaceId { params["workspace_id"] = workspaceId }
-        if let surfaceId { params["surface_id"] = surfaceId }
+        let method: String
+        switch target {
+        case .surface(let workspaceId, let surfaceId):
+            if let workspaceId { params["workspace_id"] = workspaceId }
+            if let surfaceId { params["surface_id"] = surfaceId }
+            method = "surface.set_metadata"
+        case .pane(let workspaceId, let paneId):
+            if let workspaceId { params["workspace_id"] = workspaceId }
+            params["pane_id"] = paneId
+            method = "pane.set_metadata"
+        }
 
-        let payload = try client.sendV2(method: "surface.set_metadata", params: params)
+        let payload = try client.sendV2(method: method, params: params)
         printMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
     }
 
-    /// `cmux get-metadata` — M2 sugar over `surface.get_metadata`.
+    /// `cmux get-metadata` — M2 sugar over `surface.get_metadata` (or
+    /// `pane.get_metadata` when `--pane` is supplied).
     private func runGetMetadataCommand(
         commandArgs: [String],
         client: SocketClient,
@@ -8662,7 +8732,7 @@ struct CMUXCLI {
         let includeSources = hasFlag(commandArgs, name: "--sources")
             || hasFlag(commandArgs, name: "--include-sources")
         let keys = collectRepeatedOption(commandArgs, name: "--key")
-        let (workspaceId, surfaceId) = try resolveMetadataTarget(
+        let target = try resolveMetadataCommandTarget(
             commandArgs: commandArgs,
             client: client,
             windowOverride: windowOverride
@@ -8670,10 +8740,19 @@ struct CMUXCLI {
         var params: [String: Any] = [:]
         if !keys.isEmpty { params["keys"] = keys }
         if includeSources { params["include_sources"] = true }
-        if let workspaceId { params["workspace_id"] = workspaceId }
-        if let surfaceId { params["surface_id"] = surfaceId }
+        let method: String
+        switch target {
+        case .surface(let workspaceId, let surfaceId):
+            if let workspaceId { params["workspace_id"] = workspaceId }
+            if let surfaceId { params["surface_id"] = surfaceId }
+            method = "surface.get_metadata"
+        case .pane(let workspaceId, let paneId):
+            if let workspaceId { params["workspace_id"] = workspaceId }
+            params["pane_id"] = paneId
+            method = "pane.get_metadata"
+        }
 
-        let payload = try client.sendV2(method: "surface.get_metadata", params: params)
+        let payload = try client.sendV2(method: method, params: params)
         if jsonOutput {
             print(jsonString(formatIDs(payload, mode: idFormat)))
             return
@@ -8698,7 +8777,8 @@ struct CMUXCLI {
         }
     }
 
-    /// `cmux clear-metadata` — M2 sugar over `surface.clear_metadata`.
+    /// `cmux clear-metadata` — M2 sugar over `surface.clear_metadata` (or
+    /// `pane.clear_metadata` when `--pane` is supplied).
     private func runClearMetadataCommand(
         commandArgs: [String],
         client: SocketClient,
@@ -8708,17 +8788,26 @@ struct CMUXCLI {
     ) throws {
         let keys = collectRepeatedOption(commandArgs, name: "--key")
         let source = (optionValue(commandArgs, name: "--source") ?? "explicit").lowercased()
-        let (workspaceId, surfaceId) = try resolveMetadataTarget(
+        let target = try resolveMetadataCommandTarget(
             commandArgs: commandArgs,
             client: client,
             windowOverride: windowOverride
         )
         var params: [String: Any] = ["source": source]
         if !keys.isEmpty { params["keys"] = keys }
-        if let workspaceId { params["workspace_id"] = workspaceId }
-        if let surfaceId { params["surface_id"] = surfaceId }
+        let method: String
+        switch target {
+        case .surface(let workspaceId, let surfaceId):
+            if let workspaceId { params["workspace_id"] = workspaceId }
+            if let surfaceId { params["surface_id"] = surfaceId }
+            method = "surface.clear_metadata"
+        case .pane(let workspaceId, let paneId):
+            if let workspaceId { params["workspace_id"] = workspaceId }
+            params["pane_id"] = paneId
+            method = "pane.clear_metadata"
+        }
 
-        let payload = try client.sendV2(method: "surface.clear_metadata", params: params)
+        let payload = try client.sendV2(method: method, params: params)
         printMetadataResult(payload, jsonOutput: jsonOutput, idFormat: idFormat)
     }
 
@@ -12682,12 +12771,12 @@ struct CMUXCLI {
           new-workspace [--cwd <path>] [--command <text>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
-          new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]
+          new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>] [--title <text>]
           list-panes [--workspace <id|ref>]
           list-pane-surfaces [--workspace <id|ref>] [--pane <id|ref>]
           tree [--all] [--workspace <id|ref|index>]
           focus-pane --pane <id|ref> [--workspace <id|ref>]
-          new-pane [--type <terminal|browser|markdown>] [--direction <left|right|up|down>] [--workspace <id|ref>] [--url <url>] [--file <path>]
+          new-pane [--type <terminal|browser|markdown>] [--direction <left|right|up|down>] [--workspace <id|ref>] [--url <url>] [--file <path>] [--title <text>]
           new-surface [--type <terminal|browser|markdown>] [--pane <id|ref>] [--workspace <id|ref>] [--url <url>] [--file <path>]
           close-surface [--surface <id|ref>] [--workspace <id|ref>]
           move-surface --surface <id|ref|index> [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--before <id|ref|index>] [--after <id|ref|index>] [--index <n>] [--focus <true|false>]
@@ -12719,9 +12808,9 @@ struct CMUXCLI {
           clear-notifications
           claude-hook <session-start|stop|notification> [--workspace <id|ref>] [--surface <id|ref>]
           set-agent --type <terminal_type> [--model <id>] [--task <id>] [--role <id>] [--surface <id|ref>] [--workspace <id|ref>]
-          set-metadata (--json '{...}' | --key <K> --value <V> [--type string|number|bool|json]) [--surface <id|ref>] [--workspace <id|ref>] [--mode merge|replace] [--source <src>]
-          get-metadata [--key <K> ...] [--sources] [--surface <id|ref>] [--workspace <id|ref>]
-          clear-metadata [--key <K> ...] [--source <src>] [--surface <id|ref>] [--workspace <id|ref>]
+          set-metadata (--json '{...}' | --key <K> --value <V> [--type string|number|bool|json]) [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>] [--mode merge|replace] [--source <src>]
+          get-metadata [--key <K> ...] [--sources] [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]
+          clear-metadata [--key <K> ...] [--source <src>] [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]
           set-workspace-metadata <key> <value> | --key <K> --value <V> | --json '{...}'  [--workspace <id|ref>]
           get-workspace-metadata [<key>] [--workspace <id|ref>]
           clear-workspace-metadata [<key>] [--key <K> ...] [--workspace <id|ref>]

--- a/Sources/PaneMetadataStore.swift
+++ b/Sources/PaneMetadataStore.swift
@@ -261,6 +261,17 @@ final class PaneMetadataStore: @unchecked Sendable {
         var sblob: [String: SourceRecord]
         var result = WriteResult()
 
+        // Capture prior values for every key in the incoming partial, regardless
+        // of mode. Agents use this to implement read-then-write without a
+        // separate round trip. Only keys that previously existed are included;
+        // absence in `priorValues` means the key was unset.
+        let priorSnapshot = metadata[workspaceId]?[paneId] ?? [:]
+        for k in partial.keys {
+            if let prior = priorSnapshot[k] {
+                result.priorValues[k] = prior
+            }
+        }
+
         if mode == .replace {
             blob = [:]
             sblob = [:]

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -225,6 +225,12 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         var metadata: [String: Any] = [:]
         /// Post-op snapshot of the sidecar.
         var sources: [String: [String: Any]] = [:]
+        /// Prior values for keys in the incoming partial, captured before the
+        /// write was applied. Only populated when the key existed previously;
+        /// absence means the key was unset. Substrate for the read-then-write
+        /// convention (CMUX-11 Phase 2) so callers get the prior value back
+        /// in-hand without a separate round trip.
+        var priorValues: [String: Any] = [:]
     }
 
     /// Merge or replace a partial metadata object on a surface.

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2176,6 +2176,12 @@ class TerminalController {
             return v2Result(id: id, self.v2PaneLast(params: params))
         case "pane.confirm":
             return v2Result(id: id, self.v2PaneConfirm(params: params))
+        case "pane.set_metadata":
+            return v2Result(id: id, self.v2PaneSetMetadata(params: params))
+        case "pane.get_metadata":
+            return v2Result(id: id, self.v2PaneGetMetadata(params: params))
+        case "pane.clear_metadata":
+            return v2Result(id: id, self.v2PaneClearMetadata(params: params))
 
         // Notifications
         case "notification.create":
@@ -2530,6 +2536,9 @@ class TerminalController {
             "pane.break",
             "pane.join",
             "pane.last",
+            "pane.set_metadata",
+            "pane.get_metadata",
+            "pane.clear_metadata",
             "notification.create",
             "notification.create_for_surface",
             "notification.create_for_target",
@@ -5015,6 +5024,7 @@ class TerminalController {
               let direction = parseSplitDirection(directionStr) else {
             return .err(code: "invalid_params", message: "Missing or invalid direction (left|right|up|down)", data: nil)
         }
+        let titleSeed = v2String(params, "title")
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create split", data: nil)
         v2MainSync {
@@ -5037,6 +5047,8 @@ class TerminalController {
 
             if let newId = tabManager.newSplit(tabId: ws.id, surfaceId: targetSurfaceId, direction: direction) {
                 let paneUUID = ws.paneId(forPanelId: newId)?.id
+                // Seed pane title atomic with pane id becoming valid.
+                v2SeedPaneTitle(workspaceId: ws.id, paneUUID: paneUUID, title: titleSeed)
                 let windowId = v2ResolveWindowId(tabManager: tabManager)
                 result = .ok([
                     "window_id": v2OrNull(windowId?.uuidString),
@@ -6632,6 +6644,7 @@ class TerminalController {
         let urlStr = v2String(params, "url")
         let url = urlStr.flatMap { URL(string: $0) }
         let filePath = v2String(params, "file")
+        let titleSeed = v2String(params, "title")
 
         // Validate and resolve markdown file path
         var resolvedMarkdownPath: String?
@@ -6689,6 +6702,10 @@ class TerminalController {
                 return
             }
             let paneUUID = ws.paneId(forPanelId: newPanelId)?.id
+            // Seed pane title atomic with the pane id becoming valid: the
+            // caller observes the pane (via the response) only after the seed
+            // is in the store.
+            v2SeedPaneTitle(workspaceId: ws.id, paneUUID: paneUUID, title: titleSeed)
             let windowId = v2ResolveWindowId(tabManager: tabManager)
             result = .ok([
                 "window_id": v2OrNull(windowId?.uuidString),
@@ -7129,6 +7146,222 @@ class TerminalController {
             ])
         }
         return result
+    }
+
+    // MARK: - V2 Pane Metadata (CMUX-11 Phase 2)
+
+    /// Resolve the (workspaceId, paneId) pair for a pane-metadata call.
+    /// Runs its bonsplit read on main (minimum needed) and returns the tab
+    /// manager for downstream use. The actual `PaneMetadataStore` mutation
+    /// happens off-main on the store's own serial queue.
+    private func v2ResolvePaneForMetadata(
+        params: [String: Any]
+    ) -> (workspaceId: UUID, paneId: UUID, tabManager: TabManager)? {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return nil
+        }
+        return v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                return nil
+            }
+            if let paneUUID = v2UUID(params, "pane_id") {
+                guard ws.bonsplitController.allPaneIds.contains(where: { $0.id == paneUUID }) else {
+                    return nil
+                }
+                return (ws.id, paneUUID, tabManager)
+            }
+            // Fallback: default to the workspace's focused pane.
+            if let focused = ws.bonsplitController.focusedPaneId {
+                return (ws.id, focused.id, tabManager)
+            }
+            return nil
+        }
+    }
+
+    private func v2PaneSetMetadata(params: [String: Any]) -> V2CallResult {
+        guard let metadataObj = params["metadata"] as? [String: Any] else {
+            return .err(code: "invalid_json", message: "metadata must be a JSON object", data: nil)
+        }
+
+        let modeStr = (v2String(params, "mode") ?? "merge").lowercased()
+        guard let mode = SurfaceMetadataStore.WriteMode(rawValue: modeStr) else {
+            return .err(code: "invalid_mode", message: "mode must be 'merge' or 'replace'", data: nil)
+        }
+
+        let sourceStr = (v2String(params, "source") ?? "explicit").lowercased()
+        guard let source = MetadataSource(rawValue: sourceStr) else {
+            return .err(code: "invalid_source", message: "source must be one of: explicit, declare, osc, heuristic", data: nil)
+        }
+
+        guard let resolved = v2ResolvePaneForMetadata(params: params) else {
+            return .err(code: "pane_not_found", message: "Pane not found", data: nil)
+        }
+
+        do {
+            let result = try PaneMetadataStore.shared.setMetadata(
+                workspaceId: resolved.workspaceId,
+                paneId: resolved.paneId,
+                partial: metadataObj,
+                mode: mode,
+                source: source
+            )
+            return .ok(buildPaneMetadataOkPayload(
+                workspaceId: resolved.workspaceId,
+                paneId: resolved.paneId,
+                tabManager: resolved.tabManager,
+                result: result,
+                includePriorValues: true
+            ))
+        } catch let err as SurfaceMetadataStore.WriteError {
+            return .err(code: err.code, message: err.message, data: err.detailData)
+        } catch {
+            return .err(code: "internal_error", message: "\(error)", data: nil)
+        }
+    }
+
+    private func v2PaneGetMetadata(params: [String: Any]) -> V2CallResult {
+        let keys: [String]?
+        if params["keys"] is NSNull || params["keys"] == nil {
+            keys = nil
+        } else if let arr = v2StringArray(params, "keys") {
+            keys = arr
+        } else {
+            return .err(code: "invalid_keys_param", message: "keys must be an array of strings", data: nil)
+        }
+
+        let includeSources = v2Bool(params, "include_sources") ?? false
+
+        guard let resolved = v2ResolvePaneForMetadata(params: params) else {
+            return .err(code: "pane_not_found", message: "Pane not found", data: nil)
+        }
+
+        let (fullMetadata, fullSources) = PaneMetadataStore.shared.getMetadata(
+            workspaceId: resolved.workspaceId,
+            paneId: resolved.paneId
+        )
+
+        var metadataOut: [String: Any] = fullMetadata
+        var sourcesOut: [String: [String: Any]] = fullSources
+        if let filterKeys = keys {
+            metadataOut = [:]
+            sourcesOut = [:]
+            for k in filterKeys {
+                if let v = fullMetadata[k] { metadataOut[k] = v }
+                if let s = fullSources[k] { sourcesOut[k] = s }
+            }
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: resolved.tabManager)
+        var payload: [String: Any] = [
+            "workspace_id": resolved.workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: resolved.workspaceId),
+            "pane_id": resolved.paneId.uuidString,
+            "pane_ref": v2Ref(kind: .pane, uuid: resolved.paneId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "metadata": metadataOut
+        ]
+        if includeSources {
+            payload["metadata_sources"] = sourcesOut
+        }
+        return .ok(payload)
+    }
+
+    private func v2PaneClearMetadata(params: [String: Any]) -> V2CallResult {
+        let keys: [String]?
+        if params["keys"] == nil || params["keys"] is NSNull {
+            keys = nil
+        } else if let arr = v2StringArray(params, "keys") {
+            keys = arr
+        } else {
+            return .err(code: "invalid_keys_param", message: "keys must be an array of strings", data: nil)
+        }
+
+        let sourceStr = (v2String(params, "source") ?? "explicit").lowercased()
+        guard let source = MetadataSource(rawValue: sourceStr) else {
+            return .err(code: "invalid_source", message: "source must be one of: explicit, declare, osc, heuristic", data: nil)
+        }
+
+        guard let resolved = v2ResolvePaneForMetadata(params: params) else {
+            return .err(code: "pane_not_found", message: "Pane not found", data: nil)
+        }
+
+        do {
+            let result = try PaneMetadataStore.shared.clearMetadata(
+                workspaceId: resolved.workspaceId,
+                paneId: resolved.paneId,
+                keys: keys,
+                source: source
+            )
+            return .ok(buildPaneMetadataOkPayload(
+                workspaceId: resolved.workspaceId,
+                paneId: resolved.paneId,
+                tabManager: resolved.tabManager,
+                result: result,
+                includePriorValues: false
+            ))
+        } catch let err as SurfaceMetadataStore.WriteError {
+            return .err(code: err.code, message: err.message, data: err.detailData)
+        } catch {
+            return .err(code: "internal_error", message: "\(error)", data: nil)
+        }
+    }
+
+    private func buildPaneMetadataOkPayload(
+        workspaceId: UUID,
+        paneId: UUID,
+        tabManager: TabManager,
+        result: SurfaceMetadataStore.WriteResult,
+        includePriorValues: Bool
+    ) -> [String: Any] {
+        var appliedAny: [String: Any] = [:]
+        for (k, v) in result.applied { appliedAny[k] = v }
+        var reasonsAny: [String: Any] = [:]
+        for (k, v) in result.reasons { reasonsAny[k] = v }
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        var payload: [String: Any] = [
+            "workspace_id": workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+            "pane_id": paneId.uuidString,
+            "pane_ref": v2Ref(kind: .pane, uuid: paneId),
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "applied": appliedAny,
+            "reasons": reasonsAny,
+            "metadata": result.metadata,
+            "metadata_sources": result.sources
+        ]
+        if includePriorValues {
+            payload["prior_values"] = result.priorValues
+        }
+        return payload
+    }
+
+    /// Seed `PaneMetadataStore` with `{title: <value>}` at pane creation time.
+    /// Called from `v2PaneCreate` / `v2SurfaceSplit` when the caller passes a
+    /// `title` parameter. Atomic with the pane id becoming valid — agents can
+    /// assume the seed is present before the RPC response returns.
+    private func v2SeedPaneTitle(
+        workspaceId: UUID,
+        paneUUID: UUID?,
+        title: String?
+    ) {
+        guard let paneUUID, let title, !title.isEmpty else { return }
+        do {
+            _ = try PaneMetadataStore.shared.setMetadata(
+                workspaceId: workspaceId,
+                paneId: paneUUID,
+                partial: [MetadataKey.title: title],
+                mode: .merge,
+                source: .explicit
+            )
+        } catch {
+            // Seeding is best-effort: the pane is already created and the
+            // caller can retry via pane.set_metadata. Log and continue.
+            #if DEBUG
+            dlog("pane.title_seed.failed pane=\(paneUUID.uuidString) err=\(error)")
+            #endif
+        }
     }
 
     /// Socket-triggered pane confirmation. Presents a .confirm interaction on the

--- a/tests_v2/test_pane_create_title.py
+++ b/tests_v2/test_pane_create_title.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""CMUX-11 Phase 2: pane.create / surface.split --title seeding.
+
+Verifies that when `pane.create` (and `surface.split`) is called with a
+`title` parameter, the new pane's metadata is seeded with
+`{title: <value>, source: "explicit"}` atomically with the pane id
+becoming valid — no window between "pane exists" and "title set."
+
+Calling `pane.create` without `title` produces a fresh pane with empty
+metadata (matching Phase 1 default).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _test_pane_create_without_title(c: cmux) -> None:
+    workspace_id = c.new_workspace()
+    try:
+        res = c._call("pane.create", {
+            "workspace_id": workspace_id,
+            "direction": "right",
+        }) or {}
+        pane_id = res.get("pane_id")
+        _must(bool(pane_id), f"pane.create returned no pane_id: {res}")
+
+        got = c._call("pane.get_metadata", {
+            "workspace_id": workspace_id,
+            "pane_id": str(pane_id),
+        }) or {}
+        _must(got.get("metadata") == {},
+              f"pane without --title should have empty metadata: {got}")
+    finally:
+        c._call("workspace.close", {"workspace_id": workspace_id})
+
+
+def _test_pane_create_with_title(c: cmux) -> None:
+    workspace_id = c.new_workspace()
+    try:
+        title = "Parent :: Pane-With-Seed"
+        res = c._call("pane.create", {
+            "workspace_id": workspace_id,
+            "direction": "right",
+            "title": title,
+        }) or {}
+        pane_id = res.get("pane_id")
+        _must(bool(pane_id), f"pane.create returned no pane_id: {res}")
+
+        got = c._call("pane.get_metadata", {
+            "workspace_id": workspace_id,
+            "pane_id": str(pane_id),
+            "include_sources": True,
+        }) or {}
+        md = got.get("metadata", {})
+        _must(md.get("title") == title,
+              f"seeded title missing: md={md}")
+
+        src = got.get("metadata_sources", {}).get("title", {})
+        _must(src.get("source") == "explicit",
+              f"seeded title source should be explicit, got: {src}")
+    finally:
+        c._call("workspace.close", {"workspace_id": workspace_id})
+
+
+def _test_surface_split_with_title(c: cmux) -> None:
+    workspace_id = c.new_workspace()
+    try:
+        title = "Parent :: Split-Seed"
+        res = c._call("surface.split", {
+            "workspace_id": workspace_id,
+            "direction": "down",
+            "title": title,
+        }) or {}
+        pane_id = res.get("pane_id")
+        _must(bool(pane_id), f"surface.split returned no pane_id: {res}")
+
+        got = c._call("pane.get_metadata", {
+            "workspace_id": workspace_id,
+            "pane_id": str(pane_id),
+        }) or {}
+        _must(got.get("metadata", {}).get("title") == title,
+              f"surface.split title seed missing: {got}")
+    finally:
+        c._call("workspace.close", {"workspace_id": workspace_id})
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        _test_pane_create_without_title(c)
+        _test_pane_create_with_title(c)
+        _test_surface_split_with_title(c)
+
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_v2/test_pane_metadata.py
+++ b/tests_v2/test_pane_metadata.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""CMUX-11 Phase 2: pane.set_metadata / .get_metadata / .clear_metadata.
+
+Verifies the pane-metadata RPC family added in Phase 2:
+
+- Set/get/clear round-trip with source-precedence gating
+- set response includes `prior_values` (substrate for the
+  read-then-write-by-convention norm)
+- Cap enforcement (64 KiB per pane)
+- CLI `--pane pane:N` short-ref targeting
+- CLI `--surface` + `--pane` together → usage error
+
+No UI assertions — this is a mechanism-layer test. Requires a running
+c11mux instance; set CMUX_SOCKET to target a tagged build's socket
+(e.g. /tmp/c11mux-debug-cmux-11-phase2.sock).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+CLI_PATH = os.environ.get("CMUX_CLI") or "cmux"
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _cli(args: list[str], check: bool = True, env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CMUX_SOCKET"] = SOCKET_PATH
+    if env_extra:
+        env.update(env_extra)
+    result = subprocess.run(
+        [CLI_PATH, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if check and result.returncode != 0:
+        raise cmuxError(
+            f"cli {args} exited {result.returncode}: "
+            f"stdout={result.stdout.strip()!r} stderr={result.stderr.strip()!r}"
+        )
+    return result
+
+
+def _fresh_workspace_and_pane(c: cmux) -> tuple[str, str]:
+    """Create a workspace and split once so we have a second pane to target."""
+    workspace_id = c.new_workspace()
+    # surface.split always creates a new pane; grab the new pane's id.
+    split_res = c._call("surface.split", {"workspace_id": workspace_id, "direction": "right"}) or {}
+    pane_id = split_res.get("pane_id")
+    _must(bool(pane_id), f"surface.split returned no pane_id: {split_res}")
+    return workspace_id, str(pane_id)
+
+
+def _test_roundtrip_and_prior_values(c: cmux) -> None:
+    workspace_id, pane_id = _fresh_workspace_and_pane(c)
+
+    # Fresh pane — get_metadata should return empty.
+    got = c._call("pane.get_metadata", {"workspace_id": workspace_id, "pane_id": pane_id}) or {}
+    _must(got.get("metadata") == {}, f"fresh pane metadata should be empty: {got}")
+
+    # First set: prior_values empty (key was unset).
+    set_a = c._call("pane.set_metadata", {
+        "workspace_id": workspace_id,
+        "pane_id": pane_id,
+        "metadata": {"title": "Parent :: Child"},
+    }) or {}
+    _must(set_a.get("applied", {}).get("title") is True,
+          f"first set title not applied: {set_a}")
+    _must(set_a.get("prior_values", None) == {},
+          f"first set should have empty prior_values: {set_a}")
+    _must(set_a.get("metadata", {}).get("title") == "Parent :: Child",
+          f"post-op metadata wrong: {set_a}")
+
+    # Second set: prior_values should contain the previous title string.
+    set_b = c._call("pane.set_metadata", {
+        "workspace_id": workspace_id,
+        "pane_id": pane_id,
+        "metadata": {"title": "Parent :: Code Review"},
+    }) or {}
+    _must(set_b.get("applied", {}).get("title") is True,
+          f"second set title not applied: {set_b}")
+    prior = set_b.get("prior_values", {})
+    _must(prior.get("title") == "Parent :: Child",
+          f"second set should return prior title in prior_values: {set_b}")
+
+    # get_metadata reflects the latest write.
+    got2 = c._call("pane.get_metadata", {
+        "workspace_id": workspace_id,
+        "pane_id": pane_id,
+        "include_sources": True,
+    }) or {}
+    _must(got2.get("metadata", {}).get("title") == "Parent :: Code Review",
+          f"get_metadata after second set wrong: {got2}")
+    src = got2.get("metadata_sources", {}).get("title", {})
+    _must(src.get("source") == "explicit",
+          f"title source should be explicit, got: {src}")
+
+    # Clear a specific key.
+    clr = c._call("pane.clear_metadata", {
+        "workspace_id": workspace_id,
+        "pane_id": pane_id,
+        "keys": ["title"],
+    }) or {}
+    _must(clr.get("applied", {}).get("title") is True,
+          f"clear title not applied: {clr}")
+
+    got3 = c._call("pane.get_metadata", {"workspace_id": workspace_id, "pane_id": pane_id}) or {}
+    _must("title" not in got3.get("metadata", {}),
+          f"title should be absent after clear: {got3}")
+
+    c._call("workspace.close", {"workspace_id": workspace_id})
+
+
+def _test_source_precedence(c: cmux) -> None:
+    workspace_id, pane_id = _fresh_workspace_and_pane(c)
+
+    # Set with source=explicit (highest precedence).
+    c._call("pane.set_metadata", {
+        "workspace_id": workspace_id,
+        "pane_id": pane_id,
+        "metadata": {"title": "Explicit"},
+        "source": "explicit",
+    })
+
+    # Attempt to overwrite with source=declare (lower precedence) — should soft-reject.
+    lower = c._call("pane.set_metadata", {
+        "workspace_id": workspace_id,
+        "pane_id": pane_id,
+        "metadata": {"title": "Declare"},
+        "source": "declare",
+    }) or {}
+    _must(lower.get("applied", {}).get("title") is False,
+          f"lower-precedence write should be rejected: {lower}")
+    _must(lower.get("reasons", {}).get("title") == "lower_precedence",
+          f"rejection reason should be lower_precedence: {lower}")
+
+    # Verify the higher-precedence value is still in place.
+    got = c._call("pane.get_metadata", {"workspace_id": workspace_id, "pane_id": pane_id}) or {}
+    _must(got.get("metadata", {}).get("title") == "Explicit",
+          f"value should remain Explicit after rejected write: {got}")
+
+    c._call("workspace.close", {"workspace_id": workspace_id})
+
+
+def _test_cap_enforcement(c: cmux) -> None:
+    workspace_id, pane_id = _fresh_workspace_and_pane(c)
+
+    # 128 KiB string — well above the 64 KiB cap.
+    huge = "x" * (128 * 1024)
+    try:
+        c._call("pane.set_metadata", {
+            "workspace_id": workspace_id,
+            "pane_id": pane_id,
+            "metadata": {"bulk": huge},
+        })
+    except cmuxError as exc:
+        msg = str(exc)
+        _must("payload_too_large" in msg, f"expected payload_too_large, got: {msg}")
+        c._call("workspace.close", {"workspace_id": workspace_id})
+        return
+    raise cmuxError("over-cap write should have raised payload_too_large")
+
+
+def _test_replace_mode_requires_explicit(c: cmux) -> None:
+    workspace_id, pane_id = _fresh_workspace_and_pane(c)
+
+    try:
+        c._call("pane.set_metadata", {
+            "workspace_id": workspace_id,
+            "pane_id": pane_id,
+            "metadata": {"title": "X"},
+            "mode": "replace",
+            "source": "declare",
+        })
+    except cmuxError as exc:
+        msg = str(exc)
+        _must("replace_requires_explicit" in msg,
+              f"expected replace_requires_explicit, got: {msg}")
+        c._call("workspace.close", {"workspace_id": workspace_id})
+        return
+    raise cmuxError("replace with source=declare should have been rejected")
+
+
+def _test_cli_pane_short_ref(c: cmux) -> None:
+    """`cmux set-metadata --pane pane:N --key title --value ...` round-trip."""
+    workspace_id, pane_id = _fresh_workspace_and_pane(c)
+
+    # Figure out which pane index corresponds to our pane_id.
+    panes = (c._call("pane.list", {"workspace_id": workspace_id}) or {}).get("panes", [])
+    pane_index = None
+    for p in panes:
+        if str(p.get("id")) == pane_id:
+            pane_index = int(p.get("index", -1))
+            break
+    _must(pane_index is not None and pane_index >= 0,
+          f"could not find pane index for {pane_id} in {panes}")
+    short_ref = f"pane:{pane_index + 1}"  # pane:N refs are 1-indexed in the CLI.
+
+    set_res = _cli([
+        "set-metadata",
+        "--workspace", workspace_id,
+        "--pane", short_ref,
+        "--key", "title",
+        "--value", "ShortRef",
+        "--json",
+    ])
+    _must('"ShortRef"' in set_res.stdout,
+          f"cli set-metadata stdout missing title: {set_res.stdout!r}")
+
+    # Read back via CLI.
+    get_res = _cli([
+        "get-metadata",
+        "--workspace", workspace_id,
+        "--pane", short_ref,
+        "--key", "title",
+    ])
+    _must("ShortRef" in get_res.stdout,
+          f"cli get-metadata stdout missing value: {get_res.stdout!r}")
+
+    c._call("workspace.close", {"workspace_id": workspace_id})
+
+
+def _test_cli_surface_and_pane_mutually_exclusive() -> None:
+    """`--surface` + `--pane` on metadata commands must error."""
+    res = _cli([
+        "set-metadata",
+        "--surface", "surface:1",
+        "--pane", "pane:1",
+        "--key", "title",
+        "--value", "nope",
+    ], check=False)
+    _must(res.returncode != 0,
+          f"expected non-zero exit, got {res.returncode} (stdout={res.stdout!r})")
+    combined = (res.stdout + res.stderr).lower()
+    _must("mutually exclusive" in combined,
+          f"expected 'mutually exclusive' in output, got: {combined!r}")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        _test_roundtrip_and_prior_values(c)
+        _test_source_precedence(c)
+        _test_cap_enforcement(c)
+        _test_replace_mode_requires_explicit(c)
+        _test_cli_pane_short_ref(c)
+
+    # CLI-only test (doesn't need a persistent connection).
+    _test_cli_surface_and_pane_mutually_exclusive()
+
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 2 of CMUX-11 nameable panes. Wires the `PaneMetadataStore` shipped in Phase 1 (PR #22) into the v2 socket API and CLI, plus adds atomic `--title` seeding on pane creation so spawning agents can compose lineage (`Parent :: Child`) in a single call.

No UI. Phase 3 (persistence) and Phase 4 (skill cross-reference) remain follow-up PRs.

## What's in

### Socket RPCs (`Sources/TerminalController.swift`)
- `pane.set_metadata` — same arg shape as `surface.set_metadata` (`metadata`, `mode merge|replace`, `source`). Response includes `prior_values` keyed by every incoming key — substrate for the read-then-write-by-convention norm in the plan.
- `pane.get_metadata` — optional `include_sources`, optional `keys: [String]?` filter.
- `pane.clear_metadata` — `keys: [String]?` (nil = full clear, requires `source: explicit`).
- `pane.create` + `surface.split` gain optional `title: String`. Seeded atomically with the new pane id via `PaneMetadataStore.setMetadata` on the store's serial queue — no window between "pane exists" and "title set."

Off-main threading per CLAUDE.md's socket policy: params parsed off-main; resolving the `(workspaceId, paneId)` pair does a brief `v2MainSync` to read bonsplit state; the store mutation runs on its own serial queue.

### CLI (`CLI/cmux.swift`)
- `cmux set-metadata / get-metadata / clear-metadata` gain `--pane <ref>` (routes to the `pane.*` RPCs). `--surface` and `--pane` are mutually exclusive; passing both is a usage error. Default (neither) preserves the existing focused-surface behavior.
- `cmux new-pane` and `cmux new-split` gain optional `--title <text>`.
- `pane:N` short refs already resolve through `normalizePaneHandle`; verified.

### Shared type (`Sources/SurfaceMetadataStore.swift`)
- `WriteResult` gains `priorValues: [String: Any]`. Populated by `PaneMetadataStore`'s setter; the surface path doesn't expose it (yet) so behavior of surface RPC responses is unchanged.

### Tests (`tests_v2/`)
- `test_pane_metadata.py` — set/get/clear round-trip, source-precedence gating, 64 KiB cap enforcement, replace-requires-explicit, prior-value-in-response, `--pane pane:N` CLI short-ref, `--surface` + `--pane` usage-error.
- `test_pane_create_title.py` — `pane.create` with and without `title`; `surface.split` with `title`. Verifies the seeded value + `source: explicit`.

Both suites open fresh workspaces and clean up via `workspace.close`.

## Design notes

- **"It's text. Trust the LLM."** — Title is a single string; `::` is convention, not a system delimiter. No auto-copy at split time. Seeding is a hint the caller passes, not derived.
- **`prior_values` on set**: the load-bearing Phase 2 constraint from the plan. Agents get the prior title back in-hand after every write so the read-then-write pattern works without a separate round trip. Populated in `PaneMetadataStore.setMetadataLocked` before the write is applied; empty for keys that didn't exist, present for keys that did.
- **Atomicity of title seed**: the pane id is only returned to the caller after `PaneMetadataStore.setMetadata` completes. No observer can see the pane without its seeded title.

## Test plan

Unit/UI tests in CI cover the Swift side. The Python `tests_v2/` suites are deferred to CI per the testing policy in `CLAUDE.md` (never launch an untagged `cmux DEV.app` locally).

- [ ] CI Debug build passes
- [ ] `tests_v2/test_pane_metadata.py` passes
- [ ] `tests_v2/test_pane_create_title.py` passes
- [ ] Existing `SurfaceMetadataStore`/`PaneMetadataStore` unit tests still pass (shared `WriteResult` struct gained an optional-by-default field)

## Lattice

CMUX-11 (`task_01KPHENJCMVS1FFH0HDJ6V3PN8`). Plan: `docs/c11mux-pane-naming-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)