### PR TITLE
Agent Skills onboarding: install-state titles + localization docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,15 @@ The one-liner: after any code change, `./scripts/reload.sh --tag <your-branch-sl
   - `TerminalSurface.forceRefresh()` in `GhosttyTerminalView.swift`: called on every keystroke. Do not add allocations, file I/O, or formatting here.
 - **Terminal find layering contract:** `SurfaceSearchOverlay` must be mounted from `GhosttySurfaceScrollView` in `Sources/GhosttyTerminalView.swift` (AppKit portal layer), not from SwiftUI panel containers such as `Sources/Panels/TerminalPanelView.swift`. Portal-hosted terminal views can sit above SwiftUI during split/workspace churn.
 - **Submodule safety:** When modifying a submodule (ghostty, vendor/bonsplit, etc.), always push the submodule commit to its remote `main` branch BEFORE committing the updated pointer in the parent repo. Never commit on a detached HEAD or temporary branch — the commit will be orphaned and lost. Verify with: `cd <submodule> && git merge-base --is-ancestor HEAD origin/main`.
-- **All user-facing strings must be localized.** Use `String(localized: "key.name", defaultValue: "English text")` for every string shown in the UI (labels, buttons, menus, dialogs, tooltips, error messages). Keys go in `Resources/Localizable.xcstrings` with translations for all supported languages (currently English and Japanese). Never use bare string literals in SwiftUI `Text()`, `Button()`, alert titles, etc.
+
+## Localization
+
+c11 ships in English plus six translations: Japanese (ja), Ukrainian (uk), Korean (ko), Simplified Chinese (zh-Hans), Traditional Chinese (zh-Hant), and Russian (ru). All strings live in `Resources/Localizable.xcstrings`.
+
+- **Write English only.** The `defaultValue:` in `String(localized:)` is the source of truth. Don't hand-author other languages in product code — that's a separate pass.
+- **All user-facing strings must be localized at the call site.** Use `String(localized: "key.name", defaultValue: "English text")` everywhere — labels, buttons, menus, alerts, tooltips, error messages. No bare string literals in SwiftUI `Text()`, `Button()`, alert titles, etc.
+- **Delegate translation to a sub-agent in a new c11 surface.** After adding or changing English strings, spawn a translator in a fresh c11 pane to sync `Localizable.xcstrings` for the other six locales. Point it at the new/changed English values; it reads the xcstrings, emits the six translations, writes back.
+- **Parallelize when there's a lot to translate.** For a handful of strings, one sub-agent is fine. For a larger batch, spawn one sub-agent per locale — six in parallel — so the translation pass doesn't gate the next piece of work.
 
 ## Test quality policy
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2352,6 +2352,53 @@
         }
       }
     },
+    "agentSkills.onboarding.title.known": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your agent already knows c11."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントはすでに c11 を知っています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваш агент уже знає c11."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트는 이미 c11을 알고 있어요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的代理已经认识 c11。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "你的代理已經認識 c11。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ваш агент уже знает c11."
+          }
+        }
+      }
+    },
     "agentSkills.onboarding.updateAvailable": {
       "extractionState": "manual",
       "localizations": {
@@ -2405,43 +2452,90 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Built to be inspectable. The skill is plain text — read it in Finder, or hand it to a model for review. c11 won't touch your agent configuration without your permission."
+            "value": "Built to be inspectable. The skill is plain text — open it in Finder to read exactly what your agent will learn, or install it yourself in any agent that supports the SKILL.md standard."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "検証できるように作られています。スキルはプレーンテキスト — Finder で読むか、モデルに渡してレビューしてもらえます。c11 は、あなたの許可なくエージェント設定に手を加えません。"
+            "value": "検証できるように作られています。スキルはプレーンテキスト — Finder で開けば、エージェントが学ぶ内容をそのまま読めます。SKILL.md 規格に対応するどのエージェントにも、自分で入れることができます。"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Створено прозорим. Навичка — звичайний текст: відкрийте у Finder або передайте моделі на перевірку. c11 не зачепить конфігурацію агента без вашого дозволу."
+            "value": "Створено прозорим. Навичка — звичайний текст: відкрийте у Finder і прочитайте саме те, що вивчить ваш агент, або встановіть її самі в будь-якому агенті, що підтримує стандарт SKILL.md."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "검사할 수 있게 만들었어요. 스킬은 일반 텍스트 — Finder에서 열어 읽거나, 모델에 넘겨 검토받으세요. c11은 허락 없이 에이전트 설정에 손대지 않아요."
+            "value": "검사할 수 있게 만들었어요. 스킬은 일반 텍스트 — Finder에서 열어 에이전트가 배울 내용을 그대로 읽을 수 있고, SKILL.md 표준을 지원하는 어떤 에이전트든 직접 설치할 수 있어요."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "为可查验而生。技能是纯文本 — 在 Finder 中阅读,或交给模型审阅。未经你的许可,c11 不会动你的代理配置。"
+            "value": "为可查验而生。技能是纯文本 — 在 Finder 中打开,就能读到代理将要学到的内容,也可以自己把它装进任何支持 SKILL.md 标准的代理。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "為了可檢視而打造。skill 是純文字 — 在 Finder 裡讀,或交給模型審視。未經你允許,c11 不會動你的代理設定。"
+            "value": "為可檢視而打造。skill 是純文字 — 在 Finder 裡打開,就能讀到代理將要學到的內容,也可以自己裝進任何支援 SKILL.md 標準的代理。"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Создано прозрачным. Навык — обычный текст: откройте в Finder или передайте модели на проверку. c11 не тронет конфигурацию агента без вашего разрешения."
+            "value": "Создано прозрачным. Навык — обычный текст: откройте в Finder и прочитайте ровно то, чему научится агент, или установите его сами в любой агент, поддерживающий стандарт SKILL.md."
+          }
+        }
+      }
+    },
+    "agentSkills.onboarding.permission": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 won't touch your agent configuration without your permission."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 は、あなたの許可なくエージェント設定に手を加えません。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 не зачепить конфігурацію агента без вашого дозволу."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11은 허락 없이 에이전트 설정에 손대지 않아요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未经你的许可,c11 不会动你的代理配置。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未經你允許,c11 不會動你的代理設定。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 не тронет конфигурацию агента без вашего разрешения."
           }
         }
       }

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -601,6 +601,10 @@ struct AgentSkillsOnboardingSheet: View {
         detectedRows.contains { $0.needsInstallOrUpdate }
     }
 
+    private var anyRowInstalled: Bool {
+        detectedRows.contains { $0.anyInstalled }
+    }
+
     private var primaryActionDisabled: Bool {
         detectedRows.isEmpty || (hasActionNeeded && !anySelected)
     }
@@ -627,7 +631,7 @@ struct AgentSkillsOnboardingSheet: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(String(localized: "agentSkills.onboarding.title", defaultValue: "Your agent doesn't know c11 yet."))
+            Text(headerTitle)
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundStyle(BrandColors.whiteSwiftUI)
 
@@ -637,6 +641,19 @@ struct AgentSkillsOnboardingSheet: View {
                 .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.76))
                 .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    private var headerTitle: String {
+        if anyRowInstalled {
+            return String(
+                localized: "agentSkills.onboarding.title.known",
+                defaultValue: "Your agent already knows c11."
+            )
+        }
+        return String(
+            localized: "agentSkills.onboarding.title",
+            defaultValue: "Your agent doesn't know c11 yet."
+        )
     }
 
     private var headerBody: String {
@@ -770,12 +787,18 @@ struct AgentSkillsOnboardingSheet: View {
                 .fill(BrandColors.ruleSwiftUI.opacity(0.8))
                 .frame(height: 1)
 
-            VStack(alignment: .leading, spacing: 6) {
+            VStack(alignment: .leading, spacing: 8) {
                 Text(String(localized: "agentSkills.onboarding.learnMoreTitle", defaultValue: "What gets installed"))
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
 
-                Text(String(localized: "agentSkills.onboarding.transparency", defaultValue: "Built to be inspectable. The skill is plain text — read it in Finder, or hand it to a model for review. c11 won't touch your agent configuration without your permission."))
+                Text(String(localized: "agentSkills.onboarding.transparency", defaultValue: "Built to be inspectable. The skill is plain text — open it in Finder to read exactly what your agent will learn, or install it yourself in any agent that supports the SKILL.md standard."))
+                    .font(.system(size: 12))
+                    .lineSpacing(2)
+                    .foregroundColor(BrandColors.whiteSwiftUI.opacity(0.66))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text(String(localized: "agentSkills.onboarding.permission", defaultValue: "c11 won't touch your agent configuration without your permission."))
                     .font(.system(size: 12))
                     .lineSpacing(2)
                     .foregroundColor(BrandColors.whiteSwiftUI.opacity(0.66))


### PR DESCRIPTION
## Summary
- Agent Skills onboarding sheet: title adapts to install state, transparency copy clarified (d1cc3db9)
- CLAUDE.md: document the localization workflow and the six target languages (ja / uk / ko / zh-Hans / zh-Hant / ru) (76934420)

## Test plan
- [ ] Open Agent Skills sheet with no skills installed → title reflects empty state
- [ ] Open with some skills installed → title reflects installed state
- [ ] Localizable.xcstrings updates pick up in ja/uk/ko/zh-Hans/zh-Hant/ru

🤖 Generated with [Claude Code](https://claude.com/claude-code)