### PR TITLE
CLI: fix set-metadata / set-agent defaulting to focused surface

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -8967,9 +8967,14 @@ struct CMUXCLI {
         let workspaceRaw = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowOverride)
         let workspaceId = try normalizeWorkspaceHandle(workspaceRaw, client: client)
 
+        // Only fall back to CMUX_SURFACE_ID when the caller did not explicitly pass
+        // --workspace. workspaceRaw includes the env-derived workspace, so gating
+        // on workspaceRaw == nil defeats the env-surface fallback whenever the
+        // agent is running inside c11 (CMUX_WORKSPACE_ID is always set).
+        let explicitWorkspaceFlag = optionValue(commandArgs, name: "--workspace")
         let surfaceRaw = optionValue(commandArgs, name: "--surface")
             ?? optionValue(commandArgs, name: "--panel")
-            ?? (workspaceRaw == nil && windowOverride == nil
+            ?? (explicitWorkspaceFlag == nil && windowOverride == nil
                 ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
                 : nil)
         let surfaceId = try normalizeSurfaceHandle(

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -84,7 +84,7 @@ Think of the manifest as the extension point for c11: the host provides the surf
 ```bash
 # Write
 c11 set-metadata --json '{"role":"reviewer","task":"lat-412","progress":0.4}'
-c11 set-metadata --key status --value "running" 
+c11 set-metadata --key status --value "running"
 c11 set-metadata --key progress --value 0.6 --type number
 
 # Read
@@ -96,6 +96,13 @@ c11 get-metadata --sources              # include provenance (who wrote each key
 c11 clear-metadata --key task
 c11 clear-metadata                      # clear everything (explicit source only)
 ```
+
+> **Always pass `--surface "$CMUX_SURFACE_ID"` explicitly on surface-write commands** — `set-metadata`, `set-agent`, `set-title`, `set-description`, `rename-tab`, `clear-metadata`, etc. The env-var default is only safe on c11 binaries built after the `fix/set-metadata-env-default` fix; older binaries silently write to whatever surface the *operator* is focused on, which in a multi-surface workspace means you'll stomp a peer agent's metadata instead of your own. Defensive form costs one flag and works on every c11 version.
+>
+> ```bash
+> c11 set-metadata --surface "$CMUX_SURFACE_ID" --key status --value "running"
+> c11 set-title    --surface "$CMUX_SURFACE_ID" "TICKET-42 :: Impl"
+> ```
 
 **Canonical keys** (typed, rendered, size-capped):
 


### PR DESCRIPTION
## Summary

- `c11 set-metadata` (and `set-agent`, `clear-metadata`) silently wrote to the operator's **focused** surface instead of the agent's own surface when `--surface` wasn't passed, even though `CMUX_SURFACE_ID` was set.
- Root cause: `resolveMetadataTarget` in `CLI/c11.swift` gated the env-var surface fallback on `workspaceRaw == nil`, but `workspaceRaw` is populated from `CMUX_WORKSPACE_ID` (always set inside a c11 surface) — so the env-surface fallback was effectively dead code. Sibling handler (`identify`) already uses the correct pattern: check the raw `--workspace` **flag**, not the env-merged value.
- Discovered when an agent in surface:52 called `c11 set-metadata --json '{\"title\":\"...\"}'` and stomped surface:53 (a peer agent's surface).

## Changes

- **`CLI/c11.swift`**: in `resolveMetadataTarget`, check `optionValue(commandArgs, name: \"--workspace\")` (raw flag only) instead of `workspaceRaw` (flag-OR-env) when deciding whether to read `CMUX_SURFACE_ID`.
- **`skills/c11/SKILL.md`**: add defensive guidance telling agents to always pass `--surface \"\$CMUX_SURFACE_ID\"` explicitly on surface-write commands. Works on every c11 version, pre- and post-fix.

## Why the skill update too

Even after the fix ships, agents can't tell which c11 binary is running. The defensive form (`--surface \"\$CMUX_SURFACE_ID\"`) costs one flag and works everywhere — better to bake it into the skill than rely on every agent running a fixed binary.

## Test plan

- [ ] Before the fix (current main), confirm: from a c11 surface, `c11 set-metadata --key title --value \"X\"` (no flags) writes to the focused surface.
- [ ] After the fix, confirm: same call writes to `\$CMUX_SURFACE_ID` (the caller's own surface).
- [ ] `--surface <other>` still targets the specified surface.
- [ ] `--workspace <ws> --surface <sf>` still targets the remote surface (no regression in cross-workspace targeting).
- [ ] `c11 set-agent` picks up the same fix (shares `resolveMetadataTarget`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)