### PR TITLE
C11-7: migrate `c11 notify` to v2 notification methods

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2179,12 +2179,15 @@ struct CMUXCLI {
             let workspaceArg = notifyWsFlag ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceArg = optionValue(commandArgs, name: "--surface") ?? (notifyWsFlag == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
 
-            let targetWorkspace = try resolveWorkspaceId(workspaceArg, client: client)
-            let targetSurface = try resolveSurfaceId(surfaceArg, workspaceId: targetWorkspace, client: client)
+            var params: [String: Any] = ["title": title, "subtitle": subtitle, "body": body]
+            let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
+            if let wsId { params["workspace_id"] = wsId }
+            let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)
+            if let sfId { params["surface_id"] = sfId }
 
-            let payload = "\(title)|\(subtitle)|\(body)"
-            let response = try sendV1Command("notify_target \(targetWorkspace) \(targetSurface) \(payload)", client: client)
-            print(response)
+            let method = sfId != nil ? "notification.create_for_surface" : "notification.create"
+            let payload = try client.sendV2(method: method, params: params)
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
 
         case "list-notifications":
             let response = try sendV1Command("list_notifications", client: client)


### PR DESCRIPTION
## Summary

Closes item 4 of C11-7 (`task_01KPS4FBHSSCCJC3EP43YJ7XMZ`).

The `c11 notify` command was routing through legacy v1 `notify_target`, which hits risky `DispatchQueue.main.sync` paths and was fingered in the 2026-04-21 dogfood as blocking without attribution.

### What changed

`CLI/c11.swift` — the `case "notify":` handler now calls v2 instead of v1:

| Flags provided | v2 method called |
|---|---|
| `--workspace` + `--surface` (or env-var fallbacks) | `notification.create_for_surface` |
| `--workspace` only, no surface | `notification.create` (with `workspace_id`) |
| Neither | `notification.create` (targets focused workspace/surface) |

`notification.create_for_target` is not used here: the CLI has no distinct `--target` flag separate from `--surface`. That variant remains available for direct v2 callers.

The flag/env-var fallback logic for `--workspace` and `--surface` is unchanged. Output now goes through `printV2Payload` matching the pattern of other v2 commands (`send`, `send-key`, etc.).

### Out of scope

- `claude-hook notification/notify` still uses v1 `notify_target` — separate deprecation ticket.
- v1 `notify_target` server-side handler is untouched.
- No bounded-wait/timeout/trace work (sibling agent on `c11-7/bounded-waits`).

### Smoke output

```
$ C11_SOCKET=/tmp/c11-debug-c11-7-v2-notify.sock c11 notify "hello"
OK

$ C11_SOCKET=/tmp/c11-debug-c11-7-v2-notify.sock c11 notify --workspace workspace:1 --surface surface:64 "hello surface"
OK

$ C11_SOCKET=/tmp/c11-debug-c11-7-v2-notify.sock c11 notify --workspace workspace:1 --surface surface:64 --title "C11-7 smoke" --body "v2 notify working"
OK
```

Build: `./scripts/reload.sh --tag c11-7-v2-notify` — **BUILD SUCCEEDED**.

## Related

- C11-7: `task_01KPS4FBHSSCCJC3EP43YJ7XMZ`
- CMUX-37: `task_01KPMTEY4WGECM9MNZ4XARN7Y6`