### PR TITLE
fix: TCCPrimerSheet call site — use renamed init params (unblocks main build)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6320,11 +6320,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.isReleasedWhenClosed = false
         window.level = .modalPanel
         let rootView = TCCPrimerSheet(
-            onGotIt: { [weak window] in
+            onGrantFDA: { TCCPrimer.openFullDiskAccessPane() },
+            onContinueWithout: { [weak window] in
                 UserDefaults.standard.set(true, forKey: TCCPrimer.shownKey)
                 window?.close()
             },
-            onOpenSettings: { TCCPrimer.openFullDiskAccessPane() },
             onDismiss: { [weak window] in window?.close() }
         )
         window.contentView = NSHostingView(rootView: rootView)


### PR DESCRIPTION
## Summary

Main is currently broken: commit `4348d474` (`TCCPrimerView: promote FDA to primary CTA, flip button order, refresh copy`) renamed `TCCPrimerSheet`'s init parameters but did not update the caller in `AppDelegate.swift`. Every Debug build fails with:

```
AppDelegate.swift:6322:38: error: extra arguments at positions #1, #2 in call
```

This PR is the two-line call-site update.

## Rename mapping (semantic-preserving)

| Old param | New param | Handler intent |
|---|---|---|
| `onGotIt` | `onContinueWithout` | sets `shownKey` + closes window |
| `onOpenSettings` | `onGrantFDA` | opens Full Disk Access pane (does not close) |
| `onDismiss` | `onDismiss` | closes window |

This matches how the new view wires its buttons — the primary "Grant FDA" CTA fires `onGrantFDA`; the secondary "Continue Without" fires `onContinueWithout`; Escape / programmatic dismiss fires `onDismiss`.

## Build

`xcodebuild -project GhosttyTabs.xcodeproj -scheme c11 -configuration Debug -destination 'platform=macOS' build` → **BUILD SUCCEEDED**, zero errors.

## Why this wasn't caught

The rename was a one-file commit that didn't touch the call site. No CI gate on `xcodebuild` for that commit slipped through.

## Blocks

C11-7 (`task_01KPS4FBHSSCCJC3EP43YJ7XMZ`) — the bounded-waits / named-timeout / trace-mode PR can't land until main compiles. Ready to push the moment this merges.

## Related

- C11-7: `task_01KPS4FBHSSCCJC3EP43YJ7XMZ`
- CMUX-37: `task_01KPMTEY4WGECM9MNZ4XARN7Y6` (the big one C11-7 feeds)