### PR TITLE
CMUX-36: Bottom status bar + jump-to-unread button

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -78,6 +78,10 @@
 			A5001093 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001090 /* AppDelegate.swift */; };
 			A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
 			A5001095 /* TerminalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001092 /* TerminalNotificationStore.swift */; };
+			A5C36001 /* BottomStatusBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C36011 /* BottomStatusBarView.swift */; };
+			A5C36002 /* JumpToUnreadStatusBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C36012 /* JumpToUnreadStatusBarButton.swift */; };
+			A5C36003 /* StatusBarButtonDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C36013 /* StatusBarButtonDisplay.swift */; };
+			A5C36021 /* StatusBarButtonDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C36031 /* StatusBarButtonDisplayTests.swift */; };
 			A5001250 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
 			B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
 			A5001270 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = A5001271 /* PostHog */; };
@@ -322,6 +326,10 @@
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A5001091 /* NotificationsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsPage.swift; sourceTree = "<group>"; };
 		A5001092 /* TerminalNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationStore.swift; sourceTree = "<group>"; };
+		A5C36011 /* BottomStatusBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar/BottomStatusBarView.swift; sourceTree = "<group>"; };
+		A5C36012 /* JumpToUnreadStatusBarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar/JumpToUnreadStatusBarButton.swift; sourceTree = "<group>"; };
+		A5C36013 /* StatusBarButtonDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar/StatusBarButtonDisplay.swift; sourceTree = "<group>"; };
+		A5C36031 /* StatusBarButtonDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarButtonDisplayTests.swift; sourceTree = "<group>"; };
 		A5001301 /* SurfaceSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/SurfaceSearchOverlay.swift; sourceTree = "<group>"; };
 		A5008370 /* BrowserSearchOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserSearchOverlay.swift; sourceTree = "<group>"; };
 		A5008372 /* BrowserFindJavaScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Find/BrowserFindJavaScript.swift; sourceTree = "<group>"; };
@@ -562,6 +570,9 @@
 				A5001090 /* AppDelegate.swift */,
 				A5001091 /* NotificationsPage.swift */,
 				A5001092 /* TerminalNotificationStore.swift */,
+				A5C36011 /* BottomStatusBarView.swift */,
+				A5C36012 /* JumpToUnreadStatusBarButton.swift */,
+				A5C36013 /* StatusBarButtonDisplay.swift */,
 				A5001301 /* SurfaceSearchOverlay.swift */,
 				A5008370 /* BrowserSearchOverlay.swift */,
 				A5008372 /* BrowserFindJavaScript.swift */,
@@ -716,6 +727,7 @@
 					D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */,
 					D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */,
 					D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */,
+					A5C36031 /* StatusBarButtonDisplayTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -913,6 +925,9 @@
 				A5001093 /* AppDelegate.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
 				A5001095 /* TerminalNotificationStore.swift in Sources */,
+				A5C36001 /* BottomStatusBarView.swift in Sources */,
+				A5C36002 /* JumpToUnreadStatusBarButton.swift in Sources */,
+				A5C36003 /* StatusBarButtonDisplay.swift in Sources */,
 				A5001303 /* SurfaceSearchOverlay.swift in Sources */,
 				A5008371 /* BrowserSearchOverlay.swift in Sources */,
 				A5008373 /* BrowserFindJavaScript.swift in Sources */,
@@ -991,6 +1006,7 @@
 					A5F1001001A1B2C3D4E5F013 /* ThemeManagerLifecycleTests.swift in Sources */,
 					A5F1001001A1B2C3D4E5F014 /* ResolverCacheKeyTests.swift in Sources */,
 					A5F1001001A1B2C3D4E5F015 /* C11muxThemeLoaderTests.swift in Sources */,
+					A5C36021 /* StatusBarButtonDisplayTests.swift in Sources */,
 						A5F1001001A1B2C3D4E5F016 /* ThemeResolverBenchmarks.swift in Sources */,
 						A5F1001001A1B2C3D4E5F017 /* ThemeResolvedSnapshotArtifactTests.swift in Sources */,
 						A5F1001001A1B2C3D4E5F018 /* ThemeCycleAndInvalidValueTests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -67877,6 +67877,23 @@
         }
       }
     },
+    "statusBar.jumpToUnread.accessibility": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jump to latest unread notification"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最新の未読通知へジャンプ"
+          }
+        }
+      }
+    },
     "statusMenu.clearAll": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2399,17 +2399,20 @@ struct ContentView: View {
 
     var body: some View {
         var view = AnyView(
-            contentAndSidebarLayout
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-                .overlay(alignment: .topLeading) {
-                    if isFullScreen && sidebarState.isVisible && !isMinimalMode {
-                        fullscreenControls
-                            .padding(.leading, 10)
-                            .padding(.top, 4)
+            VStack(spacing: 0) {
+                contentAndSidebarLayout
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .overlay(alignment: .topLeading) {
+                        if isFullScreen && sidebarState.isVisible && !isMinimalMode {
+                            fullscreenControls
+                                .padding(.leading, 10)
+                                .padding(.top, 4)
+                        }
                     }
-                }
-                .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
-                .background(Color.clear)
+                BottomStatusBarView(leading: { JumpToUnreadStatusBarButton() })
+            }
+            .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
+            .background(Color.clear)
         )
 
         view = AnyView(view.onAppear {

--- a/Sources/StatusBar/BottomStatusBarView.swift
+++ b/Sources/StatusBar/BottomStatusBarView.swift
@@ -6,6 +6,8 @@ import SwiftUI
 /// app state, so mounting it does not subscribe the parent view to any
 /// observable.
 struct BottomStatusBarView<Leading: View, Center: View, Trailing: View>: View {
+    // `static let` is disallowed on generic types; the `static var { 24 }`
+    // form returns the literal every call but inlines to a constant.
     private static var barHeight: CGFloat { 24 }
 
     private let leading: Leading

--- a/Sources/StatusBar/BottomStatusBarView.swift
+++ b/Sources/StatusBar/BottomStatusBarView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Persistent window-scoped footer chrome. A multi-slot container (leading,
+/// center, trailing) whose only job is to lay out tenant views. Tenants
+/// themselves own their own observation graphs — the container never reads
+/// app state, so mounting it does not subscribe the parent view to any
+/// observable.
+struct BottomStatusBarView<Leading: View, Center: View, Trailing: View>: View {
+    private static var barHeight: CGFloat { 24 }
+
+    private let leading: Leading
+    private let center: Center
+    private let trailing: Trailing
+
+    init(
+        @ViewBuilder leading: () -> Leading,
+        @ViewBuilder center: () -> Center = { EmptyView() },
+        @ViewBuilder trailing: () -> Trailing = { EmptyView() }
+    ) {
+        self.leading = leading()
+        self.center = center()
+        self.trailing = trailing()
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+                .opacity(0.6)
+            HStack(spacing: 8) {
+                leading
+                Spacer(minLength: 8)
+                center
+                Spacer(minLength: 8)
+                trailing
+            }
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity)
+            .frame(height: Self.barHeight)
+        }
+        .background(.bar)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("window.bottomStatusBar")
+    }
+}

--- a/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
+++ b/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
@@ -26,7 +26,8 @@ struct JumpToUnreadStatusBarButton: View {
     }
 
     var body: some View {
-        Button(action: jump) {
+        let display = self.display
+        return Button(action: jump) {
             ZStack(alignment: .topTrailing) {
                 Image(systemName: "bell")
                     .font(.system(size: 13, weight: .regular))
@@ -54,7 +55,7 @@ struct JumpToUnreadStatusBarButton: View {
         .opacity(display.isEnabled ? 1.0 : 0.45)
         .accessibilityIdentifier("statusBar.jumpToUnread.button")
         .accessibilityLabel(accessibilityLabel)
-        .accessibilityValue(display.badgeText ?? "0")
+        .accessibilityValue(display.badgeText ?? "")
         .safeHelp(
             KeyboardShortcutSettings.Action.jumpToUnread.tooltip(tooltipBase)
         )

--- a/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
+++ b/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// First tenant of the bottom status bar. Icon + badge only — no visible
+/// text label (tooltip carries the affordance copy). Mirrors the binding
+/// and click-handler pattern at `UpdateTitlebarAccessory.swift:1008` and
+/// the `.safeHelp` shortcut-tooltip pattern at `NotificationsPage.swift:117`.
+struct JumpToUnreadStatusBarButton: View {
+    @EnvironmentObject private var notificationStore: TerminalNotificationStore
+
+    private var display: StatusBarButtonDisplay {
+        StatusBarButtonDisplay(unreadCount: notificationStore.unreadCount)
+    }
+
+    private var tooltipBase: String {
+        String(
+            localized: "notifications.jumpToLatestUnread",
+            defaultValue: "Jump to Latest Unread"
+        )
+    }
+
+    private var accessibilityLabel: String {
+        String(
+            localized: "statusBar.jumpToUnread.accessibility",
+            defaultValue: "Jump to latest unread notification"
+        )
+    }
+
+    var body: some View {
+        Button(action: jump) {
+            ZStack(alignment: .topTrailing) {
+                Image(systemName: "bell")
+                    .font(.system(size: 13, weight: .regular))
+                    .frame(width: 16, height: 16)
+
+                if let badge = display.badgeText {
+                    Text(badge)
+                        .font(.system(size: 9, weight: .semibold))
+                        .monospacedDigit()
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 1)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(Color.accentColor)
+                        )
+                        .foregroundColor(.white)
+                        .offset(x: 7, y: -5)
+                        .accessibilityHidden(true)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .contentShape(Rectangle())
+        .disabled(!display.isEnabled)
+        .opacity(display.isEnabled ? 1.0 : 0.45)
+        .accessibilityIdentifier("statusBar.jumpToUnread.button")
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(display.badgeText ?? "0")
+        .safeHelp(
+            KeyboardShortcutSettings.Action.jumpToUnread.tooltip(tooltipBase)
+        )
+    }
+
+    private func jump() {
+        DispatchQueue.main.async {
+            AppDelegate.shared?.jumpToLatestUnread()
+        }
+    }
+}

--- a/Sources/StatusBar/StatusBarButtonDisplay.swift
+++ b/Sources/StatusBar/StatusBarButtonDisplay.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Pure value type mapping raw unread count → presentation state for the
+/// jump-to-latest-unread status-bar button. Kept free of SwiftUI and AppKit
+/// so it is trivially unit-testable under the `cmuxTests` target.
+struct StatusBarButtonDisplay: Equatable {
+    let unreadCount: Int
+    let isEnabled: Bool
+    let badgeText: String?
+
+    init(unreadCount: Int) {
+        let count = max(0, unreadCount)
+        self.unreadCount = count
+        self.isEnabled = count > 0
+        self.badgeText = Self.badgeText(for: count)
+    }
+
+    /// Two-digit cap matches `MenuBarBadgeLabelFormatter.badgeText(for:)`
+    /// (AppDelegate.swift) and `TerminalNotificationStore.dockBadgeLabel`
+    /// so the bar agrees with the menu-bar and dock surfaces.
+    private static func badgeText(for count: Int) -> String? {
+        guard count > 0 else { return nil }
+        if count > 99 { return "99+" }
+        return String(count)
+    }
+}

--- a/cmuxTests/StatusBarButtonDisplayTests.swift
+++ b/cmuxTests/StatusBarButtonDisplayTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import cmux
+
+final class StatusBarButtonDisplayTests: XCTestCase {
+    func testZeroCount_buttonDisabledAndNoBadge() {
+        let display = StatusBarButtonDisplay(unreadCount: 0)
+        XCTAssertFalse(display.isEnabled)
+        XCTAssertNil(display.badgeText)
+        XCTAssertEqual(display.unreadCount, 0)
+    }
+
+    func testSingleUnread_buttonEnabledAndBadgeOne() {
+        let display = StatusBarButtonDisplay(unreadCount: 1)
+        XCTAssertTrue(display.isEnabled)
+        XCTAssertEqual(display.badgeText, "1")
+    }
+
+    func testTwoDigitUnread_rendersExactCount() {
+        let display = StatusBarButtonDisplay(unreadCount: 99)
+        XCTAssertTrue(display.isEnabled)
+        XCTAssertEqual(display.badgeText, "99")
+    }
+
+    func testThreeDigitUnread_capsAtNinetyNinePlus() {
+        let display = StatusBarButtonDisplay(unreadCount: 100)
+        XCTAssertTrue(display.isEnabled)
+        XCTAssertEqual(display.badgeText, "99+")
+    }
+
+    func testLargeUnread_stillCapsAtNinetyNinePlus() {
+        let display = StatusBarButtonDisplay(unreadCount: 5000)
+        XCTAssertTrue(display.isEnabled)
+        XCTAssertEqual(display.badgeText, "99+")
+    }
+
+    func testNegativeCount_clampedToZero() {
+        // Defensive: notification counts should never be negative, but if a
+        // caller passes one, we clamp to the disabled/no-badge state rather
+        // than render "-3" or crash.
+        let display = StatusBarButtonDisplay(unreadCount: -3)
+        XCTAssertFalse(display.isEnabled)
+        XCTAssertNil(display.badgeText)
+        XCTAssertEqual(display.unreadCount, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- Scaffold a bottom status bar primitive under ContentView with a reusable button display model.
- Add a jump-to-unread status bar button, localized strings, and unit tests for the button display.
- Review nits applied: hoist display + cleaner accessibility.

## Files
- `Sources/ContentView.swift` — mount the status bar
- `Sources/StatusBar/BottomStatusBarView.swift` — bar primitive
- `Sources/StatusBar/JumpToUnreadStatusBarButton.swift` — jump-to-unread button
- `Sources/StatusBar/StatusBarButtonDisplay.swift` — display model
- `Resources/Localizable.xcstrings` — localized strings
- `cmuxTests/StatusBarButtonDisplayTests.swift` — unit tests

## Test plan
- [ ] Status bar renders at bottom of ContentView without layout regressions
- [ ] Jump-to-unread button appears when unread state is present, hidden otherwise
- [ ] Accessibility labels present and localized
- [ ] Unit tests pass (`StatusBarButtonDisplayTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)