### PR TITLE
[codex] Keep workspace names primary in sidebar cards

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -77708,6 +77708,23 @@
         }
       }
     },
+    "workspace.defaultTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace %lld"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース %lld"
+          }
+        }
+      }
+    },
     "workspace.placement.afterCurrent": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3066,7 +3066,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
               visibleFrame.height > 0 else {
             return nil
         }
-        return visibleFrame.integral
+        let minWidth = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
+        let minHeight = CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+        let preferredFrame = CGRect(
+            x: visibleFrame.midX - CGFloat(SessionPersistencePolicy.defaultWindowWidth) / 2,
+            y: visibleFrame.midY - CGFloat(SessionPersistencePolicy.defaultWindowHeight) / 2,
+            width: CGFloat(SessionPersistencePolicy.defaultWindowWidth),
+            height: CGFloat(SessionPersistencePolicy.defaultWindowHeight)
+        )
+        return clampFrame(
+            preferredFrame,
+            within: visibleFrame,
+            minWidth: minWidth,
+            minHeight: minHeight
+        ).integral
     }
 
     nonisolated static func resolvedStartupPrimaryWindowFrame(
@@ -3110,18 +3123,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let minWidth = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
         let minHeight = CGFloat(SessionPersistencePolicy.minimumWindowHeight)
-        guard frame.width >= minWidth,
-              frame.height >= minHeight else {
+        guard frame.width > 0,
+              frame.height > 0 else {
             return nil
         }
 
-        guard !availableDisplays.isEmpty else { return frame }
+        guard !availableDisplays.isEmpty else {
+            return frameWithMinimumSize(frame, minWidth: minWidth, minHeight: minHeight)
+        }
 
         if let targetDisplay = display(for: displaySnapshot, in: availableDisplays) {
             if shouldPreserveExactFrame(
                 frame: frame,
                 displaySnapshot: displaySnapshot,
-                targetDisplay: targetDisplay
+                targetDisplay: targetDisplay,
+                minWidth: minWidth,
+                minHeight: minHeight
             ) {
                 return frame
             }
@@ -3302,6 +3319,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return CGRect(x: x, y: y, width: width, height: height)
     }
 
+    private nonisolated static func frameWithMinimumSize(
+        _ frame: CGRect,
+        minWidth: CGFloat,
+        minHeight: CGFloat
+    ) -> CGRect {
+        CGRect(
+            x: frame.minX,
+            y: frame.minY,
+            width: max(frame.width, minWidth),
+            height: max(frame.height, minHeight)
+        )
+    }
+
     private nonisolated static func intersectionArea(_ lhs: CGRect, _ rhs: CGRect) -> CGFloat {
         let intersection = lhs.intersection(rhs)
         guard !intersection.isNull else { return 0 }
@@ -3317,7 +3347,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private nonisolated static func shouldPreserveExactFrame(
         frame: CGRect,
         displaySnapshot: SessionDisplaySnapshot?,
-        targetDisplay: SessionDisplayGeometry
+        targetDisplay: SessionDisplayGeometry,
+        minWidth: CGFloat,
+        minHeight: CGFloat
     ) -> Bool {
         guard let displaySnapshot else { return false }
         guard let snapshotDisplayID = displaySnapshot.displayID,
@@ -3338,6 +3370,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             && frame.height.isFinite
             && frame.origin.x.isFinite
             && frame.origin.y.isFinite
+            && frame.width >= minWidth
+            && frame.height >= minHeight
     }
 
     private nonisolated static func rectApproximatelyEqual(
@@ -6058,7 +6092,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .environmentObject(sidebarSelectionState)
 
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 460, height: 360),
+            contentRect: NSRect(
+                x: 0,
+                y: 0,
+                width: CGFloat(SessionPersistencePolicy.defaultWindowWidth),
+                height: CGFloat(SessionPersistencePolicy.defaultWindowHeight)
+            ),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
             defer: false
@@ -6068,9 +6107,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.titlebarAppearsTransparent = true
         window.isMovableByWindowBackground = false
         window.isMovable = false
+        applyMainWindowSizeConstraints(to: window)
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
         if let restoredFrame {
             window.setFrame(restoredFrame, display: false)
+        } else if let defaultFrame = Self.firstLaunchPrimaryWindowFrame(
+            window: window,
+            fallbackDisplay: currentDisplayGeometries().fallback
+        ) {
+            window.setFrame(defaultFrame, display: false)
         } else {
             window.center()
         }
@@ -6117,6 +6162,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
         }
         return windowId
+    }
+
+    func applyMainWindowSizeConstraints(to window: NSWindow) {
+        let minContentSize = NSSize(
+            width: CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+            height: CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+        )
+        window.contentMinSize = minContentSize
+        window.minSize = window.frameRect(forContentRect: NSRect(origin: .zero, size: minContentSize)).size
     }
 
     @objc func checkForUpdates(_ sender: Any?) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11036,43 +11036,42 @@ private struct TabItemView: View, Equatable {
         }()
 
         VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 8) {
-                if unreadCount > 0 {
-                    ZStack {
-                        Circle()
-                            .fill(activeUnreadBadgeFillColor)
-                        Text("\(unreadCount)")
-                            .font(.system(size: 9, weight: .semibold))
-                            // Badge fill is always gold (`activeUnreadBadgeFillColor`).
-                            // Use black on the gold circle whenever the tab is the
-                            // active selection in .solidFill — including custom-color
-                            // workspaces, where the broader text palette stays primary
-                            // but black-on-gold remains the only legible badge choice.
-                            .foregroundColor(isActive && activeTabIndicatorStyle == .solidFill ? BrandColors.blackSwiftUI : .white)
-                    }
-                    .frame(width: 16, height: 16)
-                }
-
-                if tab.isPinned {
-                    Image(systemName: "pin.fill")
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundColor(activeSecondaryColor(0.8))
-                }
-
-                AgentChipBadge(
-                    chip: agentChip,
-                    showsLabel: !isMinimalMode,
-                    foreground: activePrimaryTextColor,
-                    secondary: activeSecondaryColor(0.75)
-                )
-
-                Text(TitleFormatting.sidebarLabel(from: tab.title))
+            HStack(alignment: .top, spacing: 6) {
+                Text(tab.title)
                     .font(.system(size: 12.5, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
-                    .lineLimit(1)
+                    .lineLimit(2)
                     .truncationMode(.tail)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .layoutPriority(1)
 
-                Spacer()
+                Spacer(minLength: 4)
+
+                HStack(spacing: 5) {
+                    if tab.isPinned {
+                        Image(systemName: "pin.fill")
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundColor(activeSecondaryColor(0.8))
+                    }
+
+                    if unreadCount > 0 {
+                        ZStack {
+                            Circle()
+                                .fill(activeUnreadBadgeFillColor)
+                            Text("\(unreadCount)")
+                                .font(.system(size: 9, weight: .semibold))
+                                // Badge fill is always gold (`activeUnreadBadgeFillColor`).
+                                // Use black on the gold circle whenever the tab is the
+                                // active selection in .solidFill — including custom-color
+                                // workspaces, where the broader text palette stays primary
+                                // but black-on-gold remains the only legible badge choice.
+                                .foregroundColor(isActive && activeTabIndicatorStyle == .solidFill ? BrandColors.blackSwiftUI : .white)
+                        }
+                        .frame(width: 16, height: 16)
+                    }
+                }
+                .padding(.top, 1)
 
                 ZStack(alignment: .trailing) {
                     Button(action: {
@@ -11110,6 +11109,19 @@ private struct TabItemView: View, Equatable {
                 }
                 .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
                 .frame(width: workspaceHintSlotWidth, height: 16, alignment: .trailing)
+            }
+
+            if agentChip != nil {
+                HStack(spacing: 4) {
+                    AgentChipBadge(
+                        chip: agentChip,
+                        showsLabel: !isMinimalMode,
+                        foreground: activeSecondaryColor(0.78),
+                        secondary: activeSecondaryColor(0.68)
+                    )
+                    Spacer(minLength: 0)
+                }
+                .padding(.top, 1)
             }
 
             if let subtitle = effectiveSubtitle {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2947,6 +2947,7 @@ struct ContentView: View {
                 let tintColor = (NSColor(hex: bgGlassTintHex) ?? .black).withAlphaComponent(bgGlassTintOpacity)
                 WindowGlassEffect.apply(to: window, tintColor: tintColor)
             }
+            AppDelegate.shared?.applyMainWindowSizeConstraints(to: window)
             AppDelegate.shared?.attachUpdateAccessory(to: window)
             AppDelegate.shared?.applyWindowDecorations(to: window)
             AppDelegate.shared?.registerMainWindow(

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -10,8 +10,10 @@ enum SessionPersistencePolicy {
     static let defaultSidebarWidth: Double = 200
     static let minimumSidebarWidth: Double = 180
     static let maximumSidebarWidth: Double = 600
-    static let minimumWindowWidth: Double = 300
-    static let minimumWindowHeight: Double = 200
+    static let defaultWindowWidth: Double = 1120
+    static let defaultWindowHeight: Double = 840
+    static let minimumWindowWidth: Double = 900
+    static let minimumWindowHeight: Double = 640
     static let autosaveInterval: TimeInterval = 8.0
     static let maxWindowsPerSnapshot: Int = 12
     static let maxWorkspacesPerWindow: Int = 128

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -429,6 +429,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var id: UUID
     var processTitle: String
     var customTitle: String?
+    var stableDefaultTitle: String? = nil
     var customColor: String?
     var isPinned: Bool
     var currentDirectory: String

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -668,6 +668,13 @@ class TabManager: ObservableObject {
         let executionError: String?
     }
 
+    private static func defaultWorkspaceTitle(number: Int) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "workspace.defaultTitle", defaultValue: "Workspace %lld"),
+            Int64(number)
+        )
+    }
+
     private struct WorkspaceGitProbeKey: Hashable {
         let workspaceId: UUID
         let panelId: UUID
@@ -1109,6 +1116,7 @@ class TabManager: ObservableObject {
         // bounce through Combine-backed accessors while we're preparing the new workspace.
         let snapshot = workspaceCreationSnapshot()
         let nextTabCount = snapshot.tabs.count + 1
+        let defaultTitle = Self.defaultWorkspaceTitle(number: nextTabCount)
         sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
         let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
         let workingDirectory = explicitWorkingDirectory ?? preferredWorkingDirectoryForNewTab(snapshot: snapshot)
@@ -1116,7 +1124,8 @@ class TabManager: ObservableObject {
         let ordinal = Self.nextPortOrdinal
         Self.nextPortOrdinal += 1
         let newWorkspace = Workspace(
-            title: "Terminal \(nextTabCount)",
+            title: defaultTitle,
+            stableDefaultTitle: defaultTitle,
             workingDirectory: workingDirectory,
             portOrdinal: ordinal,
             configTemplate: inheritedConfig,
@@ -5173,7 +5182,8 @@ extension TabManager {
                 : nil
             let workspace = Workspace(
                 id: restoredWorkspaceId,
-                title: workspaceSnapshot.processTitle,
+                title: workspaceSnapshot.stableDefaultTitle ?? workspaceSnapshot.processTitle,
+                stableDefaultTitle: workspaceSnapshot.stableDefaultTitle,
                 workingDirectory: workspaceSnapshot.currentDirectory,
                 portOrdinal: ordinal
             )
@@ -5186,7 +5196,8 @@ extension TabManager {
         if newTabs.isEmpty {
             let ordinal = Self.nextPortOrdinal
             Self.nextPortOrdinal += 1
-            let fallback = Workspace(title: "Terminal 1", portOrdinal: ordinal)
+            let defaultTitle = Self.defaultWorkspaceTitle(number: 1)
+            let fallback = Workspace(title: defaultTitle, stableDefaultTitle: defaultTitle, portOrdinal: ordinal)
             fallback.owningTabManager = self
             wireClosedBrowserTracking(for: fallback)
             newTabs.append(fallback)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -212,6 +212,7 @@ extension Workspace {
             id: id,
             processTitle: processTitle,
             customTitle: customTitle,
+            stableDefaultTitle: stableDefaultTitle,
             customColor: customColor,
             isPinned: isPinned,
             currentDirectory: currentDirectory,
@@ -267,6 +268,8 @@ extension Workspace {
         pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))
         applySessionDividerPositions(snapshotNode: snapshot.layout, liveNode: bonsplitController.treeSnapshot())
 
+        let restoredStableDefaultTitle = snapshot.stableDefaultTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        stableDefaultTitle = restoredStableDefaultTitle.isEmpty ? nil : restoredStableDefaultTitle
         applyProcessTitle(snapshot.processTitle)
         setCustomTitle(snapshot.customTitle)
         setCustomColor(snapshot.customColor)
@@ -5134,6 +5137,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     private var processTitle: String
+    private var stableDefaultTitle: String?
 
     private enum SurfaceKind {
         static let terminal = "terminal"
@@ -5333,6 +5337,7 @@ final class Workspace: Identifiable, ObservableObject {
     init(
         id: UUID? = nil,
         title: String = "Terminal",
+        stableDefaultTitle: String? = nil,
         workingDirectory: String? = nil,
         portOrdinal: Int = 0,
         configTemplate: ghostty_surface_config_s? = nil,
@@ -5346,6 +5351,8 @@ final class Workspace: Identifiable, ObservableObject {
         self.id = id ?? UUID()
         self.portOrdinal = portOrdinal
         self.processTitle = title
+        let trimmedStableDefaultTitle = stableDefaultTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        self.stableDefaultTitle = trimmedStableDefaultTitle.isEmpty ? nil : trimmedStableDefaultTitle
         self.title = title
         self.customTitle = nil
 
@@ -5968,7 +5975,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     func applyProcessTitle(_ title: String) {
         processTitle = title
-        guard customTitle == nil else { return }
+        guard customTitle == nil, stableDefaultTitle == nil else { return }
         self.title = title
     }
 
@@ -5988,7 +5995,7 @@ final class Workspace: Identifiable, ObservableObject {
         let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if trimmed.isEmpty {
             customTitle = nil
-            self.title = processTitle
+            self.title = stableDefaultTitle ?? processTitle
         } else {
             customTitle = trimmed
             self.title = trimmed
@@ -6203,9 +6210,10 @@ final class Workspace: Identifiable, ObservableObject {
             }
         }
 
-        // If this is the only panel and no custom title, update workspace title
+        // If this is the only panel and no custom/default title, update workspace title.
+        // Stable default workspace names keep the process title as secondary surface state.
         if panels.count == 1, customTitle == nil {
-            if self.title != trimmed {
+            if stableDefaultTitle == nil, self.title != trimmed {
                 self.title = trimmed
                 didMutate = true
             }
@@ -6385,7 +6393,10 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         if panels.count == 1, customTitle == nil {
-            if self.title != trimmed {
+            if processTitle != trimmed {
+                processTitle = trimmed
+            }
+            if stableDefaultTitle == nil, self.title != trimmed {
                 self.title = trimmed
             }
         }

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -369,6 +369,11 @@ struct cmuxApp: App {
                 }
         }
         .windowStyle(.hiddenTitleBar)
+        .defaultSize(
+            width: CGFloat(SessionPersistencePolicy.defaultWindowWidth),
+            height: CGFloat(SessionPersistencePolicy.defaultWindowHeight)
+        )
+        .windowResizability(.contentMinSize)
         .commands {
             CommandGroup(replacing: .appSettings) { }
 

--- a/c11Tests/SessionPersistenceTests.swift
+++ b/c11Tests/SessionPersistenceTests.swift
@@ -514,7 +514,7 @@ final class SessionPersistenceTests: XCTestCase {
     }
 
     func testResolvedWindowFramePrefersSavedDisplayIdentity() {
-        let savedFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
+        let savedFrame = SessionRectSnapshot(x: 1_050, y: 100, width: 900, height: 640)
         let savedDisplay = SessionDisplaySnapshot(
             displayID: 2,
             frame: SessionRectSnapshot(x: 1_000, y: 0, width: 1_000, height: 800),
@@ -544,18 +544,18 @@ final class SessionPersistenceTests: XCTestCase {
         guard let restored else { return }
         XCTAssertTrue(display2.visibleFrame.intersects(restored))
         XCTAssertFalse(display1.visibleFrame.intersects(restored))
-        XCTAssertEqual(restored.width, 600, accuracy: 0.001)
-        XCTAssertEqual(restored.height, 400, accuracy: 0.001)
-        XCTAssertEqual(restored.minX, 200, accuracy: 0.001)
+        XCTAssertEqual(restored.width, 900, accuracy: 0.001)
+        XCTAssertEqual(restored.height, 640, accuracy: 0.001)
+        XCTAssertEqual(restored.minX, 50, accuracy: 0.001)
         XCTAssertEqual(restored.minY, 100, accuracy: 0.001)
     }
 
     func testResolvedWindowFrameKeepsIntersectingFrameWithoutDisplayMetadata() {
-        let savedFrame = SessionRectSnapshot(x: 120, y: 80, width: 500, height: 350)
+        let savedFrame = SessionRectSnapshot(x: 120, y: 80, width: 950, height: 650)
         let display = AppDelegate.SessionDisplayGeometry(
             displayID: 1,
-            frame: CGRect(x: 0, y: 0, width: 1_000, height: 800),
-            visibleFrame: CGRect(x: 0, y: 0, width: 1_000, height: 800)
+            frame: CGRect(x: 0, y: 0, width: 1_200, height: 900),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_200, height: 900)
         )
 
         let restored = AppDelegate.resolvedWindowFrame(
@@ -569,8 +569,55 @@ final class SessionPersistenceTests: XCTestCase {
         guard let restored else { return }
         XCTAssertEqual(restored.minX, 120, accuracy: 0.001)
         XCTAssertEqual(restored.minY, 80, accuracy: 0.001)
-        XCTAssertEqual(restored.width, 500, accuracy: 0.001)
-        XCTAssertEqual(restored.height, 350, accuracy: 0.001)
+        XCTAssertEqual(restored.width, 950, accuracy: 0.001)
+        XCTAssertEqual(restored.height, 650, accuracy: 0.001)
+    }
+
+    func testResolvedWindowFrameExpandsSavedFrameBelowMinimumSize() {
+        let savedFrame = SessionRectSnapshot(x: 120, y: 80, width: 420, height: 900)
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_440, height: 1_000),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_440, height: 1_000)
+        )
+
+        let restored = AppDelegate.resolvedWindowFrame(
+            from: savedFrame,
+            display: SessionDisplaySnapshot(
+                displayID: 1,
+                frame: SessionRectSnapshot(x: 0, y: 0, width: 1_440, height: 1_000),
+                visibleFrame: SessionRectSnapshot(x: 0, y: 0, width: 1_440, height: 1_000)
+            ),
+            availableDisplays: [display],
+            fallbackDisplay: display
+        )
+
+        XCTAssertNotNil(restored)
+        guard let restored else { return }
+        XCTAssertEqual(restored.minX, 120, accuracy: 0.001)
+        XCTAssertEqual(restored.minY, 80, accuracy: 0.001)
+        XCTAssertEqual(restored.width, CGFloat(SessionPersistencePolicy.minimumWindowWidth), accuracy: 0.001)
+        XCTAssertEqual(restored.height, 900, accuracy: 0.001)
+    }
+
+    func testFirstLaunchPrimaryWindowFrameUsesCenteredDefaultSize() {
+        let display = AppDelegate.SessionDisplayGeometry(
+            displayID: 1,
+            frame: CGRect(x: 0, y: 0, width: 1_600, height: 1_000),
+            visibleFrame: CGRect(x: 0, y: 0, width: 1_600, height: 1_000)
+        )
+
+        let frame = AppDelegate.firstLaunchPrimaryWindowFrame(
+            window: nil,
+            fallbackDisplay: display
+        )
+
+        XCTAssertNotNil(frame)
+        guard let frame else { return }
+        XCTAssertEqual(frame.width, CGFloat(SessionPersistencePolicy.defaultWindowWidth), accuracy: 0.001)
+        XCTAssertEqual(frame.height, CGFloat(SessionPersistencePolicy.defaultWindowHeight), accuracy: 0.001)
+        XCTAssertEqual(frame.midX, display.visibleFrame.midX, accuracy: 0.001)
+        XCTAssertEqual(frame.midY, display.visibleFrame.midY, accuracy: 0.001)
     }
 
     func testResolvedStartupPrimaryWindowFrameFallsBackToPersistedGeometryWhenPrimaryMissing() {

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -212,6 +212,62 @@ final class WorkspaceShortcutMapperTests: XCTestCase {
 }
 
 
+@MainActor
+final class WorkspaceDefaultTitleTests: XCTestCase {
+    private func expectedDefaultWorkspaceTitle(_ number: Int) -> String {
+        String.localizedStringWithFormat(
+            String(localized: "workspace.defaultTitle", defaultValue: "Workspace %lld"),
+            Int64(number)
+        )
+    }
+
+    func testNewManagerWorkspacesUseStableWorkspaceDefaultTitles() {
+        let manager = TabManager()
+        let first = manager.tabs[0]
+        let second = manager.addWorkspace()
+
+        XCTAssertEqual(first.title, expectedDefaultWorkspaceTitle(1))
+        XCTAssertEqual(second.title, expectedDefaultWorkspaceTitle(2))
+
+        second.applyProcessTitle("codex-agent-title")
+        XCTAssertEqual(second.title, expectedDefaultWorkspaceTitle(2))
+
+        second.setCustomTitle("Research")
+        XCTAssertEqual(second.title, "Research")
+
+        second.setCustomTitle(nil)
+        XCTAssertEqual(second.title, expectedDefaultWorkspaceTitle(2))
+    }
+
+    func testLegacyProcessDrivenWorkspaceTitlesStillUpdate() {
+        let workspace = Workspace(title: "Terminal 1")
+
+        workspace.applyProcessTitle("zsh")
+
+        XCTAssertEqual(workspace.title, "zsh")
+    }
+
+    func testStableDefaultTitleRoundTripsThroughSessionSnapshot() throws {
+        let manager = TabManager()
+        let second = manager.addWorkspace()
+        second.applyProcessTitle("agent-title")
+
+        let snapshot = manager.sessionSnapshot(includeScrollback: false)
+        let secondSnapshot = try XCTUnwrap(snapshot.workspaces.first { $0.id == second.id })
+        XCTAssertEqual(secondSnapshot.processTitle, "agent-title")
+        XCTAssertEqual(secondSnapshot.stableDefaultTitle, expectedDefaultWorkspaceTitle(2))
+
+        let restored = TabManager()
+        restored.restoreSessionSnapshot(snapshot)
+        let restoredSecond = try XCTUnwrap(restored.tabs.first { $0.id == second.id })
+        XCTAssertEqual(restoredSecond.title, expectedDefaultWorkspaceTitle(2))
+
+        restoredSecond.applyProcessTitle("later-agent-title")
+        XCTAssertEqual(restoredSecond.title, expectedDefaultWorkspaceTitle(2))
+    }
+}
+
+
 final class WorkspacePlacementSettingsTests: XCTestCase {
     func testCurrentPlacementDefaultsToAfterCurrentWhenUnset() {
         let suiteName = "WorkspacePlacementSettingsTests.Default.\(UUID().uuidString)"

--- a/docs/c11-workspace-sidebar-card-map.md
+++ b/docs/c11-workspace-sidebar-card-map.md
@@ -1,0 +1,24 @@
+# Workspace Sidebar Card Map
+
+C11-5 makes the workspace name the first visual anchor in every sidebar card.
+
+| Input | Source | Sidebar location |
+| --- | --- | --- |
+| Workspace name | `Workspace.title`; custom names still come from `Workspace.customTitle` | First row, left aligned, before all metadata; wraps to two lines before tail truncation |
+| Close button / shortcut hint | Hover state, keyboard shortcut settings | First row, trailing fixed slot |
+| Pinned state | `Workspace.isPinned` | First row, trailing indicator before the close/shortcut slot |
+| Unread notification badge | `TerminalNotificationStore.unreadCount(forTabId:)` | First row, trailing badge before the close/shortcut slot |
+| Active / multi-select state | `TabManager.selectedTabId`, sidebar multi-selection | Card background, border, foreground palette, drag opacity |
+| Workspace custom color | `Workspace.customColor`, theme sidebar roles | Card fill/rail/outline styling |
+| Agent identity chip | Focused surface metadata `terminal_type`, `model`, `model_label` via `AgentChipResolver` | Second row, subdued; never precedes the workspace name |
+| Latest notification message | `TerminalNotificationStore.latestNotification(forTabId:)` | Below agent chip, when the sidebar notification-message setting is enabled |
+| Remote / SSH target and status | `Workspace.remoteDisplayTarget`, `remoteConnectionState`, remote error status entries | Below notification, when SSH details are enabled |
+| Custom sidebar metadata rows | `Workspace.statusEntries` from `set_status` / `report_meta` | Auxiliary detail area below remote status |
+| Markdown metadata blocks | `Workspace.metadataBlocks` from `report_meta_block` | Auxiliary detail area below status rows |
+| Latest log row | `Workspace.logEntries.last` from `log` | Auxiliary detail area below metadata blocks |
+| Progress bar and label | `Workspace.progress` from `set_progress` | Auxiliary detail area below latest log |
+| Branch and directory rows | Workspace and per-surface branch/directory state | Auxiliary detail area below progress; vertical or inline per setting |
+| PR / MR rows | `Workspace.pullRequest`, `panelPullRequests` from `report_pr` / `report_review` | Auxiliary detail area below branch/directory rows |
+| Ports row | `Workspace.listeningPorts` | Bottom of auxiliary detail area |
+
+The global hide-details setting still hides auxiliary rows. The workspace name, first-row controls, and agent chip layout remain independent of that setting so identity stays scannable.


### PR DESCRIPTION
## Summary

- Reworks workspace sidebar cards so the workspace name is the first row, wraps up to two lines, and stays visually primary.
- Moves agent identity chips below the workspace name with subdued styling so agent metadata no longer competes with the stable workspace anchor.
- Names newly created default workspaces `Workspace N` and persists that stable default separately from process-driven surface titles.
- Adds runtime-focused coverage for stable default workspace titles and a concise sidebar card parameter map.

## Notes

This branch also contains the existing committed branch-tip change `980c36fb Fix main window startup sizing` that was present before publishing the PR.

## Validation

- `git diff --check`
- `jq empty Resources/Localizable.xcstrings`
- `./scripts/reload.sh --tag c11-5-sidebar-card` succeeded
- Tagged debug app left running for visual inspection as requested

Local tests were not run, per the repo testing policy.