### PR TITLE
OSS contributor surface: code of conduct, security policy, expanded docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# c11 code owners.
+#
+# Adding a user / team here makes them a default reviewer on touched paths.
+# Entries are matched top-to-bottom; the last match wins.
+#
+# Keep the list tight — default owner for everything, then add narrower rules
+# only when a path genuinely needs a different reviewer.
+
+*  @BenevolentFutures

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for reporting a bug! Please fill out the information below so we can reproduce and fix it.
+        A specific, reproducible report is worth a hundred "it's broken" messages. Fill in what you know; skip what you don't.
 
   - type: input
     id: cmux-version

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug in c11mux
+description: Report a bug in c11
 labels: ["bug"]
 body:
   - type: markdown
@@ -10,9 +10,9 @@ body:
   - type: input
     id: cmux-version
     attributes:
-      label: c11mux version
-      description: "Run `cmux --version` or check About c11mux in the menu bar."
-      placeholder: "e.g. 0.3.2"
+      label: c11 version
+      description: "Run `c11 --version` or check About c11 in the menu bar."
+      placeholder: "e.g. 0.41.0"
     validations:
       required: true
 
@@ -49,8 +49,8 @@ body:
   - type: dropdown
     id: nightly-repro
     attributes:
-      label: Can you reproduce this on cmux NIGHTLY?
-      description: "Please test with the latest NIGHTLY build first: https://github.com/manaflow-ai/cmux?tab=readme-ov-file#nightly-builds"
+      label: Can you reproduce this on c11 NIGHTLY?
+      description: "Please test with the latest NIGHTLY build first from the [c11 releases page](https://github.com/Stage-11-Agentics/c11/releases)."
       options:
         - Yes, it still reproduces on NIGHTLY
         - No, it does not reproduce on NIGHTLY
@@ -81,7 +81,7 @@ body:
       label: Steps to reproduce
       description: "Minimal steps to reproduce the bug."
       placeholder: |
-        1. Open cmux
+        1. Open c11
         2. ...
         3. See error
     validations:
@@ -102,7 +102,7 @@ body:
       label: Relevant logs or crash reports
       description: |
         If applicable, paste logs or crash reports. Crash reports are in `~/Library/Logs/DiagnosticReports/`.
-        You can also check `Console.app` for cmux-related messages.
+        You can also check `Console.app` for c11-related messages.
       render: text
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Discussions
     url: https://github.com/Stage-11-Agentics/c11/discussions
-    about: Ask questions, share ideas, or chat with other c11 users and contributors.
+    about: Questions, ideas, and open-ended conversation with other c11 users and contributors.
   - name: Security vulnerability
     url: https://github.com/Stage-11-Agentics/c11/security/advisories/new
-    about: Please report security issues privately instead of opening a public issue.
+    about: Report security issues privately — public issues turn bad news into worse news.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Discussions
-    url: https://github.com/manaflow-ai/cmux/discussions
-    about: Ask questions and share ideas
+    url: https://github.com/Stage-11-Agentics/c11/discussions
+    about: Ask questions, share ideas, or chat with other c11 users and contributors.
+  - name: Security vulnerability
+    url: https://github.com/Stage-11-Agentics/c11/security/advisories/new
+    about: Please report security issues privately instead of opening a public issue.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 5

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,83 +1,42 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
 
-## Our Pledge
+c11 is built by a small team, their agents, and whoever else shows up wanting to make it better. This is how we treat each other while we do that.
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+## The baseline
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+Be direct. Be kind. Assume the other person is here in good faith until you have a specific reason to think otherwise. Review the work, not the person. Disagree concretely — "this approach breaks X because Y" beats "this is bad." If you're wrong, say so and move on; nobody loses status by updating.
 
-## Our Standards
+Tell the truth. Include your uncertainty. Ask when you don't know. The standard is the same whether you're a human, an agent, or the compound actor of the two.
 
-Examples of behavior that contributes to a positive environment for our community include:
+Unkindness slows everybody down, and so does politeness that hides what you actually think. We want neither.
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
+## What isn't welcome
 
-Examples of unacceptable behavior include:
+Harassment. Personal attacks. Sustained hostility. Doxxing. Sexual attention that wasn't invited. Threats. These aren't more tolerable because of who the target is or who the sender is — they're not part of the deal here, full stop.
 
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Enforcement Responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Public slap-fights in issues and PRs also aren't part of the deal. If a thread has gone sideways, step out of it and bring the matter to the maintainers privately.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This applies everywhere c11 happens: issues, pull requests, discussions, the code itself, any chat we run, and any public venue where you're visibly representing c11 (speaking as a maintainer, posting from a project account, etc.). Off-platform behavior toward another contributor can be in scope when it meaningfully affects work here.
 
-## Enforcement
+## Reporting
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at benevolent.futures@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+Email `benevolent.futures@gmail.com` with `c11 conduct` in the subject. Include what happened, where, when, and any evidence you have — links, screenshots, context. We read everything, respond within a few business days, and won't share the reporter's identity with the subject of the report beyond what's strictly necessary to resolve it.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+Bad-faith reports are themselves a violation.
 
-## Enforcement Guidelines
+## Consequences
 
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+Maintainers may ask you to edit a comment, step back from a thread, cool off for a while, or — in severe or sustained cases — leave the project. You'll be told which line was crossed and why. The response escalates with the pattern:
 
-### 1. Correction
+1. **A quiet word.** Private note clarifying what crossed the line. Usually this is enough.
+2. **A formal warning.** Named consequence for continued behavior; time-bound cooling off from a thread or venue.
+3. **Temporary ban.** Time-limited removal from project spaces.
+4. **Permanent ban.** For a pattern of sustained harassment, unrepentant hostility, or any single severe violation.
 
-**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series of actions.
-
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within the community.
+Maintainers are held to the same standard. If we're the problem, use the same reporting channel — the operator reads that inbox.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
-
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
-
-For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
-
-[homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
+The enforcement ladder borrows structure from the [Contributor Covenant](https://www.contributor-covenant.org), which in turn borrows from Mozilla's enforcement guidelines. Credit where due; the voice is ours.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at benevolent.futures@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,15 @@
 # Contributing to c11
 
-Thanks for considering a contribution. c11 is built by a small team and a rotating cast of their agents — outside PRs from humans and from humans-with-agents are both welcome, and both read the same way to us.
+c11 is built by a small team and a rotating cast of their agents. Outside contributions from humans, from humans-with-agents, and from agents-with-humans-reviewing are all welcome — they read the same way to us. What matters is whether the change is correct, well-shaped, and defensible.
 
-Start here, skim the links at the bottom for depth.
+This doc is the practical onramp. Skim the links at the end for depth.
 
 ## Before you start
 
 - **Read [PHILOSOPHY.md](PHILOSOPHY.md)** if your change touches product shape or primitives. c11 has strong opinions about staying unopinionated; knowing where those opinions live saves review rounds.
-- **Glance at [CLAUDE.md](CLAUDE.md)** for operational guardrails — testing policy, submodule etiquette, latency-sensitive code paths, socket threading rules. CLAUDE.md is written for agents but it's accurate, terse, and useful to humans too.
-- **Check open issues and the `TODO.md` / `C11_TODO.md` files** before opening a feature PR. Some ideas are intentionally parked.
-- **File an issue first** for anything non-trivial. A two-line sketch of the approach in an issue is much cheaper than a rejected 800-line PR.
+- **Glance at [CLAUDE.md](CLAUDE.md)** for the operational guardrails — testing policy, submodule etiquette, latency-sensitive code paths, socket threading rules. It's written for agents, but it's terse, accurate, and useful to humans too.
+- **Check open issues and `TODO.md` / `C11_TODO.md`** before opening a feature PR. Some ideas are intentionally parked.
+- **File an issue first for anything non-trivial.** A two-line sketch of the approach is much cheaper than a rejected 800-line PR.
 
 ## Prerequisites
 
@@ -26,11 +26,11 @@ cd c11
 ./scripts/setup.sh
 ```
 
-`setup.sh` initializes submodules (ghostty, bonsplit, homebrew-c11), builds `GhosttyKit.xcframework`, and sets up symlinks. Run it once, and re-run it if submodules change.
+`setup.sh` initializes submodules (ghostty, bonsplit, homebrew-c11), builds `GhosttyKit.xcframework`, and lays down symlinks. Run it once; re-run when submodules change.
 
 ## The hot-reload loop
 
-The day-to-day workflow is `./scripts/reload.sh`, which builds and launches a Debug app. **Always use `--tag`** — it gives your build its own name, bundle ID, socket, and DerivedData path so it doesn't fight with a co-located instance:
+Day-to-day builds go through `./scripts/reload.sh`, which builds and launches a Debug app. **Always use `--tag`** — it gives your build its own name, bundle ID, socket, and DerivedData path, so it doesn't fight a co-located instance:
 
 ```bash
 ./scripts/reload.sh --tag my-branch-slug
@@ -40,66 +40,66 @@ Relevant variants:
 
 | Script | What it does |
 |---|---|
-| `./scripts/reload.sh --tag <tag>` | Build + launch Debug, isolated (the default) |
+| `./scripts/reload.sh --tag <tag>` | Build + launch Debug, isolated (the default you want) |
 | `./scripts/reloadp.sh` | Build + launch Release (kills running c11 first) |
 | `./scripts/reloads.sh` | Build + launch Release as "c11 STAGING" |
 | `./scripts/rebuild.sh` | Clean rebuild |
 
-Full detail and gotchas live in [`skills/c11-hotload/SKILL.md`](skills/c11-hotload/SKILL.md).
+Full detail and the gotchas live in [`skills/c11-hotload/SKILL.md`](skills/c11-hotload/SKILL.md).
 
 ## Running tests
 
-c11 has three test suites. Order of escalation:
+c11 has three test suites. In order of escalation:
 
-1. **Swift unit tests** (`c11Tests/`) — `xcodebuild -scheme c11-unit` or run them from Xcode. No app launch, fast.
-2. **Python socket tests** (`tests_v2/`) — these attach to a running c11 instance over its socket. Launch a tagged Debug build first (`./scripts/reload.sh --tag testing`), then point the test runner at that build's socket:
+1. **Swift unit tests** (`c11Tests/`) — `xcodebuild -scheme c11-unit`, or run from Xcode. No app launch, fast.
+2. **Python socket tests** (`tests_v2/`) — attach to a running c11 over its socket. Launch a tagged Debug build first (`./scripts/reload.sh --tag testing`), then point the runner at that build's socket:
    ```bash
    C11_SOCKET=/tmp/c11-debug-testing.sock ./scripts/run-tests-v2.sh
    ```
-   Never run these against an untagged build while another c11 instance is also running — you will collide with it on `/tmp/c11.sock`.
-3. **E2E / UI tests** (`c11UITests/`) — heavyweight, prefer running these on CI via `gh workflow run test-e2e.yml`. You can run them locally but they're slow and occasionally flaky on low-RAM machines.
+   Never run these against an untagged build while another c11 is also running — you'll collide on `/tmp/c11.sock`.
+3. **E2E / UI tests** (`c11UITests/`) — heavyweight; prefer CI via `gh workflow run test-e2e.yml`. You can run them locally, but they're slow and occasionally flaky on low-RAM machines.
 
-> **Note for agent contributors working inside a live c11 session:** `CLAUDE.md` says "never run tests locally" — that rule exists because an agent launching an untagged debug build will hijack the operator's running socket. It does *not* apply to a human on their own machine running their own tests. When in doubt, use `--tag`.
+> **Note for agent contributors working inside a live c11 session:** `CLAUDE.md` says "never run tests locally." That rule exists because an agent launching an untagged debug build will hijack the operator's running socket. It does *not* apply to a human running their own tests on their own machine. When in doubt, use `--tag`.
 
 ## Opening a pull request
 
 ### Commit style
 
-- **New commits, not amends.** If a pre-commit hook fails, fix it and push a new commit — don't rewrite history the reviewer might have already pulled.
-- Write messages that explain *why*, not *what*. The diff already shows what.
-- Sign off with your name as the git author; Co-Authored-By trailers for agents are encouraged when agents did meaningful work on the change.
-- If your PR touches code that came from upstream [cmux](https://github.com/manaflow-ai/cmux), call it out so we can decide whether to also float the fix upstream. See the "cmux ↔ c11 relationship" section in [CLAUDE.md](CLAUDE.md).
+- **New commits, not amends.** If a pre-commit hook fails, fix the issue and push a new commit — don't rewrite history the reviewer may have already pulled.
+- Write messages that explain *why*, not *what*. The diff already shows the *what*.
+- Sign off as the git author; use `Co-Authored-By` trailers for agents when they did meaningful work on the change. Honest attribution helps us calibrate review depth and normalizes the practice.
+- If your PR touches code that clearly came from upstream [cmux](https://github.com/manaflow-ai/cmux), flag it in the description so we can decide whether to also float the fix upstream. See the "cmux ↔ c11 relationship" section in [CLAUDE.md](CLAUDE.md).
 
 ### The PR template and review bots
 
-Every PR uses [`.github/pull_request_template.md`](.github/pull_request_template.md). The important parts:
+Every PR uses [`.github/pull_request_template.md`](.github/pull_request_template.md). The non-obvious parts:
 
-- **Demo video** for UI / behavior changes. A 20-second screen capture saves five rounds of review.
-- **Review-bot trigger block.** After your latest commit, paste the `@codex review` / `@coderabbitai review` / etc. block as a PR comment to kick off automated reviewers. Resolve their feedback (or explain why not) before a human reviews.
+- **Demo video** for UI or behavior changes. A twenty-second screen capture saves five rounds of review.
+- **Review-bot trigger block.** After your latest commit, paste the `@codex review` / `@coderabbitai review` / etc. block as a PR comment. Resolve what they surface — or explain why it's wrong — before a human reviews.
 
 ### UI changes need a demo
 
-We don't merge UI changes without a video. It's faster than prose, catches regressions reviewers wouldn't notice from the diff, and is the only way to verify typing-latency-sensitive paths didn't regress.
+We don't merge UI changes without a video. Prose can't catch typing-latency regressions; a recording can.
 
 ### Localization
 
 c11 ships in English plus six translations (ja, uk, ko, zh-Hans, zh-Hant, ru). All strings live in `Resources/Localizable.xcstrings`.
 
-- **Author English only.** Use `String(localized: "key.name", defaultValue: "English text")` at every user-facing call site. Don't hand-write the non-English values in product code.
-- **Translations come after.** A follow-up pass syncs `Localizable.xcstrings` across the six locales. If your PR adds new English strings, flag that in the description so we know to schedule the translation sync.
+- **Write English only.** Use `String(localized: "key.name", defaultValue: "English text")` at every user-facing call site. Don't hand-author the non-English values in product code.
+- **Translations come after.** A follow-up pass syncs `Localizable.xcstrings` across the six locales. If your PR adds new English strings, flag it in the description so we know to schedule the translation sync.
 
 ### Code quality guardrails
 
-A few areas have strict rules. If you're editing near any of these, read the full note in [`CLAUDE.md`](CLAUDE.md):
+A few areas carry strict rules. If you're editing near any of these, read the full note in [`CLAUDE.md`](CLAUDE.md):
 
-- **Typing-latency-sensitive paths** (e.g., `WindowTerminalHostView.hitTest()`, `TabItemView`, `TerminalSurface.forceRefresh()`). Extra allocations or main-thread work here are visible as typing lag.
-- **Socket command threading.** Telemetry hot paths (`report_*`, status / progress updates) must not hop `DispatchQueue.main.sync`. Default new socket commands to off-main handling unless you have a concrete reason otherwise.
-- **Socket focus policy.** Socket commands must not steal app focus — only explicit focus-intent commands (`window.focus`, `surface.focus`, etc.) may change selection.
-- **Test quality.** Tests must verify observable runtime behavior. Do not add tests that grep source text, read `Info.plist`, or assert on AST shape. If a behavior isn't exercisable yet, add a seam first and test through it.
+- **Typing-latency-sensitive paths** (`WindowTerminalHostView.hitTest()`, `TabItemView`, `TerminalSurface.forceRefresh()`). Extra allocations or main-thread work here is visible as typing lag.
+- **Socket command threading.** Telemetry hot paths (`report_*`, status / progress updates) must not hop `DispatchQueue.main.sync`. Default new socket commands to off-main unless you have a concrete reason otherwise.
+- **Socket focus policy.** Socket commands don't steal app focus — only explicit focus-intent commands (`window.focus`, `surface.focus`, etc.) may change selection.
+- **Test quality.** Tests verify observable runtime behavior. Tests that grep source text, read `Info.plist`, or assert on AST shape get rejected. If a behavior isn't exercisable yet, add a seam first and test through it.
 
 ## Working on the ghostty submodule
 
-The `ghostty` submodule points at [`manaflow-ai/ghostty`](https://github.com/manaflow-ai/ghostty) — a fork of upstream Ghostty with c11-specific patches.
+The `ghostty` submodule points at [`manaflow-ai/ghostty`](https://github.com/manaflow-ai/ghostty) — a fork of upstream Ghostty carrying c11-specific patches.
 
 ```bash
 cd ghostty
@@ -118,25 +118,25 @@ git add ghostty
 git commit -m "Bump ghostty submodule"
 ```
 
-**Always push the submodule commit to `manaflow/main` (or a branch on the fork) before committing the parent pointer.** A detached-HEAD submodule commit is orphaned and lost.
+**Always push the submodule commit to `manaflow/main` (or a branch on the fork) before committing the parent pointer.** A detached-HEAD submodule commit is orphaned and lost — verify with `git merge-base --is-ancestor HEAD origin/main` inside `ghostty/` before bumping.
 
 Conflict notes and fork status live in [`docs/ghostty-fork.md`](docs/ghostty-fork.md) and [`docs/upstream-sync.md`](docs/upstream-sync.md).
 
 ## Contributing with your agent
 
-c11 is agent-native — we expect a lot of contributions to involve one. If you're bringing an agent to help, give it a look at [`docs/contributing-with-your-agent.md`](docs/contributing-with-your-agent.md) before you hand it the keyboard. It covers how to point the agent at the right context files and how the PR review flow works for agent-authored changes.
+c11 is agent-native. We expect a lot of contributions to involve one. If you're bringing an agent, hand it [`docs/contributing-with-your-agent.md`](docs/contributing-with-your-agent.md) before you hand it the keyboard. It covers context files, the PR flow for agent-authored changes, and the footguns we've seen repeat.
 
 ## Security
 
-Please don't open public issues for security bugs. See [`SECURITY.md`](SECURITY.md) for the private disclosure flow.
+Don't open public issues for security bugs. See [`SECURITY.md`](SECURITY.md) for the private disclosure flow.
 
 ## Code of Conduct
 
-By participating in this project you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md). Unkindness slows everybody down.
+By participating here, you agree to the [Code of Conduct](CODE_OF_CONDUCT.md). Be direct, be kind; review the work, not the person.
 
 ## License
 
-By contributing, you agree that your changes are licensed under the project's GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`). See [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE) for details and upstream attribution.
+By contributing, you agree that your changes are licensed under the project's GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`). See [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE) for the full text and upstream attribution.
 
 ## Where to go next
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,102 +1,147 @@
 # Contributing to c11
 
+Thanks for considering a contribution. c11 is built by a small team and a rotating cast of their agents — outside PRs from humans and from humans-with-agents are both welcome, and both read the same way to us.
+
+Start here, skim the links at the bottom for depth.
+
+## Before you start
+
+- **Read [PHILOSOPHY.md](PHILOSOPHY.md)** if your change touches product shape or primitives. c11 has strong opinions about staying unopinionated; knowing where those opinions live saves review rounds.
+- **Glance at [CLAUDE.md](CLAUDE.md)** for operational guardrails — testing policy, submodule etiquette, latency-sensitive code paths, socket threading rules. CLAUDE.md is written for agents but it's accurate, terse, and useful to humans too.
+- **Check open issues and the `TODO.md` / `C11_TODO.md` files** before opening a feature PR. Some ideas are intentionally parked.
+- **File an issue first** for anything non-trivial. A two-line sketch of the approach in an issue is much cheaper than a rejected 800-line PR.
+
 ## Prerequisites
 
-- macOS 14+
+- macOS 14+ (Sonoma or later)
 - Xcode 15+
-- [Zig](https://ziglang.org/) (install via `brew install zig`)
+- [Zig](https://ziglang.org/) (`brew install zig`) — needed to build the bundled Ghostty as an xcframework
+- Git with submodule support (stock git is fine)
 
-## Getting Started
+## Getting the source
 
-1. Clone the repository with submodules:
-   ```bash
-   git clone --recursive https://github.com/Stage-11-Agentics/c11.git
-   cd c11
-   ```
+```bash
+git clone --recursive https://github.com/Stage-11-Agentics/c11.git
+cd c11
+./scripts/setup.sh
+```
 
-2. Run the setup script:
-   ```bash
-   ./scripts/setup.sh
-   ```
+`setup.sh` initializes submodules (ghostty, bonsplit, homebrew-c11), builds `GhosttyKit.xcframework`, and sets up symlinks. Run it once, and re-run it if submodules change.
 
-   This will:
-   - Initialize git submodules (ghostty, homebrew-c11)
-   - Build the GhosttyKit.xcframework from source
-   - Create the necessary symlinks
+## The hot-reload loop
 
-3. Build and run the debug app:
-   ```bash
-   ./scripts/reload.sh
-   ```
+The day-to-day workflow is `./scripts/reload.sh`, which builds and launches a Debug app. **Always use `--tag`** — it gives your build its own name, bundle ID, socket, and DerivedData path so it doesn't fight with a co-located instance:
 
-## Development Scripts
+```bash
+./scripts/reload.sh --tag my-branch-slug
+```
 
-| Script | Description |
-|--------|-------------|
-| `./scripts/setup.sh` | One-time setup (submodules + xcframework) |
-| `./scripts/reload.sh` | Build and launch Debug app |
-| `./scripts/reloadp.sh` | Build and launch Release app |
-| `./scripts/reload2.sh` | Reload both Debug and Release |
+Relevant variants:
+
+| Script | What it does |
+|---|---|
+| `./scripts/reload.sh --tag <tag>` | Build + launch Debug, isolated (the default) |
+| `./scripts/reloadp.sh` | Build + launch Release (kills running c11 first) |
+| `./scripts/reloads.sh` | Build + launch Release as "c11 STAGING" |
 | `./scripts/rebuild.sh` | Clean rebuild |
 
-## Rebuilding GhosttyKit
+Full detail and gotchas live in [`skills/c11-hotload/SKILL.md`](skills/c11-hotload/SKILL.md).
 
-If you make changes to the ghostty submodule, rebuild the xcframework:
+## Running tests
+
+c11 has three test suites. Order of escalation:
+
+1. **Swift unit tests** (`c11Tests/`) — `xcodebuild -scheme c11-unit` or run them from Xcode. No app launch, fast.
+2. **Python socket tests** (`tests_v2/`) — these attach to a running c11 instance over its socket. Launch a tagged Debug build first (`./scripts/reload.sh --tag testing`), then point the test runner at that build's socket:
+   ```bash
+   C11_SOCKET=/tmp/c11-debug-testing.sock ./scripts/run-tests-v2.sh
+   ```
+   Never run these against an untagged build while another c11 instance is also running — you will collide with it on `/tmp/c11.sock`.
+3. **E2E / UI tests** (`c11UITests/`) — heavyweight, prefer running these on CI via `gh workflow run test-e2e.yml`. You can run them locally but they're slow and occasionally flaky on low-RAM machines.
+
+> **Note for agent contributors working inside a live c11 session:** `CLAUDE.md` says "never run tests locally" — that rule exists because an agent launching an untagged debug build will hijack the operator's running socket. It does *not* apply to a human on their own machine running their own tests. When in doubt, use `--tag`.
+
+## Opening a pull request
+
+### Commit style
+
+- **New commits, not amends.** If a pre-commit hook fails, fix it and push a new commit — don't rewrite history the reviewer might have already pulled.
+- Write messages that explain *why*, not *what*. The diff already shows what.
+- Sign off with your name as the git author; Co-Authored-By trailers for agents are encouraged when agents did meaningful work on the change.
+- If your PR touches code that came from upstream [cmux](https://github.com/manaflow-ai/cmux), call it out so we can decide whether to also float the fix upstream. See the "cmux ↔ c11 relationship" section in [CLAUDE.md](CLAUDE.md).
+
+### The PR template and review bots
+
+Every PR uses [`.github/pull_request_template.md`](.github/pull_request_template.md). The important parts:
+
+- **Demo video** for UI / behavior changes. A 20-second screen capture saves five rounds of review.
+- **Review-bot trigger block.** After your latest commit, paste the `@codex review` / `@coderabbitai review` / etc. block as a PR comment to kick off automated reviewers. Resolve their feedback (or explain why not) before a human reviews.
+
+### UI changes need a demo
+
+We don't merge UI changes without a video. It's faster than prose, catches regressions reviewers wouldn't notice from the diff, and is the only way to verify typing-latency-sensitive paths didn't regress.
+
+### Localization
+
+c11 ships in English plus six translations (ja, uk, ko, zh-Hans, zh-Hant, ru). All strings live in `Resources/Localizable.xcstrings`.
+
+- **Author English only.** Use `String(localized: "key.name", defaultValue: "English text")` at every user-facing call site. Don't hand-write the non-English values in product code.
+- **Translations come after.** A follow-up pass syncs `Localizable.xcstrings` across the six locales. If your PR adds new English strings, flag that in the description so we know to schedule the translation sync.
+
+### Code quality guardrails
+
+A few areas have strict rules. If you're editing near any of these, read the full note in [`CLAUDE.md`](CLAUDE.md):
+
+- **Typing-latency-sensitive paths** (e.g., `WindowTerminalHostView.hitTest()`, `TabItemView`, `TerminalSurface.forceRefresh()`). Extra allocations or main-thread work here are visible as typing lag.
+- **Socket command threading.** Telemetry hot paths (`report_*`, status / progress updates) must not hop `DispatchQueue.main.sync`. Default new socket commands to off-main handling unless you have a concrete reason otherwise.
+- **Socket focus policy.** Socket commands must not steal app focus — only explicit focus-intent commands (`window.focus`, `surface.focus`, etc.) may change selection.
+- **Test quality.** Tests must verify observable runtime behavior. Do not add tests that grep source text, read `Info.plist`, or assert on AST shape. If a behavior isn't exercisable yet, add a seam first and test through it.
+
+## Working on the ghostty submodule
+
+The `ghostty` submodule points at [`manaflow-ai/ghostty`](https://github.com/manaflow-ai/ghostty) — a fork of upstream Ghostty with c11-specific patches.
 
 ```bash
 cd ghostty
-zig build -Demit-xcframework=true -Doptimize=ReleaseFast
-```
-
-## Running Tests
-
-### Basic tests (run on VM)
-
-```bash
-ssh c11-vm 'cd /Users/c11/GhosttyTabs && xcodebuild -project GhosttyTabs.xcodeproj -scheme c11 -configuration Debug -destination "platform=macOS" build && pkill -x "c11 DEV" || true && APP=$(find /Users/c11/Library/Developer/Xcode/DerivedData -path "*/Build/Products/Debug/c11 DEV.app" -print -quit) && open "$APP" && for i in {1..20}; do [ -S /tmp/c11.sock ] && break; sleep 0.5; done && python3 tests/test_update_timing.py && python3 tests/test_signals_auto.py && python3 tests/test_ctrl_socket.py && python3 tests/test_notifications.py'
-```
-
-### UI tests (run on VM)
-
-```bash
-ssh c11-vm 'cd /Users/c11/GhosttyTabs && xcodebuild -project GhosttyTabs.xcodeproj -scheme c11 -configuration Debug -destination "platform=macOS" -only-testing:c11UITests test'
-```
-
-## Ghostty Submodule
-
-The `ghostty` submodule points to [manaflow-ai/ghostty](https://github.com/manaflow-ai/ghostty), a fork of the upstream Ghostty project.
-
-### Making changes to ghostty
-
-```bash
-cd ghostty
-git checkout -b my-feature
+git checkout -b my-ghostty-feature
 # make changes
 git add .
 git commit -m "Description of changes"
-git push manaflow my-feature
+git push manaflow my-ghostty-feature
 ```
 
-### Keeping the fork updated
-
-```bash
-cd ghostty
-git fetch origin
-git checkout main
-git merge origin/main
-git push manaflow main
-```
-
-Then update the parent repo:
+Then bump the submodule pointer in the parent repo:
 
 ```bash
 cd ..
 git add ghostty
-git commit -m "Update ghostty submodule"
+git commit -m "Bump ghostty submodule"
 ```
 
-See `docs/ghostty-fork.md` for details on fork changes and conflict notes.
+**Always push the submodule commit to `manaflow/main` (or a branch on the fork) before committing the parent pointer.** A detached-HEAD submodule commit is orphaned and lost.
+
+Conflict notes and fork status live in [`docs/ghostty-fork.md`](docs/ghostty-fork.md) and [`docs/upstream-sync.md`](docs/upstream-sync.md).
+
+## Contributing with your agent
+
+c11 is agent-native — we expect a lot of contributions to involve one. If you're bringing an agent to help, give it a look at [`docs/contributing-with-your-agent.md`](docs/contributing-with-your-agent.md) before you hand it the keyboard. It covers how to point the agent at the right context files and how the PR review flow works for agent-authored changes.
+
+## Security
+
+Please don't open public issues for security bugs. See [`SECURITY.md`](SECURITY.md) for the private disclosure flow.
+
+## Code of Conduct
+
+By participating in this project you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md). Unkindness slows everybody down.
 
 ## License
 
-By contributing to this repository, you agree that your contributions are licensed under the project's GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`).
+By contributing, you agree that your changes are licensed under the project's GNU Affero General Public License v3.0 or later (`AGPL-3.0-or-later`). See [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE) for details and upstream attribution.
+
+## Where to go next
+
+- [`PHILOSOPHY.md`](PHILOSOPHY.md) — why c11 is shaped the way it is
+- [`CLAUDE.md`](CLAUDE.md) — operational notes, latency-sensitive paths, testing policy
+- [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md) — architecture tour, where things live in `Sources/`
+- [`docs/socket-api-reference.md`](docs/socket-api-reference.md) — the socket API every c11 surface speaks
+- [`skills/c11/SKILL.md`](skills/c11/SKILL.md) — the agent-facing guide to driving c11 (useful for humans too)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,39 +1,39 @@
-# Security Policy
+# Security
 
-## Reporting a vulnerability
+Found something that looks like a security issue in c11? Report it privately. Public issues turn bad news into worse news.
 
-If you believe you've found a security vulnerability in c11, please **do not open a public issue**. Report it privately through one of these channels:
+## How to report
 
-- **GitHub Security Advisories** (preferred): <https://github.com/Stage-11-Agentics/c11/security/advisories/new>
-- **Email**: `benevolent.futures@gmail.com` — please put `c11 security` in the subject line.
+- **Preferred — GitHub Security Advisories:** <https://github.com/Stage-11-Agentics/c11/security/advisories/new>
+- **Fallback — email:** `benevolent.futures@gmail.com`, subject line `c11 security`.
 
-We aim to acknowledge receipt within 3 business days, work with you to understand and reproduce the issue, and coordinate public disclosure once a fix has shipped.
+Include what you found, how to trigger it, and anything you've already established about impact. We'll acknowledge within three business days, work with you on reproduction and a fix, and coordinate public disclosure after the patch ships. Credit however you want it — your name, a handle, or not at all.
 
-## Supported versions
+## What counts
 
-c11 is pre-1.0 and ships as a rolling release via the `stage-11-agentics/c11` Homebrew tap and DMG downloads on the [Releases](https://github.com/Stage-11-Agentics/c11/releases) page. Security fixes land on the latest version — users are expected to update promptly. Older versions are not maintained.
-
-## Scope
-
-c11 is a macOS desktop app with a local Unix socket API, an embedded terminal (Ghostty), an embedded browser (WKWebView), and an agent-facing metadata layer. In-scope reports include:
+c11 is a macOS app with a local Unix socket, an embedded terminal (Ghostty), an embedded browser (WKWebView), and an agent-facing metadata layer. In scope:
 
 - Arbitrary code execution via crafted socket commands, malformed metadata, or malicious terminal output.
 - Privilege escalation, sandbox escape, or TCC / entitlement abuse specific to c11.
 - Credential or secret leakage in logs, crash reports, or persisted workspace state.
-- Auto-update / Sparkle signature or delivery issues specific to c11's release pipeline.
+- Auto-update / Sparkle signing or delivery issues on c11's release pipeline.
 
 Out of scope:
 
-- Social engineering against operators.
-- Vulnerabilities in upstream dependencies (Ghostty, Sparkle, Bonsplit, etc.) that are not exploitable through c11's configuration — please report those to the respective upstream projects.
-- Issues that require physical access to an already-compromised machine.
+- Social engineering of operators.
+- Bugs in upstream dependencies (Ghostty, Sparkle, Bonsplit, etc.) that aren't reachable through c11's configuration. Report those upstream; we'll help route if you're not sure where.
+- Anything that requires physical access to an already-compromised machine.
+
+## Supported versions
+
+c11 is pre-1.0 and ships as a rolling release through the `stage-11-agentics/c11` Homebrew tap and DMGs on the [Releases](https://github.com/Stage-11-Agentics/c11/releases) page. Security fixes land on the latest build; older versions aren't maintained. Keep current.
 
 ## Safe harbor
 
-We will not pursue legal action against researchers who:
+We won't pursue legal action against researchers who:
 
-- Act in good faith and make a reasonable effort to contact us before any public disclosure.
+- Act in good faith and reach out before public disclosure.
 - Avoid privacy violations, data destruction, and service disruption.
-- Do not exploit a finding beyond what's necessary to demonstrate the issue.
+- Stay inside the minimum needed to demonstrate the issue.
 
-Thank you for helping keep c11 and its users safe.
+Report the thing, we'll fix the thing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you believe you've found a security vulnerability in c11, please **do not open a public issue**. Report it privately through one of these channels:
+
+- **GitHub Security Advisories** (preferred): <https://github.com/Stage-11-Agentics/c11/security/advisories/new>
+- **Email**: `benevolent.futures@gmail.com` — please put `c11 security` in the subject line.
+
+We aim to acknowledge receipt within 3 business days, work with you to understand and reproduce the issue, and coordinate public disclosure once a fix has shipped.
+
+## Supported versions
+
+c11 is pre-1.0 and ships as a rolling release via the `stage-11-agentics/c11` Homebrew tap and DMG downloads on the [Releases](https://github.com/Stage-11-Agentics/c11/releases) page. Security fixes land on the latest version — users are expected to update promptly. Older versions are not maintained.
+
+## Scope
+
+c11 is a macOS desktop app with a local Unix socket API, an embedded terminal (Ghostty), an embedded browser (WKWebView), and an agent-facing metadata layer. In-scope reports include:
+
+- Arbitrary code execution via crafted socket commands, malformed metadata, or malicious terminal output.
+- Privilege escalation, sandbox escape, or TCC / entitlement abuse specific to c11.
+- Credential or secret leakage in logs, crash reports, or persisted workspace state.
+- Auto-update / Sparkle signature or delivery issues specific to c11's release pipeline.
+
+Out of scope:
+
+- Social engineering against operators.
+- Vulnerabilities in upstream dependencies (Ghostty, Sparkle, Bonsplit, etc.) that are not exploitable through c11's configuration — please report those to the respective upstream projects.
+- Issues that require physical access to an already-compromised machine.
+
+## Safe harbor
+
+We will not pursue legal action against researchers who:
+
+- Act in good faith and make a reasonable effort to contact us before any public disclosure.
+- Avoid privacy violations, data destruction, and service disruption.
+- Do not exploit a finding beyond what's necessary to demonstrate the issue.
+
+Thank you for helping keep c11 and its users safe.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,8 +1,8 @@
 # c11 development
 
-A one-screen map of the codebase so a new contributor (or their agent) can find their way without grepping blindly.
+A one-screen map of the codebase so a new contributor — or their agent — can land somewhere useful on the first grep instead of the fifteenth.
 
-This doc describes *where things live*. For *how to work* — setup, build, reload, commit style, PR flow — see [`../CONTRIBUTING.md`](../CONTRIBUTING.md). For *why things are shaped the way they are*, see [`../PHILOSOPHY.md`](../PHILOSOPHY.md).
+This doc is *where things live*. For *how to work* — setup, build, reload, commit style, PR flow — see [`../CONTRIBUTING.md`](../CONTRIBUTING.md). For *why things are shaped the way they are*, see [`../PHILOSOPHY.md`](../PHILOSOPHY.md).
 
 ## Top-level layout
 
@@ -30,7 +30,7 @@ c11/
 
 ## The Xcode project
 
-The project file is still called `GhosttyTabs.xcodeproj` from before the cmux → c11 rename — cheap to rename, expensive in merge-conflict risk, so we left it. Schemes inside it are the current names:
+The project file is still called `GhosttyTabs.xcodeproj` from before the cmux → c11 rename. Cheap to rename, expensive in merge-conflict risk — so we left it. Schemes inside it use the current names:
 
 - **c11** — full app, Debug/Release configurations
 - **c11-unit** — unit test target only; no app launch, safe to run from Xcode
@@ -98,7 +98,7 @@ The socket protocol it speaks is documented in [`socket-api-reference.md`](socke
 
 ## Latency-sensitive paths — read before editing
 
-A small number of code paths are called on every keystroke. Work added here shows up as visible typing lag. Full details in [`../CLAUDE.md`](../CLAUDE.md); the TL;DR:
+A small number of code paths are called on every keystroke. Work added here shows up as visible typing lag. Full detail in [`../CLAUDE.md`](../CLAUDE.md); the short version:
 
 - **`WindowTerminalHostView.hitTest()`** in `TerminalWindowPortal.swift` — all divider/sidebar/drag routing is gated to pointer events only. Don't add work outside the `isPointerEvent` guard.
 - **`TabItemView` in `ContentView.swift`** — uses `Equatable` + `.equatable()` to skip body re-evaluation during typing. Don't add `@EnvironmentObject`, `@ObservedObject` (besides `tab`), or `@Binding` without updating `==`. Don't remove `.equatable()` from the `ForEach`.
@@ -139,7 +139,7 @@ The `ghostty/` submodule tracks [`manaflow-ai/ghostty`](https://github.com/manaf
 
 ## Where the upstream lineage shows
 
-c11 is a fork of [`manaflow-ai/cmux`](https://github.com/manaflow-ai/cmux). A lot of code paths still carry the upstream shape — file names, module names, socket protocol. When you touch code that clearly came from upstream and your fix isn't c11-specific, flag it in the PR description so we can decide whether to float the change back upstream. See the "cmux ↔ c11 relationship" section in [`../CLAUDE.md`](../CLAUDE.md).
+c11 is a fork of [`manaflow-ai/cmux`](https://github.com/manaflow-ai/cmux). Lots of code paths still carry the upstream shape — file names, module names, socket protocol. If you touch code that clearly came from upstream and your fix isn't c11-specific, flag it in the PR description so we can decide whether to also float the change back upstream. Shared improvements should flow both ways; silent divergence on shared code makes future merges painful and costs both projects wins they'd otherwise share. See the "cmux ↔ c11 relationship" section in [`../CLAUDE.md`](../CLAUDE.md).
 
 ## Further reading
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,152 @@
+# c11 development
+
+A one-screen map of the codebase so a new contributor (or their agent) can find their way without grepping blindly.
+
+This doc describes *where things live*. For *how to work* — setup, build, reload, commit style, PR flow — see [`../CONTRIBUTING.md`](../CONTRIBUTING.md). For *why things are shaped the way they are*, see [`../PHILOSOPHY.md`](../PHILOSOPHY.md).
+
+## Top-level layout
+
+```
+c11/
+├── Sources/            Swift app code (the c11 macOS app)
+├── CLI/                The `c11` CLI binary (single Swift file, ~16k lines)
+├── Resources/          Bundled assets (Info.plist, xcstrings, shell integration, welcome.md, themes)
+├── skills/             Agent-facing skill files (c11, c11-browser, c11-markdown, c11-hotload, release)
+├── ghostty/            Submodule — fork of Ghostty rendering the terminals
+├── vendor/
+│   └── bonsplit/       Submodule — tab bar and split chrome
+├── homebrew-c11/       Submodule — Homebrew tap for the `c11` cask
+├── web/                Next.js marketing site
+├── daemon/             Remote daemon prototype (see docs/remote-daemon-spec.md)
+├── c11Tests/           Swift unit tests (XCTest)
+├── c11UITests/         Swift UI tests (XCUITest, run in CI)
+├── tests/              Shell + Python v1 tests (older)
+├── tests_v2/           Python socket tests (newer, preferred for new socket work)
+├── scripts/            Build / reload / release automation
+├── docs/               You are here
+├── design/             Design assets, mockups, references
+└── GhosttyTabs.xcodeproj   Xcode project (original project name, pre-rename)
+```
+
+## The Xcode project
+
+The project file is still called `GhosttyTabs.xcodeproj` from before the cmux → c11 rename — cheap to rename, expensive in merge-conflict risk, so we left it. Schemes inside it are the current names:
+
+- **c11** — full app, Debug/Release configurations
+- **c11-unit** — unit test target only; no app launch, safe to run from Xcode
+
+## `Sources/` tour
+
+The app is ~50 top-level Swift files plus subdirs. Entry points and the most-touched areas:
+
+### App lifecycle & window shell
+
+| File | Role |
+|---|---|
+| `c11App.swift` | SwiftUI `App` entry point |
+| `AppDelegate.swift` | NSApplicationDelegate — 13k LOC — lifecycle, menu bar, tab/workspace routing, IPC |
+| `ContentView.swift` | Root SwiftUI view — 14k LOC — sidebar + workspace split + tab bar |
+| `WindowAccessor.swift`, `WindowDecorationsController.swift`, `WindowToolbarController.swift`, `WindowDragHandleView.swift` | Window chrome and AppKit-SwiftUI bridge |
+
+### Terminals, browsers, markdown (the surface types)
+
+| Area | Files |
+|---|---|
+| Terminal | `TerminalView.swift`, `GhosttyTerminalView.swift`, `GhosttyConfig.swift`, `TerminalController.swift`, `TerminalWindowPortal.swift` |
+| Browser | `BrowserWindowPortal.swift`, `Panels/BrowserPanel.swift`, `Panels/BrowserPanelView.swift`, `Panels/CmuxWebView.swift` |
+| Markdown | `Panels/MarkdownPanel.swift`, `Panels/MarkdownPanelView.swift`, `Panels/FencedCodeRenderer.swift`, `Panels/MermaidRenderer.swift` |
+| Panel base | `Panels/Panel.swift`, `Panels/PanelContentView.swift`, `Panels/PaneInteraction.swift` |
+
+### Panes, tabs, workspaces
+
+| File | Role |
+|---|---|
+| `TabManager.swift` | Tab lifecycle |
+| `Workspace.swift`, `WorkspaceContentView.swift`, `WorkspaceMetadataKeys.swift` | Workspace model & view |
+| `SessionPersistence.swift`, `PersistedMetadata.swift` | Restore across launches |
+
+### Agent-facing surface (metadata / skills / status)
+
+| File | Role |
+|---|---|
+| `AgentDetector.swift` | Identifies which agent (Claude Code / Codex / Gemini / shell) is running in a pane |
+| `AgentChip.swift`, `AgentChipBadge.swift` | Sidebar chip UI |
+| `AgentSkillsView.swift`, `SkillInstaller.swift` | Skills onboarding sheet |
+| `PaneMetadataStore.swift`, `SurfaceMetadataStore.swift`, `SurfaceTitleBarView.swift` | The surface manifest — the open JSON blob agents read/write over the socket |
+
+### Theming
+
+`Sources/Theme/` is its own small world — canonicalization, AST, evaluator, socket methods, directory watcher. If you're adding theme keys, start with `ThemeRoleRegistry.swift` and `ThemeCanonicalizer.swift`.
+
+### Update (Sparkle)
+
+`Sources/Update/` holds the Sparkle integration (controller, delegate, UI pill, test URL protocol). Sparkle keys, appcast generation, and the signing story live in `scripts/sparkle_*`.
+
+### Find / search overlay
+
+`Sources/Find/SurfaceSearchOverlay.swift` is the terminal find UI. **It must be mounted from `GhosttySurfaceScrollView` in `GhosttyTerminalView.swift`** (the AppKit portal layer), not from SwiftUI panel containers — portal-hosted terminal views can sit above SwiftUI during split churn. See the note in [`../CLAUDE.md`](../CLAUDE.md) before moving it.
+
+## The CLI and socket
+
+`CLI/c11.swift` is one enormous Swift file — the `c11` binary. It:
+
+- parses subcommands (`c11 split`, `c11 send`, `c11 tree`, `c11 browser ...`, `c11 set-metadata`, etc.)
+- talks to the running app over a Unix socket (`/tmp/c11.sock` in production, `/tmp/c11-debug-<tag>.sock` for tagged dev builds)
+- doubles as a compat shim for the legacy `cmux` command (hardlink in the bundle)
+
+The socket protocol it speaks is documented in [`socket-api-reference.md`](socket-api-reference.md). New CLI commands almost always pair with a new socket method on the app side — the canonical pattern is: add the socket method in `AppDelegate.swift` or a domain-specific handler (e.g., `Theme/ThemeSocketMethods.swift`), wire it into the CLI dispatch in `CLI/c11.swift`, and add a Python test in `tests_v2/`.
+
+## Latency-sensitive paths — read before editing
+
+A small number of code paths are called on every keystroke. Work added here shows up as visible typing lag. Full details in [`../CLAUDE.md`](../CLAUDE.md); the TL;DR:
+
+- **`WindowTerminalHostView.hitTest()`** in `TerminalWindowPortal.swift` — all divider/sidebar/drag routing is gated to pointer events only. Don't add work outside the `isPointerEvent` guard.
+- **`TabItemView` in `ContentView.swift`** — uses `Equatable` + `.equatable()` to skip body re-evaluation during typing. Don't add `@EnvironmentObject`, `@ObservedObject` (besides `tab`), or `@Binding` without updating `==`. Don't remove `.equatable()` from the `ForEach`.
+- **`TerminalSurface.forceRefresh()`** in `GhosttyTerminalView.swift` — no allocations, file I/O, or formatting here.
+
+## Socket threading — read before adding a socket command
+
+Default new socket commands to **off-main** handling. Only commands that directly mutate AppKit / Ghostty UI state (focus, open/close, send-key, synchronous snapshot queries) should run on main. Telemetry hot paths (`report_*`, status/progress updates) must not use `DispatchQueue.main.sync`. See the "Socket command threading policy" in [`../CLAUDE.md`](../CLAUDE.md).
+
+## Tests
+
+c11 has four test surfaces, roughly in order of how often you'll touch them:
+
+| Suite | Where | How to run | When to use |
+|---|---|---|---|
+| Swift unit | `c11Tests/` (~60 files) | `xcodebuild -scheme c11-unit` or from Xcode | Pure logic, metadata store, theme evaluator, CLI arg parsing |
+| Python socket v2 | `tests_v2/` (~140 files) | `C11_SOCKET=/tmp/c11-debug-<tag>.sock ./scripts/run-tests-v2.sh` against a tagged Debug build | New socket commands, CLI flows, browser automation, pane/workspace lifecycle |
+| Python socket v1 | `tests/` (~90 files, shell + python) | `./scripts/run-tests-v1.sh` | Older coverage; generally don't add new tests here, prefer v2 |
+| Swift UI | `c11UITests/` (~16 files) | `gh workflow run test-e2e.yml`, or Xcode (slow, flaky on low-RAM) | Full app flows — menu routing, dialogs, drag/drop, keybind regressions |
+
+**Test quality rule** ([`../CLAUDE.md`](../CLAUDE.md#test-quality-policy)): tests must verify observable runtime behavior. Tests that grep source text, assert on `Info.plist` shape, or check AST fragments get rejected. If a behavior isn't exercisable end-to-end yet, add a runtime seam first and test through it.
+
+## Build & reload
+
+Covered in [`../CONTRIBUTING.md`](../CONTRIBUTING.md#the-hot-reload-loop) and deeply in [`../skills/c11-hotload/SKILL.md`](../skills/c11-hotload/SKILL.md). The one-liner for day-to-day dev:
+
+```bash
+./scripts/reload.sh --tag <your-branch-slug>
+```
+
+## Release
+
+Release machinery lives in `scripts/` (signing, notarization, DMG assembly, appcast, Homebrew cask bump) and `.github/workflows/release.yml`. The flow is documented in [`../skills/release/SKILL.md`](../skills/release/SKILL.md) and triggered by the `/release` command.
+
+## Ghostty submodule
+
+The `ghostty/` submodule tracks [`manaflow-ai/ghostty`](https://github.com/manaflow-ai/ghostty), a fork carrying c11-specific patches. Fork status, merge hygiene, and conflict notes live in [`ghostty-fork.md`](ghostty-fork.md) and [`upstream-sync.md`](upstream-sync.md). Always push the submodule commit to the fork before bumping the parent pointer — detached-HEAD commits are orphaned.
+
+## Where the upstream lineage shows
+
+c11 is a fork of [`manaflow-ai/cmux`](https://github.com/manaflow-ai/cmux). A lot of code paths still carry the upstream shape — file names, module names, socket protocol. When you touch code that clearly came from upstream and your fix isn't c11-specific, flag it in the PR description so we can decide whether to float the change back upstream. See the "cmux ↔ c11 relationship" section in [`../CLAUDE.md`](../CLAUDE.md).
+
+## Further reading
+
+- [`../PHILOSOPHY.md`](../PHILOSOPHY.md) — the worldview
+- [`../CLAUDE.md`](../CLAUDE.md) — operational guardrails (testing, threading, latency, submodules)
+- [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — human contributor workflow
+- [`contributing-with-your-agent.md`](contributing-with-your-agent.md) — agent-operator supplement
+- [`socket-api-reference.md`](socket-api-reference.md) — socket protocol reference
+- [`browser-automation-reference.md`](browser-automation-reference.md) — browser surface automation
+- [`../skills/c11/SKILL.md`](../skills/c11/SKILL.md) — the agent-facing how-to-use-c11

--- a/docs/contributing-with-your-agent.md
+++ b/docs/contributing-with-your-agent.md
@@ -1,19 +1,19 @@
 # Contributing to c11 with your agent
 
-c11 is agent-native. It was built with agents, is maintained with agents, and expects to be extended with agents. If you're here to help your agent help us, you're in the right place.
+c11 is agent-native. It was built with agents, is maintained with agents, and expects to be extended with agents. If you've brought one along, this is the page for you.
 
-This doc is the agent-specific supplement to [`CONTRIBUTING.md`](../CONTRIBUTING.md). Read that first for the human-facing workflow (setup, hot reload, tests, PR template). This page covers the parts that are specific to having an agent in the driver's seat.
+This is the agent-specific supplement to [`CONTRIBUTING.md`](../CONTRIBUTING.md). Read that first for the general workflow (setup, hot reload, tests, PR template). This page is the part specific to having an agent in the driver's seat.
 
 ## Ground rules
 
 - **Agent-authored PRs are welcome.** We don't gate on who held the keyboard. We gate on whether the change is correct, tested, and well-shaped.
-- **You are still the author.** Review the diff before opening the PR. Understand the change well enough to answer review comments. An agent that can't be explained by its operator is a liability; a change its operator can defend is a contribution.
-- **Signal agent involvement.** Add a `Co-Authored-By` trailer naming the agent(s) when they did meaningful work on the commit. It's honest, helps us calibrate review depth, and normalizes the practice.
-- **Read before you write.** Agents that skip [`CLAUDE.md`](../CLAUDE.md), [`PHILOSOPHY.md`](../PHILOSOPHY.md), and the relevant files in [`skills/`](../skills/) consistently produce PRs that miss load-bearing invariants (threading rules, latency-sensitive paths, primitives-before-policy). Load the context first.
+- **You are still the author.** Review the diff before opening the PR. Understand the change well enough to answer review comments. An agent whose operator can't defend its work is a liability; the same change, explained by an operator who actually read it, is a contribution.
+- **Signal agent involvement.** Add a `Co-Authored-By` trailer for the agent(s) that did meaningful work on the commit. It's honest, helps us calibrate review depth, and normalizes the practice.
+- **Read before you write.** Agents that skip [`CLAUDE.md`](../CLAUDE.md), [`PHILOSOPHY.md`](../PHILOSOPHY.md), and the relevant files in [`skills/`](../skills/) consistently produce PRs that miss load-bearing invariants — threading rules, latency-sensitive paths, primitives-before-policy. Load the context first. An extra 30 seconds of reading saves a rejected PR.
 
 ## Point your agent at the right files
 
-Before your agent touches c11 source, make sure it's read these. They're terse, they're accurate, and they save review rounds.
+Before your agent touches c11 source, make sure it's read these. Terse, accurate, and save review rounds.
 
 | File | What it's for | Why your agent needs it |
 |---|---|---|
@@ -37,10 +37,10 @@ We maintain `AGENTS.md` as a symlink to `CLAUDE.md` so both Claude Code and Code
 
 ## The PR flow for agent-authored changes
 
-The flow is identical to the human flow, with two additions:
+Identical to the human flow, with two additions:
 
-1. **Bot review block.** After your agent's latest commit, paste the review-bot trigger block from [`.github/pull_request_template.md`](../.github/pull_request_template.md) as a PR comment. This invokes `@codex`, `@coderabbitai`, `@greptile-apps`, and `@cubic-dev-ai` for independent review. Resolve their feedback (or explain why it's wrong) before requesting human review.
-2. **Validation evidence.** UI changes need a demo video. Behavior changes need enough test output, log snippets, or screenshots in the PR description that a reviewer can confirm the change worked without rebuilding locally. A confident PR description saves everybody time.
+1. **Bot review block.** After your agent's latest commit, paste the review-bot trigger block from [`.github/pull_request_template.md`](../.github/pull_request_template.md) as a PR comment. That invokes `@codex`, `@coderabbitai`, `@greptile-apps`, and `@cubic-dev-ai` for independent review. Resolve what they surface — or explain why they're wrong — before a human reviews.
+2. **Validation evidence.** UI changes get a demo video. Behavior changes get enough test output, log snippets, or screenshots in the PR description that a reviewer can confirm the change worked without rebuilding locally. A confident PR description is a gift to everyone downstream of it.
 
 ## Common failure modes
 
@@ -54,7 +54,7 @@ Patterns we've seen cause PR rework:
 
 ## Tell us what your agent learned
 
-If your agent hit a surprising pothole getting a PR landed — missing documentation, an unclear invariant, a skill file that didn't cover the case — open a small follow-up PR updating the docs. We'd rather fix the onboarding than watch the next agent trip on the same rock.
+If your agent hit a surprising pothole getting a PR landed — missing documentation, an unclear invariant, a skill file that didn't cover the case — open a small follow-up PR updating the docs. We'd rather fix the onboarding than watch the next agent trip on the same rock. One agent's hard-won discovery becomes every agent's baseline.
 
 ## Growing this page
 

--- a/docs/contributing-with-your-agent.md
+++ b/docs/contributing-with-your-agent.md
@@ -1,0 +1,68 @@
+# Contributing to c11 with your agent
+
+c11 is agent-native. It was built with agents, is maintained with agents, and expects to be extended with agents. If you're here to help your agent help us, you're in the right place.
+
+This doc is the agent-specific supplement to [`CONTRIBUTING.md`](../CONTRIBUTING.md). Read that first for the human-facing workflow (setup, hot reload, tests, PR template). This page covers the parts that are specific to having an agent in the driver's seat.
+
+## Ground rules
+
+- **Agent-authored PRs are welcome.** We don't gate on who held the keyboard. We gate on whether the change is correct, tested, and well-shaped.
+- **You are still the author.** Review the diff before opening the PR. Understand the change well enough to answer review comments. An agent that can't be explained by its operator is a liability; a change its operator can defend is a contribution.
+- **Signal agent involvement.** Add a `Co-Authored-By` trailer naming the agent(s) when they did meaningful work on the commit. It's honest, helps us calibrate review depth, and normalizes the practice.
+- **Read before you write.** Agents that skip [`CLAUDE.md`](../CLAUDE.md), [`PHILOSOPHY.md`](../PHILOSOPHY.md), and the relevant files in [`skills/`](../skills/) consistently produce PRs that miss load-bearing invariants (threading rules, latency-sensitive paths, primitives-before-policy). Load the context first.
+
+## Point your agent at the right files
+
+Before your agent touches c11 source, make sure it's read these. They're terse, they're accurate, and they save review rounds.
+
+| File | What it's for | Why your agent needs it |
+|---|---|---|
+| [`CLAUDE.md`](../CLAUDE.md) | Operational guardrails for agents working in this repo | Threading policy, focus-steal policy, latency-sensitive paths, test quality rules, submodule etiquette |
+| [`PHILOSOPHY.md`](../PHILOSOPHY.md) | Why c11 is shaped the way it is | Keeps the agent from proposing features that violate "host and primitive, not intelligence layer" |
+| [`skills/c11/SKILL.md`](../skills/c11/SKILL.md) | How to drive c11 from outside the process | Lets your agent use c11 itself while working — split panes, open a browser to validate, report status |
+| [`skills/c11-hotload/SKILL.md`](../skills/c11-hotload/SKILL.md) | Build / reload loop | Keeps the agent from launching untagged debug builds that collide with your running session |
+| [`skills/release/SKILL.md`](../skills/release/SKILL.md) | Release flow | Only load if the agent is touching release machinery |
+| [`docs/DEVELOPMENT.md`](DEVELOPMENT.md) | Architecture tour | One-screen map of `Sources/` before the agent starts grepping blindly |
+| [`docs/socket-api-reference.md`](socket-api-reference.md) | The socket API every c11 surface speaks | Essential for CLI, browser, or metadata changes |
+
+### Pointing different agents at these files
+
+How you load these into your agent's context is your problem, not c11's (see the "unopinionated about the terminal" principle in [`CLAUDE.md`](../CLAUDE.md)). A few patterns that work:
+
+- **Claude Code** — `CLAUDE.md` and `AGENTS.md` (symlink to `CLAUDE.md`) are auto-loaded from the repo root. For deeper context, have the agent `Read` the linked files on demand. `skills/c11/SKILL.md` can be surfaced via the Skill tool if you have the c11 skill installed globally or per-repo.
+- **Codex CLI** — `AGENTS.md` at the repo root is auto-loaded. For skills and reference docs, instruct the agent to fetch them as needed.
+- **Other agents (Kimi, Gemini, custom)** — pass the file paths in the initial prompt or system message.
+
+We maintain `AGENTS.md` as a symlink to `CLAUDE.md` so both Claude Code and Codex see the same instructions. If you're adding support for a new agent format that expects a different filename, prefer a symlink over a copy — drift between them is a footgun.
+
+## The PR flow for agent-authored changes
+
+The flow is identical to the human flow, with two additions:
+
+1. **Bot review block.** After your agent's latest commit, paste the review-bot trigger block from [`.github/pull_request_template.md`](../.github/pull_request_template.md) as a PR comment. This invokes `@codex`, `@coderabbitai`, `@greptile-apps`, and `@cubic-dev-ai` for independent review. Resolve their feedback (or explain why it's wrong) before requesting human review.
+2. **Validation evidence.** UI changes need a demo video. Behavior changes need enough test output, log snippets, or screenshots in the PR description that a reviewer can confirm the change worked without rebuilding locally. A confident PR description saves everybody time.
+
+## Common failure modes
+
+Patterns we've seen cause PR rework:
+
+- **Missing the tag rule.** The agent runs `xcodebuild` or `open` on an untagged `c11 DEV.app` and hijacks the operator's running socket. Fix: always use `./scripts/reload.sh --tag <branch-slug>`. See [`skills/c11-hotload/SKILL.md`](../skills/c11-hotload/SKILL.md).
+- **Adding main-thread work to a typing path.** `WindowTerminalHostView.hitTest()`, `TabItemView.body`, and `TerminalSurface.forceRefresh()` are called every keystroke. New allocations, `@ObservedObject` bindings, or `DispatchQueue.main.sync` in these spots cause visible typing lag.
+- **Agent-side hook feature requests.** Proposals that require c11 to "ask the agent to write a file" or "call back to Claude" violate the "observe from outside — never hook into agents" principle in [`PHILOSOPHY.md`](../PHILOSOPHY.md). c11 stays agent-agnostic; reach for external observation (`c11 tree`, pane scrollback) plus a small local model instead.
+- **Tests that read source text.** Tests that grep source files or assert on `Info.plist` shape get rejected. Verify observable runtime behavior through real executable paths.
+- **Submodule commits on detached HEAD.** Your agent commits in `ghostty/` without pushing the submodule commit to `manaflow/main` first. The commit is orphaned; the parent pointer references a SHA nobody else can fetch. Push the submodule first, then bump the parent pointer.
+
+## Tell us what your agent learned
+
+If your agent hit a surprising pothole getting a PR landed — missing documentation, an unclear invariant, a skill file that didn't cover the case — open a small follow-up PR updating the docs. We'd rather fix the onboarding than watch the next agent trip on the same rock.
+
+## Growing this page
+
+This doc is the designated growing seam for c11's agent-facing contributor experience. If you find yourself wanting to tell every future agent-operator the same thing, add a section here. Good candidates:
+
+- New agent platforms we've tested contributions from
+- Skill-file patterns that worked well
+- Agent-specific footguns we've seen in PRs
+- Communication conventions (tagging, metadata, log formats) that make multi-agent review smoother
+
+Keep it terse. This is the agent's briefing, not a textbook.


### PR DESCRIPTION
## Summary

Makes it easier for outside humans — and their agents — to contribute to c11. No product changes; all files are text additions (and a voice pass) on the contributor surface.

**Clear gaps filled:**
- `CODE_OF_CONDUCT.md` — rewritten in c11's voice (not the stock Contributor Covenant pledge). Substance retained: be direct/kind, no harassment, enforcement ladder, private reporting to `benevolent.futures@gmail.com`. The Contributor Covenant attribution stays at the bottom for the borrowed ladder structure.
- `SECURITY.md` — private disclosure via GitHub Security Advisories + email fallback, scope, safe harbor.
- `.github/CODEOWNERS` — default owner `@BenevolentFutures`.
- `.github/dependabot.yml` — weekly GitHub Actions updates. Intentionally skipped `gitsubmodule` (ghostty tracks a patched fork, would be noisy).
- `.github/ISSUE_TEMPLATE/config.yml` — replaced broken `manaflow-ai/cmux` Discussions link with this repo's newly enabled Discussions + a private security-advisory link.
- `.github/ISSUE_TEMPLATE/bug_report.yml` — scrubbed stale `c11mux` / `cmux` strings, fixed the nightly URL, bumped the version placeholder to 0.41.0, voice-polished the intro. Field IDs preserved for schema stability.

**Expanded developer docs:**
- `CONTRIBUTING.md` — rewritten: hot-reload loop, PR + review-bot flow, localization expectations, latency-sensitive paths pointer, ghostty submodule etiquette. Clarifies that the "never run tests locally" rule in `CLAUDE.md` is agent-specific (avoids clobbering the operator's live socket), not blanket guidance for human contributors on their own machines.
- `docs/contributing-with-your-agent.md` — new standalone doc, designed as a growing seam. Which files to load into agent context, how `CLAUDE.md` / `AGENTS.md` are picked up by Claude Code / Codex / other agents, the PR flow for agent-authored changes, common failure modes.
- `docs/DEVELOPMENT.md` — new architecture tour: top-level layout, `Sources/` map by area (lifecycle, surface types, panes/workspaces, agent metadata, theme, update, find), CLI + socket pattern, latency-sensitive paths, socket threading, test suite matrix.

**Voice pass (follow-up commit):**
- Second commit on this branch (`126133d1`) rewrites the opening register across the new files so the contributor surface sounds like c11, not a corporate template. Substance and operational detail unchanged; structure unchanged. The Code of Conduct is the biggest change — the Contributor Covenant opening pledge was the wrong register for this project and led with a long protected-class list that read as boilerplate rather than something c11 would author. The enforcement ladder and attribution to Contributor Covenant / Mozilla are retained.

**Repo setting change (not in this diff):**
- GitHub Discussions enabled on the repo. The new `config.yml` contact link now resolves.

## Test plan

- [ ] Visit <https://github.com/Stage-11-Agentics/c11/issues/new/choose> and confirm the Discussions and Security contact links resolve.
- [ ] Confirm GitHub surfaces `SECURITY.md` (the "Report a vulnerability" button appears under Security tab) and `CODE_OF_CONDUCT.md` (link in the Community Standards / Insights view).
- [ ] Confirm `CODEOWNERS` is picked up by auto-assigning `@BenevolentFutures` as a reviewer on any new PR.
- [ ] Dependabot opens a PR on its next weekly run (Monday) — or trigger a manual check via Repo → Insights → Dependency graph → Dependabot.
- [ ] Skim the three expanded docs (`CONTRIBUTING.md`, `docs/contributing-with-your-agent.md`, `docs/DEVELOPMENT.md`) for voice and accuracy against current repo reality.
- [ ] Skim `CODE_OF_CONDUCT.md` for voice match against `PHILOSOPHY.md` and the broader c11 register.

## Review Trigger (Copy/Paste as PR comment)

\`\`\`text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)