### PR TITLE
ci: cut Actions spend — move nightly to cron, add paths-ignore + concurrency

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -4,7 +4,21 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'notes/**'
+      - 'Resources/Localizable.xcstrings'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'notes/**'
+      - 'Resources/Localizable.xcstrings'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-ghosttykit:

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -4,7 +4,21 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'notes/**'
+      - 'Resources/Localizable.xcstrings'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'notes/**'
+      - 'Resources/Localizable.xcstrings'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   compat-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'notes/**'
+      - 'Resources/Localizable.xcstrings'
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'notes/**'
+      - 'Resources/Localizable.xcstrings'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,11 @@
 name: Nightly c11 macOS build
 
 on:
-  push:
-    branches: [main]
+  schedule:
+    # Daily at 10:00 UTC (~02:00–03:00 Pacific). The `decide` job still skips
+    # the expensive build if main has no new commits since the last nightly tag,
+    # so an idle day costs only the cheap Ubuntu gate.
+    - cron: '0 10 * * *'
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
## Summary

Three changes to reduce GitHub Actions spend (was burning ~4,400 macOS billable min / 3 days ≈ $300–400/mo extrapolated):

- **`nightly.yml`**: swap `push: branches: [main]` for `schedule: cron '0 10 * * *'` (daily ~02–03:00 Pacific). "Nightly" was actually firing on every push to main (12× in 3 days). The existing `decide` job still no-ops on unchanged main, so an idle day costs only the cheap Ubuntu gate.
- **`paths-ignore`** on `ci.yml`, `ci-macos-compat.yml`, `build-ghosttykit.yml`: skip when a push/PR touches only `**/*.md`, `docs/**`, `notes/**`, or `Resources/Localizable.xcstrings`. Translation-only and docs-only commits no longer spin macOS runners.
- **`concurrency: cancel-in-progress: pull_request`** on `ci-macos-compat.yml` and `build-ghosttykit.yml` (`ci.yml` already had this). Superseded PR pushes cancel prior runs.

## Test plan

- [ ] This PR's own CI runs (it touches workflows, not md/docs), so all three macOS workflows should fire on this PR
- [ ] Verify `ci-macos-compat` and `build-ghosttykit` now show the `concurrency` group in the run summary
- [ ] On merge to main, confirm `nightly.yml` does *not* fire automatically; trigger once manually via `gh workflow run nightly.yml` to confirm the cron/dispatch path still works
- [ ] Observe over ~1 week that main-only nightly runs (should be 1/day instead of 4+/day)