### PR TITLE
CMUX-20: follow-up fixes for default pane grid (retina, remote, delay, diagnostic)

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1258,9 +1258,7 @@ class TabManager: ObservableObject {
 
         if let terminalPanel = workspace.focusedTerminalPanel,
            terminalPanel.surface.surface != nil {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                performGrid(terminalPanel)
-            }
+            performGrid(terminalPanel)
             return
         }
 
@@ -1277,9 +1275,7 @@ class TabManager: ObservableObject {
                 NotificationCenter.default.removeObserver(readyObserver)
             }
             panelsCancellable?.cancel()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                performGrid(terminalPanel)
-            }
+            performGrid(terminalPanel)
         }
 
         panelsCancellable = workspace.$panels

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3891,12 +3891,18 @@ enum DefaultGridSettings {
             ?? window.flatMap(bestScreen(for:))
             ?? NSScreen.main
         guard let screen else { return .zero }
-        let scale = screen.backingScaleFactor
-        return NSRect(
+        return scaledPhysicalFrame(logicalFrame: screen.frame, scale: screen.backingScaleFactor)
+    }
+
+    /// Pure helper that converts a logical-point screen frame into its
+    /// physical-pixel size at the origin. Factored out so the scaling math
+    /// can be unit-tested directly without staging an `NSScreen` fixture.
+    static func scaledPhysicalFrame(logicalFrame: NSRect, scale: CGFloat) -> NSRect {
+        NSRect(
             x: 0,
             y: 0,
-            width: screen.frame.width * scale,
-            height: screen.frame.height * scale
+            width: logicalFrame.width * scale,
+            height: logicalFrame.height * scale
         )
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3880,16 +3880,24 @@ enum DefaultGridSettings {
     }
 
     /// Resolves the pixel frame of the screen that best contains the given
-    /// window. Returns `.zero` if no screen can be resolved, which the
-    /// classifier treats as the 1×1 fallback (no grid).
+    /// window. `NSScreen.frame` reports logical points; multiply by
+    /// `backingScaleFactor` so `classify()` compares against physical
+    /// pixel thresholds (a 32" 4K in a HiDPI mode reports 2560×1440 points
+    /// and would misclassify as QHD without the scale). Returns `.zero` if
+    /// no screen can be resolved, which the classifier treats as the 1×1
+    /// fallback (no grid).
     static func resolvedScreenFrame(for window: NSWindow?) -> NSRect {
-        if let screen = window?.screen {
-            return screen.frame
-        }
-        if let window, let best = bestScreen(for: window) {
-            return best.frame
-        }
-        return NSScreen.main?.frame ?? .zero
+        let screen: NSScreen? = window?.screen
+            ?? window.flatMap(bestScreen(for:))
+            ?? NSScreen.main
+        guard let screen else { return .zero }
+        let scale = screen.backingScaleFactor
+        return NSRect(
+            x: 0,
+            y: 0,
+            width: screen.frame.width * scale,
+            height: screen.frame.height * scale
+        )
     }
 
     private static func bestScreen(for window: NSWindow) -> NSScreen? {
@@ -3908,6 +3916,11 @@ enum DefaultGridSettings {
         initialPanel: TerminalPanel,
         screenFrame: NSRect
     ) {
+        // Remote workspaces spawn a fresh SSH session per pane via
+        // `remoteTerminalStartupCommand()`. Fanning out up to 9 sessions on
+        // workspace creation is the wrong default; require an explicit split.
+        guard !workspace.isRemoteWorkspace else { return }
+
         let (cols, rows) = classify(screenFrame: screenFrame)
         guard cols > 1 || rows > 1 else { return }
 
@@ -3923,23 +3936,43 @@ enum DefaultGridSettings {
             case .horizontalToNewColumn:
                 // Chain off the previous column's head so columns march rightward.
                 let sourceColumn = op.column - 1
-                guard let source = columnTails[sourceColumn] else { return }
+                guard let source = columnTails[sourceColumn] else {
+                    #if DEBUG
+                    dlog("grid.split.failed col=\(op.column) dir=\(op.direction) reason=missing_source")
+                    #endif
+                    return
+                }
                 guard let newPanel = workspace.newTerminalSplit(
                     from: source.id,
                     orientation: .horizontal,
                     insertFirst: false,
                     focus: false
-                ) else { return }
+                ) else {
+                    #if DEBUG
+                    dlog("grid.split.failed col=\(op.column) dir=\(op.direction)")
+                    #endif
+                    return
+                }
                 columnTails[op.column] = newPanel
 
             case .verticalDownInColumn:
-                guard let source = columnTails[op.column] else { return }
+                guard let source = columnTails[op.column] else {
+                    #if DEBUG
+                    dlog("grid.split.failed col=\(op.column) dir=\(op.direction) reason=missing_source")
+                    #endif
+                    return
+                }
                 guard let newPanel = workspace.newTerminalSplit(
                     from: source.id,
                     orientation: .vertical,
                     insertFirst: false,
                     focus: false
-                ) else { return }
+                ) else {
+                    #if DEBUG
+                    dlog("grid.split.failed col=\(op.column) dir=\(op.direction)")
+                    #endif
+                    return
+                }
                 columnTails[op.column] = newPanel
             }
         }

--- a/cmuxTests/DefaultGridSettingsTests.swift
+++ b/cmuxTests/DefaultGridSettingsTests.swift
@@ -62,6 +62,26 @@ final class DefaultGridSettingsTests: XCTestCase {
         XCTAssertEqual(rows, 3)
     }
 
+    func testClassifyRetina27ScaledProducesTwoByThree() {
+        // Mid-tier retina display class: logical 1440×900 at backingScaleFactor
+        // 2.0 → physical 2880×1800. Sits above QHD (2560×1440) and below 4K
+        // (3840×2160). Post-fix classify() is called with the scaled rect and
+        // correctly returns 2×3.
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 2880, height: 1800))
+        XCTAssertEqual(cols, 2)
+        XCTAssertEqual(rows, 3)
+    }
+
+    func testClassifyRetina32ScaledProducesThreeByThree() {
+        // Exact 32" 4K bug scenario: logical 2560×1440 at backingScaleFactor
+        // 1.5 ("Looks like 2560" HiDPI mode) → physical 3840×2160. Pre-fix
+        // classify() saw the logical 2560×1440 and misclassified as 2×3
+        // (QHD bucket); post-fix it sees the scaled 4K rect and returns 3×3.
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: NSRect(x: 0, y: 0, width: 3840, height: 2160))
+        XCTAssertEqual(cols, 3)
+        XCTAssertEqual(rows, 3)
+    }
+
     // MARK: - gridSplitOperations()
 
     func testGridOpsOneByOneProducesNoSplits() {

--- a/cmuxTests/DefaultGridSettingsTests.swift
+++ b/cmuxTests/DefaultGridSettingsTests.swift
@@ -82,6 +82,57 @@ final class DefaultGridSettingsTests: XCTestCase {
         XCTAssertEqual(rows, 3)
     }
 
+    // MARK: - scaledPhysicalFrame()
+
+    func testScaledPhysicalFrameNonRetinaIsIdentity() {
+        // backingScaleFactor 1.0 (non-retina external monitor): physical == logical.
+        let result = DefaultGridSettings.scaledPhysicalFrame(
+            logicalFrame: NSRect(x: 0, y: 0, width: 1920, height: 1080),
+            scale: 1.0
+        )
+        XCTAssertEqual(result.width, 1920)
+        XCTAssertEqual(result.height, 1080)
+    }
+
+    func testScaledPhysicalFrameRetina2xDoublesDimensions() {
+        // Standard 2.0 retina scale: logical 1440×900 → physical 2880×1800.
+        let result = DefaultGridSettings.scaledPhysicalFrame(
+            logicalFrame: NSRect(x: 0, y: 0, width: 1440, height: 900),
+            scale: 2.0
+        )
+        XCTAssertEqual(result.width, 2880)
+        XCTAssertEqual(result.height, 1800)
+    }
+
+    func testScaledPhysicalFrame32Inch4KHiDPIReaches4KBucket() {
+        // The headline bug: 32" 4K in "Looks like 2560" HiDPI mode reports
+        // logical 2560×1440 at scale 1.5 → physical 3840×2160. When fed
+        // through scaledPhysicalFrame + classify, this reaches the 4K bucket.
+        let scaled = DefaultGridSettings.scaledPhysicalFrame(
+            logicalFrame: NSRect(x: 0, y: 0, width: 2560, height: 1440),
+            scale: 1.5
+        )
+        XCTAssertEqual(scaled.width, 3840)
+        XCTAssertEqual(scaled.height, 2160)
+        let (cols, rows) = DefaultGridSettings.classify(screenFrame: scaled)
+        XCTAssertEqual(cols, 3)
+        XCTAssertEqual(rows, 3)
+    }
+
+    func testScaledPhysicalFrameOriginIsZeroed() {
+        // The helper intentionally flattens to origin (0,0) — classify() only
+        // looks at size, but downstream callers should not accidentally rely
+        // on the original origin.
+        let result = DefaultGridSettings.scaledPhysicalFrame(
+            logicalFrame: NSRect(x: 1440, y: 900, width: 1280, height: 800),
+            scale: 2.0
+        )
+        XCTAssertEqual(result.origin.x, 0)
+        XCTAssertEqual(result.origin.y, 0)
+        XCTAssertEqual(result.width, 2560)
+        XCTAssertEqual(result.height, 1600)
+    }
+
     // MARK: - gridSplitOperations()
 
     func testGridOpsOneByOneProducesNoSplits() {


### PR DESCRIPTION
## Summary
Four bug fixes for CMUX-15 (PR #24) surfaced by trident plan review, plus one follow-up test-coverage improvement prompted by the trident code review on this branch.

- **Retina scaling** — `DefaultGridSettings.resolvedScreenFrame` multiplies by `backingScaleFactor` so `classify()` sees physical pixels. Fixes the 32" 4K "Looks like 2560" HiDPI misclassification → now correctly 3×3.
- **Remote workspace guard** — `performDefaultGrid` early-returns on `workspace.isRemoteWorkspace` so a 9-pane default grid does not fan out 9 SSH sessions on workspace creation.
- **Latency** — removed two 0.5s `DispatchQueue.main.asyncAfter` wrappers inside `TabManager.spawnDefaultGridWhenReady` (they were copy-pasted from the welcome-once path; the grid runs per workspace). The ticket claimed `AppDelegate.spawnDefaultGridWhenReady` also had the wrapper — in the current tree it does not, so only TabManager was affected here.
- **Diagnostic** — all four split-failure `return`s inside `performDefaultGrid` are wrapped with `#if DEBUG dlog("grid.split.failed col=... dir=...") #endif` via the bonsplit `dlog` helper, so partial-grid field reports are diagnosable.

### Follow-up commit (4a71ba4a)
Trident code review on commit `9d752ee4` flagged that the two added retina tests exercise `classify()` with pre-scaled rects, not the `backingScaleFactor` multiplication in `resolvedScreenFrame` itself — a regression there would have stayed green. Factored the scaling math into a pure `DefaultGridSettings.scaledPhysicalFrame(logicalFrame:scale:)` helper and added four direct tests (non-retina identity, 2.0 retina, the exact 32" 4K HiDPI scenario chained with `classify`, and origin flattening). No behavior change.

## Decisions explicitly not addressed here
Documented in the CMUX-20 ticket as accepted:
- **5A** 3×3 grid produces 50/25/25 column widths rather than 1/3/1/3/1/3 (bonsplit binary-tree split semantics).
- **6A** Welcome-quad → all-terminal-grid visual jump on the 2nd workspace.
- **7A** Default-on for existing users; escape hatch is `defaults write com.cmux.app cmuxDefaultGridEnabled -bool false`.

## Trident code review findings not addressed
Noted for the record; each is either out of scope for CMUX-20 or already covered:
- `TabManager.spawnDefaultGridWhenReady` passes `nil` to `resolvedScreenFrame` — pre-existing fallback path behavior, only runs when `AppDelegate.shared` is nil (tests / detached contexts). Out of scope.
- Retina scaling may over-densify MBP "More Space" modes → 9 panes on a 14"/16" laptop. Accepted per ticket 7A with the `defaults write` escape hatch.
- Split-failure is silent in Release builds. Ticket explicitly scopes the diagnostic to DEBUG; release-path telemetry is a separate ticket.

## Lattice
[CMUX-20](./.lattice/tasks/task_01KPJ319529BDNPGFVFBADTK1M.json) — ticket.
Parent: [CMUX-15](./.lattice/tasks/task_01KPHHQ6T4K09KE9YF20KPT8VS.json) — PR #24.

## Test plan
- [x] Unit tests added for retina-scaled classification (two tests) and for the pure scaling helper (four tests).
- [x] Debug build succeeds (`xcodebuild ... -scheme cmux -configuration Debug build`) on both commits.
- [ ] CI runs the full unit + UI suites; local `xcodebuild test` is blocked by cmux policy.
- [ ] Manual verification of zero-delay grid spawn deferred to reviewer / CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)