### PR TITLE
[codex] Polish notification button and help menu

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -68529,13 +68529,30 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Jump to latest unread notification"
+            "value": "Jump to next unread notification"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "最新の未読通知へジャンプ"
+            "value": "次の未読通知へジャンプ"
+          }
+        }
+      }
+    },
+    "statusBar.nextNotification.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next Notification"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の通知"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -68546,13 +68546,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Next Notification"
+            "value": "Go To Next Notification"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "次の通知"
+            "value": "次の通知へ移動"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -65001,23 +65001,6 @@
         }
       }
     },
-    "sidebar.help.discord": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discord"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Discord"
-          }
-        }
-      }
-    },
     "sidebar.help.feedback.attachImages": {
       "extractionState": "manual",
       "localizations": {
@@ -65490,23 +65473,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "メッセージと添付ファイルを確認して、もう一度お試しください。"
-          }
-        }
-      }
-    },
-    "sidebar.help.githubIssues": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GitHub Issues"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "GitHub Issues"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9580,8 +9580,6 @@ private enum SidebarHelpMenuAction {
     case docs
     case changelog
     case github
-    case githubIssues
-    case discord
     case checkForUpdates
     case sendFeedback
     case welcome
@@ -10079,11 +10077,9 @@ enum FeedbackComposerBridge {
 }
 
 private struct SidebarHelpMenuButton: View {
-    private let docsURL = URL(string: "https://cmux.com/docs")
-    private let changelogURL = URL(string: "https://cmux.com/docs/changelog")
-    private let githubURL = URL(string: "https://github.com/manaflow-ai/cmux")
-    private let githubIssuesURL = URL(string: "https://github.com/manaflow-ai/cmux/issues")
-    private let discordURL = URL(string: "https://discord.gg/xsgFEVrWCZ")
+    private let docsURL = URL(string: "https://github.com/Stage-11-Agentics/c11/tree/main/docs")
+    private let changelogURL = URL(string: "https://github.com/Stage-11-Agentics/c11/blob/main/CHANGELOG.md")
+    private let githubURL = URL(string: "https://github.com/Stage-11-Agentics/c11")
     private let helpTitle = String(localized: "sidebar.help.button", defaultValue: "Help")
     private let buttonSize: CGFloat = 22
     private let iconSize: CGFloat = 11
@@ -10174,22 +10170,6 @@ private struct SidebarHelpMenuButton: View {
                     title: String(localized: "about.github", defaultValue: "GitHub"),
                     action: .github,
                     accessibilityIdentifier: "SidebarHelpMenuOptionGitHub",
-                    isExternalLink: true
-                )
-            }
-            if githubIssuesURL != nil {
-                helpOptionButton(
-                    title: String(localized: "sidebar.help.githubIssues", defaultValue: "GitHub Issues"),
-                    action: .githubIssues,
-                    accessibilityIdentifier: "SidebarHelpMenuOptionGitHubIssues",
-                    isExternalLink: true
-                )
-            }
-            if discordURL != nil {
-                helpOptionButton(
-                    title: String(localized: "sidebar.help.discord", defaultValue: "Discord"),
-                    action: .discord,
-                    accessibilityIdentifier: "SidebarHelpMenuOptionDiscord",
                     isExternalLink: true
                 )
             }
@@ -10285,12 +10265,6 @@ private struct SidebarHelpMenuButton: View {
         case .github:
             guard let githubURL else { return }
             NSWorkspace.shared.open(githubURL)
-        case .githubIssues:
-            guard let githubIssuesURL else { return }
-            NSWorkspace.shared.open(githubIssuesURL)
-        case .discord:
-            guard let discordURL else { return }
-            NSWorkspace.shared.open(discordURL)
         case .checkForUpdates:
             Task { @MainActor in
                 AppDelegate.shared?.checkForUpdates(nil)

--- a/Sources/StatusBar/BottomStatusBarView.swift
+++ b/Sources/StatusBar/BottomStatusBarView.swift
@@ -6,9 +6,9 @@ import SwiftUI
 /// app state, so mounting it does not subscribe the parent view to any
 /// observable.
 struct BottomStatusBarView<Leading: View, Center: View, Trailing: View>: View {
-    // `static let` is disallowed on generic types; the `static var { 24 }`
+    // `static let` is disallowed on generic types; the `static var { 32 }`
     // form returns the literal every call but inlines to a constant.
-    private static var barHeight: CGFloat { 24 }
+    private static var barHeight: CGFloat { 32 }
 
     private let leading: Leading
     private let center: Center

--- a/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
+++ b/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
@@ -1,9 +1,8 @@
 import SwiftUI
 
-/// First tenant of the bottom status bar. Icon + badge only — no visible
-/// text label (tooltip carries the affordance copy). Mirrors the binding
-/// and click-handler pattern at `UpdateTitlebarAccessory.swift:1008` and
-/// the `.safeHelp` shortcut-tooltip pattern at `NotificationsPage.swift:117`.
+/// First tenant of the bottom status bar. Mirrors the binding and
+/// click-handler pattern at `UpdateTitlebarAccessory.swift:1008` and the
+/// `.safeHelp` shortcut-tooltip pattern at `NotificationsPage.swift:117`.
 struct JumpToUnreadStatusBarButton: View {
     @EnvironmentObject private var notificationStore: TerminalNotificationStore
 
@@ -12,47 +11,66 @@ struct JumpToUnreadStatusBarButton: View {
     }
 
     private var tooltipBase: String {
-        String(
-            localized: "notifications.jumpToLatestUnread",
-            defaultValue: "Jump to Latest Unread"
-        )
+        label
     }
 
     private var accessibilityLabel: String {
         String(
             localized: "statusBar.jumpToUnread.accessibility",
-            defaultValue: "Jump to latest unread notification"
+            defaultValue: "Jump to next unread notification"
+        )
+    }
+
+    private var label: String {
+        String(
+            localized: "statusBar.nextNotification.title",
+            defaultValue: "Next Notification"
         )
     }
 
     var body: some View {
         let display = self.display
         return Button(action: jump) {
-            ZStack(alignment: .topTrailing) {
+            HStack(spacing: 7) {
                 Image(systemName: "bell")
-                    .font(.system(size: 13, weight: .regular))
-                    .frame(width: 16, height: 16)
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 14, height: 14)
+
+                Text(label)
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
 
                 if let badge = display.badgeText {
                     Text(badge)
-                        .font(.system(size: 9, weight: .semibold))
+                        .font(.system(size: 9, weight: .bold))
                         .monospacedDigit()
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
                         .background(
                             Capsule(style: .continuous)
-                                .fill(Color.accentColor)
+                                .fill(BrandColors.blackSwiftUI.opacity(0.18))
                         )
-                        .foregroundColor(.white)
-                        .offset(x: 7, y: -5)
+                        .foregroundColor(BrandColors.blackSwiftUI)
                         .accessibilityHidden(true)
                 }
             }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .frame(minHeight: 24)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(cmuxAccentColor().opacity(display.isEnabled ? 1.0 : 0.18))
+            )
+            .overlay(
+                Capsule(style: .continuous)
+                    .stroke(cmuxAccentColor().opacity(display.isEnabled ? 0 : 0.5), lineWidth: 1)
+            )
+            .foregroundColor(display.isEnabled ? BrandColors.blackSwiftUI : .secondary)
+            .contentShape(Capsule(style: .continuous))
         }
         .buttonStyle(.plain)
-        .contentShape(Rectangle())
         .disabled(!display.isEnabled)
-        .opacity(display.isEnabled ? 1.0 : 0.45)
+        .opacity(display.isEnabled ? 1.0 : 0.72)
         .accessibilityIdentifier("statusBar.jumpToUnread.button")
         .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(display.badgeText ?? "")

--- a/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
+++ b/Sources/StatusBar/JumpToUnreadStatusBarButton.swift
@@ -24,7 +24,7 @@ struct JumpToUnreadStatusBarButton: View {
     private var label: String {
         String(
             localized: "statusBar.nextNotification.title",
-            defaultValue: "Next Notification"
+            defaultValue: "Go To Next Notification"
         )
     }
 


### PR DESCRIPTION
## Summary

- Make the bottom status-bar notification jump control a larger themed pill with full `Go To Next Notification` copy and unread badge.
- Increase the bottom status bar height so the notification control reads as a visible action.
- Point the sidebar help menu at c11-owned GitHub/docs/changelog links, and remove the Discord and GitHub Issues items.

## Validation

- `jq empty Resources/Localizable.xcstrings`
- `git diff --check origin/main...HEAD`
- `./scripts/reload.sh --tag c11-5-workspace-sidebar-card`

## Notes

- This branch was created fresh from `origin/main` and only cherry-picks the three UI commits, avoiding the already-merged `c11-5-workspace-sidebar-card` PR history.