### PR TITLE
[codex] Polish agent skill onboarding

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1642,13 +1642,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Already installed and up to date."
+            "value": "Already current"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "インストール済み・最新の状態です。"
+            "value": "最新です"
           }
         }
       }
@@ -1683,6 +1683,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "c11 の CLI やサイドバー情報は、c11 スキルファイルを読み込んだエージェントだけが理解します。スキルを入れるエージェントを選んでください。設定 → エージェントスキル からいつでも変更できます。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.body.detected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 found %@. Install the skill there so your agents can use panes, browser surfaces, markdown, sidebar status, and the c11 CLI."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 は %@ を検出しました。ここにスキルをインストールすると、エージェントがペイン、ブラウザサーフェス、Markdown、サイドバーの状態、c11 CLI を使えるようになります。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.body.detecting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Looking for coding agents on this Mac. When c11 finds one, it can install a small plain-text skill that teaches the agent how to drive this workspace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac 上のコーディングエージェントを探しています。検出すると、このワークスペースの操作方法を伝える小さなプレーンテキストのスキルをインストールできます。"
           }
         }
       }
@@ -1738,6 +1772,23 @@
         }
       }
     },
+    "agentSkills.onboarding.installSection": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Install into"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール先"
+          }
+        }
+      }
+    },
     "agentSkills.onboarding.later": {
       "extractionState": "manual",
       "localizations": {
@@ -1751,6 +1802,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "あとでインストール"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.learnMoreTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What gets installed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールされるもの"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.noDetectedTools": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No supported agent config folders were detected yet. You can run this later from Settings → Agent Skills."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対応しているエージェント設定フォルダはまだ検出されていません。後で 設定 → エージェントスキル から実行できます。"
           }
         }
       }
@@ -1772,19 +1857,36 @@
         }
       }
     },
+    "agentSkills.onboarding.notDetectedSummary": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not detected: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未検出: %@"
+          }
+        }
+      }
+    },
     "agentSkills.onboarding.partialInstalled": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Partially installed. Install Now completes the current skill set."
+            "value": "Will complete the skill set"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "一部のみインストール済みです。今すぐインストールすると現在のスキルセットを補完します。"
+            "value": "スキルセットを補完します"
           }
         }
       }
@@ -1863,13 +1965,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Teach your agents about c11"
+            "value": "Install the c11 skill"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "エージェントに c11 を伝える"
+            "value": "c11 スキルをインストール"
           }
         }
       }
@@ -1880,13 +1982,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Older c11 skill installed. Install Now updates it."
+            "value": "Will update the installed skill"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "古い c11 スキルがインストールされています。今すぐインストールすると更新します。"
+            "value": "インストール済みのスキルを更新します"
           }
         }
       }
@@ -1914,13 +2016,30 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Trust should be inspectable. The c11 skill is plain text; open it in Finder or copy a review prompt and hand it to any coding agent before installing."
+            "value": "The skill is plain text. It tells agents how to use c11; it does not run code by itself. Inspect it in Finder or copy a review prompt for another agent."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "信頼は確認できるべきものです。c11 スキルはプレーンテキストです。インストール前に Finder で開くか、レビュープロンプトをコピーして任意のコーディングエージェントに渡せます。"
+            "value": "スキルはプレーンテキストです。エージェントに c11 の使い方を伝えるもので、それ自体がコードを実行することはありません。Finder で確認するか、別のエージェント用にレビュープロンプトをコピーできます。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.willInstall": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Will install the skill"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スキルをインストールします"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1245,23 +1245,6 @@
         }
       }
     },
-    "agentSkills.action.copied": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied install command to clipboard."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストールコマンドをクリップボードにコピーしました。"
-          }
-        }
-      }
-    },
     "agentSkills.action.envelope": {
       "extractionState": "manual",
       "localizations": {
@@ -1381,23 +1364,6 @@
         }
       }
     },
-    "agentSkills.button.copyCommand": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Command"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "コマンドをコピー"
-          }
-        }
-      }
-    },
     "agentSkills.button.install": {
       "extractionState": "manual",
       "localizations": {
@@ -1462,6 +1428,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "スキルを表示"
+          }
+        }
+      }
+    },
+    "agentSkills.button.revealFolder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal Folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを表示"
           }
         }
       }
@@ -1653,36 +1636,19 @@
         }
       }
     },
-    "agentSkills.onboarding.alreadyInstalledVersioned": {
+    "agentSkills.onboarding.allSet": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Already installed and up to date (%@)."
+            "value": "You're Good"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "インストール済み・最新の状態です（%@）。"
-          }
-        }
-      }
-    },
-    "agentSkills.onboarding.body": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Agents only know about c11's CLI and sidebar metadata when they've read the c11 skill file. Pick which agents should get it — you can change this any time in Settings → Agent Skills."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "c11 の CLI やサイドバー情報は、c11 スキルファイルを読み込んだエージェントだけが理解します。スキルを入れるエージェントを選んでください。設定 → エージェントスキル からいつでも変更できます。"
+            "value": "準備完了"
           }
         }
       }
@@ -1693,13 +1659,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "c11 found %@. Install the skill there so your agents can use panes, browser surfaces, markdown, sidebar status, and the c11 CLI."
+            "value": "c11 is designed to be great for agents, but they need the skill to know what to ask for. Install it in %@ so they can use panes, the browser, markdown files, statuses, and the rest of the c11 workspace."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "c11 は %@ を検出しました。ここにスキルをインストールすると、エージェントがペイン、ブラウザサーフェス、Markdown、サイドバーの状態、c11 CLI を使えるようになります。"
+            "value": "c11 はエージェントにとって使いやすいように設計されていますが、何を頼めるかを知るにはスキルが必要です。%@ にインストールすると、ペイン、ブラウザ、Markdown ファイル、ステータス、c11 ワークスペースのその他の機能を使えるようになります。"
           }
         }
       }
@@ -1710,30 +1676,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Looking for coding agents on this Mac. When c11 finds one, it can install a small plain-text skill that teaches the agent how to drive this workspace."
+            "value": "c11 is designed to be great for agents, but they need the skill to know what to ask for. Install it so they can use panes, the browser, markdown files, statuses, and the rest of the c11 workspace."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "この Mac 上のコーディングエージェントを探しています。検出すると、このワークスペースの操作方法を伝える小さなプレーンテキストのスキルをインストールできます。"
-          }
-        }
-      }
-    },
-    "agentSkills.onboarding.copyReviewPrompt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copy Review Prompt"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "レビュープロンプトをコピー"
+            "value": "c11 はエージェントにとって使いやすいように設計されていますが、何を頼めるかを知るにはスキルが必要です。インストールすると、ペイン、ブラウザ、Markdown ファイル、ステータス、c11 ワークスペースのその他の機能を使えるようになります。"
           }
         }
       }
@@ -1761,13 +1710,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install Now"
+            "value": "Skillify Your Agent"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "今すぐインストール"
+            "value": "エージェントをスキル化"
           }
         }
       }
@@ -1891,70 +1840,19 @@
         }
       }
     },
-    "agentSkills.onboarding.partialInstalledVersioned": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Partially installed. Install Now completes %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "一部のみインストール済みです。今すぐインストールすると %@ を補完します。"
-          }
-        }
-      }
-    },
-    "agentSkills.onboarding.reviewPrompt": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Please review the c11 skill at %@ before I install it. Tell me what it instructs agents to do, what files or settings it may touch, and flag anything unsafe or surprising."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "インストールする前に、%@ にある c11 スキルをレビューしてください。エージェントに何を指示しているか、どのファイルや設定に触れる可能性があるか、危険または予想外に見える内容がないかを教えてください。"
-          }
-        }
-      }
-    },
-    "agentSkills.onboarding.reviewPromptCopied": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Copied review prompt to clipboard."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "レビュープロンプトをクリップボードにコピーしました。"
-          }
-        }
-      }
-    },
     "agentSkills.onboarding.showSkill": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show Skill in Finder"
+            "value": "Show Skill Files in Finder"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Finderでスキルを表示"
+            "value": "Finderでスキルファイルを表示"
           }
         }
       }
@@ -1965,13 +1863,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install the c11 skill"
+            "value": "Agentically use c11"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "c11 スキルをインストール"
+            "value": "c11 をエージェント的に使う"
           }
         }
       }
@@ -1993,36 +1891,19 @@
         }
       }
     },
-    "agentSkills.onboarding.updateAvailableVersioned": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Older c11 skill installed. Install Now updates it to %@."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "古い c11 スキルがインストールされています。今すぐインストールすると %@ に更新します。"
-          }
-        }
-      }
-    },
     "agentSkills.onboarding.transparency": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The skill is plain text. It tells agents how to use c11; it does not run code by itself. Inspect it in Finder or copy a review prompt for another agent."
+            "value": "We take developer trust seriously. The skill is plain text: inspect the exact files in Finder or hand them to your preferred model for a security review. c11 will never change your agent configuration without your permission."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "スキルはプレーンテキストです。エージェントに c11 の使い方を伝えるもので、それ自体がコードを実行することはありません。Finder で確認するか、別のエージェント用にレビュープロンプトをコピーできます。"
+            "value": "開発者の信頼を真剣に扱っています。スキルはプレーンテキストです。Finder で実際のファイルを確認するか、好みのモデルに渡してセキュリティレビューできます。c11 は許可なくエージェント設定を変更しません。"
           }
         }
       }
@@ -2125,6 +2006,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "一部インストール"
+          }
+        }
+      }
+    },
+    "agentSkills.status.shared": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "shared"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "共有"
+          }
+        }
+      }
+    },
+    "agentSkills.status.sharedWith": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uses the %@ skill files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のスキルファイルを使用します"
           }
         }
       }
@@ -42925,13 +42840,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "c11 installs its skill file into Claude Code (~/.claude/skills) on request. For other agents, c11 copies a ready-to-paste command — the operator runs it."
+            "value": "c11 installs its skill files into detected agent skill folders only with your approval. Linked skill folders are shown as shared so one remove action cannot silently affect another agent."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "c11 は Claude Code (~/.claude/skills) にのみスキルファイルを書き込みます。他のエージェントには、そのままペーストできるコマンドをクリップボードにコピーします — 実行はオペレーター側で行います。"
+            "value": "c11 は承認がある場合にのみ、検出したエージェントのスキルフォルダへスキルファイルをインストールします。リンクされたスキルフォルダは共有として表示され、1つの削除操作が別のエージェントに暗黙に影響しないようにします。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1653,6 +1653,23 @@
         }
       }
     },
+    "agentSkills.onboarding.alreadyInstalledVersioned": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Already installed and up to date (%@)."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストール済み・最新の状態です（%@）。"
+          }
+        }
+      }
+    },
     "agentSkills.onboarding.body": {
       "extractionState": "manual",
       "localizations": {
@@ -1666,6 +1683,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "c11 の CLI やサイドバー情報は、c11 スキルファイルを読み込んだエージェントだけが理解します。スキルを入れるエージェントを選んでください。設定 → エージェントスキル からいつでも変更できます。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.copyReviewPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Review Prompt"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レビュープロンプトをコピー"
           }
         }
       }
@@ -1693,13 +1727,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install"
+            "value": "Install Now"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "インストール"
+            "value": "今すぐインストール"
           }
         }
       }
@@ -1710,13 +1744,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Later"
+            "value": "Install Later"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "あとで"
+            "value": "あとでインストール"
           }
         }
       }
@@ -1738,6 +1772,91 @@
         }
       }
     },
+    "agentSkills.onboarding.partialInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partially installed. Install Now completes the current skill set."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部のみインストール済みです。今すぐインストールすると現在のスキルセットを補完します。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.partialInstalledVersioned": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Partially installed. Install Now completes %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一部のみインストール済みです。今すぐインストールすると %@ を補完します。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.reviewPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Please review the c11 skill at %@ before I install it. Tell me what it instructs agents to do, what files or settings it may touch, and flag anything unsafe or surprising."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "インストールする前に、%@ にある c11 スキルをレビューしてください。エージェントに何を指示しているか、どのファイルや設定に触れる可能性があるか、危険または予想外に見える内容がないかを教えてください。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.reviewPromptCopied": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied review prompt to clipboard."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レビュープロンプトをクリップボードにコピーしました。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.showSkill": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Skill in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderでスキルを表示"
+          }
+        }
+      }
+    },
     "agentSkills.onboarding.title": {
       "extractionState": "manual",
       "localizations": {
@@ -1751,6 +1870,57 @@
           "stringUnit": {
             "state": "translated",
             "value": "エージェントに c11 を伝える"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.updateAvailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Older c11 skill installed. Install Now updates it."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古い c11 スキルがインストールされています。今すぐインストールすると更新します。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.updateAvailableVersioned": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Older c11 skill installed. Install Now updates it to %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古い c11 スキルがインストールされています。今すぐインストールすると %@ に更新します。"
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.transparency": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trust should be inspectable. The c11 skill is plain text; open it in Finder or copy a review prompt and hand it to any coding agent before installing."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "信頼は確認できるべきものです。c11 スキルはプレーンテキストです。インストール前に Finder で開くか、レビュープロンプトをコピーして任意のコーディングエージェントに渡せます。"
           }
         }
       }

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -18,11 +18,19 @@ final class AgentSkillsModel: ObservableObject {
         var hasOutdated: Bool {
             packages.contains { $0.state == .installedOutdated || $0.state == .installedNoManifest || $0.state == .schemaMismatch }
         }
+        var needsInstallOrUpdate: Bool {
+            !packages.isEmpty && packages.contains { $0.state == .notInstalled || $0.state == .installedOutdated }
+        }
         var anyInstalled: Bool {
             packages.contains { $0.state != .notInstalled }
         }
         var allCurrent: Bool {
             !packages.isEmpty && packages.allSatisfy { $0.state == .installedCurrent }
+        }
+        var sourceVersionLabel: String? {
+            let versions = Set(packages.map { $0.package.version }.filter { !$0.isEmpty && $0 != "0" })
+            guard !versions.isEmpty else { return nil }
+            return versions.sorted().map { "v\($0)" }.joined(separator: ", ")
         }
     }
 
@@ -157,6 +165,37 @@ final class AgentSkillsModel: ObservableObject {
 
     func revealInFinder(url: URL) {
         NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    var primarySkillURL: URL? {
+        guard let sourceDir else { return nil }
+        let skillFile = sourceDir
+            .appendingPathComponent("c11", isDirectory: true)
+            .appendingPathComponent("SKILL.md", isDirectory: false)
+        if fileManager.fileExists(atPath: skillFile.path) {
+            return skillFile
+        }
+        return sourceDir
+    }
+
+    func revealPrimarySkillInFinder() {
+        guard let url = primarySkillURL else { return }
+        revealInFinder(url: url)
+    }
+
+    func copySkillReviewPromptToPasteboard() {
+        guard let url = primarySkillURL else { return }
+        let format = String(
+            localized: "agentSkills.onboarding.reviewPrompt",
+            defaultValue: "Please review the c11 skill at %@ before I install it. Tell me what it instructs agents to do, what files or settings it may touch, and flag anything unsafe or surprising."
+        )
+        let pb = NSPasteboard.general
+        pb.clearContents()
+        pb.setString(String(format: format, url.path), forType: .string)
+        lastActionMessage = String(
+            localized: "agentSkills.onboarding.reviewPromptCopied",
+            defaultValue: "Copied review prompt to clipboard."
+        )
     }
 
     /// Snippet the operator copies to the clipboard to install skills via
@@ -538,18 +577,19 @@ private struct AgentSkillsRow: View {
 
 // MARK: - First-run onboarding sheet
 
-/// Sheet shown once, after the welcome flow, when c11 detects Claude Code
-/// but has never offered a skill install. User can consent, skip (this run),
-/// or defer forever (don't ask again). Settings exposes the same controls, so
-/// "don't ask again" is not a dead-end.
+/// Sheet shown once, after the welcome flow, when c11 detects an agent
+/// environment that is missing or running an older c11 skill set. User can
+/// consent, skip (this run), or defer forever (don't ask again). Settings
+/// exposes the same controls, so "don't ask again" is not a dead-end.
 struct AgentSkillsOnboardingSheet: View {
     let onDismiss: () -> Void
     @StateObject private var model = AgentSkillsModel()
 
-    @State private var claudeOptIn: Bool = true
+    @State private var claudeOptIn: Bool = false
     @State private var codexOptIn: Bool = false
     @State private var kimiOptIn: Bool = false
     @State private var opencodeOptIn: Bool = false
+    @State private var initializedDefaultOptIns: Bool = false
 
     init(onDismiss: @escaping () -> Void = {}) {
         self.onDismiss = onDismiss
@@ -577,36 +617,71 @@ struct AgentSkillsOnboardingSheet: View {
                     .foregroundColor(.secondary)
             }
 
+            transparencyControls
+
             HStack(spacing: 8) {
+                Spacer()
+
                 Button(String(localized: "agentSkills.onboarding.dontAsk", defaultValue: "Don't ask again")) {
                     UserDefaults.standard.set(true, forKey: AgentSkillsOnboarding.sheetShownKey)
                     onDismiss()
                 }
                 .buttonStyle(.bordered)
+                .controlSize(.small)
 
-                Spacer()
-
-                Button(String(localized: "agentSkills.onboarding.later", defaultValue: "Later")) {
+                Button(String(localized: "agentSkills.onboarding.later", defaultValue: "Install Later")) {
                     AgentSkillsOnboarding.markDismissedThisLaunch()
                     onDismiss()
                 }
                 .buttonStyle(.bordered)
+                .controlSize(.small)
 
-                Button(String(localized: "agentSkills.onboarding.install", defaultValue: "Install")) {
+                Button(String(localized: "agentSkills.onboarding.install", defaultValue: "Install Now")) {
                     applySelection()
                 }
                 .keyboardShortcut(.defaultAction)
                 .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .frame(minWidth: 132, minHeight: 34)
                 .disabled(!anySelected)
             }
         }
         .padding(20)
-        .frame(width: 520)
+        .frame(width: 560)
         .onAppear { model.refresh() }
+        .onReceive(model.$rows) { rows in
+            guard !initializedDefaultOptIns, !rows.isEmpty else { return }
+            applyDefaultOptIns(rows: rows)
+            initializedDefaultOptIns = true
+        }
     }
 
     private var anySelected: Bool {
-        claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn
+        initializedDefaultOptIns && (claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn)
+    }
+
+    private var transparencyControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "agentSkills.onboarding.transparency", defaultValue: "Trust should be inspectable. The c11 skill is plain text; open it in Finder or copy a review prompt and hand it to any coding agent before installing."))
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                Button(String(localized: "agentSkills.onboarding.showSkill", defaultValue: "Show Skill in Finder")) {
+                    model.revealPrimarySkillInFinder()
+                }
+                .buttonStyle(.bordered)
+                .disabled(model.primarySkillURL == nil)
+
+                Button(String(localized: "agentSkills.onboarding.copyReviewPrompt", defaultValue: "Copy Review Prompt")) {
+                    model.copySkillReviewPromptToPasteboard()
+                }
+                .buttonStyle(.bordered)
+                .disabled(model.primarySkillURL == nil)
+            }
+            .controlSize(.regular)
+        }
     }
 
     @ViewBuilder
@@ -634,9 +709,42 @@ struct AgentSkillsOnboardingSheet: View {
             )
         }
         if row.allCurrent {
+            if let version = row.sourceVersionLabel {
+                let format = String(
+                    localized: "agentSkills.onboarding.alreadyInstalledVersioned",
+                    defaultValue: "Already installed and up to date (%@)."
+                )
+                return String(format: format, version)
+            }
             return String(
                 localized: "agentSkills.onboarding.alreadyInstalled",
                 defaultValue: "Already installed and up to date."
+            )
+        }
+        if row.hasOutdated {
+            if let version = row.sourceVersionLabel {
+                let format = String(
+                    localized: "agentSkills.onboarding.updateAvailableVersioned",
+                    defaultValue: "Older c11 skill installed. Install Now updates it to %@."
+                )
+                return String(format: format, version)
+            }
+            return String(
+                localized: "agentSkills.onboarding.updateAvailable",
+                defaultValue: "Older c11 skill installed. Install Now updates it."
+            )
+        }
+        if row.anyInstalled {
+            if let version = row.sourceVersionLabel {
+                let format = String(
+                    localized: "agentSkills.onboarding.partialInstalledVersioned",
+                    defaultValue: "Partially installed. Install Now completes %@."
+                )
+                return String(format: format, version)
+            }
+            return String(
+                localized: "agentSkills.onboarding.partialInstalled",
+                defaultValue: "Partially installed. Install Now completes the current skill set."
             )
         }
         return row.destinationDir.path
@@ -665,6 +773,14 @@ struct AgentSkillsOnboardingSheet: View {
         UserDefaults.standard.set(true, forKey: AgentSkillsOnboarding.sheetShownKey)
         onDismiss()
     }
+
+    private func applyDefaultOptIns(rows: [AgentSkillsModel.TargetRow]) {
+        let defaults = AgentSkillsOnboarding.defaultOptIns(for: rows)
+        claudeOptIn = defaults[.claude] ?? false
+        codexOptIn = defaults[.codex] ?? false
+        kimiOptIn = defaults[.kimi] ?? false
+        opencodeOptIn = defaults[.opencode] ?? false
+    }
 }
 
 // MARK: - Onboarding plumbing
@@ -689,9 +805,25 @@ enum AgentSkillsOnboarding {
         _dismissedThisLaunch
     }
 
-    /// Should the onboarding sheet be offered on this launch? True iff a
-    /// claude config dir exists AND at least one bundled package is not yet
-    /// installed in it AND the user hasn't already dismissed the sheet.
+    static func defaultOptIns(for rows: [AgentSkillsModel.TargetRow]) -> [SkillInstallerTarget: Bool] {
+        var result = Dictionary(uniqueKeysWithValues: SkillInstallerTarget.allCases.map { ($0, false) })
+        for row in rows {
+            result[row.target] = row.detected
+        }
+        return result
+    }
+
+    static func shouldOffer(for rows: [AgentSkillsModel.TargetRow]) -> Bool {
+        rows.contains { $0.detected && $0.needsInstallOrUpdate }
+    }
+
+    static func shouldOffer(for statuses: [SkillInstallerPackageStatus]) -> Bool {
+        !statuses.isEmpty && statuses.contains { $0.state == .notInstalled || $0.state == .installedOutdated }
+    }
+
+    /// Should the onboarding sheet be offered on this launch? True iff at
+    /// least one detected agent environment is missing the current bundled
+    /// skill set, and the user hasn't already dismissed the sheet.
     @MainActor static func shouldPresent(
         home: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true),
         defaults: UserDefaults = .standard,
@@ -699,12 +831,18 @@ enum AgentSkillsOnboarding {
     ) -> Bool {
         if defaults.bool(forKey: sheetShownKey) { return false }
         if _dismissedThisLaunch { return false }
-        let target = SkillInstallerTarget.claude
-        guard target.isDetected(home: home, fileManager: fileManager) else { return false }
         guard let source = SkillInstaller.defaultSourceURL(executableURL: Bundle.main.executableURL) else { return false }
-        guard let statuses = try? SkillInstaller.status(for: target, home: home, sourceDir: source, fileManager: fileManager) else {
-            return false
+        for target in SkillInstallerTarget.allCases where target.isDetected(home: home, fileManager: fileManager) {
+            guard let statuses = try? SkillInstaller.status(
+                for: target,
+                home: home,
+                sourceDir: source,
+                fileManager: fileManager
+            ) else {
+                continue
+            }
+            if shouldOffer(for: statuses) { return true }
         }
-        return statuses.contains { $0.state == .notInstalled || $0.state == .installedOutdated }
+        return false
     }
 }

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -15,11 +15,12 @@ final class AgentSkillsModel: ObservableObject {
         let destinationDir: URL
         let packages: [SkillInstallerPackageStatus]
         let statusError: String?
+        let sharedWithTarget: SkillInstallerTarget?
         var hasOutdated: Bool {
             packages.contains { $0.state == .installedOutdated || $0.state == .installedNoManifest || $0.state == .schemaMismatch }
         }
         var needsInstallOrUpdate: Bool {
-            !packages.isEmpty && packages.contains { $0.state == .notInstalled || $0.state == .installedOutdated }
+            !isSharedDestination && !packages.isEmpty && packages.contains { $0.state == .notInstalled || $0.state == .installedOutdated }
         }
         var anyInstalled: Bool {
             packages.contains { $0.state != .notInstalled }
@@ -31,6 +32,9 @@ final class AgentSkillsModel: ObservableObject {
             let versions = Set(packages.map { $0.package.version }.filter { !$0.isEmpty && $0 != "0" })
             guard !versions.isEmpty else { return nil }
             return versions.sorted().map { "v\($0)" }.joined(separator: ", ")
+        }
+        var isSharedDestination: Bool {
+            sharedWithTarget != nil
         }
     }
 
@@ -96,6 +100,22 @@ final class AgentSkillsModel: ObservableObject {
             )
         }
         var newRows: [TargetRow] = []
+        var sharedOwnersByTarget: [SkillInstallerTarget: SkillInstallerTarget] = [:]
+        var ownerByResolvedDestination: [String: SkillInstallerTarget] = [:]
+        for target in SkillInstallerTarget.allCases {
+            guard target.isDetected(home: home, fileManager: fileManager) else { continue }
+            let destination = target.skillsDir(home: home)
+            var isDir: ObjCBool = false
+            guard fileManager.fileExists(atPath: destination.path, isDirectory: &isDir), isDir.boolValue else {
+                continue
+            }
+            let resolvedPath = destination.resolvingSymlinksInPath().standardizedFileURL.path
+            if let owner = ownerByResolvedDestination[resolvedPath] {
+                sharedOwnersByTarget[target] = owner
+            } else {
+                ownerByResolvedDestination[resolvedPath] = target
+            }
+        }
         for target in SkillInstallerTarget.allCases {
             let detected = target.isDetected(home: home, fileManager: fileManager)
             var packages: [SkillInstallerPackageStatus] = []
@@ -120,7 +140,8 @@ final class AgentSkillsModel: ObservableObject {
                 detected: detected,
                 destinationDir: target.skillsDir(home: home),
                 packages: packages,
-                statusError: statusError
+                statusError: statusError,
+                sharedWithTarget: sharedOwnersByTarget[target]
             ))
         }
         return RefreshSnapshot(sourceDir: source, sourceError: nil, rows: newRows)
@@ -168,56 +189,12 @@ final class AgentSkillsModel: ObservableObject {
     }
 
     var primarySkillURL: URL? {
-        guard let sourceDir else { return nil }
-        let skillFile = sourceDir
-            .appendingPathComponent("c11", isDirectory: true)
-            .appendingPathComponent("SKILL.md", isDirectory: false)
-        if fileManager.fileExists(atPath: skillFile.path) {
-            return skillFile
-        }
-        return sourceDir
+        sourceDir
     }
 
     func revealPrimarySkillInFinder() {
         guard let url = primarySkillURL else { return }
         revealInFinder(url: url)
-    }
-
-    func copySkillReviewPromptToPasteboard() {
-        guard let url = primarySkillURL else { return }
-        let format = String(
-            localized: "agentSkills.onboarding.reviewPrompt",
-            defaultValue: "Please review the c11 skill at %@ before I install it. Tell me what it instructs agents to do, what files or settings it may touch, and flag anything unsafe or surprising."
-        )
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(String(format: format, url.path), forType: .string)
-        lastActionMessage = String(
-            localized: "agentSkills.onboarding.reviewPromptCopied",
-            defaultValue: "Copied review prompt to clipboard."
-        )
-    }
-
-    /// Snippet the operator copies to the clipboard to install skills via
-    /// the managed c11 CLI path. Pure function so tests can lock down the
-    /// exact shape without mounting NSPasteboard.
-    static func manualInstallCommandSnippet(target: SkillInstallerTarget) -> String {
-        "c11 skill install --tool \(target.rawValue)"
-    }
-
-    func copyManualCommandToPasteboard(target: SkillInstallerTarget) {
-        // Route through the managed installer so the operator copies the
-        // same allowlisted + manifested install path c11 itself uses —
-        // no unmanaged rsync over the whole bundled `skills/` tree (which
-        // would also copy maintainer-only packages).
-        let snippet = Self.manualInstallCommandSnippet(target: target)
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(snippet, forType: .string)
-        lastActionMessage = String(
-            localized: "agentSkills.action.copied",
-            defaultValue: "Copied install command to clipboard."
-        )
     }
 
     private func formatInstallMessage(result: SkillInstallerApplyResult) -> String {
@@ -441,7 +418,7 @@ private struct AgentSkillsRow: View {
                         .font(.system(size: 13, weight: .medium))
                     statusChip
                 }
-                Text(row.destinationDir.path)
+                Text(rowDetailText)
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .lineLimit(1)
@@ -479,6 +456,9 @@ private struct AgentSkillsRow: View {
         if !row.detected {
             return (String(localized: "agentSkills.status.notDetected", defaultValue: "not detected"), .secondary)
         }
+        if row.isSharedDestination {
+            return (String(localized: "agentSkills.status.shared", defaultValue: "shared"), .green)
+        }
         if row.hasOutdated {
             return (String(localized: "agentSkills.status.updateAvailable", defaultValue: "update available"), .orange)
         }
@@ -489,6 +469,17 @@ private struct AgentSkillsRow: View {
             return (String(localized: "agentSkills.status.partial", defaultValue: "partial"), .orange)
         }
         return (String(localized: "agentSkills.status.notInstalled", defaultValue: "not installed"), .secondary)
+    }
+
+    private var rowDetailText: String {
+        if let sharedWithTarget = row.sharedWithTarget {
+            let format = String(
+                localized: "agentSkills.status.sharedWith",
+                defaultValue: "Uses the %@ skill files"
+            )
+            return String(format: format, sharedWithTarget.displayName)
+        }
+        return row.destinationDir.path
     }
 
     @ViewBuilder
@@ -503,16 +494,20 @@ private struct AgentSkillsRow: View {
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
-            } else if row.target == .claude {
-                claudeButtons
+            } else if row.isSharedDestination {
+                Button(String(localized: "agentSkills.button.revealFolder", defaultValue: "Reveal Folder")) {
+                    model.revealInFinder(url: row.destinationDir)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             } else {
-                operatorDirectedButtons
+                skillManagementButtons
             }
         }
     }
 
     @ViewBuilder
-    private var claudeButtons: some View {
+    private var skillManagementButtons: some View {
         if row.allCurrent {
             Button(String(localized: "agentSkills.button.refresh", defaultValue: "Refresh")) {
                 model.install(target: row.target, force: true)
@@ -540,36 +535,6 @@ private struct AgentSkillsRow: View {
                 model.install(target: row.target, force: false)
             }
             .buttonStyle(.borderedProminent)
-            .controlSize(.small)
-        }
-    }
-
-    @ViewBuilder
-    private var operatorDirectedButtons: some View {
-        // For non-Claude tools, prefer operator-driven installation (clipboard
-        // snippet + Finder reveal). The user can still use the Install/Refresh
-        // buttons if they explicitly want c11 to copy into that tool's dir.
-        Button(String(localized: "agentSkills.button.copyCommand", defaultValue: "Copy Command")) {
-            model.copyManualCommandToPasteboard(target: row.target)
-        }
-        .buttonStyle(.bordered)
-        .controlSize(.small)
-        if row.anyInstalled {
-            Button(String(localized: "agentSkills.button.update", defaultValue: "Update")) {
-                model.install(target: row.target, force: true)
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            Button(String(localized: "agentSkills.button.remove", defaultValue: "Remove")) {
-                model.remove(target: row.target)
-            }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-        } else {
-            Button(String(localized: "agentSkills.button.install", defaultValue: "Install")) {
-                model.install(target: row.target, force: false)
-            }
-            .buttonStyle(.bordered)
             .controlSize(.small)
         }
     }
@@ -632,6 +597,21 @@ struct AgentSkillsOnboardingSheet: View {
         initializedDefaultOptIns && (claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn)
     }
 
+    private var hasActionNeeded: Bool {
+        detectedRows.contains { $0.needsInstallOrUpdate }
+    }
+
+    private var primaryActionDisabled: Bool {
+        detectedRows.isEmpty || (hasActionNeeded && !anySelected)
+    }
+
+    private var primaryActionTitle: String {
+        if !detectedRows.isEmpty && !hasActionNeeded {
+            return String(localized: "agentSkills.onboarding.allSet", defaultValue: "You're Good")
+        }
+        return String(localized: "agentSkills.onboarding.install", defaultValue: "Skillify Your Agent")
+    }
+
     private var detectedRows: [AgentSkillsModel.TargetRow] {
         model.rows.filter(\.detected)
     }
@@ -647,7 +627,7 @@ struct AgentSkillsOnboardingSheet: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(String(localized: "agentSkills.onboarding.title", defaultValue: "Install the c11 skill"))
+            Text(String(localized: "agentSkills.onboarding.title", defaultValue: "Agentically use c11"))
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(BrandColors.whiteSwiftUI)
 
@@ -663,12 +643,12 @@ struct AgentSkillsOnboardingSheet: View {
         if detectedRows.isEmpty {
             return String(
                 localized: "agentSkills.onboarding.body.detecting",
-                defaultValue: "Looking for coding agents on this Mac. When c11 finds one, it can install a small plain-text skill that teaches the agent how to drive this workspace."
+                defaultValue: "c11 is designed to be great for agents, but they need the skill to know what to ask for. Install it so they can use panes, the browser, markdown files, statuses, and the rest of the c11 workspace."
             )
         }
         let format = String(
             localized: "agentSkills.onboarding.body.detected",
-            defaultValue: "c11 found %@. Install the skill there so your agents can use panes, browser surfaces, markdown, sidebar status, and the c11 CLI."
+            defaultValue: "c11 is designed to be great for agents, but they need the skill to know what to ask for. Install it in %@ so they can use panes, the browser, markdown files, statuses, and the rest of the c11 workspace."
         )
         return String(format: format, detectedTargetList)
     }
@@ -795,7 +775,7 @@ struct AgentSkillsOnboardingSheet: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
 
-                Text(String(localized: "agentSkills.onboarding.transparency", defaultValue: "The skill is plain text. It tells agents how to use c11; it does not run code by itself. Inspect it in Finder or copy a review prompt for another agent."))
+                Text(String(localized: "agentSkills.onboarding.transparency", defaultValue: "We take developer trust seriously. The skill is plain text: inspect the exact files in Finder or hand them to your preferred model for a security review. c11 will never change your agent configuration without your permission."))
                     .font(.system(size: 12))
                     .lineSpacing(2)
                     .foregroundColor(BrandColors.whiteSwiftUI.opacity(0.66))
@@ -804,15 +784,9 @@ struct AgentSkillsOnboardingSheet: View {
 
             HStack(spacing: 8) {
                 SecondaryOnboardingButton(
-                    title: String(localized: "agentSkills.onboarding.showSkill", defaultValue: "Show Skill in Finder"),
+                    title: String(localized: "agentSkills.onboarding.showSkill", defaultValue: "Show Skill Files in Finder"),
                     disabled: model.primarySkillURL == nil,
                     action: { model.revealPrimarySkillInFinder() }
-                )
-
-                SecondaryOnboardingButton(
-                    title: String(localized: "agentSkills.onboarding.copyReviewPrompt", defaultValue: "Copy Review Prompt"),
-                    disabled: model.primarySkillURL == nil,
-                    action: { model.copySkillReviewPromptToPasteboard() }
                 )
                 Spacer(minLength: 0)
             }
@@ -838,11 +812,11 @@ struct AgentSkillsOnboardingSheet: View {
             )
 
             OnboardingActionButton(
-                title: String(localized: "agentSkills.onboarding.install", defaultValue: "Install Now"),
-                kind: .primary,
+                title: primaryActionTitle,
+                kind: hasActionNeeded ? .primary : .success,
                 isSelected: selectedAction == .install,
-                disabled: !anySelected,
-                action: applySelection
+                disabled: primaryActionDisabled,
+                action: activatePrimaryAction
             )
             .keyboardShortcut(.defaultAction)
         }
@@ -872,6 +846,15 @@ struct AgentSkillsOnboardingSheet: View {
         onDismiss()
     }
 
+    private func activatePrimaryAction() {
+        if hasActionNeeded {
+            guard anySelected else { return }
+            applySelection()
+        } else if !detectedRows.isEmpty {
+            onDismiss()
+        }
+    }
+
     private func dontAskAgain() {
         UserDefaults.standard.set(true, forKey: AgentSkillsOnboarding.sheetShownKey)
         onDismiss()
@@ -889,8 +872,7 @@ struct AgentSkillsOnboardingSheet: View {
         case .later:
             installLater()
         case .install:
-            guard anySelected else { return }
-            applySelection()
+            activatePrimaryAction()
         }
     }
 
@@ -928,6 +910,7 @@ private enum AgentSkillsOnboardingAction: CaseIterable {
 
 private enum OnboardingActionButtonKind {
     case primary
+    case success
     case secondary
 }
 
@@ -941,11 +924,11 @@ private struct OnboardingActionButton: View {
     var body: some View {
         Button(action: action) {
             Text(title)
-                .font(.system(size: kind == .primary ? 13 : 12, weight: .semibold))
+                .font(.system(size: isProminent ? 13 : 12, weight: .semibold))
                 .foregroundColor(foregroundColor)
                 .lineLimit(1)
-                .frame(minWidth: kind == .primary ? 126 : 108, minHeight: kind == .primary ? 34 : 28)
-                .padding(.horizontal, kind == .primary ? 10 : 6)
+                .frame(minWidth: isProminent ? 126 : 108, minHeight: isProminent ? 34 : 28)
+                .padding(.horizontal, isProminent ? 10 : 6)
                 .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }
         .buttonStyle(.plain)
@@ -957,9 +940,13 @@ private struct OnboardingActionButton: View {
         .accessibilityAddTraits(isSelected ? .isSelected : [])
     }
 
+    private var isProminent: Bool {
+        kind == .primary || kind == .success
+    }
+
     private var foregroundColor: Color {
         switch kind {
-        case .primary:
+        case .primary, .success:
             return BrandColors.blackSwiftUI
         case .secondary:
             return BrandColors.whiteSwiftUI.opacity(0.9)
@@ -968,15 +955,37 @@ private struct OnboardingActionButton: View {
 
     private var background: some View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .fill(kind == .primary ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.08))
+            .fill(backgroundColor)
+    }
+
+    private var backgroundColor: Color {
+        switch kind {
+        case .primary:
+            return BrandColors.goldSwiftUI
+        case .success:
+            return Color.green.opacity(0.9)
+        case .secondary:
+            return BrandColors.whiteSwiftUI.opacity(0.08)
+        }
     }
 
     private var border: some View {
         RoundedRectangle(cornerRadius: 8, style: .continuous)
             .strokeBorder(
-                kind == .primary ? BrandColors.goldSwiftUI.opacity(0.9) : BrandColors.ruleSwiftUI,
+                borderColor,
                 lineWidth: 1
             )
+    }
+
+    private var borderColor: Color {
+        switch kind {
+        case .primary:
+            return BrandColors.goldSwiftUI.opacity(0.9)
+        case .success:
+            return Color.green.opacity(0.95)
+        case .secondary:
+            return BrandColors.ruleSwiftUI
+        }
     }
 }
 

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -590,64 +590,36 @@ struct AgentSkillsOnboardingSheet: View {
     @State private var kimiOptIn: Bool = false
     @State private var opencodeOptIn: Bool = false
     @State private var initializedDefaultOptIns: Bool = false
+    @State private var selectedAction: AgentSkillsOnboardingAction = .install
 
     init(onDismiss: @escaping () -> Void = {}) {
         self.onDismiss = onDismiss
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
-            Text(String(localized: "agentSkills.onboarding.title", defaultValue: "Teach your agents about c11"))
-                .font(.system(size: 18, weight: .semibold))
-            Text(String(localized: "agentSkills.onboarding.body", defaultValue: "Agents only know about c11's CLI and sidebar metadata when they've read the c11 skill file. Pick which agents should get it — you can change this any time in Settings → Agent Skills."))
-                .font(.system(size: 12))
-                .foregroundColor(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(model.rows) { row in
-                    onboardingRow(row: row)
-                }
-            }
-            .padding(.vertical, 2)
+        VStack(alignment: .leading, spacing: 18) {
+            header
+            installSection
 
             if let msg = model.lastActionMessage {
                 Text(msg)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(BrandColors.whiteSwiftUI.opacity(0.68))
             }
 
-            transparencyControls
-
-            HStack(spacing: 8) {
-                Spacer()
-
-                Button(String(localized: "agentSkills.onboarding.dontAsk", defaultValue: "Don't ask again")) {
-                    UserDefaults.standard.set(true, forKey: AgentSkillsOnboarding.sheetShownKey)
-                    onDismiss()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-
-                Button(String(localized: "agentSkills.onboarding.later", defaultValue: "Install Later")) {
-                    AgentSkillsOnboarding.markDismissedThisLaunch()
-                    onDismiss()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-
-                Button(String(localized: "agentSkills.onboarding.install", defaultValue: "Install Now")) {
-                    applySelection()
-                }
-                .keyboardShortcut(.defaultAction)
-                .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .frame(minWidth: 132, minHeight: 34)
-                .disabled(!anySelected)
-            }
+            learnMoreSection
+            footer
         }
-        .padding(20)
-        .frame(width: 560)
+        .padding(24)
+        .frame(width: 540)
+        .background(OnboardingKeyboardMonitor(
+            onMove: { direction in
+                selectedAction = AgentSkillsOnboardingAction.moved(from: selectedAction, direction: direction)
+            },
+            onActivate: { activateSelectedAction() },
+            onCancel: { installLater() }
+        ))
+        .environment(\.colorScheme, .dark)
         .onAppear { model.refresh() }
         .onReceive(model.$rows) { rows in
             guard !initializedDefaultOptIns, !rows.isEmpty else { return }
@@ -660,45 +632,116 @@ struct AgentSkillsOnboardingSheet: View {
         initializedDefaultOptIns && (claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn)
     }
 
-    private var transparencyControls: some View {
+    private var detectedRows: [AgentSkillsModel.TargetRow] {
+        model.rows.filter(\.detected)
+    }
+
+    private var notDetectedRows: [AgentSkillsModel.TargetRow] {
+        model.rows.filter { !$0.detected }
+    }
+
+    private var detectedTargetList: String {
+        let names = detectedRows.map { $0.target.displayName }
+        return ListFormatter.localizedString(byJoining: names)
+    }
+
+    private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(String(localized: "agentSkills.onboarding.transparency", defaultValue: "Trust should be inspectable. The c11 skill is plain text; open it in Finder or copy a review prompt and hand it to any coding agent before installing."))
-                .font(.system(size: 12))
-                .foregroundColor(.secondary)
+            Text(String(localized: "agentSkills.onboarding.title", defaultValue: "Install the c11 skill"))
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(BrandColors.whiteSwiftUI)
+
+            Text(headerBody)
+                .font(.system(size: 12, weight: .regular))
+                .lineSpacing(2)
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.76))
                 .fixedSize(horizontal: false, vertical: true)
+        }
+    }
 
-            HStack(spacing: 8) {
-                Button(String(localized: "agentSkills.onboarding.showSkill", defaultValue: "Show Skill in Finder")) {
-                    model.revealPrimarySkillInFinder()
-                }
-                .buttonStyle(.bordered)
-                .disabled(model.primarySkillURL == nil)
+    private var headerBody: String {
+        if detectedRows.isEmpty {
+            return String(
+                localized: "agentSkills.onboarding.body.detecting",
+                defaultValue: "Looking for coding agents on this Mac. When c11 finds one, it can install a small plain-text skill that teaches the agent how to drive this workspace."
+            )
+        }
+        let format = String(
+            localized: "agentSkills.onboarding.body.detected",
+            defaultValue: "c11 found %@. Install the skill there so your agents can use panes, browser surfaces, markdown, sidebar status, and the c11 CLI."
+        )
+        return String(format: format, detectedTargetList)
+    }
 
-                Button(String(localized: "agentSkills.onboarding.copyReviewPrompt", defaultValue: "Copy Review Prompt")) {
-                    model.copySkillReviewPromptToPasteboard()
+    private var installSection: some View {
+        VStack(alignment: .leading, spacing: 9) {
+            Text(String(localized: "agentSkills.onboarding.installSection", defaultValue: "Install into"))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
+
+            if detectedRows.isEmpty {
+                Text(String(localized: "agentSkills.onboarding.noDetectedTools", defaultValue: "No supported agent config folders were detected yet. You can run this later from Settings → Agent Skills."))
+                    .font(.system(size: 12))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
+                    .padding(.vertical, 6)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(detectedRows.enumerated()), id: \.element.id) { index, row in
+                        onboardingRow(row: row)
+                        if index < detectedRows.count - 1 {
+                            Rectangle()
+                                .fill(BrandColors.ruleSwiftUI.opacity(0.7))
+                                .frame(height: 1)
+                                .padding(.leading, 30)
+                        }
+                    }
                 }
-                .buttonStyle(.bordered)
-                .disabled(model.primarySkillURL == nil)
             }
-            .controlSize(.regular)
+
+            if !notDetectedRows.isEmpty {
+                Text(notDetectedSummary)
+                    .font(.system(size: 11))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.48))
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
     @ViewBuilder
     private func onboardingRow(row: AgentSkillsModel.TargetRow) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 10) {
+        HStack(alignment: .center, spacing: 10) {
             Toggle(isOn: optInBinding(for: row.target)) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(row.target.displayName)
-                        .font(.system(size: 13, weight: .medium))
-                    Text(detectionLabel(for: row))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+                EmptyView()
             }
+            .labelsHidden()
             .toggleStyle(.checkbox)
             .disabled(!row.detected)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 7) {
+                    Text(row.target.displayName)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(row.detected ? BrandColors.whiteSwiftUI : BrandColors.whiteSwiftUI.opacity(0.42))
+                    if let version = row.sourceVersionLabel {
+                        Text(version)
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(BrandColors.goldSwiftUI)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule(style: .continuous)
+                                    .fill(BrandColors.goldFaintSwiftUI)
+                            )
+                    }
+                }
+                Text(detectionLabel(for: row))
+                    .font(.system(size: 11))
+                    .foregroundColor(BrandColors.whiteSwiftUI.opacity(0.58))
+            }
+            Spacer(minLength: 0)
         }
+        .frame(minHeight: 42)
     }
 
     private func detectionLabel(for row: AgentSkillsModel.TargetRow) -> String {
@@ -709,45 +752,100 @@ struct AgentSkillsOnboardingSheet: View {
             )
         }
         if row.allCurrent {
-            if let version = row.sourceVersionLabel {
-                let format = String(
-                    localized: "agentSkills.onboarding.alreadyInstalledVersioned",
-                    defaultValue: "Already installed and up to date (%@)."
-                )
-                return String(format: format, version)
-            }
             return String(
                 localized: "agentSkills.onboarding.alreadyInstalled",
-                defaultValue: "Already installed and up to date."
+                defaultValue: "Already current"
             )
         }
         if row.hasOutdated {
-            if let version = row.sourceVersionLabel {
-                let format = String(
-                    localized: "agentSkills.onboarding.updateAvailableVersioned",
-                    defaultValue: "Older c11 skill installed. Install Now updates it to %@."
-                )
-                return String(format: format, version)
-            }
             return String(
                 localized: "agentSkills.onboarding.updateAvailable",
-                defaultValue: "Older c11 skill installed. Install Now updates it."
+                defaultValue: "Will update the installed skill"
             )
         }
         if row.anyInstalled {
-            if let version = row.sourceVersionLabel {
-                let format = String(
-                    localized: "agentSkills.onboarding.partialInstalledVersioned",
-                    defaultValue: "Partially installed. Install Now completes %@."
-                )
-                return String(format: format, version)
-            }
             return String(
                 localized: "agentSkills.onboarding.partialInstalled",
-                defaultValue: "Partially installed. Install Now completes the current skill set."
+                defaultValue: "Will complete the skill set"
             )
         }
-        return row.destinationDir.path
+        return String(
+            localized: "agentSkills.onboarding.willInstall",
+            defaultValue: "Will install the skill"
+        )
+    }
+
+    private var notDetectedSummary: String {
+        let names = ListFormatter.localizedString(byJoining: notDetectedRows.map { $0.target.displayName })
+        let format = String(
+            localized: "agentSkills.onboarding.notDetectedSummary",
+            defaultValue: "Not detected: %@"
+        )
+        return String(format: format, names)
+    }
+
+    private var learnMoreSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Rectangle()
+                .fill(BrandColors.ruleSwiftUI.opacity(0.8))
+                .frame(height: 1)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(String(localized: "agentSkills.onboarding.learnMoreTitle", defaultValue: "What gets installed"))
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
+
+                Text(String(localized: "agentSkills.onboarding.transparency", defaultValue: "The skill is plain text. It tells agents how to use c11; it does not run code by itself. Inspect it in Finder or copy a review prompt for another agent."))
+                    .font(.system(size: 12))
+                    .lineSpacing(2)
+                    .foregroundColor(BrandColors.whiteSwiftUI.opacity(0.66))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
+                SecondaryOnboardingButton(
+                    title: String(localized: "agentSkills.onboarding.showSkill", defaultValue: "Show Skill in Finder"),
+                    disabled: model.primarySkillURL == nil,
+                    action: { model.revealPrimarySkillInFinder() }
+                )
+
+                SecondaryOnboardingButton(
+                    title: String(localized: "agentSkills.onboarding.copyReviewPrompt", defaultValue: "Copy Review Prompt"),
+                    disabled: model.primarySkillURL == nil,
+                    action: { model.copySkillReviewPromptToPasteboard() }
+                )
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Spacer(minLength: 0)
+
+            OnboardingActionButton(
+                title: String(localized: "agentSkills.onboarding.dontAsk", defaultValue: "Don't ask again"),
+                kind: .secondary,
+                isSelected: selectedAction == .dontAsk,
+                action: dontAskAgain
+            )
+
+            OnboardingActionButton(
+                title: String(localized: "agentSkills.onboarding.later", defaultValue: "Install Later"),
+                kind: .secondary,
+                isSelected: selectedAction == .later,
+                action: installLater
+            )
+
+            OnboardingActionButton(
+                title: String(localized: "agentSkills.onboarding.install", defaultValue: "Install Now"),
+                kind: .primary,
+                isSelected: selectedAction == .install,
+                disabled: !anySelected,
+                action: applySelection
+            )
+            .keyboardShortcut(.defaultAction)
+        }
     }
 
     private func optInBinding(for target: SkillInstallerTarget) -> Binding<Bool> {
@@ -774,12 +872,239 @@ struct AgentSkillsOnboardingSheet: View {
         onDismiss()
     }
 
+    private func dontAskAgain() {
+        UserDefaults.standard.set(true, forKey: AgentSkillsOnboarding.sheetShownKey)
+        onDismiss()
+    }
+
+    private func installLater() {
+        AgentSkillsOnboarding.markDismissedThisLaunch()
+        onDismiss()
+    }
+
+    private func activateSelectedAction() {
+        switch selectedAction {
+        case .dontAsk:
+            dontAskAgain()
+        case .later:
+            installLater()
+        case .install:
+            guard anySelected else { return }
+            applySelection()
+        }
+    }
+
     private func applyDefaultOptIns(rows: [AgentSkillsModel.TargetRow]) {
         let defaults = AgentSkillsOnboarding.defaultOptIns(for: rows)
         claudeOptIn = defaults[.claude] ?? false
         codexOptIn = defaults[.codex] ?? false
         kimiOptIn = defaults[.kimi] ?? false
         opencodeOptIn = defaults[.opencode] ?? false
+    }
+}
+
+private enum AgentSkillsOnboardingAction: CaseIterable {
+    case dontAsk
+    case later
+    case install
+
+    static func moved(
+        from current: AgentSkillsOnboardingAction,
+        direction: ConfirmMoveDirection
+    ) -> AgentSkillsOnboardingAction {
+        let order = Self.allCases
+        guard let index = order.firstIndex(of: current) else { return .install }
+        switch direction {
+        case .left:
+            return order[max(order.startIndex, index - 1)]
+        case .right:
+            return order[min(order.index(before: order.endIndex), index + 1)]
+        case .toggle:
+            let next = order.index(after: index)
+            return next == order.endIndex ? order[order.startIndex] : order[next]
+        }
+    }
+}
+
+private enum OnboardingActionButtonKind {
+    case primary
+    case secondary
+}
+
+private struct OnboardingActionButton: View {
+    let title: String
+    let kind: OnboardingActionButtonKind
+    let isSelected: Bool
+    var disabled: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: kind == .primary ? 13 : 12, weight: .semibold))
+                .foregroundColor(foregroundColor)
+                .lineLimit(1)
+                .frame(minWidth: kind == .primary ? 126 : 108, minHeight: kind == .primary ? 34 : 28)
+                .padding(.horizontal, kind == .primary ? 10 : 6)
+                .contentShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .background(background)
+        .overlay(border)
+        .selectionBox(isActive: isSelected)
+        .opacity(disabled ? 0.45 : 1)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var foregroundColor: Color {
+        switch kind {
+        case .primary:
+            return BrandColors.blackSwiftUI
+        case .secondary:
+            return BrandColors.whiteSwiftUI.opacity(0.9)
+        }
+    }
+
+    private var background: some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(kind == .primary ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.08))
+    }
+
+    private var border: some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .strokeBorder(
+                kind == .primary ? BrandColors.goldSwiftUI.opacity(0.9) : BrandColors.ruleSwiftUI,
+                lineWidth: 1
+            )
+    }
+}
+
+private struct SecondaryOnboardingButton: View {
+    let title: String
+    var disabled: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(BrandColors.whiteSwiftUI.opacity(0.86))
+                .lineLimit(1)
+                .frame(minHeight: 28)
+                .padding(.horizontal, 12)
+                .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .background(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .fill(BrandColors.whiteSwiftUI.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                .strokeBorder(BrandColors.ruleSwiftUI, lineWidth: 1)
+        )
+        .opacity(disabled ? 0.45 : 1)
+    }
+}
+
+private struct OnboardingKeyboardMonitor: NSViewRepresentable {
+    let onMove: (ConfirmMoveDirection) -> Void
+    let onActivate: () -> Void
+    let onCancel: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onMove: onMove, onActivate: onActivate, onCancel: onCancel)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView(frame: .zero)
+        context.coordinator.view = view
+        context.coordinator.installMonitor()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        context.coordinator.view = nsView
+        context.coordinator.onMove = onMove
+        context.coordinator.onActivate = onActivate
+        context.coordinator.onCancel = onCancel
+        context.coordinator.installMonitor()
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.removeMonitor()
+    }
+
+    final class Coordinator {
+        weak var view: NSView?
+        var onMove: (ConfirmMoveDirection) -> Void
+        var onActivate: () -> Void
+        var onCancel: () -> Void
+        private var monitor: Any?
+
+        init(
+            onMove: @escaping (ConfirmMoveDirection) -> Void,
+            onActivate: @escaping () -> Void,
+            onCancel: @escaping () -> Void
+        ) {
+            self.onMove = onMove
+            self.onActivate = onActivate
+            self.onCancel = onCancel
+        }
+
+        func installMonitor() {
+            guard monitor == nil else { return }
+            monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                guard let self, self.shouldHandle(event: event) else { return event }
+                return self.handle(event: event) ? nil : event
+            }
+        }
+
+        func removeMonitor() {
+            if let monitor {
+                NSEvent.removeMonitor(monitor)
+            }
+            monitor = nil
+        }
+
+        private func shouldHandle(event: NSEvent) -> Bool {
+            guard let window = view?.window, event.window === window, window.isKeyWindow else {
+                return false
+            }
+            return true
+        }
+
+        private func handle(event: NSEvent) -> Bool {
+            switch event.keyCode {
+            case 123, 126:
+                onMove(.left)
+            case 124, 125:
+                onMove(.right)
+            case 48:
+                onMove(event.modifierFlags.contains(.shift) ? .left : .right)
+            case 36, 76, 49:
+                onActivate()
+            case 53:
+                onCancel()
+            default:
+                return false
+            }
+            return true
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func selectionBox(isActive: Bool) -> some View {
+        overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(Color.white, lineWidth: isActive ? 2 : 0)
+                .padding(-4)
+                .animation(.easeInOut(duration: 0.12), value: isActive)
+        )
     }
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6216,9 +6216,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var agentSkillsOnboardingWindow: NSWindow?
     private var agentSkillsOnboardingCloseObserver: NSObjectProtocol?
 
-    /// If the user has Claude Code installed and hasn't already seen the skill
-    /// onboarding sheet, show it over the frontmost window. Consent-gated; the
-    /// sheet never writes without an explicit click.
+    /// If the user has a detected agent environment missing the current skill
+    /// set and hasn't already seen the onboarding sheet, show it over the
+    /// frontmost window. Consent-gated; the sheet never writes without an
+    /// explicit click.
     func presentAgentSkillsOnboardingIfNeeded() {
         guard AgentSkillsOnboarding.shouldPresent() else { return }
         presentAgentSkillsOnboarding()
@@ -6231,7 +6232,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 400),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6232,7 +6232,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 400),
+            contentRect: NSRect(x: 0, y: 0, width: 540, height: 390),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false

--- a/Sources/SkillInstaller.swift
+++ b/Sources/SkillInstaller.swift
@@ -39,6 +39,7 @@ enum SkillInstallerTarget: String, CaseIterable {
 
 struct SkillInstallerPackage: Equatable {
     let name: String
+    let version: String
     let sourceDir: URL
 }
 
@@ -48,6 +49,7 @@ struct SkillInstallerRecord: Codable, Equatable {
 
     let schema: Int
     let packageName: String
+    let skillVersion: String?
     let installedAt: String
     let appVersion: String
     let appBuild: String
@@ -57,6 +59,7 @@ struct SkillInstallerRecord: Codable, Equatable {
     enum CodingKeys: String, CodingKey {
         case schema = "c11_skill_schema"
         case packageName = "package"
+        case skillVersion = "skill_version"
         case installedAt = "installed_at"
         case appVersion = "app_version"
         case appBuild = "app_build"
@@ -211,9 +214,36 @@ enum SkillInstaller {
             guard fileManager.fileExists(atPath: skillMd.path) else { return nil }
             let name = url.lastPathComponent
             if let allowlist, !allowlist.contains(name) { return nil }
-            return SkillInstallerPackage(name: name, sourceDir: url.standardizedFileURL)
+            return SkillInstallerPackage(
+                name: name,
+                version: readSkillVersion(from: skillMd, fileManager: fileManager) ?? "0",
+                sourceDir: url.standardizedFileURL
+            )
         }
         return packages.sorted { $0.name < $1.name }
+    }
+
+    private static func readSkillVersion(from skillFile: URL, fileManager: FileManager) -> String? {
+        guard let data = fileManager.contents(atPath: skillFile.path),
+              let text = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        var lines = text.components(separatedBy: .newlines)
+        guard lines.first?.trimmingCharacters(in: .whitespacesAndNewlines) == "---" else {
+            return nil
+        }
+        lines.removeFirst()
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed == "---" { break }
+            guard trimmed.hasPrefix("version:") else { continue }
+            let rawValue = String(trimmed.dropFirst("version:".count))
+            let value = rawValue
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            return value.isEmpty ? nil : value
+        }
+        return nil
     }
 
     /// Returns the `installable` allowlist from `MANIFEST.json`, or nil if the
@@ -542,6 +572,7 @@ enum SkillInstaller {
             let record = SkillInstallerRecord(
                 schema: SkillInstallerRecord.schemaVersion,
                 packageName: st.package.name,
+                skillVersion: st.package.version,
                 installedAt: timestamp,
                 appVersion: appIdentity.version,
                 appBuild: appIdentity.build,

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4007,7 +4007,7 @@ enum WelcomeSettings {
 
 enum DefaultGridSettings {
     static let enabledKey = "cmuxDefaultGridEnabled"
-    static let defaultEnabled = true
+    static let defaultEnabled = false
 
     // Pixel-dimension thresholds (width × height) that classify the host screen
     // into a default grid shape. Chosen on width primarily, matching typical
@@ -5762,7 +5762,7 @@ struct SettingsView: View {
                     }
                     SettingsCardNote(String(
                         localized: "settings.agentSkills.note",
-                        defaultValue: "c11 installs its skill file into Claude Code (~/.claude/skills) on request. For other agents, c11 copies a ready-to-paste command — the operator runs it."
+                        defaultValue: "c11 installs its skill files into detected agent skill folders only with your approval. Linked skill folders are shown as shared so one remove action cannot silently affect another agent."
                     ))
 
                     SettingsSectionHeader(title: String(localized: "settings.section.reset", defaultValue: "Reset"))

--- a/c11Tests/DefaultGridSettingsTests.swift
+++ b/c11Tests/DefaultGridSettingsTests.swift
@@ -188,10 +188,10 @@ final class DefaultGridSettingsTests: XCTestCase {
 
     // MARK: - isEnabled()
 
-    func testIsEnabledDefaultsTrueWhenKeyUnset() {
+    func testIsEnabledDefaultsFalseWhenKeyUnset() {
         let defaults = UserDefaults(suiteName: "DefaultGridSettingsTests.\(UUID().uuidString)")!
         defaults.removeObject(forKey: DefaultGridSettings.enabledKey)
-        XCTAssertTrue(DefaultGridSettings.isEnabled(defaults: defaults))
+        XCTAssertFalse(DefaultGridSettings.isEnabled(defaults: defaults))
     }
 
     func testIsEnabledReturnsFalseWhenKeyFalse() {

--- a/c11Tests/SocketControlPasswordStoreTests.swift
+++ b/c11Tests/SocketControlPasswordStoreTests.swift
@@ -560,41 +560,6 @@ final class CmuxCLIPathInstallerTests: XCTestCase {
     }
 }
 
-final class AgentSkillsManualInstallCommandTests: XCTestCase {
-    func testSnippetUsesC11BinaryAndTargetRawValue() {
-        XCTAssertEqual(
-            AgentSkillsModel.manualInstallCommandSnippet(target: .claude),
-            "c11 skill install --tool claude"
-        )
-        XCTAssertEqual(
-            AgentSkillsModel.manualInstallCommandSnippet(target: .codex),
-            "c11 skill install --tool codex"
-        )
-        XCTAssertEqual(
-            AgentSkillsModel.manualInstallCommandSnippet(target: .kimi),
-            "c11 skill install --tool kimi"
-        )
-        XCTAssertEqual(
-            AgentSkillsModel.manualInstallCommandSnippet(target: .opencode),
-            "c11 skill install --tool opencode"
-        )
-    }
-
-    func testSnippetNeverUsesLegacyCmuxBinary() {
-        for target in SkillInstallerTarget.allCases {
-            let snippet = AgentSkillsModel.manualInstallCommandSnippet(target: target)
-            XCTAssertFalse(
-                snippet.hasPrefix("cmux "),
-                "snippet for \(target.rawValue) still starts with cmux: \(snippet)"
-            )
-            XCTAssertTrue(
-                snippet.hasPrefix("c11 "),
-                "snippet for \(target.rawValue) must start with c11: \(snippet)"
-            )
-        }
-    }
-}
-
 final class AgentSkillsOnboardingDefaultOptInTests: XCTestCase {
     func testDefaultsSelectEveryDetectedTarget() {
         let rows = SkillInstallerTarget.allCases.map { target in
@@ -640,10 +605,20 @@ final class AgentSkillsOnboardingDefaultOptInTests: XCTestCase {
         XCTAssertFalse(AgentSkillsOnboarding.shouldOffer(for: rows))
     }
 
+    func testSharedDestinationRowsAreNotActionable() {
+        let rows = [
+            makeRow(target: .claude, detected: true, states: [.installedCurrent]),
+            makeRow(target: .codex, detected: true, states: [.installedOutdated], sharedWith: .claude),
+        ]
+
+        XCTAssertFalse(AgentSkillsOnboarding.shouldOffer(for: rows))
+    }
+
     private func makeRow(
         target: SkillInstallerTarget,
         detected: Bool,
-        states: [SkillInstallerState] = []
+        states: [SkillInstallerState] = [],
+        sharedWith: SkillInstallerTarget? = nil
     ) -> AgentSkillsModel.TargetRow {
         AgentSkillsModel.TargetRow(
             id: target.rawValue,
@@ -651,7 +626,8 @@ final class AgentSkillsOnboardingDefaultOptInTests: XCTestCase {
             detected: detected,
             destinationDir: URL(fileURLWithPath: "/tmp/\(target.rawValue)", isDirectory: true),
             packages: states.map { makeStatus(target: target, state: $0) },
-            statusError: nil
+            statusError: nil,
+            sharedWithTarget: sharedWith
         )
     }
 

--- a/c11Tests/SocketControlPasswordStoreTests.swift
+++ b/c11Tests/SocketControlPasswordStoreTests.swift
@@ -594,3 +594,114 @@ final class AgentSkillsManualInstallCommandTests: XCTestCase {
         }
     }
 }
+
+final class AgentSkillsOnboardingDefaultOptInTests: XCTestCase {
+    func testDefaultsSelectEveryDetectedTarget() {
+        let rows = SkillInstallerTarget.allCases.map { target in
+            makeRow(target: target, detected: target != .kimi)
+        }
+
+        let defaults = AgentSkillsOnboarding.defaultOptIns(for: rows)
+
+        XCTAssertEqual(defaults[.claude], true)
+        XCTAssertEqual(defaults[.codex], true)
+        XCTAssertEqual(defaults[.kimi], false)
+        XCTAssertEqual(defaults[.opencode], true)
+    }
+
+    func testMissingTargetsDefaultToFalse() {
+        let defaults = AgentSkillsOnboarding.defaultOptIns(for: [
+            makeRow(target: .claude, detected: true),
+        ])
+
+        XCTAssertEqual(defaults[.claude], true)
+        XCTAssertEqual(defaults[.codex], false)
+        XCTAssertEqual(defaults[.kimi], false)
+        XCTAssertEqual(defaults[.opencode], false)
+    }
+
+    func testOfferAppearsOnlyWhenDetectedTargetNeedsInstallOrUpdate() {
+        let rows = [
+            makeRow(target: .claude, detected: true, states: [.installedCurrent]),
+            makeRow(target: .codex, detected: true, states: [.installedOutdated]),
+            makeRow(target: .kimi, detected: false, states: [.notInstalled]),
+        ]
+
+        XCTAssertTrue(AgentSkillsOnboarding.shouldOffer(for: rows))
+    }
+
+    func testOfferIsSuppressedWhenDetectedTargetsAreCurrent() {
+        let rows = [
+            makeRow(target: .claude, detected: true, states: [.installedCurrent]),
+            makeRow(target: .codex, detected: true, states: [.installedCurrent]),
+            makeRow(target: .kimi, detected: false, states: [.notInstalled]),
+        ]
+
+        XCTAssertFalse(AgentSkillsOnboarding.shouldOffer(for: rows))
+    }
+
+    private func makeRow(
+        target: SkillInstallerTarget,
+        detected: Bool,
+        states: [SkillInstallerState] = []
+    ) -> AgentSkillsModel.TargetRow {
+        AgentSkillsModel.TargetRow(
+            id: target.rawValue,
+            target: target,
+            detected: detected,
+            destinationDir: URL(fileURLWithPath: "/tmp/\(target.rawValue)", isDirectory: true),
+            packages: states.map { makeStatus(target: target, state: $0) },
+            statusError: nil
+        )
+    }
+
+    private func makeStatus(
+        target: SkillInstallerTarget,
+        state: SkillInstallerState
+    ) -> SkillInstallerPackageStatus {
+        let packageDir = URL(fileURLWithPath: "/tmp/source/c11", isDirectory: true)
+        let destinationDir = URL(fileURLWithPath: "/tmp/\(target.rawValue)/skills/c11", isDirectory: true)
+        return SkillInstallerPackageStatus(
+            package: SkillInstallerPackage(name: "c11", version: "1", sourceDir: packageDir),
+            target: target,
+            destinationDir: destinationDir,
+            state: state,
+            record: nil,
+            sourceContentHash: "sha256:test"
+        )
+    }
+}
+
+final class SkillInstallerPackageVersionTests: XCTestCase {
+    func testDiscoverPackagesReadsSkillFrontmatterVersion() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("c11-skill-version-tests-\(UUID().uuidString)", isDirectory: true)
+        let packageDir = root.appendingPathComponent("c11", isDirectory: true)
+        try FileManager.default.createDirectory(at: packageDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try """
+        {"installable":["c11"]}
+        """.write(
+            to: root.appendingPathComponent("MANIFEST.json", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+        try """
+        ---
+        name: c11
+        version: 7
+        description: test
+        ---
+        """.write(
+            to: packageDir.appendingPathComponent("SKILL.md", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let packages = try SkillInstaller.discoverPackages(sourceDir: root)
+
+        XCTAssertEqual(packages.map(\.name), ["c11"])
+        XCTAssertEqual(packages.first?.version, "7")
+    }
+}

--- a/skills/c11-browser/SKILL.md
+++ b/skills/c11-browser/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: c11-browser
+version: 1
 description: Browser automation for c11 browser surfaces (WKWebView-backed). Use to open sites, interact with pages, wait for state changes, extract data, save/load auth state, and validate UI changes without leaving c11. Prefer this over Chrome MCP whenever c11 is running.
 ---
 

--- a/skills/c11-debug-windows/SKILL.md
+++ b/skills/c11-debug-windows/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: c11-debug-windows
+version: 1
 description: Manage c11 debug windows and related debug menu wiring for Sidebar Debug, Background Debug, and Menu Bar Extra Debug. Use this when the user asks to open/tune these debug controls, add or adjust Debug menu entries, or capture/copy a combined debug config snapshot. Applies to the c11 macOS app (binary `c11`).
 ---
 

--- a/skills/c11-markdown/SKILL.md
+++ b/skills/c11-markdown/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: c11-markdown
+version: 1
 description: Open markdown files in a c11 markdown surface with live reload. Use when you need to display plans, documentation, or notes alongside terminals and browser surfaces with rich rendering (headings, code blocks, tables, lists, Mermaid diagrams). Prefer this over external viewers when c11 is running.
 ---
 

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: c11
+version: 1
 description: c11 — Stage 11's native macOS terminal multiplexer built as infrastructure for the Spike. Use when (1) session starts inside c11 (env var CMUX_SHELL_INTEGRATION=1), (2) creating pane splits, surfaces, or workspaces, (3) sending text or commands to another surface, (4) launching or orchestrating sub-agents in sibling panes, (5) declaring agent identity or writing the surface manifest, (6) reading surface contents or spatial layout via `c11 tree`, (7) setting surface title or description, (8) reporting progress via sidebar status/log/progress, (9) using the embedded browser for web validation (preferred over Chrome MCP when inside c11), (10) any c11-specific command or troubleshooting question. Auto-load whenever c11 is detected in the environment.
 ---
 


### PR DESCRIPTION
## Summary

- Adds version-aware c11 skill detection and defaults detected agents into the install/update flow.
- Redesigns the Agent Skills onboarding dialog around a clearer install section, trust/inspection section, larger keyboard-friendly actions, and the `Skillify Your Agent` CTA.
- Handles shared skill folders such as Codex symlinked to Claude by marking duplicate destinations as shared and avoiding destructive duplicate actions.
- Removes the confusing review-prompt/copy-command affordances and adds Finder reveal for the exact skill files.
- Makes the default pane grid opt-in so tagged dev launches do not surprise users with a multi-pane workspace.

## Validation

- `jq empty Resources/Localizable.xcstrings`
- `git diff --check origin/main..HEAD`
- `./scripts/reload.sh --tag skill-dialog-ux` succeeded
- Verified the tagged dev app reports one workspace with one terminal pane after relaunch via `c11 tree --json`.

Local tests were not run, following the repo testing policy.
