### PR TITLE
skills: stop assuming `cc` is a universal alias; use `claude --dangerously-skip-permissions`

### DIFF
--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -56,7 +56,7 @@ Also populate `role`, `task`, and `status` via `c11 set-metadata` **if known** f
 
 **Show lineage for downstream tabs.** When a pane is spawned from another — sub-agents under an orchestrator, review agents over a feature's work, follow-ups rooted in earlier output — chain parent to child with `::`, parent first: `Login Button :: MA Review :: Claude`. Multiple rungs chain in order. The sidebar truncates to the parent (grouping siblings visibly); the full chain shows in the title bar. Users may override; lineage is the default whenever a parent exists. Before renaming, check `c11 get-titlebar-state` — if a chain is already present, preserve the prefix and only refine the trailing segment. See [references/orchestration.md#tab-naming-mandatory](references/orchestration.md#tab-naming-mandatory) for the full convention.
 
-**Sibling workers are not downstream.** When the operator sets up peer panes they'll drive directly — e.g., two `cc` panes for parallel feature work, a standing "Lattice Manager" next to them — skip the `::` chain and use a short positional or role anchor: `Feature Left`, `Feature Right`, `Lattice Manager`. Reserve `::` lineage for true hierarchical orchestration where a parent agent routes work down to sub-agents it will read back from.
+**Sibling workers are not downstream.** When the operator sets up peer panes they'll drive directly — e.g., two Claude Code panes for parallel feature work, a standing "Lattice Manager" next to them — skip the `::` chain and use a short positional or role anchor: `Feature Left`, `Feature Right`, `Lattice Manager`. Reserve `::` lineage for true hierarchical orchestration where a parent agent routes work down to sub-agents it will read back from.
 
 **If the user's opening message is absent or ambiguous, ask before orienting.** This aligns with the global "dialogue" norm — don't silently rename a tab `"Explore"` just to have something in the sidebar. A direct request ("fix this bug", "what is X called") is not ambiguous; proceed with the request and run orientation in the same turn.
 
@@ -277,15 +277,17 @@ c11 list-status
 c11 clear-status task
 ```
 
-**Constraint**: these only work from a direct c11 child process. Headless `claude -p` subprocesses are reparented to `launchd` and lose the auth chain — they cannot call any `c11` command. Interactive `cc` keeps the chain intact.
+**Constraint**: these only work from a direct c11 child process. Headless `claude -p` subprocesses are reparented to `launchd` and lose the auth chain — they cannot call any `c11` command. Interactive `claude` keeps the chain intact.
 
 ## Launching sub-agents
 
-Use **`cc`** (the `--dangerously-skip-permissions` alias) — never bare `claude` or `claude -p`:
+Use **`claude --dangerously-skip-permissions`** — never bare `claude` (stalls on approvals) or `claude -p` (headless, breaks the auth chain):
 
 - `claude -p` (headless) breaks the auth chain; sub-agents can't self-report.
 - Plain `claude` stalls on permission approvals.
-- `cc` in an interactive pane inherits c11 env vars, preserves the auth chain, and skips approvals. Sub-agents can `c11 set-status`, `c11 log`, `c11 set-progress` freely.
+- `claude --dangerously-skip-permissions` in an interactive pane inherits c11 env vars, preserves the auth chain, and skips approvals. Sub-agents can `c11 set-status`, `c11 log`, `c11 set-progress` freely.
+
+> **`claude` on PATH is the c11 wrapper.** Inside a c11 surface, `claude` resolves to `Resources/bin/claude` — a PATH-scoped wrapper that injects session-id and hook settings so the sidebar gets `claude_code` status. `cc` is **not** a c11-provided command; some operators set `alias cc='claude --dangerously-skip-permissions'` in their shell config, but you cannot assume it exists. Always invoke `claude --dangerously-skip-permissions` explicitly in anything you send to a pane.
 
 For **Codex** in a visible c11 surface, launch the interactive TUI with `codex --yolo`, not `codex exec`. `codex exec` is headless/non-interactive and is only appropriate for background jobs whose output will be read after completion; it is the wrong tool when the operator should be able to watch, inspect, or take over the agent in c11.
 
@@ -294,7 +296,7 @@ c11 send --workspace $WS --surface $SURF "cd /path && codex --yolo \"Read /tmp/l
 c11 send-key --workspace $WS --surface $SURF enter
 ```
 
-**Preferred launch — one-shot prompt via cc argv.** Write the prompt to a file first, then launch `cc` with a short positional argument that tells it to read the file. cc boots and submits the initial message in one step, so there is no ready-state race to solve:
+**Preferred launch — one-shot prompt via claude argv.** Write the prompt to a file first, then launch `claude --dangerously-skip-permissions` with a short positional argument that tells it to read the file. It boots and submits the initial message in one step, so there is no ready-state race to solve:
 
 ```bash
 # 1. Stage the prompt (complex content → file; shell escaping in `c11 send` is brittle)
@@ -303,25 +305,25 @@ cat > /tmp/lat-xxx-prompt.md <<'EOF'
 EOF
 
 # 2. One-shot launch
-c11 send --workspace $WS --surface $SURF "cd /path && cc \"Read /tmp/lat-xxx-prompt.md and follow the instructions.\""
+c11 send --workspace $WS --surface $SURF "cd /path && claude --dangerously-skip-permissions \"Read /tmp/lat-xxx-prompt.md and follow the instructions.\""
 c11 send-key --workspace $WS --surface $SURF enter
 ```
 
 This is the default pattern for all orchestrated sub-agent launches. No polling, no sleep, no screen-scraping.
 
-**Two-call launch — only when you need to interact post-boot.** Launch `cc` bare, wait for the sidebar `claude_code` status to hit `Idle` (the cc wrapper emits it), then send additional input:
+**Two-call launch — only when you need to interact post-boot.** Launch `claude --dangerously-skip-permissions` bare, wait for the sidebar `claude_code` status to hit `Idle` (the c11 claude wrapper emits it), then send additional input:
 
 ```bash
-c11 send --workspace $WS --surface $SURF "cd /path && cc"
+c11 send --workspace $WS --surface $SURF "cd /path && claude --dangerously-skip-permissions"
 c11 send-key --workspace $WS --surface $SURF enter
 until c11 list-status --workspace $WS 2>/dev/null | grep -q '^claude_code=Idle '; do sleep 1; done
 c11 send --workspace $WS --surface $SURF "Read /tmp/prompt.md and follow the instructions."
 c11 send-key --workspace $WS --surface $SURF enter
 ```
 
-> **Multi-cc gotcha:** `c11 list-status` is **workspace-scoped**; `--surface` is silently ignored. The `claude_code=Running|Idle` row reflects activity across every cc surface in the workspace, not the one you're targeting. With two or more cc's running in the same workspace (the common orchestration case — planner + triage + impl, or orchestrator + sub-agent), the row never decisively reports `Idle` and the `until` loop deadlocks. Prefer the one-shot pattern above when any sibling cc is in flight. Polling is only safe when your target is the sole cc in the workspace.
+> **Multi-claude gotcha:** `c11 list-status` is **workspace-scoped**; `--surface` is silently ignored. The `claude_code=Running|Idle` row reflects activity across every Claude Code surface in the workspace, not the one you're targeting. With two or more claudes running in the same workspace (the common orchestration case — planner + triage + impl, or orchestrator + sub-agent), the row never decisively reports `Idle` and the `until` loop deadlocks. Prefer the one-shot pattern above when any sibling claude is in flight. Polling is only safe when your target is the sole claude in the workspace.
 
-**Never screen-scrape `c11 read-screen` for `❯`, `> `, `Welcome to Claude Code`, `Claude Code v`, or any other banner string** — those drift across cc releases and fail silently. See [references/orchestration.md](references/orchestration.md) for the full pattern including tab-naming conventions and agent-to-agent handoffs.
+**Never screen-scrape `c11 read-screen` for `❯`, `> `, `Welcome to Claude Code`, `Claude Code v`, or any other banner string** — those drift across Claude Code releases and fail silently. See [references/orchestration.md](references/orchestration.md) for the full pattern including tab-naming conventions and agent-to-agent handoffs.
 
 ## Web validation
 
@@ -350,7 +352,7 @@ disown
 ## References
 
 - **[references/api.md](references/api.md)** — full command surface: addressing, discovery, workspace/pane/surface management, surface initialization quirks, sidebar metadata, notifications, troubleshooting
-- **[references/orchestration.md](references/orchestration.md)** — multi-agent patterns: layout, tab naming, launching `cc` sub-agents, agent-to-agent communication, sidebar reporting, writing c11-aware prompts
+- **[references/orchestration.md](references/orchestration.md)** — multi-agent patterns: layout, tab naming, launching Claude Code sub-agents, agent-to-agent communication, sidebar reporting, writing c11-aware prompts
 - **[references/metadata.md](references/metadata.md)** — metadata deep dive: socket methods, precedence table, all canonical keys, sidecar sources, consumer patterns
 - **[../c11-browser/SKILL.md](../c11-browser/SKILL.md)** — c11 embedded browser automation
 - **[../c11-markdown/SKILL.md](../c11-markdown/SKILL.md)** — markdown surface viewer

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -287,7 +287,7 @@ Use **`claude --dangerously-skip-permissions`** — never bare `claude` (stalls 
 - Plain `claude` stalls on permission approvals.
 - `claude --dangerously-skip-permissions` in an interactive pane inherits c11 env vars, preserves the auth chain, and skips approvals. Sub-agents can `c11 set-status`, `c11 log`, `c11 set-progress` freely.
 
-> **`claude` on PATH is the c11 wrapper.** Inside a c11 surface, `claude` resolves to `Resources/bin/claude` — a PATH-scoped wrapper that injects session-id and hook settings so the sidebar gets `claude_code` status. `cc` is **not** a c11-provided command; some operators set `alias cc='claude --dangerously-skip-permissions'` in their shell config, but you cannot assume it exists. Always invoke `claude --dangerously-skip-permissions` explicitly in anything you send to a pane.
+> **`claude` on PATH is the c11 wrapper.** Inside a c11 surface, `claude` resolves to `Resources/bin/claude` — a PATH-scoped wrapper that injects session-id and hook settings so the sidebar gets `claude_code` status. Always invoke `claude --dangerously-skip-permissions` explicitly in anything you send to a pane.
 
 For **Codex** in a visible c11 surface, launch the interactive TUI with `codex --yolo`, not `codex exec`. `codex exec` is headless/non-interactive and is only appropriate for background jobs whose output will be read after completion; it is the wrong tool when the operator should be able to watch, inspect, or take over the agent in c11.
 

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -214,7 +214,7 @@ c11 list-log [--limit <n>]
 c11 clear-log
 ```
 
-**Constraint:** these must be called from a direct c11 child process. Subprocesses spawned by `claude -p` get reparented to `launchd`, breaking the auth chain. Interactive `cc` keeps it intact.
+**Constraint:** these must be called from a direct c11 child process. Subprocesses spawned by `claude -p` get reparented to `launchd`, breaking the auth chain. Interactive `claude --dangerously-skip-permissions` keeps it intact.
 
 ## Spatial layout (`c11 tree`)
 
@@ -267,7 +267,7 @@ Consent is always requested before any write. The installer also installs the c1
 - **Browser commands fail with "not a browser"** — you're targeting a terminal surface. Find the browser surface ref with `c11 tree` and pass `--surface <ref>`.
 - **Commands do nothing** — check `CMUX_SOCKET_PATH` matches the running instance. Default is `/tmp/cmux.sock`; tagged debug builds use `/tmp/cmux-debug-<tag>.sock`. (`C11_SOCKET_PATH` is the primary name going forward; `CMUX_SOCKET_PATH` still works.)
 - **Surface doesn't respond after creation** — it may not be initialized. Run `c11 select-workspace --workspace workspace:N && sleep 2` to trigger the layout pass.
-- **Sub-agent can't call `c11`** — happens with `claude -p` (headless). Interactive `cc` launched via `c11 send "cc\n"` + `send-key enter` maintains the auth chain.
+- **Sub-agent can't call `c11`** — happens with `claude -p` (headless). Interactive `claude --dangerously-skip-permissions` launched via `c11 send "claude --dangerously-skip-permissions\n"` + `send-key enter` maintains the auth chain.
 - **Metadata write returns `applied: false` with `lower_precedence`** — a higher-precedence source already owns that key. See [metadata.md](metadata.md) precedence table.
 
 ## Notes

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -88,11 +88,13 @@ The orchestrator writes the first lineage line when it spawns the child so the c
 
 ## Launching sub-agents in panes
 
-Use **`cc`** (the `--dangerously-skip-permissions` alias) — never bare `claude` or `claude -p`:
+Use **`claude --dangerously-skip-permissions`** — never bare `claude` (stalls on approvals) or `claude -p` (headless, breaks the auth chain):
 
 - **`claude -p` (headless)** breaks the c11 auth chain. The subprocess is reparented to `launchd` and cannot call any `c11` command. Sub-agents lose the ability to self-report.
 - **Plain `claude`** stalls on every tool call waiting for permission approvals nobody answers.
-- **`cc` in an interactive pane** inherits c11 env vars, preserves the auth chain, and skips approvals. Sub-agents can self-report via `c11 set-status`, `c11 log`, `c11 set-progress`, `c11 set-metadata`.
+- **`claude --dangerously-skip-permissions` in an interactive pane** inherits c11 env vars, preserves the auth chain, and skips approvals. Sub-agents can self-report via `c11 set-status`, `c11 log`, `c11 set-progress`, `c11 set-metadata`.
+
+> **`claude` on PATH is the c11 wrapper.** Inside a c11 surface, `claude` resolves to `Resources/bin/claude` — a PATH-scoped wrapper that injects session-id and hook settings so the sidebar gets `claude_code` status. `cc` is **not** a c11-provided command; some operators set `alias cc='claude --dangerously-skip-permissions'` in their shell config, but you cannot assume it exists in a spawned pane's shell. Always invoke `claude --dangerously-skip-permissions` explicitly in anything you send.
 
 ### Standard launch pattern
 
@@ -101,11 +103,11 @@ Use **`cc`** (the `--dangerously-skip-permissions` alias) — never bare `claude
 c11 new-split right
 # → returns surface:NNN
 
-# 2. Launch cc
-c11 send --workspace $WS --surface $SURF "cc"
+# 2. Launch claude
+c11 send --workspace $WS --surface $SURF "claude --dangerously-skip-permissions"
 c11 send-key --workspace $WS --surface $SURF enter
 
-# 3. Wait for cc to be ready (see polling section), then name the tab with lineage
+# 3. Wait for claude to be ready (see polling section), then name the tab with lineage
 #    (parent first, `::` separator — see Tab naming above)
 c11 rename-tab       --workspace $WS --surface $SURF "Login Button :: Lint Fixes"
 c11 set-description  --workspace $WS --surface $SURF "Lineage: Login Button → Lint Fixes sub-agent.
@@ -139,11 +141,11 @@ c11 send-key --workspace $WS --surface $SURF enter
 
 ## Ready-state handoff
 
-`cc` takes a few seconds to start. Do not `sleep 5` and do not screen-scrape for the prompt glyph. Two patterns solve this depending on whether you need a post-boot conversation or a single-turn handoff.
+`claude` takes a few seconds to start. Do not `sleep 5` and do not screen-scrape for the prompt glyph. Two patterns solve this depending on whether you need a post-boot conversation or a single-turn handoff.
 
-### Preferred — one-shot prompt via cc argv
+### Preferred — one-shot prompt via claude argv
 
-For the common orchestration case ("spawn a fresh-context sub-agent with a complete brief"), pass the initial prompt to `cc` as a positional argument. cc boots and submits the message in one step, so there is no ready-state race to solve:
+For the common orchestration case ("spawn a fresh-context sub-agent with a complete brief"), pass the initial prompt to `claude --dangerously-skip-permissions` as a positional argument. It boots and submits the message in one step, so there is no ready-state race to solve:
 
 ```bash
 # Complex prompt → stage to file (shell escaping in c11 send is brittle)
@@ -151,19 +153,19 @@ cat > /tmp/agent-prompt.md <<'EOF'
 [full prompt here, with backticks / code blocks / etc.]
 EOF
 
-# One-shot launch — cc consumes the short argv instruction, which points it at the file
-c11 send --workspace $WS --surface $SURF "cd /path && cc \"Read /tmp/agent-prompt.md and follow the instructions.\""
+# One-shot launch — claude consumes the short argv instruction, which points it at the file
+c11 send --workspace $WS --surface $SURF "cd /path && claude --dangerously-skip-permissions \"Read /tmp/agent-prompt.md and follow the instructions.\""
 c11 send-key --workspace $WS --surface $SURF enter
 ```
 
-This is the default for orchestrated sub-agents. No polling, no sleep, no screen-scraping. Works regardless of how many other cc surfaces are in the workspace.
+This is the default for orchestrated sub-agents. No polling, no sleep, no screen-scraping. Works regardless of how many other Claude Code surfaces are in the workspace.
 
 ### Fallback — polling the workspace `claude_code` status
 
-When you need cc interactive first (e.g. to send follow-up messages over the course of the session) and can guarantee no sibling cc is running concurrently in the workspace, you can poll the sidebar status that cc's PATH wrapper populates:
+When you need claude interactive first (e.g. to send follow-up messages over the course of the session) and can guarantee no sibling claude is running concurrently in the workspace, you can poll the sidebar status that the c11 claude PATH wrapper populates:
 
 ```bash
-# Wait for cc to reach Idle before sending the prompt
+# Wait for claude to reach Idle before sending the prompt
 until c11 list-status --workspace $WS 2>/dev/null | grep -q '^claude_code=Idle '; do sleep 1; done
 c11 send --workspace $WS --surface $SURF "Read /tmp/prompt.md and follow the instructions."
 c11 send-key --workspace $WS --surface $SURF enter
@@ -171,17 +173,17 @@ c11 send-key --workspace $WS --surface $SURF enter
 
 Supported status values: `Idle` (prompt waiting), `Running` (processing a turn), `Needs input` (permission/dialog), plus opt-in verbose tool descriptions. Values are `TitleCase`. The trailing space in the grep anchors the match to just `Idle`.
 
-> **Critical gotcha — workspace aggregation.** `c11 list-status` is workspace-scoped; `--surface` is silently ignored. The `claude_code=...` row reflects activity across **every** cc surface in the workspace, not the one you're targeting. With two or more cc's running (orchestrator + sub-agent, planner + triage + impl, or any parallel review fan-out), the row never decisively reports `Idle` and the `until` loop deadlocks. Prefer the one-shot pattern above whenever any sibling cc is in flight. This gotcha is a known binary limitation (no surface-scoped agent-status query exists); there is no polling recipe that safely substitutes in the multi-cc case.
+> **Critical gotcha — workspace aggregation.** `c11 list-status` is workspace-scoped; `--surface` is silently ignored. The `claude_code=...` row reflects activity across **every** Claude Code surface in the workspace, not the one you're targeting. With two or more claudes running (orchestrator + sub-agent, planner + triage + impl, or any parallel review fan-out), the row never decisively reports `Idle` and the `until` loop deadlocks. Prefer the one-shot pattern above whenever any sibling claude is in flight. This gotcha is a known binary limitation (no surface-scoped agent-status query exists); there is no polling recipe that safely substitutes in the multi-claude case.
 
 Additional notes on the polling signal:
-- The signal only exists when cc was launched through c11's bundled PATH. A cc / claude invocation that bypasses the PATH wrapper will not emit status. For sub-agents you orchestrate from inside a c11 surface this is almost always fine — the wrapper is the default for `cc` / `claude` in that context.
+- The signal only exists when claude was launched through c11's bundled PATH. A `claude` invocation that bypasses the PATH wrapper will not emit status. For sub-agents you orchestrate from inside a c11 surface this is almost always fine — the wrapper is the default for `claude` in that context.
 - Other TUIs (codex, kimi, opencode, etc.) do **not** get an equivalent wrapper, by design. For those, agents self-report by calling `c11 set-metadata --key status --value idle` / `running` themselves, following instructions in the c11 skill file they load at session start. If an agent hasn't been taught to self-report, you won't see status for them — that's expected.
 
-**Do not** regex for `❯`, `> `, or `Welcome to Claude Code`. Those patterns drift across cc releases and produce silent stalls when they miss (v2.1.114 dropped the box prompt and changed the banner, breaking every previous recipe). Use one-shot argv delivery, or poll the status row when it's safe to do so.
+**Do not** regex for `❯`, `> `, or `Welcome to Claude Code`. Those patterns drift across Claude Code releases and produce silent stalls when they miss (v2.1.114 dropped the box prompt and changed the banner, breaking every previous recipe). Use one-shot argv delivery, or poll the status row when it's safe to do so.
 
-### Why this works only for cc, and why that's okay
+### Why this works only for Claude Code, and why that's okay
 
-The cc PATH wrapper at `Resources/bin/claude` is a **grandfathered, cc-specific concession** — c11 does not write to any TUI's persistent config, and will not install analogous wrappers for codex, kimi, or opencode. The host is deliberately unopinionated about the terminal: c11 provides the surface, the socket, and the skill file; what an agent does with them is the agent's business. For every TUI except cc, the skill-driven self-reporting path above is how status gets populated — there is no installer, no config-writing, no hook injection performed by c11.
+The claude PATH wrapper at `Resources/bin/claude` is a **grandfathered, Claude Code-specific concession** — c11 does not write to any TUI's persistent config, and will not install analogous wrappers for codex, kimi, or opencode. The host is deliberately unopinionated about the terminal: c11 provides the surface, the socket, and the skill file; what an agent does with them is the agent's business. For every TUI except Claude Code, the skill-driven self-reporting path above is how status gets populated — there is no installer, no config-writing, no hook injection performed by c11.
 
 ## Agent-to-agent communication
 
@@ -198,7 +200,7 @@ Structured handoffs can also ride on the metadata blob — agent A writes `c11 s
 
 ## Sub-agent self-reporting
 
-Because `cc` preserves the auth chain, sub-agents can update the sidebar and the metadata blob directly:
+Because interactive `claude --dangerously-skip-permissions` preserves the auth chain, sub-agents can update the sidebar and the metadata blob directly:
 
 ```bash
 c11 set-status task "3/5 complete" --icon "play.fill" --color "#00FF00"
@@ -237,7 +239,7 @@ When spawning sub-agents in c11, include these as first-class instructions in th
 
 1. **Self-identify immediately.** First action: `c11 identify` + `c11 get-titlebar-state` (to read any lineage the orchestrator pre-wrote) + `c11 rename-tab "<descriptive name>"` + `c11 set-agent --type <tui> --model <model-id>`. An unnamed, undeclared tab is an unidentifiable agent. If a lineage prefix (`Parent :: …`) is already present, preserve it and refine only the trailing segment.
 2. **Name every tab you create with lineage.** Format: `<parent title> :: <child role>` (e.g., `Login Button :: Plan`). Chain additional rungs as needed. Also write `c11 set-description` with a `Lineage: A → B → C` breadcrumb so the sub-agent inherits the chain and preserves it when self-updating. Pass the parent title in the spawn prompt so the sub-agent can recompose if it ever has to rename from scratch.
-3. **Report at milestones** via `c11 set-metadata`, `c11 set-status`, `c11 set-progress`, `c11 log`. Interactive `cc` inherits the auth chain, so sub-agents can self-report. Preserve any lineage prefix/breadcrumb when updating title/description on task change.
+3. **Report at milestones** via `c11 set-metadata`, `c11 set-status`, `c11 set-progress`, `c11 log`. Interactive `claude --dangerously-skip-permissions` inherits the auth chain, so sub-agents can self-report. Preserve any lineage prefix/breadcrumb when updating title/description on task change.
 4. **Deliver complex prompts via temp files** — write to a file, tell the agent to read it. Avoids shell-escaping issues with `c11 send`.
 5. **Do not make silent splits.** For multiple related outputs, prefer tabs over splits. Propose layouts when they would help; do not impose them.
 6. **Read the room before reshaping it.** `c11 tree --json` gives pixel and percent coordinates for every pane — check whether a new split will fit before asking for one.

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -94,7 +94,7 @@ Use **`claude --dangerously-skip-permissions`** — never bare `claude` (stalls 
 - **Plain `claude`** stalls on every tool call waiting for permission approvals nobody answers.
 - **`claude --dangerously-skip-permissions` in an interactive pane** inherits c11 env vars, preserves the auth chain, and skips approvals. Sub-agents can self-report via `c11 set-status`, `c11 log`, `c11 set-progress`, `c11 set-metadata`.
 
-> **`claude` on PATH is the c11 wrapper.** Inside a c11 surface, `claude` resolves to `Resources/bin/claude` — a PATH-scoped wrapper that injects session-id and hook settings so the sidebar gets `claude_code` status. `cc` is **not** a c11-provided command; some operators set `alias cc='claude --dangerously-skip-permissions'` in their shell config, but you cannot assume it exists in a spawned pane's shell. Always invoke `claude --dangerously-skip-permissions` explicitly in anything you send.
+> **`claude` on PATH is the c11 wrapper.** Inside a c11 surface, `claude` resolves to `Resources/bin/claude` — a PATH-scoped wrapper that injects session-id and hook settings so the sidebar gets `claude_code` status. Always invoke `claude --dangerously-skip-permissions` explicitly in anything you send to a pane.
 
 ### Standard launch pattern
 


### PR DESCRIPTION
## Summary

- The c11 skill treated `cc` as a universally available command for launching Claude Code sub-agents, but c11 never ships a `cc` binary — it's only an operator-defined shell alias. When a new operator installed c11, any sub-agent that followed the skill literally (`c11 send "... cc ..."`) sent `cc` into a freshly spawned pane where it didn't exist, and the command failed silently.
- Replaces command invocations in `skills/c11/SKILL.md`, `skills/c11/references/orchestration.md`, and `skills/c11/references/api.md` with `claude --dangerously-skip-permissions`.
- Adds a note in the launching-sub-agents sections of SKILL.md and orchestration.md explaining that `claude` on PATH is the c11 wrapper (`Resources/bin/claude`, the one grandfathered runtime shim), while `cc` is an optional operator alias that cannot be assumed to exist in a spawned pane's shell.

Prose around the new wording was also tightened (e.g. "multi-cc gotcha" → "multi-claude gotcha", "cc releases" → "Claude Code releases", "the cc PATH wrapper" → "the claude PATH wrapper") so the skill stays internally consistent.

## Test plan

- [ ] Read through the three updated files and confirm the new callouts read correctly in context.
- [ ] Spawn a fresh c11 pane where `cc` is **not** aliased in the shell, and verify that following the skill's launch pattern (`claude --dangerously-skip-permissions`) boots Claude Code successfully and populates the `claude_code=…` sidebar status.
- [ ] Spawn a pane in a shell that **does** alias `cc=claude --dangerously-skip-permissions` and confirm the note's framing still matches the operator's mental model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)