### PR TITLE
TCC primer onboarding: explain macOS permission dialogs on first run

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
 		D7012BF0A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */; };
 		D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */; };
+		D7016BF0A1B2C3D4E5F60718 /* TCCPrimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */; };
 		D7006BF0A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */; };
 		D7007BF0A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */; };
 		D7008BF0A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */; };
@@ -119,6 +120,7 @@
 		CC401002A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */; };
 		CC401003A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */; };
 		CC401005A1B2C3D4E5F60719 /* AgentSkillsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */; };
+		CC401007A1B2C3D4E5F60719 /* TCCPrimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */; };
 		B900000BA1B2C3D4E5F60719 /* c11 in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* c11 */; };
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
 		D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */ = {isa = PBXBuildFile; fileRef = D1BEF00001A1B2C3D4E5F719 /* open */; };
@@ -266,6 +268,7 @@
 		D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStoreTests.swift; sourceTree = "<group>"; };
 		D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataPersistenceTests.swift; sourceTree = "<group>"; };
 		D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGridSettingsTests.swift; sourceTree = "<group>"; };
+		D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCCPrimerTests.swift; sourceTree = "<group>"; };
 		D7006BF1A1B2C3D4E5F60718 /* MetadataPersistenceRoundTripTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceRoundTripTests.swift; sourceTree = "<group>"; };
 		D7007BF1A1B2C3D4E5F60718 /* MetadataPersistencePrecedenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistencePrecedenceTests.swift; sourceTree = "<group>"; };
 		D7008BF1A1B2C3D4E5F60718 /* MetadataPersistenceUncoercibleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataPersistenceUncoercibleTests.swift; sourceTree = "<group>"; };
@@ -383,6 +386,7 @@
 		B9000001A1B2C3D4E5F60719 /* c11.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = c11.swift; sourceTree = "<group>"; };
 		CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillInstaller.swift; sourceTree = "<group>"; };
 		CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSkillsView.swift; sourceTree = "<group>"; };
+		CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCCPrimerView.swift; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* c11 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = c11; sourceTree = BUILT_PRODUCTS_DIR; };
 				B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
 					B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpToUnreadUITests.swift; sourceTree = "<group>"; };
@@ -636,6 +640,7 @@
 				A5005B01 /* BrandColors.swift */,
 				CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */,
 				CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */,
+				CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -758,6 +763,7 @@
 					D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */,
 					D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */,
 					D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */,
+					D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */,
 					A5C36031 /* StatusBarButtonDisplayTests.swift */,
 				);
 				path = c11Tests;
@@ -989,6 +995,7 @@
 				A5005B02 /* BrandColors.swift in Sources */,
 				CC401002A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */,
 				CC401005A1B2C3D4E5F60719 /* AgentSkillsView.swift in Sources */,
+				CC401007A1B2C3D4E5F60719 /* TCCPrimerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1075,6 +1082,7 @@
 					D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */,
 					D7012BF0A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift in Sources */,
 					D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */,
+					D7016BF0A1B2C3D4E5F60718 /* TCCPrimerTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -45,6 +45,34 @@
 	<string>A program running within c11 would like to use your microphone.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>A program running within c11 would like to use your camera.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>A program running within c11 would like to access files in your Downloads folder.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>A program running within c11 would like to access files in your Documents folder.</string>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>A program running within c11 would like to access files on your Desktop.</string>
+	<key>NSFileProviderDomainUsageDescription</key>
+	<string>A program running within c11 would like to access files managed by iCloud Drive or another file provider.</string>
+	<key>NSFileProviderPresenceUsageDescription</key>
+	<string>A program running within c11 is checking which of your cloud files are available locally.</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>A program running within c11 would like to access files on a removable volume.</string>
+	<key>NSNetworkVolumesUsageDescription</key>
+	<string>A program running within c11 would like to access files on a network volume.</string>
+	<key>NSAppleMusicUsageDescription</key>
+	<string>A program running within c11 would like to access your Music library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>A program running within c11 would like to access your Photos library.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>A program running within c11 would like to access your Contacts.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>A program running within c11 would like to access your Calendar.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>A program running within c11 would like to access your Reminders.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>A program running within c11 would like to discover devices on your local network.</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>A program running within c11 would like to control other applications via AppleScript.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -68,6 +68,42 @@
             "state": "translated",
             "value": "A program running within c11 would like to access files in your Downloads folder."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、ダウンロードフォルダ内のファイルへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до файлів у вашій теці «Завантаження»."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 다운로드 폴더의 파일에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您“下载”文件夹中的文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您「下載」檔案夾中的檔案。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к файлам в вашей папке «Загрузки»."
+          }
         }
       }
     },
@@ -78,6 +114,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "A program running within c11 would like to access files in your Documents folder."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、書類フォルダ内のファイルへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до файлів у вашій теці «Документи»."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 문서 폴더의 파일에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您“文稿”文件夹中的文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您「文件」檔案夾中的檔案。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к файлам в вашей папке «Документы»."
           }
         }
       }
@@ -90,6 +162,42 @@
             "state": "translated",
             "value": "A program running within c11 would like to access files on your Desktop."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、デスクトップ上のファイルへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до файлів на вашому Робочому столі."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 데스크탑의 파일에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您桌面上的文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您桌面上的檔案。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к файлам на вашем Рабочем столе."
+          }
         }
       }
     },
@@ -100,6 +208,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "A program running within c11 would like to access files managed by iCloud Drive or another file provider."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、iCloud Drive などの File Provider が管理するファイルへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до файлів, якими керує iCloud Drive або інший File Provider."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 iCloud Drive 또는 다른 File Provider가 관리하는 파일에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问由 iCloud Drive 或其他 File Provider 管理的文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取由 iCloud Drive 或其他 File Provider 管理的檔案。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к файлам, управляемым iCloud Drive или другим File Provider."
           }
         }
       }
@@ -112,6 +256,42 @@
             "state": "translated",
             "value": "A program running within c11 is checking which of your cloud files are available locally."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、クラウド上のどのファイルがローカルで利用可能かを確認しようとしています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, перевіряє, які з ваших хмарних файлів доступні локально."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 클라우드 파일 중 어떤 것이 로컬에서 사용 가능한지 확인하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序正在检查您的云端文件中哪些在本地可用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式正在檢查您的雲端檔案中哪些在本機可用。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, проверяет, какие из ваших облачных файлов доступны локально."
+          }
         }
       }
     },
@@ -122,6 +302,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "A program running within c11 would like to access files on a removable volume."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、リムーバブルボリューム上のファイルへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до файлів на знімному носії."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 이동식 볼륨의 파일에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问可移除卷上的文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取可移除卷宗上的檔案。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к файлам на съёмном томе."
           }
         }
       }
@@ -134,6 +350,42 @@
             "state": "translated",
             "value": "A program running within c11 would like to access files on a network volume."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、ネットワークボリューム上のファイルへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до файлів на мережевому томі."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 네트워크 볼륨의 파일에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问网络卷上的文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取網路卷宗上的檔案。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к файлам на сетевом томе."
+          }
         }
       }
     },
@@ -144,6 +396,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "A program running within c11 would like to access your Music library."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、ミュージックライブラリへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до вашої медіатеки Музики."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 음악 보관함에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您的音乐资料库。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您的音樂資料庫。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к вашей медиатеке Музыки."
           }
         }
       }
@@ -156,6 +444,42 @@
             "state": "translated",
             "value": "A program running within c11 would like to access your Photos library."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、写真ライブラリへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до вашої медіатеки Фото."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 사진 보관함에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您的照片图库。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您的照片圖庫。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к вашей медиатеке Фото."
+          }
         }
       }
     },
@@ -166,6 +490,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "A program running within c11 would like to access your Contacts."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、連絡先へのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до ваших Контактів."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 연락처에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您的通讯录。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您的聯絡資訊。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к вашим Контактам."
           }
         }
       }
@@ -178,6 +538,42 @@
             "state": "translated",
             "value": "A program running within c11 would like to access your Calendar."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、カレンダーへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до вашого Календаря."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 캘린더에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您的日历。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您的行事曆。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к вашему Календарю."
+          }
         }
       }
     },
@@ -188,6 +584,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "A program running within c11 would like to access your Reminders."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、リマインダーへのアクセスを求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче отримати доступ до ваших Нагадувань."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 미리 알림에 접근하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要访问您的提醒事项。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要存取您的提醒事項。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы получить доступ к вашим Напоминаниям."
           }
         }
       }
@@ -200,6 +632,42 @@
             "state": "translated",
             "value": "A program running within c11 would like to discover devices on your local network."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、ローカルネットワーク上のデバイスの検出を求めています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче виявляти пристрої у вашій локальній мережі."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 로컬 네트워크의 기기를 검색하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要发现您本地网络上的设备。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要探索您本地網路上的裝置。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы обнаруживать устройства в вашей локальной сети."
+          }
         }
       }
     },
@@ -210,6 +678,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "A program running within c11 would like to control other applications via AppleScript."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 内で実行中のプログラムが、AppleScript を通じて他のアプリケーションを制御しようとしています。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Програма, запущена в c11, хоче керувати іншими застосунками через AppleScript."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 내에서 실행 중인 프로그램이 AppleScript를 통해 다른 응용 프로그램을 제어하려고 합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中运行的程序想要通过 AppleScript 控制其他应用程序。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 c11 中執行的程式想要透過 AppleScript 控制其他應用程式。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в c11, хотела бы управлять другими приложениями через AppleScript."
           }
         }
       }

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -60,6 +60,160 @@
         }
       }
     },
+    "NSDownloadsFolderUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access files in your Downloads folder."
+          }
+        }
+      }
+    },
+    "NSDocumentsFolderUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access files in your Documents folder."
+          }
+        }
+      }
+    },
+    "NSDesktopFolderUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access files on your Desktop."
+          }
+        }
+      }
+    },
+    "NSFileProviderDomainUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access files managed by iCloud Drive or another file provider."
+          }
+        }
+      }
+    },
+    "NSFileProviderPresenceUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 is checking which of your cloud files are available locally."
+          }
+        }
+      }
+    },
+    "NSRemovableVolumesUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access files on a removable volume."
+          }
+        }
+      }
+    },
+    "NSNetworkVolumesUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access files on a network volume."
+          }
+        }
+      }
+    },
+    "NSAppleMusicUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access your Music library."
+          }
+        }
+      }
+    },
+    "NSPhotoLibraryUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access your Photos library."
+          }
+        }
+      }
+    },
+    "NSContactsUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access your Contacts."
+          }
+        }
+      }
+    },
+    "NSCalendarsUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access your Calendar."
+          }
+        }
+      }
+    },
+    "NSRemindersUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to access your Reminders."
+          }
+        }
+      }
+    },
+    "NSLocalNetworkUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to discover devices on your local network."
+          }
+        }
+      }
+    },
+    "NSAppleEventsUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within c11 would like to control other applications via AppleScript."
+          }
+        }
+      }
+    },
     "New c11mux Workspace Here": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2664,6 +2664,42 @@
             "state": "translated",
             "value": "If you'd rather not see the dialogs one by one, you can grant c11 Full Disk Access once in System Settings → Privacy & Security. Most engineers running many agents do this; it's the same tradeoff iTerm2, Warp, and Ghostty document. You can revoke it any time."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダイアログを一つずつ見るのが面倒なら、システム設定 → プライバシーとセキュリティで c11 に Full Disk Access を一度だけ許可できます。多くのエージェントを動かすエンジニアの多くはこうしています — iTerm2、Warp、Ghostty でも同じトレードオフが案内されています。いつでも取り消せます。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Якщо не хочете бачити ці діалоги по одному, можете один раз надати c11 Full Disk Access у System Settings → Privacy & Security. Саме так роблять більшість інженерів, які керують багатьма агентами; це той самий компроміс, що описують iTerm2, Warp і Ghostty. Ви можете відкликати його будь-коли."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대화상자를 하나씩 보고 싶지 않다면, System Settings → Privacy & Security에서 c11에 Full Disk Access를 한 번 허용하면 돼요. 여러 에이전트를 돌리는 엔지니어 대부분이 이 방식을 써요 — iTerm2, Warp, Ghostty에서도 똑같은 트레이드오프를 안내하죠. 언제든지 취소할 수 있어요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果不想一个个看这些对话框,可以在 System Settings → Privacy & Security 中一次性授予 c11 Full Disk Access。多数同时跑很多代理的工程师都会这么做 — iTerm2、Warp 和 Ghostty 记录的就是同样的取舍。你可以随时撤销。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "如果不想一個一個看這些對話框,可以在 System Settings → Privacy & Security 裡一次給 c11 Full Disk Access。大多同時跑很多代理的工程師都是這麼做 — iTerm2、Warp 和 Ghostty 所記載的就是同一個取捨。你隨時都能撤銷。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Если не хотите видеть эти диалоги по одному, можно один раз выдать c11 Full Disk Access в System Settings → Privacy & Security. Большинство инженеров, запускающих много агентов, так и делают — это тот же компромисс, что описан у iTerm2, Warp и Ghostty. Вы можете отозвать его в любой момент."
+          }
         }
       }
     },
@@ -2674,6 +2710,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Feel free to say no to any of them."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "どれも遠慮なく「許可しない」で大丈夫です。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сміливо відмовляйте будь-якому з них."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어느 것이든 편하게 거절해도 괜찮아요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任何一项都可以放心拒绝。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任何一項都可以放心拒絕。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Смело отказывайте любому из них."
           }
         }
       }
@@ -2686,6 +2758,42 @@
             "state": "translated",
             "value": " c11 itself doesn't scan your files, and nothing is forwarded to Stage 11. If you deny a folder, the command that tripped it will just fail, and you can grant it later in System Settings."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " c11 自体があなたのファイルをスキャンすることはなく、Stage 11 に何かが送られることもありません。フォルダを拒否しても、きっかけになったコマンドが失敗するだけで、あとから System Settings で許可できます。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " Сам c11 не сканує ваші файли, і нічого не пересилається до Stage 11. Якщо ви відмовите в доступі до теки, команда, яка його спричинила, просто завершиться з помилкою, а ви зможете надати дозвіл пізніше в System Settings."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " c11 자체는 파일을 스캔하지 않고, Stage 11으로 아무것도 전송되지 않아요. 폴더를 거부하면 해당 권한을 요청한 명령이 그냥 실패할 뿐이고, 나중에 System Settings에서 허용할 수 있어요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " c11 本身不会扫描你的文件,也不会把任何内容转发给 Stage 11。如果你拒绝某个文件夹,触发该提示的命令只会失败,之后你可以在 System Settings 里再授予权限。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " c11 本身不會掃描你的檔案,也不會把任何內容轉發給 Stage 11。如果你拒絕某個檔案夾,觸發該提示的指令只會失敗,之後你可以在 System Settings 裡再開啟權限。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " Сам c11 не сканирует ваши файлы, и ничего не пересылается в Stage 11. Если вы откажете в доступе к папке, команда, вызвавшая запрос, просто завершится ошибкой, а разрешение вы сможете выдать позже в System Settings."
+          }
         }
       }
     },
@@ -2696,6 +2804,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "The dialog will say \"c11 wants to access…\" because macOS attributes the request to the parent app. The actual requester is whatever you — or an agent — just ran."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ダイアログには「c11 がアクセスを求めています…」と表示されます。macOS が要求を親アプリのものとして扱うからです。実際にリクエストしているのは、あなた — もしくはエージェント — がたった今実行したものです。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "У діалозі буде написано «c11 хоче отримати доступ…», бо macOS приписує запит батьківському застосунку. Насправді його робить те, що ви — або агент — щойно запустили."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대화상자에는 \"c11이 접근하려고 합니다…\"라고 표시돼요. macOS가 요청을 부모 앱의 것으로 간주하기 때문이에요. 실제로 요청한 건 방금 당신 — 또는 에이전트 — 이 실행한 무언가예요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对话框会写“c11 想要访问…”,因为 macOS 把请求归到父应用名下。真正发起请求的,其实是你 — 或者某个代理 — 刚刚运行的东西。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "對話框會寫「c11 想要存取…」,因為 macOS 把請求歸到父應用程式名下。真正發起請求的,其實是你 — 或某個代理 — 剛剛執行的東西。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "В диалоге будет написано «c11 запрашивает доступ…», потому что macOS приписывает запрос родительскому приложению. На самом деле запрос исходит от того, что вы — или агент — только что запустили."
           }
         }
       }
@@ -2708,6 +2852,42 @@
             "state": "translated",
             "value": "c11 is a host for your shells and agents. The moment a process you started inside c11 touches a protected place — Downloads, Documents, Desktop, iCloud Drive, Music, Photos, Contacts, an external drive — macOS pauses and asks you whether that's OK. That's how TCC works: each folder is its own consent, and only you can grant it."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 はあなたのシェルやエージェントの入れ物です。c11 の中で始めたプロセスが保護対象の場所 — Downloads、Documents、Desktop、iCloud Drive、Music、Photos、Contacts、外付けドライブ — に触れた瞬間、macOS はいったん止まって、それを許可してよいかあなたに尋ねます。これが TCC の仕組みです。フォルダごとに個別の同意が必要で、それを与えられるのはあなただけです。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 — це хост для ваших оболонок та агентів. Щойно процес, який ви запустили всередині c11, торкається захищеного місця — Downloads, Documents, Desktop, iCloud Drive, Music, Photos, Contacts, зовнішнього диска — macOS призупиняється й запитує, чи це нормально. Саме так працює TCC: кожна тека — це окрема згода, і дати її можете лише ви."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11은 당신의 셸과 에이전트를 담는 호스트예요. c11 안에서 시작한 프로세스가 보호된 곳 — Downloads, Documents, Desktop, iCloud Drive, Music, Photos, Contacts, 외장 드라이브 — 에 닿는 순간, macOS는 잠깐 멈춰서 그래도 괜찮은지 당신에게 물어봐요. TCC는 이렇게 동작해요: 폴더마다 별도의 동의가 필요하고, 그 동의는 오직 당신만 줄 수 있어요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 是你的 shell 和代理的宿主。当你在 c11 里启动的进程触及受保护的地方 — Downloads、Documents、Desktop、iCloud Drive、Music、Photos、Contacts、外接硬盘 — 时,macOS 会暂停,问你这是否可以。这就是 TCC 的工作方式:每个文件夹都要单独授权,而且只有你能授权。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 是你 shell 和代理的宿主。當你在 c11 裡啟動的程序觸及受保護的位置 — Downloads、Documents、Desktop、iCloud Drive、Music、Photos、Contacts、外接硬碟 — 時,macOS 會暫停,詢問你是否允許。TCC 就是這樣運作的:每個檔案夾都要單獨同意,而且只有你能給出同意。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 — это хост для ваших оболочек и агентов. В тот момент, когда процесс, запущенный вами внутри c11, касается защищённого места — Downloads, Documents, Desktop, iCloud Drive, Music, Photos, Contacts, внешнего диска — macOS приостанавливается и спрашивает, согласны ли вы. Так устроен TCC: каждая папка — отдельное согласие, и дать его можете только вы."
+          }
         }
       }
     },
@@ -2718,6 +2898,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Got it"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "わかりました"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зрозуміло"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "알겠어요"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "明白了"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "明白了"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Понятно"
           }
         }
       }
@@ -2730,6 +2946,42 @@
             "state": "translated",
             "value": "Open Privacy & Security"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プライバシーとセキュリティを開く"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити Privacy & Security"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy & Security 열기"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打开 Privacy & Security"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "打開 Privacy & Security"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть Privacy & Security"
+          }
         }
       }
     },
@@ -2740,6 +2992,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Each prompt is tied to a specific macOS permission: folder prompts (Downloads, Documents, Desktop) fire when a child process reads or writes there; the iCloud Drive prompt fires when anything touches a File Provider domain; Music and Photos fire when a process reads the media libraries; Local Network fires on Bonjour or LAN HTTP. The copy inside each dialog comes from Info.plist and is c11-authored."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "それぞれのプロンプトは特定の macOS 権限に対応しています。フォルダ系(Downloads、Documents、Desktop)は子プロセスがそこを読み書きした瞬間に出ます。iCloud Drive のプロンプトは何かが File Provider ドメインに触れたときに。Music と Photos はプロセスがそのメディアライブラリを読んだときに。Local Network は Bonjour や LAN HTTP で発火します。各ダイアログ内の文面は Info.plist 由来で、c11 が書いたものです。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кожен запит прив'язаний до конкретного дозволу macOS: запити на теки (Downloads, Documents, Desktop) спрацьовують, коли дочірній процес читає або пише в них; запит iCloud Drive — коли щось торкається домену File Provider; Music і Photos — коли процес читає медіатеки; Local Network — на Bonjour або LAN HTTP. Текст усередині кожного діалогу береться з Info.plist і написаний c11."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 프롬프트는 특정 macOS 권한에 연결돼 있어요. 폴더 프롬프트(Downloads, Documents, Desktop)는 자식 프로세스가 거기서 읽거나 쓸 때 뜨고, iCloud Drive 프롬프트는 무언가가 File Provider 도메인에 닿을 때, Music과 Photos는 프로세스가 해당 미디어 보관함을 읽을 때, Local Network는 Bonjour나 LAN HTTP에서 뜨죠. 각 대화상자 안의 문구는 Info.plist에서 오고, c11이 직접 작성한 것이에요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个提示都绑定到一个具体的 macOS 权限:文件夹提示(Downloads、Documents、Desktop)在子进程读写时出现;iCloud Drive 提示在任何东西触及 File Provider 域时出现;Music 和 Photos 在进程读取对应媒体库时出现;Local Network 在 Bonjour 或 LAN HTTP 时出现。每个对话框里的文字都来自 Info.plist,是由 c11 撰写的。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每個提示都對應一個特定的 macOS 權限:檔案夾提示(Downloads、Documents、Desktop)在子程序讀寫時出現;iCloud Drive 提示在任何東西觸及 File Provider 網域時出現;Music 和 Photos 在程序讀取相應媒體資料庫時出現;Local Network 在 Bonjour 或 LAN HTTP 時出現。每個對話框裡的文字都來自 Info.plist,是由 c11 撰寫的。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Каждый запрос привязан к конкретному разрешению macOS: запросы папок (Downloads, Documents, Desktop) срабатывают, когда дочерний процесс читает или пишет в них; запрос iCloud Drive — когда что-то касается домена File Provider; Music и Photos — когда процесс читает эти медиатеки; Local Network — при Bonjour или LAN HTTP. Текст внутри каждого диалога берётся из Info.plist и написан c11."
           }
         }
       }
@@ -2752,6 +3040,42 @@
             "state": "translated",
             "value": "What triggers each prompt"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各プロンプトが出る条件"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Що спричиняє кожен запит"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 프롬프트가 뜨는 조건"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个提示的触发条件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各提示的觸發條件"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Что вызывает каждый запрос"
+          }
         }
       }
     },
@@ -2762,6 +3086,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "macOS will ask about folders."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS がフォルダについて尋ねてきます。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS питатиме про теки."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS가 폴더에 대해 물어볼 거예요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 会询问文件夹权限。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 會詢問檔案夾權限。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS будет спрашивать про папки."
           }
         }
       }
@@ -2774,6 +3134,42 @@
             "state": "translated",
             "value": "c11 and macOS permissions"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 と macOS の権限"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 та дозволи macOS"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11과 macOS 권한"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 与 macOS 权限"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 與 macOS 權限"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 и разрешения macOS"
+          }
         }
       }
     },
@@ -2784,6 +3180,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Show permissions primer…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限のガイドを表示…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати ознайомлення з дозволами…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "권한 안내 다시 보기…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示权限说明…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示權限說明…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать памятку о разрешениях…"
           }
         }
       }
@@ -38375,6 +38807,42 @@
             "state": "translated",
             "value": "Permissions"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дозволи"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "권한"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "權限"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разрешения"
+          }
         }
       }
     },
@@ -38386,6 +38854,42 @@
             "state": "translated",
             "value": "Permissions primer"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "権限のガイド"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ознайомлення з дозволами"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "권한 안내"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "权限说明"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "權限說明"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Памятка о разрешениях"
+          }
         }
       }
     },
@@ -38396,6 +38900,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Re-open the explainer for macOS folder prompts. Covers why you see the dialogs, how to say no, and the Full Disk Access shortcut."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS のフォルダ確認ダイアログについての説明をもう一度開きます。なぜ出るのか、断り方、Full Disk Access でまとめて済ませる方法まで。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Знову відкрити пояснення про запити macOS на теки. Про те, чому ви їх бачите, як відмовитись і про ярлик Full Disk Access."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS 폴더 프롬프트에 대한 설명을 다시 엽니다. 왜 뜨는지, 어떻게 거절하는지, Full Disk Access 지름길까지 담고 있어요."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新打开 macOS 文件夹提示的说明。涵盖你为什么会看到这些对话框、如何拒绝,以及 Full Disk Access 这个捷径。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新開啟 macOS 檔案夾提示的說明。包含你為什麼會看到這些對話框、如何拒絕,以及 Full Disk Access 這條捷徑。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снова открыть пояснение про запросы macOS к папкам. О том, почему они появляются, как отказать и про быстрый путь через Full Disk Access."
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2656,6 +2656,138 @@
         }
       }
     },
+    "tccPrimer.body.fullDisk": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "If you'd rather not see the dialogs one by one, you can grant c11 Full Disk Access once in System Settings → Privacy & Security. Most engineers running many agents do this; it's the same tradeoff iTerm2, Warp, and Ghostty document. You can revoke it any time."
+          }
+        }
+      }
+    },
+    "tccPrimer.body.sayNo.lead": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Feel free to say no to any of them."
+          }
+        }
+      }
+    },
+    "tccPrimer.body.sayNo.tail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": " c11 itself doesn't scan your files, and nothing is forwarded to Stage 11. If you deny a folder, the command that tripped it will just fail, and you can grant it later in System Settings."
+          }
+        }
+      }
+    },
+    "tccPrimer.body.whoAsks": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The dialog will say \"c11 wants to access…\" because macOS attributes the request to the parent app. The actual requester is whatever you — or an agent — just ran."
+          }
+        }
+      }
+    },
+    "tccPrimer.body.why": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 is a host for your shells and agents. The moment a process you started inside c11 touches a protected place — Downloads, Documents, Desktop, iCloud Drive, Music, Photos, Contacts, an external drive — macOS pauses and asks you whether that's OK. That's how TCC works: each folder is its own consent, and only you can grant it."
+          }
+        }
+      }
+    },
+    "tccPrimer.button.gotIt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Got it"
+          }
+        }
+      }
+    },
+    "tccPrimer.button.openSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Privacy & Security"
+          }
+        }
+      }
+    },
+    "tccPrimer.learnMore.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Each prompt is tied to a specific macOS permission: folder prompts (Downloads, Documents, Desktop) fire when a child process reads or writes there; the iCloud Drive prompt fires when anything touches a File Provider domain; Music and Photos fire when a process reads the media libraries; Local Network fires on Bonjour or LAN HTTP. The copy inside each dialog comes from Info.plist and is c11-authored."
+          }
+        }
+      }
+    },
+    "tccPrimer.learnMore.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What triggers each prompt"
+          }
+        }
+      }
+    },
+    "tccPrimer.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS will ask about folders."
+          }
+        }
+      }
+    },
+    "tccPrimer.windowTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 and macOS permissions"
+          }
+        }
+      }
+    },
+    "settings.tccPrimer.showAgain": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show permissions primer…"
+          }
+        }
+      }
+    },
     "agentSkills.status.installed": {
       "extractionState": "manual",
       "localizations": {
@@ -38231,6 +38363,39 @@
           "stringUnit": {
             "state": "translated",
             "value": "Оттенок боковой панели"
+          }
+        }
+      }
+    },
+    "settings.section.permissions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions"
+          }
+        }
+      }
+    },
+    "settings.tccPrimer.row.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Permissions primer"
+          }
+        }
+      }
+    },
+    "settings.tccPrimer.row.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Re-open the explainer for macOS folder prompts. Covers why you see the dialogs, how to say no, and the Full Disk Access shortcut."
           }
         }
       }

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -946,13 +946,13 @@ private enum AgentSkillsOnboardingAction: CaseIterable {
     }
 }
 
-private enum OnboardingActionButtonKind {
+enum OnboardingActionButtonKind {
     case primary
     case success
     case secondary
 }
 
-private struct OnboardingActionButton: View {
+struct OnboardingActionButton: View {
     let title: String
     let kind: OnboardingActionButtonKind
     let isSelected: Bool
@@ -1056,7 +1056,7 @@ private struct SecondaryOnboardingButton: View {
     }
 }
 
-private struct OnboardingKeyboardMonitor: NSViewRepresentable {
+struct OnboardingKeyboardMonitor: NSViewRepresentable {
     let onMove: (ConfirmMoveDirection) -> Void
     let onActivate: () -> Void
     let onCancel: () -> Void

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2342,6 +2342,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // else touches UserDefaults. One-time, idempotent, guarded by a flag key.
         migrateLegacyPreferencesIfNeeded()
 
+        // Existing users who've already seen the welcome are presumed to have
+        // navigated macOS TCC dialogs the old way — don't surprise them with a
+        // retroactive primer. Runs once, idempotent.
+        TCCPrimer.migrateExistingUserIfNeeded()
+
         // Register fenced code renderers for the markdown panel content pipeline.
         FencedCodeRendererRegistry.shared.register(MermaidRenderer.shared)
 
@@ -6201,7 +6206,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             WelcomeSettings.performQuadLayout(on: workspace, initialPanel: initialPanel)
             DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
-                self?.presentAgentSkillsOnboardingIfNeeded()
+                guard let self else { return }
+                if AgentSkillsOnboarding.shouldPresent() {
+                    // Agent Skills sheet runs first; its willClose observer
+                    // chains the TCC primer (see presentAgentSkillsOnboarding).
+                    self.presentAgentSkillsOnboarding()
+                } else {
+                    self.presentTCCPrimerIfNeeded()
+                }
             }
         }
     }
@@ -6264,6 +6276,73 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             self.agentSkillsOnboardingCloseObserver = nil
             self.agentSkillsOnboardingWindow = nil
+            // Chain the TCC primer after the skills sheet closes, so a
+            // fresh user sees one sheet at a time. Short delay lets the
+            // close animation finish before the next window animates in.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+                self?.presentTCCPrimerIfNeeded()
+            }
+        }
+    }
+
+    // MARK: - TCC primer onboarding
+
+    /// See the note on `agentSkillsOnboardingWindow` for why this is a strong
+    /// reference. Same AppKit retention gotcha applies.
+    private var tccPrimerWindow: NSWindow?
+    private var tccPrimerCloseObserver: NSObjectProtocol?
+
+    /// First-run primer explaining why macOS is about to ask about folders.
+    /// Consent-gated; the "Got it" button is the only thing that writes the
+    /// persistent flag. Closing via the red button or Cmd-W counts as
+    /// dismissed for the launch only.
+    func presentTCCPrimerIfNeeded() {
+        guard TCCPrimer.shouldPresent() else { return }
+        presentTCCPrimer()
+    }
+
+    func presentTCCPrimer() {
+        if let existing = tccPrimerWindow {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 540, height: 500),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(
+            localized: "tccPrimer.windowTitle",
+            defaultValue: "c11 and macOS permissions"
+        )
+        window.isReleasedWhenClosed = false
+        window.level = .modalPanel
+        let rootView = TCCPrimerSheet(
+            onGotIt: { [weak window] in
+                UserDefaults.standard.set(true, forKey: TCCPrimer.shownKey)
+                window?.close()
+            },
+            onOpenSettings: { TCCPrimer.openFullDiskAccessPane() },
+            onDismiss: { [weak window] in window?.close() }
+        )
+        window.contentView = NSHostingView(rootView: rootView)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        tccPrimerWindow = window
+        tccPrimerCloseObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            TCCPrimer.markDismissedThisLaunch()
+            if let observer = self.tccPrimerCloseObserver {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            self.tccPrimerCloseObserver = nil
+            self.tccPrimerWindow = nil
         }
     }
 

--- a/Sources/TCCPrimerView.swift
+++ b/Sources/TCCPrimerView.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+import AppKit
+
+// MARK: - First-run TCC primer sheet
+
+/// Shown once on first run, after the Agent Skills onboarding dismisses,
+/// to explain the cascade of macOS permission dialogs a new c11 user is
+/// about to see. Qualified-engineer audience: the goal is to frame each
+/// prompt as expected and reassuringly deniable, and to offer Full Disk
+/// Access as the one-time escape hatch iTerm2 / Warp / Ghostty all
+/// document.
+struct TCCPrimerSheet: View {
+    let onGotIt: () -> Void
+    let onOpenSettings: () -> Void
+    let onDismiss: () -> Void
+
+    init(
+        onGotIt: @escaping () -> Void = {},
+        onOpenSettings: @escaping () -> Void = {},
+        onDismiss: @escaping () -> Void = {}
+    ) {
+        self.onGotIt = onGotIt
+        self.onOpenSettings = onOpenSettings
+        self.onDismiss = onDismiss
+    }
+
+    @State private var selectedAction: TCCPrimerAction = .gotIt
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            header
+            bodyCopy
+            learnMoreSection
+            footer
+        }
+        .padding(24)
+        .frame(width: 540)
+        .background(OnboardingKeyboardMonitor(
+            onMove: { direction in
+                selectedAction = TCCPrimerAction.moved(
+                    from: selectedAction,
+                    direction: direction
+                )
+            },
+            onActivate: { activateSelectedAction() },
+            onCancel: { onGotIt() }
+        ))
+        .environment(\.colorScheme, .dark)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(
+                localized: "tccPrimer.title",
+                defaultValue: "macOS will ask about folders."
+            ))
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundStyle(BrandColors.whiteSwiftUI)
+
+            Text(String(
+                localized: "tccPrimer.body.why",
+                defaultValue: "c11 is a host for your shells and agents. The moment a process you started inside c11 touches a protected place — Downloads, Documents, Desktop, iCloud Drive, Music, Photos, Contacts, an external drive — macOS pauses and asks you whether that's OK. That's how TCC works: each folder is its own consent, and only you can grant it."
+            ))
+            .font(.system(size: 12, weight: .regular))
+            .lineSpacing(2)
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.76))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var bodyCopy: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(String(
+                localized: "tccPrimer.body.whoAsks",
+                defaultValue: "The dialog will say \"c11 wants to access…\" because macOS attributes the request to the parent app. The actual requester is whatever you — or an agent — just ran."
+            ))
+            .font(.system(size: 12, weight: .regular))
+            .lineSpacing(2)
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.76))
+            .fixedSize(horizontal: false, vertical: true)
+
+            Text(sayNoAttributed)
+                .font(.system(size: 12, weight: .regular))
+                .lineSpacing(2)
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.86))
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(String(
+                localized: "tccPrimer.body.fullDisk",
+                defaultValue: "If you'd rather not see the dialogs one by one, you can grant c11 Full Disk Access once in System Settings → Privacy & Security. Most engineers running many agents do this; it's the same tradeoff iTerm2, Warp, and Ghostty document. You can revoke it any time."
+            ))
+            .font(.system(size: 12, weight: .regular))
+            .lineSpacing(2)
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.76))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var sayNoAttributed: AttributedString {
+        let bold = String(
+            localized: "tccPrimer.body.sayNo.lead",
+            defaultValue: "Feel free to say no to any of them."
+        )
+        let tail = String(
+            localized: "tccPrimer.body.sayNo.tail",
+            defaultValue: " c11 itself doesn't scan your files, and nothing is forwarded to Stage 11. If you deny a folder, the command that tripped it will just fail, and you can grant it later in System Settings."
+        )
+        var leadStr = AttributedString(bold)
+        leadStr.font = .system(size: 12, weight: .semibold)
+        var tailStr = AttributedString(tail)
+        tailStr.font = .system(size: 12, weight: .regular)
+        return leadStr + tailStr
+    }
+
+    private var learnMoreSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Rectangle()
+                .fill(BrandColors.ruleSwiftUI.opacity(0.7))
+                .frame(height: 1)
+            Text(String(
+                localized: "tccPrimer.learnMore.title",
+                defaultValue: "What triggers each prompt"
+            ))
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
+
+            Text(String(
+                localized: "tccPrimer.learnMore.body",
+                defaultValue: "Each prompt is tied to a specific macOS permission: folder prompts (Downloads, Documents, Desktop) fire when a child process reads or writes there; the iCloud Drive prompt fires when anything touches a File Provider domain; Music and Photos fire when a process reads the media libraries; Local Network fires on Bonjour or LAN HTTP. The copy inside each dialog comes from Info.plist and is c11-authored."
+            ))
+            .font(.system(size: 11, weight: .regular))
+            .lineSpacing(2)
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.66))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Spacer(minLength: 0)
+
+            OnboardingActionButton(
+                title: String(
+                    localized: "tccPrimer.button.openSettings",
+                    defaultValue: "Open Privacy & Security"
+                ),
+                kind: .secondary,
+                isSelected: selectedAction == .openSettings,
+                action: onOpenSettings
+            )
+
+            OnboardingActionButton(
+                title: String(
+                    localized: "tccPrimer.button.gotIt",
+                    defaultValue: "Got it"
+                ),
+                kind: .primary,
+                isSelected: selectedAction == .gotIt,
+                action: onGotIt
+            )
+        }
+    }
+
+    private func activateSelectedAction() {
+        switch selectedAction {
+        case .gotIt:
+            onGotIt()
+        case .openSettings:
+            onOpenSettings()
+        }
+    }
+}
+
+private enum TCCPrimerAction: CaseIterable {
+    case openSettings
+    case gotIt
+
+    static func moved(
+        from current: TCCPrimerAction,
+        direction: ConfirmMoveDirection
+    ) -> TCCPrimerAction {
+        let order = Self.allCases
+        guard let index = order.firstIndex(of: current) else { return .gotIt }
+        switch direction {
+        case .left:
+            return order[max(order.startIndex, index - 1)]
+        case .right:
+            return order[min(order.endIndex - 1, index + 1)]
+        case .toggle:
+            let next = (index + 1) % order.count
+            return order[next]
+        }
+    }
+}
+
+// MARK: - Presentation gate
+
+enum TCCPrimer {
+    /// Persistent "primer shown" flag. Set by the Got-it button and also by
+    /// the one-shot migration that marks existing welcome-completed users as
+    /// already-seen on first launch of a build that ships this sheet.
+    static let shownKey = "cmuxTCCPrimerShown"
+
+    /// In-memory flag scoped to the current launch. Set when the user
+    /// dismisses the sheet via the red close button (which never runs
+    /// onGotIt). Prevents a chained welcome workspace or re-entry path from
+    /// popping the sheet again in the same run.
+    @MainActor private static var _dismissedThisLaunch: Bool = false
+
+    @MainActor static func markDismissedThisLaunch() {
+        _dismissedThisLaunch = true
+    }
+
+    @MainActor static var dismissedThisLaunch: Bool {
+        _dismissedThisLaunch
+    }
+
+    @MainActor static func shouldPresent(
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        if defaults.bool(forKey: shownKey) { return false }
+        if _dismissedThisLaunch { return false }
+        return true
+    }
+
+    /// One-shot migration for pre-existing users: anyone who has already
+    /// seen the welcome workspace is assumed to have already navigated the
+    /// permission dialogs the old-fashioned way, and shouldn't be surprised
+    /// by a retroactive primer. Safe to call on every launch — runs once.
+    @MainActor static func migrateExistingUserIfNeeded(
+        defaults: UserDefaults = .standard
+    ) {
+        guard defaults.object(forKey: shownKey) == nil else { return }
+        if defaults.bool(forKey: WelcomeSettings.shownKey) {
+            defaults.set(true, forKey: shownKey)
+        }
+    }
+
+    @MainActor static func openFullDiskAccessPane() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles") else { return }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -5842,6 +5842,32 @@ struct SettingsView: View {
             defaultValue: "c11 installs its skill files into detected agent skill folders only with your approval. Linked skill folders are shown as shared so one remove action cannot silently affect another agent."
         ))
 
+        SettingsSectionHeader(title: String(
+            localized: "settings.section.permissions",
+            defaultValue: "Permissions"
+        ))
+        SettingsCard {
+            SettingsCardRow(
+                String(
+                    localized: "settings.tccPrimer.row.title",
+                    defaultValue: "Permissions primer"
+                ),
+                subtitle: String(
+                    localized: "settings.tccPrimer.row.subtitle",
+                    defaultValue: "Re-open the explainer for macOS folder prompts. Covers why you see the dialogs, how to say no, and the Full Disk Access shortcut."
+                )
+            ) {
+                Button(String(
+                    localized: "settings.tccPrimer.showAgain",
+                    defaultValue: "Show permissions primer…"
+                )) {
+                    (NSApp.delegate as? AppDelegate)?.presentTCCPrimer()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+        }
+
         SettingsSectionHeader(title: String(localized: "settings.section.socketAccess", defaultValue: "Socket Access"))
         SettingsCard {
             SettingsPickerRow(

--- a/c11Tests/TCCPrimerTests.swift
+++ b/c11Tests/TCCPrimerTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class TCCPrimerTests: XCTestCase {
+
+    // MARK: - shouldPresent()
+
+    func testShouldPresentReturnsTrueWhenShownKeyUnset() {
+        let defaults = UserDefaults(suiteName: "TCCPrimerTests.\(UUID().uuidString)")!
+        defaults.removeObject(forKey: TCCPrimer.shownKey)
+        XCTAssertTrue(TCCPrimer.shouldPresent(defaults: defaults))
+    }
+
+    func testShouldPresentReturnsFalseWhenShownKeyTrue() {
+        let defaults = UserDefaults(suiteName: "TCCPrimerTests.\(UUID().uuidString)")!
+        defaults.set(true, forKey: TCCPrimer.shownKey)
+        XCTAssertFalse(TCCPrimer.shouldPresent(defaults: defaults))
+    }
+
+    // MARK: - migrateExistingUserIfNeeded()
+
+    func testMigrationMarksShownWhenWelcomeAlreadySeen() {
+        let defaults = UserDefaults(suiteName: "TCCPrimerTests.\(UUID().uuidString)")!
+        defaults.removeObject(forKey: TCCPrimer.shownKey)
+        defaults.set(true, forKey: WelcomeSettings.shownKey)
+        TCCPrimer.migrateExistingUserIfNeeded(defaults: defaults)
+        XCTAssertTrue(defaults.bool(forKey: TCCPrimer.shownKey))
+    }
+
+    func testMigrationLeavesShownUnsetForFreshInstall() {
+        let defaults = UserDefaults(suiteName: "TCCPrimerTests.\(UUID().uuidString)")!
+        defaults.removeObject(forKey: TCCPrimer.shownKey)
+        defaults.removeObject(forKey: WelcomeSettings.shownKey)
+        TCCPrimer.migrateExistingUserIfNeeded(defaults: defaults)
+        XCTAssertNil(defaults.object(forKey: TCCPrimer.shownKey))
+    }
+
+    func testMigrationIsIdempotentOncePrimerExplicitlyShown() {
+        // A user who already saw (or dismissed) the primer should not get
+        // their setting flipped by a subsequent migration pass.
+        let defaults = UserDefaults(suiteName: "TCCPrimerTests.\(UUID().uuidString)")!
+        defaults.set(true, forKey: TCCPrimer.shownKey)
+        defaults.set(true, forKey: WelcomeSettings.shownKey)
+        TCCPrimer.migrateExistingUserIfNeeded(defaults: defaults)
+        XCTAssertTrue(defaults.bool(forKey: TCCPrimer.shownKey))
+    }
+
+    func testMigrationDoesNotReopenAfterExplicitDeclineByUser() {
+        // Explicit false (hypothetical "I don't want to be asked" preset)
+        // must survive migration. Migration runs only when the key is truly
+        // unset, per the `object(forKey:) == nil` guard.
+        let defaults = UserDefaults(suiteName: "TCCPrimerTests.\(UUID().uuidString)")!
+        defaults.set(false, forKey: TCCPrimer.shownKey)
+        defaults.set(true, forKey: WelcomeSettings.shownKey)
+        TCCPrimer.migrateExistingUserIfNeeded(defaults: defaults)
+        XCTAssertFalse(defaults.bool(forKey: TCCPrimer.shownKey))
+    }
+}


### PR DESCRIPTION
## Summary

First-run sheet that explains why macOS is about to ask about Downloads, Documents, Desktop, iCloud Drive, Music, Photos, and other protected resources when a user first opens c11. Pairs with a set of custom \`NS*UsageDescription\` strings so each native dialog itself reads in c11's voice instead of the system default. Follows the iTerm2 / Warp / Ghostty pattern: grant as they come up, or take Full Disk Access once and silence them.

- **Sheet** (\`Sources/TCCPrimerView.swift\`) chains after the Agent Skills onboarding on first run. Copy emphasizes "Feel free to say no to any of them" and attributes the requests to "a program running within c11" — dialogs fire because a shell or agent touched a protected folder, not because c11 itself is scanning.
- **14 new \`NS*UsageDescription\` keys** in \`Resources/Info.plist\` (Downloads, Documents, Desktop, File Provider, Removable/Network Volumes, Music, Photos, Contacts, Calendars, Reminders, Local Network, AppleScript) customize the native dialog copy.
- **Existing users are skipped** via a one-shot migration tied to \`cmuxWelcomeShown\` — anyone who's already survived the dialogs doesn't get surprised by a retroactive primer.
- **Settings re-entry** under a new *Permissions* section so the primer isn't a dead-end.
- **Full Disk Access deep-link** opens \`x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles\` directly.
- **Localized** into ja / uk / ko / zh-Hans / zh-Hant / ru across both \`Info.plist\` dialog copy and sheet copy. Product names (c11, iTerm2, Warp, Ghostty, iCloud Drive, Full Disk Access, etc.) kept as Latin per convention.
- **Shared primitives:** promoted \`OnboardingActionButton\` and \`OnboardingKeyboardMonitor\` from \`private\` to module-internal so the primer reuses the Agent Skills visual language.

## First-run sequence

\`\`\`
Welcome workspace quad
  → +1.2s Agent Skills onboarding (if applicable)
       └── on close → +0.35s TCC primer
  → (no agent skills sheet) → TCC primer directly
\`\`\`

Both sheets are window-backed \`.modalPanel\`s with \`willClose\` observers that track dismissal for the current launch. "Got it" is the only thing that writes the persistent flag; red-X counts as dismissed-this-launch only.

## Test plan

- [x] \`xcodebuild\` green on tagged dev build (\`./scripts/reload.sh --tag tcc-primer\`)
- [x] Unit tests added (\`c11Tests/TCCPrimerTests.swift\`) covering \`shouldPresent\` and the migration — verifies new users see the primer, existing welcome-completed users don't.
- [ ] On a fresh UserDefaults profile: launch c11, confirm the primer appears after the Agent Skills sheet (or directly, if no agents are detected).
- [ ] Click **Open Privacy & Security** and verify it lands on the Full Disk Access pane.
- [ ] Dismiss with **Got it**; relaunch and confirm it doesn't re-appear.
- [ ] Dismiss with red-X; relaunch and confirm it DOES re-appear (session-scoped dismissal).
- [ ] Open **Settings → Permissions → Show permissions primer…** and confirm the sheet re-opens.
- [ ] On an existing profile (\`cmuxWelcomeShown = true\`), confirm the primer does NOT fire.
- [ ] Spot-check one non-English locale renders correctly in the sheet header, body, and buttons.
- [ ] Trigger a real \`NS*UsageDescription\` dialog (e.g., \`ls ~/Downloads\` from a shell) and confirm the dialog body reads with the c11-authored copy rather than the system default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)