### PR TITLE
CMUX-30 Phase 2: move toolbar buttons to host TabBarTrailingAccessory

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		A5001403 /* TerminalPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001413 /* TerminalPanelView.swift */; };
 		A5001404 /* BrowserPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001414 /* BrowserPanelView.swift */; };
 		A5007420 /* BrowserPopupWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007421 /* BrowserPopupWindowController.swift */; };
+		C30A0000A1B2C3D4E5F60718 /* TabBarTrailingAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30A0001A1B2C3D4E5F60718 /* TabBarTrailingAccessory.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5C101A0 /* PaneInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B0 /* PaneInteraction.swift */; };
 		A5C101A1 /* PaneInteractionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B1 /* PaneInteractionCardView.swift */; };
@@ -306,6 +307,7 @@
 		A5001413 /* TerminalPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelView.swift; sourceTree = "<group>"; };
 		A5001414 /* BrowserPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanelView.swift; sourceTree = "<group>"; };
 		A5007421 /* BrowserPopupWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPopupWindowController.swift; sourceTree = "<group>"; };
+		C30A0001A1B2C3D4E5F60718 /* TabBarTrailingAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TabBarTrailingAccessory.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5C101B0 /* PaneInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteraction.swift; sourceTree = "<group>"; };
@@ -571,6 +573,7 @@
 				A5001413 /* TerminalPanelView.swift */,
 				A5001414 /* BrowserPanelView.swift */,
 				A5007421 /* BrowserPopupWindowController.swift */,
+				C30A0001A1B2C3D4E5F60718 /* TabBarTrailingAccessory.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5C101B0 /* PaneInteraction.swift */,
 				A5C101B1 /* PaneInteractionCardView.swift */,
@@ -922,6 +925,7 @@
 				A5001403 /* TerminalPanelView.swift in Sources */,
 				A5001404 /* BrowserPanelView.swift in Sources */,
 				A5007420 /* BrowserPopupWindowController.swift in Sources */,
+				C30A0000A1B2C3D4E5F60718 /* TabBarTrailingAccessory.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5C101A0 /* PaneInteraction.swift in Sources */,
 				A5C101A1 /* PaneInteractionCardView.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -69007,6 +69007,684 @@
         }
       }
     },
+    "tabbar.newTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいターミナル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Terminal"
+          }
+        }
+      }
+    },
+    "tabbar.newBrowser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいブラウザ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Browser"
+          }
+        }
+      }
+    },
+    "tabbar.newMarkdown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Markdown"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいMarkdown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Markdown"
+          }
+        }
+      }
+    },
+    "tabbar.splitRight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Split Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右に分割"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Right"
+          }
+        }
+      }
+    },
+    "tabbar.splitDown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Split Down"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "下に分割"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "Split Down"
+          }
+        }
+      }
+    },
+    "tabbar.newTab": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Tab"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいタブ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "needs_review",
+            "value": "New Tab"
+          }
+        }
+      }
+    },
     "textbox.escapeBehavior.focusTerminal": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/TabBarTrailingAccessory.swift
+++ b/Sources/Panels/TabBarTrailingAccessory.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+import Bonsplit
+
+@MainActor
+struct TabBarTrailingAccessory: View {
+    let paneId: PaneID
+    let chromeSaturation: Double
+    let workspace: Workspace
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ToolbarIconButton(
+                systemImage: "terminal",
+                tooltip: String(localized: "tabbar.newTerminal", defaultValue: "New Terminal")
+            ) {
+                _ = workspace.newTerminalSurface(inPane: paneId)
+            }
+            ToolbarIconButton(
+                systemImage: "globe",
+                tooltip: String(localized: "tabbar.newBrowser", defaultValue: "New Browser")
+            ) {
+                _ = workspace.newBrowserSurface(inPane: paneId)
+            }
+            ToolbarIconButton(
+                systemImage: "doc.text",
+                tooltip: String(localized: "tabbar.newMarkdown", defaultValue: "New Markdown")
+            ) {
+                _ = workspace.newMarkdownSurface(inPane: paneId)
+            }
+            ToolbarSeparator()
+            ToolbarIconButton(
+                systemImage: "square.split.2x1",
+                tooltip: String(localized: "tabbar.splitRight", defaultValue: "Split Right")
+            ) {
+                _ = workspace.bonsplitController.splitPane(paneId, orientation: .horizontal)
+            }
+            ToolbarIconButton(
+                systemImage: "square.split.1x2",
+                tooltip: String(localized: "tabbar.splitDown", defaultValue: "Split Down")
+            ) {
+                _ = workspace.bonsplitController.splitPane(paneId, orientation: .vertical)
+            }
+            ToolbarIconButton(
+                systemImage: "plus",
+                tooltip: String(localized: "tabbar.newTab", defaultValue: "New Tab")
+            ) {
+                workspace.createNewTabOfFocusedKind(inPane: paneId)
+            }
+        }
+        .padding(.leading, 6)
+        .padding(.trailing, 8)
+        .saturation(chromeSaturation)
+        // Minimal-mode hover-fade is still handled by bonsplit's internal splitButtons
+        // row during Phase 2 (it renders behind this accessory). Phase 3 will delete
+        // the internal row; c11mux will then own the fade via @Environment(\.bonsplitTabBarHover).
+    }
+}
+
+private struct ToolbarIconButton: View {
+    let systemImage: String
+    let tooltip: String
+    let action: () -> Void
+    @State private var isMouseInside = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .regular))
+                .foregroundStyle(.secondary)
+                .frame(width: 22, height: 22)
+                .background(
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isMouseInside ? Color.primary.opacity(0.08) : Color.clear)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isMouseInside = $0 }
+        .help(tooltip)
+    }
+}
+
+private struct ToolbarSeparator: View {
+    var body: some View {
+        Rectangle()
+            .fill(Color.secondary.opacity(0.3))
+            .frame(width: 1, height: 18)
+            .padding(.horizontal, 8)
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10462,15 +10462,12 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID) {
+        // After CMUX-30 Phase 2, only the "terminal" kind reaches here — from bonsplit's
+        // empty-space drop zone and dropZoneAfterTabs. Browser/markdown/newTab are invoked
+        // directly by Sources/Panels/TabBarTrailingAccessory.swift.
         switch kind {
         case "terminal":
             _ = newTerminalSurface(inPane: pane)
-        case "browser":
-            _ = newBrowserSurface(inPane: pane)
-        case "markdown":
-            _ = newMarkdownSurface(inPane: pane)
-        case "newTab":
-            createNewTabOfFocusedKind(inPane: pane)
         default:
             _ = newTerminalSurface(inPane: pane)
         }
@@ -10480,7 +10477,7 @@ extension Workspace: BonsplitDelegate {
     /// the same kind as whatever surface is currently selected in that pane.
     /// Falls back to terminal when the pane has no selection or no matching
     /// panel type.
-    private func createNewTabOfFocusedKind(inPane pane: PaneID) {
+    func createNewTabOfFocusedKind(inPane pane: PaneID) {
         let selectedPanelId = effectiveSelectedPanelId(inPane: pane)
         let panel = selectedPanelId.flatMap { panels[$0] }
         switch panel?.panelType {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -73,61 +73,72 @@ struct WorkspaceContentView: View {
             }
         }()
 
-        let bonsplitView = BonsplitView(controller: workspace.bonsplitController) { tab, paneId in
-            // Content for each tab in bonsplit
-            let _ = Self.debugPanelLookup(tab: tab, workspace: workspace)
-            if let panel = workspace.panel(for: tab.id) {
-                let isFocused = isWorkspaceInputActive && workspace.focusedPanelId == panel.id
-                let isSelectedInPane = workspace.bonsplitController.selectedTab(inPane: paneId)?.id == tab.id
-                let isVisibleInUI = Self.panelVisibleInUI(
-                    isWorkspaceVisible: isWorkspaceVisible,
-                    isSelectedInPane: isSelectedInPane,
-                    isFocused: isFocused
-                )
-                let hasUnreadNotification = Workspace.shouldShowUnreadIndicator(
-                    hasUnreadNotification: notificationStore.hasUnreadNotification(forTabId: workspace.id, surfaceId: panel.id),
-                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panel.id)
-                )
-                PanelContentView(
-                    workspace: workspace,
-                    panel: panel,
-                    paneId: paneId,
-                    isFocused: isFocused,
-                    isSelectedInPane: isSelectedInPane,
-                    isVisibleInUI: isVisibleInUI,
-                    portalPriority: workspacePortalPriority,
-                    isSplit: isSplit,
-                    appearance: appearance,
-                    hasUnreadNotification: hasUnreadNotification,
-                    onFocus: {
-                        // Keep bonsplit focus in sync with the AppKit first responder for the
-                        // active workspace. This prevents divergence between the blue focused-tab
-                        // indicator and where keyboard input/flash-focus actually lands.
-                        guard isWorkspaceInputActive else { return }
-                        guard workspace.panels[panel.id] != nil else { return }
-                        workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
-                    },
-                    onRequestPanelFocus: {
-                        guard isWorkspaceInputActive else { return }
-                        guard workspace.panels[panel.id] != nil else { return }
-                        workspace.focusPanel(panel.id)
-                    },
-                    onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
-                )
-                .onTapGesture {
-                    workspace.bonsplitController.focusPane(paneId)
+        let bonsplitView = BonsplitView(
+            controller: workspace.bonsplitController,
+            content: { tab, paneId in
+                // Content for each tab in bonsplit
+                let _ = Self.debugPanelLookup(tab: tab, workspace: workspace)
+                if let panel = workspace.panel(for: tab.id) {
+                    let isFocused = isWorkspaceInputActive && workspace.focusedPanelId == panel.id
+                    let isSelectedInPane = workspace.bonsplitController.selectedTab(inPane: paneId)?.id == tab.id
+                    let isVisibleInUI = Self.panelVisibleInUI(
+                        isWorkspaceVisible: isWorkspaceVisible,
+                        isSelectedInPane: isSelectedInPane,
+                        isFocused: isFocused
+                    )
+                    let hasUnreadNotification = Workspace.shouldShowUnreadIndicator(
+                        hasUnreadNotification: notificationStore.hasUnreadNotification(forTabId: workspace.id, surfaceId: panel.id),
+                        isManuallyUnread: workspace.manualUnreadPanelIds.contains(panel.id)
+                    )
+                    PanelContentView(
+                        workspace: workspace,
+                        panel: panel,
+                        paneId: paneId,
+                        isFocused: isFocused,
+                        isSelectedInPane: isSelectedInPane,
+                        isVisibleInUI: isVisibleInUI,
+                        portalPriority: workspacePortalPriority,
+                        isSplit: isSplit,
+                        appearance: appearance,
+                        hasUnreadNotification: hasUnreadNotification,
+                        onFocus: {
+                            // Keep bonsplit focus in sync with the AppKit first responder for the
+                            // active workspace. This prevents divergence between the blue focused-tab
+                            // indicator and where keyboard input/flash-focus actually lands.
+                            guard isWorkspaceInputActive else { return }
+                            guard workspace.panels[panel.id] != nil else { return }
+                            workspace.focusPanel(panel.id, trigger: .terminalFirstResponder)
+                        },
+                        onRequestPanelFocus: {
+                            guard isWorkspaceInputActive else { return }
+                            guard workspace.panels[panel.id] != nil else { return }
+                            workspace.focusPanel(panel.id)
+                        },
+                        onTriggerFlash: { workspace.triggerDebugFlash(panelId: panel.id) }
+                    )
+                    .onTapGesture {
+                        workspace.bonsplitController.focusPane(paneId)
+                    }
+                } else {
+                    // Fallback for tabs without panels (shouldn't happen normally)
+                    EmptyPanelView(workspace: workspace, paneId: paneId)
                 }
-            } else {
-                // Fallback for tabs without panels (shouldn't happen normally)
+            },
+            emptyPane: { paneId in
+                // Empty pane content
                 EmptyPanelView(workspace: workspace, paneId: paneId)
+                    .onTapGesture {
+                        workspace.bonsplitController.focusPane(paneId)
+                    }
+            },
+            trailingAccessory: { paneId, chromeSaturation in
+                TabBarTrailingAccessory(
+                    paneId: paneId,
+                    chromeSaturation: chromeSaturation,
+                    workspace: workspace
+                )
             }
-        } emptyPane: { paneId in
-            // Empty pane content
-            EmptyPanelView(workspace: workspace, paneId: paneId)
-                .onTapGesture {
-                    workspace.bonsplitController.focusPane(paneId)
-                }
-        }
+        )
         .internalOnlyTabDrag()
         // Split zoom swaps Bonsplit between the full split tree and a single pane view.
         // Recreate the Bonsplit subtree on zoom enter/exit so stale pre-zoom pane chrome


### PR DESCRIPTION
## Summary

Phase 2 of CMUX-30: c11mux consumes the bonsplit `trailingAccessory` slot shipped in [bonsplit Phase 1 PR #2](https://github.com/Stage-11-Agentics/bonsplit/pull/2). The six toolbar buttons (Terminal/Browser/Markdown/SplitH/SplitV/+) now live host-side in `Sources/Panels/TabBarTrailingAccessory.swift` and are supplied into `BonsplitView` via the new builder. Bonsplit's internal `splitButtons` row is **not yet deleted** — it still renders behind the host accessory as zero-regression insurance during the transition. Phase 3 (separate bonsplit PR) deletes the internal row and ships bonsplit 2.0.0.

- **Bumps `vendor/bonsplit`** from ee7c0fd to `a45400dc0dae171d31b59c85f333d3da87d96178` (Phase 1 merge on bonsplit/main). Submodule-safety invariant verified: pointer is on bonsplit/origin/main.
- **New file** `Sources/Panels/TabBarTrailingAccessory.swift` (90 lines): `TabBarTrailingAccessory` + private `ToolbarIconButton` / `ToolbarSeparator` helpers. Plain `let workspace: Workspace` binding (no `@ObservedObject` per plan §13.9). `@MainActor`-annotated.
- **Promotes** `Workspace.createNewTabOfFocusedKind(inPane:)` from `private` to internal (default). No signature change.
- **Trims** `Workspace.splitTabBar(_:didRequestNewTab:inPane:)` to keep only the `"terminal"` arm — the other three kinds are now invoked directly by the host accessory. The `"terminal"` arm stays because bonsplit's empty-space drop-zone overlay (`TabBarView.swift:430-452`) and `dropZoneAfterTabs` (L743-L754) still call `controller.requestNewTab(kind: "terminal", inPane:)` outside `splitButtons`.
- **Wires** the 4-arg `BonsplitView(controller:content:emptyPane:trailingAccessory:)` initializer at `Sources/WorkspaceContentView.swift`. Existing content-builder body preserved verbatim inside the explicit `content:` label.
- **Localizes** six new `tabbar.*` keys in `Resources/Localizable.xcstrings`. English and Japanese are translated; other existing languages are `needs_review` with English placeholder text.

### Decisions at flex points

- **Minimal-mode hover-fade**: deferred to Phase 3. Bonsplit's internal `splitButtons` row still handles the fade in Phase 2 because it continues to render behind the host accessory. Once Phase 3 deletes the internal row, c11mux's `TabBarTrailingAccessory` will consume `@Environment(\.bonsplitTabBarHover)` to own the fade. Marked with a code comment for follow-up.
- **Toolbar button styling**: c11mux-local helpers (`ToolbarIconButton`, `ToolbarSeparator`) rather than bonsplit's internal `SplitToolbarButton`. Keeps bonsplit shrink-friendly and avoids promoting internal types to public (plan §13.8).
- **Delegate arm retention**: `"terminal"` stays because `TabBarView.swift:439` and `L751` still use it. Not a CMUX-30 goal to move those two sites.

## Commits (4 atomic)

```
3fae5be3 CMUX-30 Phase 2: localize tabbar tooltips
026b700d CMUX-30 Phase 2: add host trailing accessory
fbf74f26 CMUX-30 Phase 2: promote createNewTab and trim delegate
0ae87c92 CMUX-30 Phase 2: bump vendor/bonsplit to a45400d for trailingAccessory slot
```

## Test plan

- [ ] Tagged DEV build `cmux-30-phase2` built and launched successfully (exit 0, PID 81271 as of orchestrator check).
- [ ] **Visual smoke test (Atin):** tab bar renders the six buttons in the trailing region. Click each button — Terminal/Browser/Markdown create the expected surface in the current pane; SplitRight/SplitDown split correctly; + creates a new tab matching the focused pane's kind. Tooltips render (English on this machine).
- [ ] Empty-space double-click in a pane's tab bar still creates a terminal tab (via the retained `"terminal"` delegate arm, routed through bonsplit's drop-zone overlay).
- [ ] Minimal-mode hover-fade still works — bonsplit's internal splitButtons handles it during Phase 2.
- [ ] CI: c11mux build + unit tests pass (no local runs per c11mux/CLAUDE.md).

## Next

- Phase 3 codex is queued on the same pane; will be triggered with \`GO PHASE 3\` after this PR merges.
- Phase 3 = bonsplit cleanup (delete internal splitButtons row + deprecated Appearance fields + update Example app) → bonsplit 2.0.0.
- Post-Phase-3 follow-up: bump `vendor/bonsplit` pointer to the 2.0.0 commit (separate c11mux PR).

---

Plan: \`.lattice/plans/task_01KPKJ68Q9CZHMN7YCWWD4AH8S.md\` §13.

🤖 Dispatched via CMUX-30 orchestrator → Codex Phase 2+3 interactive sub-agent → orchestrator push.