### PR TITLE
CMUX-37 Phase 0: WorkspaceApplyPlan + WorkspaceLayoutExecutor

### DIFF
--- a/.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md
+++ b/.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md
@@ -201,3 +201,294 @@ Restore preserves CMUX-11 pane manifests + CMUX-14 lineage chains verbatim.
 
 - `sanghun0724/cmux-claude-skills` — private session JSON + spinner-char detection + fuzzy ID matching. We use the public manifest.
 - `drolosoft/cmux-resurrect` (crex) — community save/restore for upstream `manaflow-ai/cmux`, adjacent design. Inspired the Blueprint/Snapshot naming. c11 keeps the primitive narrower; templates/REPL/daemon stay ecosystem territory.
+
+---
+
+## Phase 0 Implementation Plan (2026-04-24)
+
+*Agent:* `agent:claude-opus-4-7-cmux-37-plan`. Scope is the `WorkspaceApplyPlan` value type and the app-side `WorkspaceLayoutExecutor` only — no Blueprints, Snapshots, restart registry, or CLI sugar beyond the one debug entry point. Later phases build on top.
+
+### 1. Value types
+
+All new types live in a single new file **`Sources/WorkspaceApplyPlan.swift`**, with small extensions added to existing stores where noted. Types are `Codable, Sendable, Equatable` unless noted.
+
+**Reuse `PersistedJSONValue` as the metadata value flavor.** It already exists at `Sources/PersistedMetadata.swift:10` with the exact shape we need (`string | number | bool | array | object | null`), already round-trips through `PaneMetadataStore` and `SurfaceMetadataStore` via the `PersistedMetadataBridge` at `Sources/PersistedMetadata.swift:77-307`, and already composes with `SessionWorkspaceLayoutSnapshot` at `Sources/SessionPersistence.swift:331` / `:379`. Introducing a second JSON flavor would force a conversion layer at exactly the boundaries that are load-bearing for the executor. Per the C11-13 alignment doc (`docs/c11-13-cmux-37-alignment.md`:49-55) **v1 only writes `.string(...)` values**; the executor fails fast with a typed warning on non-string values in reserved pane keys, but the codable shape stays JSON-complete so v1.1+ can ship structured values without a schema migration. No new `JSONValue`/`AnyCodable` — if the codebase later grows a canonical alias, `typealias WorkspaceJSONValue = PersistedJSONValue` is the follow-up.
+
+```swift
+// Sources/WorkspaceApplyPlan.swift
+
+struct WorkspaceApplyPlan: Codable, Sendable, Equatable {
+    var version: Int                    // Phase 0 ships `1`; bumped on breaking schema changes
+    var workspace: WorkspaceSpec
+    var layout: LayoutTreeSpec          // nested, mirrors SessionWorkspaceLayoutSnapshot
+    var surfaces: [SurfaceSpec]         // keyed by SurfaceSpec.id; referenced from LayoutTreeSpec leaves
+}
+
+struct WorkspaceSpec: Codable, Sendable, Equatable {
+    var title: String?                  // becomes Workspace.customTitle via setCustomTitle (Sources/Workspace.swift:5383+)
+    var customColor: String?            // hex, e.g. "#C0392B" — matches Workspace.customColor at :4976
+    var workingDirectory: String?       // passed to TabManager.addWorkspace (Sources/TabManager.swift:1139)
+    /// Operator-authored workspace-level metadata. Matches the existing
+    /// `SessionWorkspaceSnapshot.metadata: [String: String]?` shape at
+    /// `Sources/SessionPersistence.swift:447`. Strings-only per C11-13 alignment.
+    var metadata: [String: String]?
+}
+
+enum SurfaceSpecKind: String, Codable, Sendable, Equatable {
+    case terminal
+    case browser
+    case markdown
+}
+
+struct SurfaceSpec: Codable, Sendable, Equatable {
+    var id: String                      // plan-local stable id, referenced from LayoutTreeSpec.pane.surfaceIds
+    var kind: SurfaceSpecKind
+    var title: String?                  // applied via setPanelCustomTitle (Sources/Workspace.swift:5854)
+    var description: String?            // applied via SurfaceMetadataStore key "description" (reserved; Sources/SurfaceMetadataStore.swift:143-152)
+    var workingDirectory: String?       // terminal: passed to newTerminalSurface/newTerminalSplit
+    var command: String?                // terminal: sent via TerminalPanel.sendText after surface ready
+    var url: String?                    // browser: passed to newBrowserSplit(url:)/newBrowserSurface(url:)
+    var filePath: String?               // markdown: passed to newMarkdownSplit(filePath:)
+    /// Surface metadata — routes through SurfaceMetadataStore.setMetadata at
+    /// Sources/SurfaceMetadataStore.swift:245. Writer source is `.explicit`.
+    var metadata: [String: PersistedJSONValue]?
+    /// Pane metadata — routes through PaneMetadataStore.setMetadata at
+    /// Sources/PaneMetadataStore.swift:59. The `mailbox.*` namespace is
+    /// reserved per docs/c11-13-cmux-37-alignment.md; executor writes values
+    /// verbatim with source `.explicit`. Strings-only in v1; any non-string
+    /// value on a `mailbox.*` key surfaces as a warning in ApplyResult.
+    var paneMetadata: [String: PersistedJSONValue]?
+}
+
+/// Mirrors `SessionWorkspaceLayoutSnapshot` (Sources/SessionPersistence.swift:394-428)
+/// so Phase 1 Snapshot capture is a structural copy. `SessionSplitOrientation` at
+/// Sources/SessionPersistence.swift:337 and `SplitOrientation` from Bonsplit are
+/// the two sides of the translation.
+indirect enum LayoutTreeSpec: Codable, Sendable, Equatable {
+    case pane(PaneSpec)
+    case split(SplitSpec)
+
+    private enum CodingKeys: String, CodingKey { case type, pane, split }
+
+    struct PaneSpec: Codable, Sendable, Equatable {
+        /// Plan-local surface ids referenced into `WorkspaceApplyPlan.surfaces`.
+        /// Order matches tab order in the pane. At least one entry required.
+        var surfaceIds: [String]
+        /// Index into `surfaceIds` of the initially selected tab. Defaults to 0.
+        var selectedIndex: Int?
+    }
+
+    struct SplitSpec: Codable, Sendable, Equatable {
+        var orientation: Orientation
+        var dividerPosition: Double     // 0...1, mirrors SessionSplitLayoutSnapshot.dividerPosition
+        var first: LayoutTreeSpec
+        var second: LayoutTreeSpec
+
+        enum Orientation: String, Codable, Sendable, Equatable {
+            case horizontal
+            case vertical
+        }
+    }
+}
+
+struct ApplyOptions: Codable, Sendable, Equatable {
+    /// Select + foreground the created workspace once ready. Defaults true
+    /// so the debug CLI behaves like `workspace.create`. Passed through to
+    /// `TabManager.addWorkspace(select:)`.
+    var select: Bool = true
+    /// Per-step deadline guard. If any StepTiming exceeds it, the executor
+    /// writes a warning but continues — partial-failure semantics, not
+    /// hard-abort. A zero value disables the guard. Default: 2_000 ms, matching
+    /// the acceptance target.
+    var perStepTimeoutMs: Int = 2_000
+    /// Hint for the acceptance fixture: bypass the welcome/default-grid
+    /// auto-spawn by calling addWorkspace(autoWelcomeIfNeeded: false).
+    /// Executor always sets this to `false`; the field exists for future
+    /// callers (Phase 1 restore) that may want it.
+    var autoWelcomeIfNeeded: Bool = false
+}
+
+struct ApplyResult: Codable, Sendable, Equatable {
+    /// Assigned workspace ref in the live ref scheme (`workspace:N`). Populated
+    /// from `TabManager.workspaceRef(for:)` post-addWorkspace.
+    var workspaceRef: String
+    /// Parallel arrays in plan-surface-id order: the ref the executor minted
+    /// for each SurfaceSpec.id. `surfaceRefs[i]` corresponds to
+    /// `plan.surfaces[i].id`. Empty for any surface whose creation failed;
+    /// the failure surfaces in `warnings`.
+    var surfaceRefs: [String: String]   // plan-local surface id → "surface:N"
+    var paneRefs: [String: String]      // plan-local surface id → "pane:N" of the pane that hosts it
+    var timings: [StepTiming]
+    var warnings: [String]
+    /// Subset of warnings carrying a machine-readable code for later phases
+    /// (Snapshot restore in particular). Strings-only in the `message` leg so
+    /// the v2 socket response stays JSON-clean.
+    var failures: [ApplyFailure]
+}
+
+struct StepTiming: Codable, Sendable, Equatable {
+    var step: String                    // "workspace.create", "surface[main].create", "metadata.surface.write", "metadata.pane.write", "layout.split[0].create", "total"
+    var durationMs: Double
+}
+
+struct ApplyFailure: Codable, Sendable, Equatable {
+    var code: String                    // "surface_create_failed" | "metadata_write_failed" | "split_failed" | "unknown_surface_ref" | "mailbox_non_string_value"
+    var step: String                    // matches a StepTiming.step
+    var message: String
+}
+```
+
+**Rationale for shape choices (cited):**
+
+- `WorkspaceSpec.metadata: [String: String]?` matches `SessionWorkspaceSnapshot.metadata` at `Sources/SessionPersistence.swift:447` exactly — Phase 1 Snapshot restore becomes a one-line assignment.
+- `SurfaceSpec.metadata` / `SurfaceSpec.paneMetadata` use `[String: PersistedJSONValue]?`, which is the same shape `SessionPanelSnapshot.metadata` (`Sources/SessionPersistence.swift:331`) and `SessionPaneLayoutSnapshot.metadata` (`Sources/SessionPersistence.swift:379`) already carry. The executor decodes via `PersistedMetadataBridge.decodeValues` (`Sources/PersistedMetadata.swift:171`) before handing the `[String: Any]` to the stores.
+- `LayoutTreeSpec` mirrors `SessionWorkspaceLayoutSnapshot` keys and orientation enum so `Phase 1 Snapshot.capture` is `SessionWorkspaceLayoutSnapshot → LayoutTreeSpec` via a 20-line translator, not a rewrite.
+- `ApplyResult.surfaceRefs`/`paneRefs` map plan-local ids → live refs, making Blueprint/Snapshot re-materialization straightforward in Phase 1 without leaking live UUIDs into the persisted format.
+
+### 2. File layout
+
+**New files:**
+
+- `Sources/WorkspaceApplyPlan.swift` — value types (section 1). Single file, ~250 LOC including Codable boilerplate. No behavior.
+- `Sources/WorkspaceLayoutExecutor.swift` — the `@MainActor` executor (section 3). ~400 LOC including diagnostics.
+- `c11Tests/WorkspaceApplyPlanCodableTests.swift` — round-trip Codable tests for every value type, including a mixed-kind LayoutTreeSpec and `mailbox.*` keys in `paneMetadata`. Pure struct tests, no AppKit — runs in the existing `c11Tests` target (registered under `F1000004A1B2C3D4E5F60718` in `GhosttyTabs.xcodeproj/project.pbxproj:834`).
+- `c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift` — the 5-workspace acceptance fixture (section 6). Runs through the executor on a real `TabManager`; uses existing test harness patterns from `DefaultGridSettingsTests.swift` and `MetadataPersistenceRoundTripTests.swift`.
+- `c11Tests/Fixtures/workspace-apply-plans/` — one JSON per workspace in the acceptance set, decoded via `JSONDecoder`. Human-readable; doubles as Phase 2 Blueprint reference material.
+
+**Modified files:**
+
+- `Sources/Workspace.swift` — no new split primitive. Add one internal helper `func paneIdForPanel(_ panelId: UUID) -> PaneID?` alongside `surfaceIdFromPanelId` at `Sources/Workspace.swift:5599` (the inline loop inside `newTerminalSplit` at `:7215-7223` already does this; extract it so the executor can resolve the pane of a just-created panel without re-walking). Small refactor, keeps existing call sites unchanged.
+- `Sources/TabManager.swift` — add `func workspaceRef(for workspaceId: UUID) -> String?` if one doesn't already exist; otherwise reuse the v2 ref minting used by `workspace.create` at `Sources/TerminalController.swift:2066` (`v2WorkspaceCreate` is the anchor). Grep the v2 handler to find the canonical ref helper before adding a duplicate.
+- `Sources/c11App.swift` at lines `3983-4040` (`WelcomeSettings.performQuadLayout`) and `4042-4141` (`DefaultGridSettings.performDefaultGrid`) — **keep today's call sites as-is** (partial migration; see section 5). Add one `// TODO(CMUX-37 Phase 0+): migrate to WorkspaceLayoutExecutor once the executor supports post-create-on-existing-workspace mode.` comment on each.
+- `Sources/TerminalController.swift` — register one new v2 handler `case "workspace.apply":` in the switch starting at `Sources/TerminalController.swift:2062` (register immediately after the existing workspace commands, e.g. after `workspace.clear_metadata` at `:2101`). Handler decodes `WorkspaceApplyPlan` from params, calls `WorkspaceLayoutExecutor.apply`, returns `ApplyResult` as a JSON dict. This is the **debug/test surface only** for Phase 0; the CLI wiring (`c11 workspace apply --file <path>`) is a one-command add in `CLI/c11.swift` near the existing `workspace.create` call at `:1724` but is **optional** for Phase 0 — the acceptance fixture drives the executor through a direct call, so the socket surface can slip to Phase 1 if Impl is scope-constrained. If shipped in Phase 0, keep the CLI one-liner minimal: read file → `sendV2(method: "workspace.apply", params: [...])` → pretty-print result.
+
+Nothing else changes. No new Swift package, no new target, no Resources changes.
+
+### 3. Executor walk — `WorkspaceLayoutExecutor.apply(_:options:) async -> ApplyResult`
+
+Single `@MainActor` function. Numbered steps; each wraps a timing record.
+
+1. **Validate plan locally (no AppKit).** Walk `plan.surfaces` for duplicate `id`s, walk `plan.layout` for unknown surface id references, reject empty panes. Validation failures short-circuit to `ApplyResult` with the workspace never created; `failures` names the bad id. No partial workspace is ever created on a validation error. Timing step: `"validate"`.
+2. **Create workspace.** Call `TabManager.shared.addWorkspace(workingDirectory: plan.workspace.workingDirectory, initialTerminalCommand: nil, select: options.select, eagerLoadTerminal: false, autoWelcomeIfNeeded: options.autoWelcomeIfNeeded)` (`Sources/TabManager.swift:1138`). Critical: **pass `autoWelcomeIfNeeded: false`** so the executor never collides with welcome/default-grid auto-spawns — those are Phase 0+5 migration targets, not executor dependencies. Capture the returned `Workspace`. Apply `plan.workspace.title` via `workspace.setCustomTitle` and `plan.workspace.customColor` via `workspace.setCustomColor` (existing setters at `Sources/Workspace.swift:6019+`). Timing step: `"workspace.create"`.
+3. **Apply workspace-level metadata.** For each `(key, value)` in `plan.workspace.metadata`, mirror whatever persistence path `SessionWorkspaceSnapshot.metadata` uses today (confirmed via `Sources/SessionPersistence.swift:447` round-trip; if it's a dedicated setter, call it — if it's direct dictionary assignment on `Workspace`, proxy through a new `Workspace.setOperatorMetadata(key:value:)` helper that mirrors `setPanelCustomTitle`'s shape). Timing step: `"metadata.workspace.write"`.
+4. **Seed root pane with the first leaf's initial surface.** `TabManager.addWorkspace` always creates a seed `TerminalPanel` in a single root pane. Walk `plan.layout` and find the first leaf (`LayoutTreeSpec.pane`); its first `surfaceId` maps onto that seed panel:
+   - If the first surface is `.terminal`, **reuse** the seed. Rename via `setPanelCustomTitle` and apply metadata (step 6).
+   - If the first surface is `.browser` or `.markdown`, **replace** the seed: open the target kind in the same pane via `newBrowserSurface` / `newMarkdownSurface` equivalent in-pane creation (no `newXSplit` — those create a new pane), then close the seed terminal panel. Open question in section 9.
+   This keeps the invariant "one pane per LayoutTreeSpec.pane node" without an extra seed pane.
+5. **Walk the layout tree and materialize splits.** Depth-first traversal. For each `LayoutTreeSpec.split` encountered:
+   - Pick the "parent" panel = the tail of whatever the `first` subtree resolves to (for `split.first` we descend into `first` and remember the last panel id we created there; for `split.second` we split off that panel).
+   - Call `workspace.newTerminalSplit(from: parentPanelId, orientation: split.orientation, insertFirst: false, focus: false)` (`Sources/Workspace.swift:7208`) — or `newBrowserSplit` (`:7408`) / `newMarkdownSplit` (`:7568`) depending on the first surface kind of the leaf we're creating inside the new pane. `focus: false` is mandatory — the executor does not steal focus per `CLAUDE.md` socket focus policy.
+   - Apply the `split.dividerPosition` via whatever bonsplit setter already exists (grep `dividerPosition` / `divider_position` in `Sources/Workspace.swift` — likely `bonsplitController.setDividerPosition(paneId:position:)` or similar; if it doesn't exist, file a small follow-up and accept default in Phase 0).
+   - For each additional `surfaceId` in the pane (`surfaceIds.count > 1`): call `workspace.newTerminalSurface(inPane:)` (`:7327`) / `newBrowserSurface` (`:7495`) / equivalent markdown in-pane create. Apply title/metadata.
+   - Apply `PaneSpec.selectedIndex` via the existing tab-select path (`bonsplitController.selectTab` is the final call in both split primitives today — expose the tab id and call it).
+   - Timing steps: `"layout.split[<index>].create"` per split, `"surface[<planId>].create"` per surface.
+6. **Apply surface + pane metadata during creation.** Immediately after each surface's panel exists (still inside step 4/5, not as a post-hoc second pass):
+   - **Surface title** (if set): `workspace.setPanelCustomTitle(panelId:title:)` at `Sources/Workspace.swift:5854`. This already writes the canonical `title` key into `SurfaceMetadataStore` (`:5872-5878`) — no double-write.
+   - **Surface description** (if set): `SurfaceMetadataStore.shared.setMetadata(workspaceId: workspace.id, surfaceId: panelId, partial: ["description": trimmed], mode: .merge, source: .explicit)` — `description` is already in the reserved key set at `Sources/SurfaceMetadataStore.swift:143-152` and validates as a string.
+   - **Rest of surface metadata**: for every `(key, value)` in `surfaceSpec.metadata` besides `title`/`description` (which the above two already wrote), decode via `PersistedMetadataBridge.decodeValues([key: value])` (`Sources/PersistedMetadata.swift:171`) and call `SurfaceMetadataStore.shared.setMetadata(..., mode: .merge, source: .explicit)`. Keys that collide with `title`/`description` take the explicit `metadata` value and emit an `ApplyFailure("metadata_override")` warning — the spec is ambiguous if a caller sets both.
+   - **Pane metadata**: resolve the panel's hosting pane via the new `paneIdForPanel` helper (section 2 modifications). For every `(key, value)` in `surfaceSpec.paneMetadata`, decode and call `PaneMetadataStore.shared.setMetadata(workspaceId: workspace.id, paneId: paneId, partial: [key: decoded], mode: .merge, source: .explicit)` (`Sources/PaneMetadataStore.swift:59`). **v1 strings-only contract:** before decoding, if `key` matches `^mailbox\.` and `value` is not `.string`, append an `ApplyFailure("mailbox_non_string_value", ...)` warning and skip the write. The surface is still created; only the offending key is dropped. Per alignment doc `docs/c11-13-cmux-37-alignment.md:49-55`.
+   - Timing steps: `"metadata.surface[<planId>].write"` and `"metadata.pane[<planId>].write"` rolled up per surface.
+7. **Apply terminal initial command.** For each terminal surface where `command` is set, schedule a `sendText` via the existing `TerminalPanel.sendText` path — it already auto-queues pre-surface-ready and flushes on ready (`Sources/c11App.swift:3997-3999` documents this behavior for `performQuadLayout`). The executor does not `await` surface readiness; that's Phase 1's `readiness: ready` pass. Timing step: `"surface[<planId>].command.enqueue"`.
+8. **Assemble refs.** For each `SurfaceSpec`, mint `surface:N` and `pane:N` via the same v2 ref helper `workspace.create` uses (`Sources/TerminalController.swift:2066`). Build `ApplyResult.surfaceRefs` / `paneRefs` keyed by plan-local `SurfaceSpec.id`. Mint `workspaceRef`. Timing step: `"refs.assemble"`.
+9. **Return.** Emit `StepTiming("total", ...)` covering the full `apply()` duration and return `ApplyResult`.
+
+**Partial-failure handling lives in step 5 and step 6.** A failed split (e.g., bonsplit rejects the geometry) appends an `ApplyFailure("split_failed", step: "layout.split[<i>].create", ...)`, skips the subtree rooted at that split, and continues with the next peer split. A failed metadata write appends `ApplyFailure("metadata_write_failed", ...)` but the surface stays alive. The workspace itself is **never rolled back** — leaving a partial workspace on-screen is better UX than a silent disappear, and matches today's `performDefaultGrid` truncate-on-failure behavior (`Sources/c11App.swift:4100-4116`).
+
+### 4. Metadata write path — summary table
+
+| Plan field | Store | API | Source | When |
+|---|---|---|---|---|
+| `WorkspaceSpec.metadata` | `Workspace.metadata` (matches `SessionWorkspaceSnapshot.metadata` at `SessionPersistence.swift:447`) | direct or new `Workspace.setOperatorMetadata` helper | `.explicit` | step 3, right after workspace create |
+| `SurfaceSpec.title` | `SurfaceMetadataStore` key `title` | `workspace.setPanelCustomTitle` at `Workspace.swift:5854` (already writes the canonical key) | `.explicit` | step 6, during surface creation |
+| `SurfaceSpec.description` | `SurfaceMetadataStore` key `description` | `SurfaceMetadataStore.shared.setMetadata(..., .merge, .explicit)` at `SurfaceMetadataStore.swift:245` | `.explicit` | step 6, during surface creation |
+| `SurfaceSpec.metadata[*]` | `SurfaceMetadataStore` | `setMetadata(..., .merge, .explicit)` | `.explicit` | step 6, during surface creation |
+| `SurfaceSpec.paneMetadata[*]` | `PaneMetadataStore` | `setMetadata(..., .merge, .explicit)` at `PaneMetadataStore.swift:59` | `.explicit` | step 6, during surface creation |
+| `SurfaceSpec.paneMetadata["mailbox.*"]` | `PaneMetadataStore` | same as above; strings only; executor-level type guard drops non-string values with a warning | `.explicit` | step 6 |
+
+**All writes happen during creation, not after.** No post-hoc `c11 set-metadata` round trip, no socket call loop. This matches the locked composition convention in `docs/c11-13-cmux-37-alignment.md:58-65`.
+
+**`mailbox.*` round-trip invariant.** The executor never rewrites, normalizes, or validates `mailbox.*` keys beyond the string-value type guard. Blueprints and Snapshots can carry `mailbox.delivery = "stdin,watch"`, `mailbox.subscribe = "build.*,deploy.green"`, `mailbox.retention_days = "7"` verbatim. The executor decodes `.string(s)` → `s` and hands it to `PaneMetadataStore.setMetadata`. v1.1+ values stay strings (comma-separated lists, stringified ints) until the joint schema migration described in the alignment doc (`:49-55`).
+
+**Strings-only contract today.** If `PaneMetadataStore` later grows native structured values, the executor's decode step (`PersistedMetadataBridge.decodeValues`) already round-trips arrays/objects — no executor change needed at that migration.
+
+### 5. Welcome-quad / default-grid migration
+
+**Scope call for Phase 0: design the executor so both can converge; migrate neither today.** Both call sites are load-bearing on app startup and ship with behavioral tests (`DefaultGridSettingsTests.swift`). A migration that reshapes startup sequencing risks regressions that Phase 0 isn't set up to catch (no local-run path per `CLAUDE.md`; E2E must go through `gh workflow run test-e2e.yml`). Phase 0 ships the primitive; migration lands in a follow-up.
+
+**Welcome-quad (`Sources/c11App.swift:3983-4040`):**
+- (a) Lives at `WelcomeSettings.performQuadLayout(on:initialPanel:)`, called by `TabManager.addWorkspace` indirectly via `sendWelcomeCommandWhenReady` (`TabManager.swift:1213`) once the initial Ghostty surface is ready.
+- (b) **Not migrated in Phase 0.** Both call sites unchanged.
+- (c) TODO comment at line 4000, above `performQuadLayout`:
+  ```
+  // TODO(CMUX-37 Phase 0+): express the quad as a WorkspaceApplyPlan and
+  // apply via WorkspaceLayoutExecutor. The current implementation runs on an
+  // already-created workspace with a live terminal panel; the executor
+  // assumes workspace-creation responsibility. Migration path: extend
+  // WorkspaceLayoutExecutor with an `applyTo(existing:Workspace)` overload
+  // that skips step 2 and reuses the seed panel.
+  ```
+- (d) **Risk to startup behavior: none.** No edit to this function in Phase 0.
+
+**Default-grid (`Sources/c11App.swift:4042-4141`):**
+- (a) Lives at `DefaultGridSettings.performDefaultGrid(on:initialPanel:)`, called by `TabManager.spawnDefaultGridWhenReady` (`TabManager.swift:1290-1292`) and `AppDelegate.spawnDefaultGridWhenReady` (`AppDelegate.swift:6349-6351`).
+- (b) **Not migrated in Phase 0.** Same rationale.
+- (c) TODO comment at line 4082, above `performDefaultGrid`:
+  ```
+  // TODO(CMUX-37 Phase 0+): express the 2x2 grid as a WorkspaceApplyPlan
+  // driven by DefaultGridSettings.gridSplitOperations(). Gated on the
+  // apply-to-existing-workspace overload. Remote-workspace guard at
+  // line 4089 must move into the executor or stay at the call site.
+  ```
+- (d) **Risk to startup behavior: none.** No edit to this function in Phase 0.
+
+**Executor design bar that enables migration.** The `apply(_:options:)` signature stays creation-centric, but the internal layout walk (steps 4-5) is written against `Workspace` as an injected reference — not a freshly-minted one. Adding an `applyToExistingWorkspace(_ plan: WorkspaceApplyPlan, workspace: Workspace, seedPanel: TerminalPanel?) async -> ApplyResult` in the follow-up is purely a public-API extension, not a refactor. Phase 0's acceptance fixture validates that the creation-centric path reproduces the welcome-quad and default-grid shapes exactly (see section 6).
+
+### 6. Acceptance fixture
+
+**Location:** `c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift`. Runs in the existing `c11Tests` target (`GhosttyTabs.xcodeproj/project.pbxproj:834`). JSON fixtures at `c11Tests/Fixtures/workspace-apply-plans/*.json`.
+
+**Structure:** One `XCTestCase` with five `async` test methods, each materializing one `WorkspaceApplyPlan` through `WorkspaceLayoutExecutor.apply` on a real `TabManager` instance (no mocks — per `CLAUDE.md` test policy, real runtime behavior only). The five workspaces cover the matrix:
+
+1. `welcome-quad.json` — TL terminal + TR browser + BL markdown + BR terminal; mirrors `performQuadLayout` exactly. Asserts the resulting pane tree matches a structural fingerprint.
+2. `default-grid.json` — 2x2 all-terminal. Mirrors `performDefaultGrid`.
+3. `single-large-with-metadata.json` — one terminal surface; surface metadata carries `{role: "driver", status: "ready", task: "cmux-37"}`; pane metadata carries `{"mailbox.delivery": "stdin,watch", "mailbox.subscribe": "build.*"}`; asserts post-apply store reads round-trip the values.
+4. `mixed-browser-markdown.json` — browser + markdown side-by-side + two terminal panes below; exercises mid-tree browser/markdown creation.
+5. `deep-nested-splits.json` — 4-level nested splits with mixed orientations; exercises the depth-first layout walker, dividerPosition application, and parent-panel bookkeeping.
+
+**One consolidated acceptance test** drives the full 5-workspace set through **one loop** and asserts `sum(StepTiming.durationMs) < 2_000` for each workspace individually. This is the fixture referenced in the plan's "Performance / reliability acceptance" section (`:181-185`). Per-step timings from `ApplyResult.timings` emit as XCTest `XCTPerformanceMetric` measurements so CI can track regressions.
+
+**Invocation under CI:** runs as part of the unit test target in `ci.yml` (the existing `c11-unit` scheme; path verified via `project.pbxproj:834-849`). **Per `CLAUDE.md` the impl agent never runs tests locally** — `xcodebuild -scheme c11-unit` is only safe for CI. UI/E2E layer runs via `gh workflow run test-e2e.yml` (workflow at `.github/workflows/test-e2e.yml:1`) with `test_filter=WorkspaceLayoutExecutorAcceptanceTests`. Validation is CI-only; the plan's impl agent commits the fixture and triggers the workflow, never runs it locally.
+
+**Acceptance gate for CI:** the workflow's pass criterion is `total < 2_000 ms` across all five fixtures run sequentially on a clean macos-15 runner. Fail-fast: if any single fixture exceeds `ApplyOptions.perStepTimeoutMs`, the warning lands in `ApplyResult.warnings` and the XCTAssert on that fixture fails with the named step in the message.
+
+### 7. Order of implementation (commit boundaries)
+
+Eight commits, each leaving the tree green:
+
+1. **Add `Sources/WorkspaceApplyPlan.swift`** with value types only. Add `WorkspaceApplyPlanCodableTests.swift` with round-trip Codable tests (including `mailbox.*` keys). No executor yet. Tree builds; tests pass in CI.
+2. **Extract `Workspace.paneIdForPanel(_:)` helper** (refactor of the inline loop in `newTerminalSplit`/`newBrowserSplit`/`newMarkdownSplit` at `Sources/Workspace.swift:7215-7223` and siblings). No behavior change. One-line callers update.
+3. **Add `WorkspaceLayoutExecutor.swift` skeleton** — signature + step 1 validation + step 2 workspace creation + step 3 workspace metadata. Returns a stub `ApplyResult` with only workspace-level fields populated. `paneRefs`/`surfaceRefs` empty.
+4. **Implement layout walker (steps 4-5)** — seed-panel handoff, DFS traversal, split primitives, in-pane surface creation. Still no metadata writes at surface level.
+5. **Implement metadata writes (step 6)** — surface + pane, including the `mailbox.*` string-value guard.
+6. **Implement terminal initial command + refs assembly (steps 7-8)** — `sendText` for terminals + `surfaceRefs`/`paneRefs` minting. `ApplyResult` fully populated.
+7. **Add TODO comments to welcome-quad and default-grid** (section 5). Two-file change, documentation only.
+8. **Add acceptance fixture + 5 JSON plans** (`c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift` + `c11Tests/Fixtures/workspace-apply-plans/*.json`). Optional commit 8b: add `case "workspace.apply":` v2 handler in `TerminalController.swift` + minimal `c11 workspace apply --file` CLI wiring in `CLI/c11.swift`. This is the observable socket surface; can slip to Phase 1 without breaking the executor.
+
+Each commit carries the `CMUX-37 Phase 0:` prefix and references the specific deliverable from the plan file. Per the global policy in `~/.claude/CLAUDE.md`, push on clean forward motion; open PR once commit 8 (or 8b) lands.
+
+### 8. Alignment with C11-13
+
+**Locked contract reaffirmed.** The executor addresses surfaces by **surface name** (via `SurfaceSpec.title` → `panelCustomTitles` → `SurfaceMetadataStore["title"]`), never by the process-local `surface:N` ref. Plan-local `SurfaceSpec.id` is a temporary handle used only during `apply()` and never persisted beyond `ApplyResult`. The `mailbox.*` namespace round-trips through `SurfaceSpec.paneMetadata` unmodified; the executor's only contribution is the strings-only type guard (alignment doc `:49-55`). `c11 mailbox configure` (C11-13's CLI) remains a separate runtime mutation path through the existing `set_metadata` socket method — **not** routed through `workspace.apply`. The executor is a creation primitive; C11-13's CLI is a post-creation mutation primitive. They share the store and the namespace, not the code path. This stays true through all of Phase 0 and does not change in later phases.
+
+### 9. Risks / open questions
+
+1. **Seed-panel replacement for non-terminal root leaves (step 4).** `TabManager.addWorkspace` always mints a `TerminalPanel` for the root pane (`TabManager.swift:1158-1166`). If `plan.layout` roots with a `LayoutTreeSpec.pane` whose first surface is `browser` or `markdown`, the executor must either (a) close the seed terminal and open the target kind in the same pane, or (b) add a `TabManager.addWorkspaceWithoutSeed` path. **Recommendation:** (a) in Phase 0 — simpler, no TabManager change, one extra panel mint+close per workspace. **Needs_human trigger:** only if operator wants to avoid the visible flash of the seed terminal; if so, (b) is a small TabManager change. Default to (a); reconsider if the acceptance fixture shows a visible flash.
+2. **`dividerPosition` API surface.** Phase 0 plan mentions applying `split.dividerPosition` but bonsplit's divider-position setter is not yet cited in this plan. If `bonsplitController` exposes `setDividerPosition(paneId:position:)` (or equivalent), wire it; if not, Phase 0 accepts the default 50/50 and files a follow-up. **Not a blocker** — Phase 1 Snapshot restore will need it, at which point the gap is obvious.
+3. **Focus behavior.** `ApplyOptions.select` defaults true so the debug CLI matches `workspace.create`. The **socket focus policy** in `CLAUDE.md` forbids non-focus-intent commands from stealing focus. `workspace.apply` is *intent-bearing* (it created the workspace), so selecting is consistent with `workspace.create`. All internal split calls pass `focus: false` and `autoWelcomeIfNeeded: false` to avoid compounding focus moves. **No human decision needed unless the Impl agent observes focus thrash during the acceptance run.**
+4. **Typing-latency hot paths untouched.** `TerminalWindowPortal.hitTest()`, `TabItemView`, and `GhosttyTerminalView.forceRefresh()` are not on the executor's write path. The executor invokes existing split primitives that already respect these invariants; no new allocation or observation is added inside their bodies. This is a confirmation, not a risk — flagged explicitly because the Impl agent might be tempted to add timing breadcrumbs inside one of those paths. **Don't.** Breadcrumbs live in the executor, not inside split primitives or terminal-refresh hot loops.
+5. **`c11 install <tui>` and wrapper generalization — NOT proposed.** Per `CLAUDE.md` c11-is-unopinionated-about-the-terminal principle, Phase 0 does not touch `Resources/bin/claude`, does not add per-agent wrappers, and does not write to any tenant config. `WorkspaceApplyPlan` is app-internal; the debug CLI `c11 workspace apply --file` reads from a path the operator supplies.
+6. **Socket method + CLI in Phase 0 or Phase 1?** The broader plan (`:137`) lists `workspace.apply` as Phase 0. The prompt's concrete deliverable list focuses on the executor and fixture. **Recommendation:** ship the socket handler + minimal CLI (`commit 8b` above); they total ~50 LOC and give the executor an observable surface for CI or operator debugging without enlarging Phase 0 scope. If Impl time is tight, defer to Phase 1 — the acceptance fixture runs the executor directly and doesn't need the socket. **No human decision needed unless Impl pushes back.**
+7. **`Workspace.setOperatorMetadata` helper — exists or new?** The plan assumes workspace-level metadata has a setter; if it's currently only written through the `SessionWorkspaceSnapshot` restore path, Impl adds a one-line helper that mirrors `setPanelCustomTitle`'s shape. **Not a blocker** — small localized change.
+8. **`TabManager.workspaceRef(for:)` helper — exists or new?** Ref minting for `workspace:N` is owned by the v2 handler layer today (`TerminalController.swift:2066`). Impl should reuse that helper rather than duplicating the logic in the executor. If the helper lives inside `TerminalController`, lift it to `TabManager` or a small `V2Refs` namespace so the executor doesn't depend on the socket layer. **Not a blocker** — trivial refactor.
+
+None of the open questions rise to a `needs_human` architectural fork. They are execution-detail calls Impl can make in-session with reasonable defaults captured above.

--- a/.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md
+++ b/.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md
@@ -51,11 +51,19 @@ Nested `LayoutTreeSpec` mirrors `SessionWorkspaceLayoutSnapshot` (`Sources/Sessi
 
 ## Executor
 
-New file: `Sources/WorkspaceLayoutExecutor.swift`. One async entry point:
+New file: `Sources/WorkspaceLayoutExecutor.swift`. One entry point (shipped
+sync in Phase 0 — the walk has no await points; Phase 1's readiness pass
+will reintroduce `async` when surface-ready awaiting lands):
 
 ```swift
 @MainActor
-func apply(_ plan: WorkspaceApplyPlan, options: ApplyOptions) async -> ApplyResult
+enum WorkspaceLayoutExecutor {
+    static func apply(
+        _ plan: WorkspaceApplyPlan,
+        options: ApplyOptions = ApplyOptions(),
+        dependencies: WorkspaceLayoutExecutorDependencies
+    ) -> ApplyResult
+}
 ```
 
 - Creates the workspace (routes through `TabManager.addWorkspace` at `Sources/TabManager.swift:1138`).
@@ -536,3 +544,7 @@ Ship as a continuation of the same feature branch (`cmux-37/phase-0-workspace-ap
 7. **Commit R7 — plan file sync.** Edit `.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md:58` to match the shipped sync signature. One-line documentation edit.
 
 After R7 lands and is pushed, the rework Impl agent posts the completion comment on CMUX-37 and the delegator spawns Trident cycle 2 on the new branch head.
+
+## Reset 2026-04-24 by agent:claude-opus-4-7-cmux-37
+
+## Reset 2026-04-24 by agent:claude-opus-4-7-cmux-37

--- a/.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md
+++ b/.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md
@@ -492,3 +492,47 @@ Each commit carries the `CMUX-37 Phase 0:` prefix and references the specific de
 8. **`TabManager.workspaceRef(for:)` helper — exists or new?** Ref minting for `workspace:N` is owned by the v2 handler layer today (`TerminalController.swift:2066`). Impl should reuse that helper rather than duplicating the logic in the executor. If the helper lives inside `TerminalController`, lift it to `TabManager` or a small `V2Refs` namespace so the executor doesn't depend on the socket layer. **Not a blocker** — trivial refactor.
 
 None of the open questions rise to a `needs_human` architectural fork. They are execution-detail calls Impl can make in-session with reasonable defaults captured above.
+
+## Review Cycle 1 Findings (2026-04-24)
+
+*Verdict:* **FAIL-IMPL-REWORK** from `/trident-code-review` (9-agent pack; 3-model consensus on both blockers). Same branch, no plan reshape. Scope: ~1 day walker + harness rework, ~½ day for the accompanying minor-fixes. Cycle 1 of max 3.
+
+*Review pack:* `notes/trident-review-CMUX-37-pack-20260424-0303/` (12 files: 9 per-agent + 3 synthesis).
+
+*What's clean (consensus — do not change):* value types + Codable round-trips; `PersistedJSONValue` reuse; `source: .explicit` throughout; `mailbox.*` strings-only guard; reserved-key routing through `setPanelCustomTitle` / canonical `setMetadata`; no typing-latency hot-path edits; no terminal-opinion creep (no `Resources/bin/claude` touch, no `c11 install <tui>`); `async` drop is clean (no trailing awaits, no spurious `Task { }` in the socket handler); 8-commit boundary hygiene; TODO comments at welcome-quad / default-grid migration sites.
+
+### BLOCKERS (must fix to pass cycle 2)
+
+**B1. Layout walker composes nested splits bottom-up against a leaf-only API.** `WorkspaceLayoutExecutor.materializeSplit` (`Sources/WorkspaceLayoutExecutor.swift:448-501`) splits a leaf of `split.first` to produce what should be a sibling of the whole `split.first` subtree, but bonsplit's `splitPane(_:orientation:insertFirst:)` only splits leaf panes. 4 of 5 acceptance fixtures materialize malformed trees (welcome-quad, default-grid, mixed-browser-markdown, deep-nested-splits); only `single-large-with-metadata` (no splits) escapes. This is a design-level defect — not a line edit. **Fix path:** top-down injection matching `Workspace.restoreSessionLayoutNode` (the existing idiom the `SessionWorkspaceLayoutSnapshot` restore path already uses), or outer-first two-pass preallocation. Trace-validate the new walker against welcome-quad and default-grid shapes before landing.
+
+**B2. Acceptance harness cannot detect B1.** `c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift:106-147` asserts only ref-set membership + the 2_000 ms timing. No bonsplit tree-shape comparison, no divider-position check, no `selectedIndex` check, no per-fixture metadata round-trip beyond `single-large-with-metadata`. Section 6 of the plan called for structural-fingerprint assertions — they were not shipped, which is why B1 passed CI silently. **Fix path:** add structural assertions to `runFixture` that normalize `workspace.bonsplitController.treeSnapshot()` (orientation + recursive pane grouping + leaf surface-id order + divider positions + `selectedIndex`) and compare against the plan's `LayoutTreeSpec`. Extend the metadata round-trip pattern from `single-large-with-metadata` to every fixture. **Land the test first, watch all 5 fail, then ship the walker fix** — this is the TDD anchor for B1.
+
+### IMPORTANT (fix in the same rework pass)
+
+**I1. `SurfaceSpec.workingDirectory` silently dropped for split-created terminals and the reused seed.** At `Sources/WorkspaceLayoutExecutor.swift:361` (seed-reuse path) and `:506-537` (split path), `newTerminalSplit` has no `cwd` parameter and no `ApplyFailure` is emitted when `workingDirectory` is non-nil. Silent data loss. **Fix path:** either plumb `cwd` through `Workspace.newTerminalSplit` / `newTerminalSurface(inPane:)` / seed-reuse, or emit `ApplyFailure("working_directory_not_applied", step: ..., message: "…")` when `workingDirectory` is set and the creation path doesn't support it. First option preferred since the single-pane path already honors `workspace.workingDirectory` via `TabManager.addWorkspace`.
+
+**I2. CLI subcommand name drift.** Impl shipped `c11 workspace-apply` at `CLI/c11.swift:1713`, but the CMUX-37 plan body (`:83`) and `docs/c11-snapshot-restore-plan.md:164` both specify `c11 workspace apply` (subcommand under `workspace`). **Fix path:** add a `c11 workspace apply` subcommand route at `CLI/c11.swift:1713` (or equivalent subcommand dispatch point) to match plan and docs. Keeping `c11 workspace-apply` as a back-compat alias is acceptable but not required — nothing else consumes it yet.
+
+**I3. `validate(plan:)` runs on MainActor inside `v2MainSync`, contradicting the handler header's off-main promise.** `Sources/TerminalController.swift:4347-4399` + `Sources/WorkspaceLayoutExecutor.swift:63-64`. The socket-command threading policy in `CLAUDE.md` requires parse/validate off-main, with only AppKit/model mutation on main. **Fix path:** hoist the `validate(plan:)` call (and any pure decode/arg-parsing) above the `v2MainSync { … }` block in `v2WorkspaceApply` so the handler comment becomes true. Only the `apply(_:options:)` body needs the MainActor.
+
+**I4. Silent-failure gaps (close in the same pass).**
+  - **I4a.** `ApplyOptions.perStepTimeoutMs` is not enforced (Codex finding). The option exists on the struct but nothing inside the executor reads it. **Fix path:** wrap each step's timing measurement with the deadline check; on breach, append a warning with the step name and keep going (soft limit, per the plan's partial-failure semantics).
+  - **I4b.** `WorkspaceApplyPlan.version` is not validated (Codex finding). Version-1 plans should be accepted; anything else should short-circuit with a typed error before any workspace is created.
+  - **I4c.** `applyDividerPositions` does not emit `ApplyFailure` on tree-shape mismatch (Gemini finding). When the plan's `SplitSpec.dividerPosition` references a split slot that doesn't exist in the live bonsplit tree (because of B1 or a future divergence), it currently no-ops silently. **Fix path:** emit `ApplyFailure("divider_apply_failed", step: "layout.split[<i>].divider", message: ...)` and continue.
+  - **I4d.** `validateLayout` does not detect duplicate `surfaceIds` references in `PaneSpec.surfaceIds` or across multiple `PaneSpec`s (Gemini finding). Two leaves referencing the same plan-local surface id produce undefined behavior. **Fix path:** add a duplicate-reference check to step 1 validation; emit a typed error and short-circuit before any workspace is created.
+
+**I5. Plan file — sync the `async` signature with what shipped.** `.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md:58` still reads `async @MainActor func apply(…)`. Impl shipped sync because Phase 0 has no await points (verified clean by review). Update the plan sketch to match so Phase 1 agents implementing the readiness pass see the correct current shape. This is a documentation-only plan edit; it does NOT change the rework scope.
+
+### Rework directive — order of work
+
+Ship as a continuation of the same feature branch (`cmux-37/phase-0-workspace-apply-plan`). Commits carry the `CMUX-37 Phase 0 (rework):` prefix.
+
+1. **Commit R1 — structural-assertion harness (lands first).** Rewrite `c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift:runFixture` to normalize `bonsplitController.treeSnapshot()` and compare against the plan `LayoutTreeSpec`. Extend metadata round-trip to every fixture. Push. CI should fail all 5 fixtures (expected — this is the TDD anchor).
+2. **Commit R2 — walker top-down rewrite.** Replace `materializeSplit` with a top-down injection / outer-first two-pass strategy modeled on `Workspace.restoreSessionLayoutNode`. Trace-validate welcome-quad + default-grid shapes in-source before pushing. CI now passes all 5 fixtures.
+3. **Commit R3 — plumb `SurfaceSpec.workingDirectory`.** Either through split primitives or via `ApplyFailure` emission when unsupported. Add a fixture that exercises `workingDirectory` on a split-created terminal.
+4. **Commit R4 — CLI subcommand rename.** Add `c11 workspace apply` route. Alias retained or removed per Impl judgment.
+5. **Commit R5 — off-main validate.** Hoist `validate(plan:)` above `v2MainSync` in `v2WorkspaceApply`.
+6. **Commit R6 — silent-failure gaps.** I4a (`perStepTimeoutMs` enforcement), I4b (`version` validation), I4c (`divider_apply_failed` warning), I4d (duplicate-ref check). Extend existing Codable/validation tests with cases for each.
+7. **Commit R7 — plan file sync.** Edit `.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md:58` to match the shipped sync signature. One-line documentation edit.
+
+After R7 lands and is pushed, the rework Impl agent posts the completion comment on CMUX-37 and the delegator spawns Trident cycle 2 on the new branch head.

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -1710,55 +1710,39 @@ struct CMUXCLI {
         case "ssh-session-end":
             try runSSHSessionEnd(commandArgs: commandArgs, client: client)
 
+        case "workspace":
+            // CMUX-37 Phase 0: `c11 workspace <subcommand>`. Plan and docs
+            // (docs/c11-snapshot-restore-plan.md:164) specify this form.
+            // Future subcommands: snapshot/restore (Phase 1), new/export-
+            // blueprint (Phase 2). For now `apply` is the only subcommand.
+            guard let sub = commandArgs.first else {
+                throw CLIError(message: "workspace: missing subcommand. Known subcommands: apply")
+            }
+            let subArgs = Array(commandArgs.dropFirst())
+            switch sub {
+            case "apply":
+                try runWorkspaceApply(
+                    subArgs,
+                    client: client,
+                    commandLabel: "workspace apply",
+                    jsonOutput: jsonOutput,
+                    idFormat: idFormat
+                )
+            default:
+                throw CLIError(message: "workspace: unknown subcommand '\(sub)'. Known subcommands: apply")
+            }
+
         case "workspace-apply":
-            // CMUX-37 Phase 0 debug/test entry point for WorkspaceLayoutExecutor.
-            // Reads a JSON-encoded WorkspaceApplyPlan from a file path (or `-` for
-            // stdin), POSTs it to the workspace.apply socket method, and prints
-            // the ApplyResult.
-            let (fileOpt, remaining) = parseOption(commandArgs, name: "--file")
-            if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-                throw CLIError(message: "workspace-apply: unknown flag '\(unknown)'. Known flags: --file <path|->")
-            }
-            guard let fileArg = fileOpt else {
-                throw CLIError(message: "workspace-apply requires --file <path|->")
-            }
-            let planData: Data
-            if fileArg == "-" {
-                planData = FileHandle.standardInput.readDataToEndOfFile()
-            } else {
-                let resolvedPath = resolvePath(fileArg)
-                guard let data = FileManager.default.contents(atPath: resolvedPath) else {
-                    throw CLIError(message: "workspace-apply: could not read '\(resolvedPath)'")
-                }
-                planData = data
-            }
-            guard let planObject = try? JSONSerialization.jsonObject(with: planData, options: []) else {
-                throw CLIError(message: "workspace-apply: --file contents are not valid JSON")
-            }
-            let payload = try client.sendV2(method: "workspace.apply", params: ["plan": planObject])
-            if jsonOutput {
-                print(jsonString(formatIDs(payload, mode: idFormat)))
-            } else {
-                let ref = (payload["workspaceRef"] as? String) ?? "?"
-                let surfaceRefs = payload["surfaceRefs"] as? [String: String] ?? [:]
-                let paneRefs = payload["paneRefs"] as? [String: String] ?? [:]
-                let warnings = payload["warnings"] as? [String] ?? []
-                let failures = payload["failures"] as? [[String: Any]] ?? []
-                print("OK workspace=\(ref) surfaces=\(surfaceRefs.count) panes=\(paneRefs.count)")
-                if !warnings.isEmpty {
-                    print("warnings: \(warnings.count)")
-                    for w in warnings { print("  - \(w)") }
-                }
-                if !failures.isEmpty {
-                    print("failures: \(failures.count)")
-                    for f in failures {
-                        let code = (f["code"] as? String) ?? "?"
-                        let step = (f["step"] as? String) ?? "?"
-                        let msg = (f["message"] as? String) ?? ""
-                        print("  - [\(code)] \(step): \(msg)")
-                    }
-                }
-            }
+            // Back-compat alias for the Phase 0 `c11 workspace apply` form
+            // that shipped before the review cycle 1 rename. Prefer the
+            // subcommand form going forward.
+            try runWorkspaceApply(
+                commandArgs,
+                client: client,
+                commandLabel: "workspace-apply",
+                jsonOutput: jsonOutput,
+                idFormat: idFormat
+            )
 
         case "new-workspace":
             let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
@@ -2587,6 +2571,64 @@ struct CMUXCLI {
         if expanded.hasPrefix("/") { return expanded }
         let cwd = FileManager.default.currentDirectoryPath
         return (cwd as NSString).appendingPathComponent(expanded)
+    }
+
+    /// Shared implementation for `c11 workspace apply` and its back-compat
+    /// alias `c11 workspace-apply`. Reads a JSON `WorkspaceApplyPlan` from a
+    /// file path (or `-` for stdin), POSTs it via `workspace.apply`, and
+    /// prints the `ApplyResult`. `commandLabel` is threaded into error
+    /// messages so operators know which spelling they invoked.
+    private func runWorkspaceApply(
+        _ args: [String],
+        client: SocketClient,
+        commandLabel: String,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) throws {
+        let (fileOpt, remaining) = parseOption(args, name: "--file")
+        if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
+            throw CLIError(message: "\(commandLabel): unknown flag '\(unknown)'. Known flags: --file <path|->")
+        }
+        guard let fileArg = fileOpt else {
+            throw CLIError(message: "\(commandLabel) requires --file <path|->")
+        }
+        let planData: Data
+        if fileArg == "-" {
+            planData = FileHandle.standardInput.readDataToEndOfFile()
+        } else {
+            let resolvedPath = resolvePath(fileArg)
+            guard let data = FileManager.default.contents(atPath: resolvedPath) else {
+                throw CLIError(message: "\(commandLabel): could not read '\(resolvedPath)'")
+            }
+            planData = data
+        }
+        guard let planObject = try? JSONSerialization.jsonObject(with: planData, options: []) else {
+            throw CLIError(message: "\(commandLabel): --file contents are not valid JSON")
+        }
+        let payload = try client.sendV2(method: "workspace.apply", params: ["plan": planObject])
+        if jsonOutput {
+            print(jsonString(formatIDs(payload, mode: idFormat)))
+        } else {
+            let ref = (payload["workspaceRef"] as? String) ?? "?"
+            let surfaceRefs = payload["surfaceRefs"] as? [String: String] ?? [:]
+            let paneRefs = payload["paneRefs"] as? [String: String] ?? [:]
+            let warnings = payload["warnings"] as? [String] ?? []
+            let failures = payload["failures"] as? [[String: Any]] ?? []
+            print("OK workspace=\(ref) surfaces=\(surfaceRefs.count) panes=\(paneRefs.count)")
+            if !warnings.isEmpty {
+                print("warnings: \(warnings.count)")
+                for w in warnings { print("  - \(w)") }
+            }
+            if !failures.isEmpty {
+                print("failures: \(failures.count)")
+                for f in failures {
+                    let code = (f["code"] as? String) ?? "?"
+                    let step = (f["step"] as? String) ?? "?"
+                    let msg = (f["message"] as? String) ?? ""
+                    print("  - [\(code)] \(step): \(msg)")
+                }
+            }
+        }
     }
 
     private func sanitizedFilenameComponent(_ raw: String) -> String {

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -1710,6 +1710,56 @@ struct CMUXCLI {
         case "ssh-session-end":
             try runSSHSessionEnd(commandArgs: commandArgs, client: client)
 
+        case "workspace-apply":
+            // CMUX-37 Phase 0 debug/test entry point for WorkspaceLayoutExecutor.
+            // Reads a JSON-encoded WorkspaceApplyPlan from a file path (or `-` for
+            // stdin), POSTs it to the workspace.apply socket method, and prints
+            // the ApplyResult.
+            let (fileOpt, remaining) = parseOption(commandArgs, name: "--file")
+            if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
+                throw CLIError(message: "workspace-apply: unknown flag '\(unknown)'. Known flags: --file <path|->")
+            }
+            guard let fileArg = fileOpt else {
+                throw CLIError(message: "workspace-apply requires --file <path|->")
+            }
+            let planData: Data
+            if fileArg == "-" {
+                planData = FileHandle.standardInput.readDataToEndOfFile()
+            } else {
+                let resolvedPath = resolvePath(fileArg)
+                guard let data = FileManager.default.contents(atPath: resolvedPath) else {
+                    throw CLIError(message: "workspace-apply: could not read '\(resolvedPath)'")
+                }
+                planData = data
+            }
+            guard let planObject = try? JSONSerialization.jsonObject(with: planData, options: []) else {
+                throw CLIError(message: "workspace-apply: --file contents are not valid JSON")
+            }
+            let payload = try client.sendV2(method: "workspace.apply", params: ["plan": planObject])
+            if jsonOutput {
+                print(jsonString(formatIDs(payload, mode: idFormat)))
+            } else {
+                let ref = (payload["workspaceRef"] as? String) ?? "?"
+                let surfaceRefs = payload["surfaceRefs"] as? [String: String] ?? [:]
+                let paneRefs = payload["paneRefs"] as? [String: String] ?? [:]
+                let warnings = payload["warnings"] as? [String] ?? []
+                let failures = payload["failures"] as? [[String: Any]] ?? []
+                print("OK workspace=\(ref) surfaces=\(surfaceRefs.count) panes=\(paneRefs.count)")
+                if !warnings.isEmpty {
+                    print("warnings: \(warnings.count)")
+                    for w in warnings { print("  - \(w)") }
+                }
+                if !failures.isEmpty {
+                    print("failures: \(failures.count)")
+                    for f in failures {
+                        let code = (f["code"] as? String) ?? "?"
+                        let step = (f["step"] as? String) ?? "?"
+                        let msg = (f["message"] as? String) ?? ""
+                        print("  - [\(code)] \(step): \(msg)")
+                    }
+                }
+            }
+
         case "new-workspace":
             let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
             let (cwdOpt, remaining) = parseOption(rem0, name: "--cwd")

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
 		D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */; };
 		D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
+		D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */; };
 		D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
 		D7012BF0A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */; };
 		D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */; };
@@ -267,6 +268,7 @@
 		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
 		D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlan.swift; sourceTree = "<group>"; };
 		D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlanCodableTests.swift; sourceTree = "<group>"; };
+		D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLayoutExecutor.swift; sourceTree = "<group>"; };
 		D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStoreTests.swift; sourceTree = "<group>"; };
 		D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataPersistenceTests.swift; sourceTree = "<group>"; };
 		D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGridSettingsTests.swift; sourceTree = "<group>"; };
@@ -574,6 +576,7 @@
 				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
 				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
 				D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */,
+				D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */,
 				A5001545 /* AgentDetector.swift */,
 				A5001701 /* TextBoxInput.swift */,
 				A5F1002001A1B2C3D4E5F001 /* ThemedValueAST.swift */,
@@ -929,6 +932,7 @@
 				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
 				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
 				D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */,
+				D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */,
 				A5001544 /* AgentDetector.swift in Sources */,
 			A5001700 /* TextBoxInput.swift in Sources */,
 			A5F1001001A1B2C3D4E5F001 /* ThemedValueAST.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
 		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
 		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
+		D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */; };
+		D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
 		D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
 		D7012BF0A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */; };
 		D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */; };
@@ -263,6 +265,8 @@
 		D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
 		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
 		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
+		D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlan.swift; sourceTree = "<group>"; };
+		D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlanCodableTests.swift; sourceTree = "<group>"; };
 		D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStoreTests.swift; sourceTree = "<group>"; };
 		D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataPersistenceTests.swift; sourceTree = "<group>"; };
 		D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGridSettingsTests.swift; sourceTree = "<group>"; };
@@ -569,6 +573,7 @@
 				D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */,
 				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
 				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
+				D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */,
 				A5001545 /* AgentDetector.swift */,
 				A5001701 /* TextBoxInput.swift */,
 				A5F1002001A1B2C3D4E5F001 /* ThemedValueAST.swift */,
@@ -758,6 +763,7 @@
 					D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */,
 					D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */,
 					D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */,
+					D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */,
 					A5C36031 /* StatusBarButtonDisplayTests.swift */,
 				);
 				path = c11Tests;
@@ -922,6 +928,7 @@
 				D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */,
 				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
 				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
+				D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */,
 				A5001544 /* AgentDetector.swift in Sources */,
 			A5001700 /* TextBoxInput.swift in Sources */,
 			A5F1001001A1B2C3D4E5F001 /* ThemedValueAST.swift in Sources */,
@@ -1075,6 +1082,7 @@
 					D7012BF0A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift in Sources */,
 					D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */,
 					D7016BF0A1B2C3D4E5F60718 /* TCCPrimerTests.swift in Sources */,
+					D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */; };
 		D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
 		D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */; };
+		D8004BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */; };
 		D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
 		D7012BF0A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */; };
 		D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */; };
@@ -269,6 +270,7 @@
 		D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlan.swift; sourceTree = "<group>"; };
 		D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlanCodableTests.swift; sourceTree = "<group>"; };
 		D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLayoutExecutor.swift; sourceTree = "<group>"; };
+		D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLayoutExecutorAcceptanceTests.swift; sourceTree = "<group>"; };
 		D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStoreTests.swift; sourceTree = "<group>"; };
 		D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataPersistenceTests.swift; sourceTree = "<group>"; };
 		D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGridSettingsTests.swift; sourceTree = "<group>"; };
@@ -767,6 +769,7 @@
 					D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */,
 					D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */,
 					D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */,
+					D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */,
 					A5C36031 /* StatusBarButtonDisplayTests.swift */,
 				);
 				path = c11Tests;
@@ -1087,6 +1090,7 @@
 					D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */,
 					D7016BF0A1B2C3D4E5F60718 /* TCCPrimerTests.swift in Sources */,
 					D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */,
+					D8004BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4377,6 +4377,33 @@ class TerminalController {
             options = ApplyOptions()
         }
 
+        // Pre-validate off-main. Per review cycle 1 I3, the v2 handler
+        // must not ride MainActor for pure validation — this block runs
+        // entirely on the socket worker thread. If the plan is malformed
+        // we encode an ApplyResult carrying the failure and return
+        // without ever entering v2MainSync.
+        if let validationFailure = WorkspaceLayoutExecutor.validate(plan: plan) {
+            let preflightResult = ApplyResult(
+                workspaceRef: "",
+                surfaceRefs: [:],
+                paneRefs: [:],
+                timings: [StepTiming(step: "validate", durationMs: 0)],
+                warnings: [validationFailure.message],
+                failures: [validationFailure]
+            )
+            do {
+                let encoded = try JSONEncoder().encode(preflightResult)
+                let asAny = try JSONSerialization.jsonObject(with: encoded, options: [])
+                return .ok(asAny)
+            } catch {
+                return .err(
+                    code: "internal_error",
+                    message: "Failed to encode preflight ApplyResult: \(error)",
+                    data: nil
+                )
+            }
+        }
+
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4379,33 +4379,39 @@ class TerminalController {
 
         // Pre-validate off-main. Per review cycle 1 I3, the v2 handler
         // must not ride MainActor for pure validation — this block runs
-        // entirely on the socket worker thread. If the plan is malformed
-        // we encode an ApplyResult carrying the failure and return
-        // without ever entering v2MainSync.
+        // entirely on the socket worker thread. A malformed plan returns
+        // a typed `invalid_params` error (JSON-RPC clients parse as
+        // failure), not an `ok` envelope with an ApplyFailure body —
+        // cycle 2 IM2 fix.
         if let validationFailure = WorkspaceLayoutExecutor.validate(plan: plan) {
-            let preflightResult = ApplyResult(
-                workspaceRef: "",
-                surfaceRefs: [:],
-                paneRefs: [:],
-                timings: [StepTiming(step: "validate", durationMs: 0)],
-                warnings: [validationFailure.message],
-                failures: [validationFailure]
+            let data: [String: Any] = [
+                "failure": [
+                    "code": validationFailure.code,
+                    "step": validationFailure.step,
+                    "message": validationFailure.message
+                ]
+            ]
+            return .err(
+                code: "invalid_params",
+                message: "WorkspaceApplyPlan validation failed: \(validationFailure.message)",
+                data: data
             )
-            do {
-                let encoded = try JSONEncoder().encode(preflightResult)
-                let asAny = try JSONSerialization.jsonObject(with: encoded, options: [])
-                return .ok(asAny)
-            } catch {
-                return .err(
-                    code: "internal_error",
-                    message: "Failed to encode preflight ApplyResult: \(error)",
-                    data: nil
-                )
-            }
         }
 
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        // Apply the socket focus policy (CLAUDE.md: "Socket/CLI commands
+        // must not steal macOS app focus"). workspace.apply is not in
+        // `focusIntentV2Methods`, so `v2FocusAllowed` returns false for
+        // this command regardless of caller intent. Zero out
+        // `options.select` before dispatch so the executor does not
+        // raise the window / select the created workspace. Cycle 2 IM1
+        // fix.
+        var effectiveOptions = options
+        if options.select && !v2FocusAllowed(requested: true) {
+            effectiveOptions.select = false
         }
 
         var result: ApplyResult?
@@ -4422,7 +4428,7 @@ class TerminalController {
                     self?.v2EnsureHandleRef(kind: .pane, uuid: uuid) ?? "pane:\(uuid.uuidString)"
                 }
             )
-            result = WorkspaceLayoutExecutor.apply(plan, options: options, dependencies: deps)
+            result = WorkspaceLayoutExecutor.apply(plan, options: effectiveOptions, dependencies: deps)
         }
 
         guard let applyResult = result else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2102,6 +2102,8 @@ class TerminalController {
             return v2Result(id: id, self.v2WorkspaceClearMetadata(params: params))
         case "workspace.set_custom_color":
             return v2Result(id: id, self.v2WorkspaceSetCustomColor(params: params))
+        case "workspace.apply":
+            return v2Result(id: id, self.v2WorkspaceApply(params: params))
 
         // Themes (CMUX-35)
         case "theme.list":
@@ -2531,6 +2533,7 @@ class TerminalController {
             "workspace.set_metadata",
             "workspace.get_metadata",
             "workspace.clear_metadata",
+            "workspace.apply",
             "settings.open",
             "feedback.open",
             "feedback.submit",
@@ -4331,6 +4334,85 @@ class TerminalController {
                 return nil
             }
             return (tabManager, selected)
+        }
+    }
+
+    /// CMUX-37 Phase 0: `workspace.apply` v2 handler. Decodes a
+    /// `WorkspaceApplyPlan` from params, runs it through
+    /// `WorkspaceLayoutExecutor` on the main actor, and returns the
+    /// `ApplyResult` as a JSON object. The debug/test surface for the
+    /// Phase 0 primitive — Blueprints (Phase 2) and Snapshots (Phase 1)
+    /// layer on top of the same executor.
+    private func v2WorkspaceApply(params: [String: Any]) -> V2CallResult {
+        // Decode the plan and (optional) options off-main. Validation
+        // failures never touch the main actor.
+        guard let planRaw = params["plan"] else {
+            return .err(code: "invalid_params", message: "Missing 'plan'", data: nil)
+        }
+        let plan: WorkspaceApplyPlan
+        do {
+            let planData = try JSONSerialization.data(withJSONObject: planRaw, options: [])
+            plan = try JSONDecoder().decode(WorkspaceApplyPlan.self, from: planData)
+        } catch {
+            return .err(
+                code: "invalid_params",
+                message: "Failed to decode WorkspaceApplyPlan: \(error)",
+                data: nil
+            )
+        }
+
+        let options: ApplyOptions
+        if let optionsRaw = params["options"] {
+            do {
+                let optionsData = try JSONSerialization.data(withJSONObject: optionsRaw, options: [])
+                options = try JSONDecoder().decode(ApplyOptions.self, from: optionsData)
+            } catch {
+                return .err(
+                    code: "invalid_params",
+                    message: "Failed to decode ApplyOptions: \(error)",
+                    data: nil
+                )
+            }
+        } else {
+            options = ApplyOptions()
+        }
+
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: ApplyResult?
+        v2MainSync {
+            let deps = WorkspaceLayoutExecutorDependencies(
+                tabManager: tabManager,
+                workspaceRefMinter: { [weak self] uuid in
+                    self?.v2EnsureHandleRef(kind: .workspace, uuid: uuid) ?? "workspace:\(uuid.uuidString)"
+                },
+                surfaceRefMinter: { [weak self] uuid in
+                    self?.v2EnsureHandleRef(kind: .surface, uuid: uuid) ?? "surface:\(uuid.uuidString)"
+                },
+                paneRefMinter: { [weak self] uuid in
+                    self?.v2EnsureHandleRef(kind: .pane, uuid: uuid) ?? "pane:\(uuid.uuidString)"
+                }
+            )
+            result = WorkspaceLayoutExecutor.apply(plan, options: options, dependencies: deps)
+        }
+
+        guard let applyResult = result else {
+            return .err(code: "internal_error", message: "Executor returned no result", data: nil)
+        }
+
+        // Encode ApplyResult back to [String: Any] for the v2 JSON envelope.
+        do {
+            let encoded = try JSONEncoder().encode(applyResult)
+            let asAny = try JSONSerialization.jsonObject(with: encoded, options: [])
+            return .ok(asAny)
+        } catch {
+            return .err(
+                code: "internal_error",
+                message: "Failed to encode ApplyResult: \(error)",
+                data: nil
+            )
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5600,6 +5600,25 @@ final class Workspace: Identifiable, ObservableObject {
         surfaceIdToPanelId.first { $0.value == panelId }?.key
     }
 
+    /// Resolve the bonsplit pane hosting the given panel.
+    ///
+    /// Walks `bonsplitController.allPaneIds` searching for a pane whose tabs
+    /// include the panel's surface id. Used by split primitives to find the
+    /// source pane of a split and by `WorkspaceLayoutExecutor` to resolve the
+    /// pane that hosts a just-created panel for pane-metadata writes.
+    ///
+    /// O(panes * tabsPerPane) worst case; workspaces in the field have
+    /// single-digit pane counts so the cost is negligible.
+    func paneIdForPanel(_ panelId: UUID) -> PaneID? {
+        guard let tabId = surfaceIdFromPanelId(panelId) else { return nil }
+        for paneId in bonsplitController.allPaneIds {
+            if bonsplitController.tabs(inPane: paneId).contains(where: { $0.id == tabId }) {
+                return paneId
+            }
+        }
+        return nil
+    }
+
 
     private func installBrowserPanelSubscription(_ browserPanel: BrowserPanel) {
         let subscription = Publishers.CombineLatest3(
@@ -7211,18 +7230,7 @@ final class Workspace: Identifiable, ObservableObject {
         insertFirst: Bool = false,
         focus: Bool = true
     ) -> TerminalPanel? {
-        // Find the pane containing the source panel
-        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
-        var sourcePaneId: PaneID?
-        for paneId in bonsplitController.allPaneIds {
-            let tabs = bonsplitController.tabs(inPane: paneId)
-            if tabs.contains(where: { $0.id == sourceTabId }) {
-                sourcePaneId = paneId
-                break
-            }
-        }
-
-        guard let paneId = sourcePaneId else { return nil }
+        guard let paneId = paneIdForPanel(panelId) else { return nil }
         let inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
         let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
 
@@ -7413,18 +7421,7 @@ final class Workspace: Identifiable, ObservableObject {
         preferredProfileID: UUID? = nil,
         focus: Bool = true
     ) -> BrowserPanel? {
-        // Find the pane containing the source panel
-        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
-        var sourcePaneId: PaneID?
-        for paneId in bonsplitController.allPaneIds {
-            let tabs = bonsplitController.tabs(inPane: paneId)
-            if tabs.contains(where: { $0.id == sourceTabId }) {
-                sourcePaneId = paneId
-                break
-            }
-        }
-
-        guard let paneId = sourcePaneId else { return nil }
+        guard let paneId = paneIdForPanel(panelId) else { return nil }
 
         // Create browser panel
         let browserPanel = BrowserPanel(
@@ -7572,17 +7569,7 @@ final class Workspace: Identifiable, ObservableObject {
         filePath: String? = nil,
         focus: Bool = true
     ) -> MarkdownPanel? {
-        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
-        var sourcePaneId: PaneID?
-        for paneId in bonsplitController.allPaneIds {
-            let tabs = bonsplitController.tabs(inPane: paneId)
-            if tabs.contains(where: { $0.id == sourceTabId }) {
-                sourcePaneId = paneId
-                break
-            }
-        }
-
-        guard let paneId = sourcePaneId else { return nil }
+        guard let paneId = paneIdForPanel(panelId) else { return nil }
 
         let markdownPanel = MarkdownPanel(workspaceId: id, filePath: filePath)
         panels[markdownPanel.id] = markdownPanel

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7245,22 +7245,33 @@ final class Workspace: Identifiable, ObservableObject {
         return nil
     }
 
-    /// Create a new split with a terminal panel
+    /// Create a new split with a terminal panel.
+    ///
+    /// If `workingDirectory` is provided and non-empty, it overrides the
+    /// source-panel / workspace inheritance chain below — used by
+    /// `WorkspaceLayoutExecutor` to honor explicit `SurfaceSpec.workingDirectory`
+    /// values declared in a `WorkspaceApplyPlan`.
     @discardableResult
     func newTerminalSplit(
         from panelId: UUID,
         orientation: SplitOrientation,
         insertFirst: Bool = false,
-        focus: Bool = true
+        focus: Bool = true,
+        workingDirectory: String? = nil
     ) -> TerminalPanel? {
         guard let paneId = paneIdForPanel(panelId) else { return nil }
         let inheritedConfig = inheritedTerminalConfig(preferredPanelId: panelId, inPane: paneId)
         let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
 
-        // Inherit working directory: prefer the source panel's reported cwd,
-        // then its requested startup cwd if shell integration has not reported
-        // back yet, and finally fall back to the workspace's current directory.
+        // Inherit working directory: caller-supplied override wins, then the
+        // source panel's reported cwd, then its requested startup cwd if
+        // shell integration has not reported back yet, and finally fall back
+        // to the workspace's current directory.
         let splitWorkingDirectory: String? = {
+            if let override = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !override.isEmpty {
+                return override
+            }
             if let panelDirectory = panelDirectories[panelId]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !panelDirectory.isEmpty {
                 return panelDirectory

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6051,6 +6051,29 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// Merge operator-authored entries into `metadata` (workspace-scoped).
+    /// Trimmed empty values clear their keys; trimmed non-empty values
+    /// overwrite. Mirrors the shape of `SessionWorkspaceSnapshot.metadata`
+    /// at the plan/snapshot boundary so `WorkspaceLayoutExecutor` and
+    /// Phase 1 Snapshot restore can land values through one setter.
+    func setOperatorMetadata(_ entries: [String: String]) {
+        guard !entries.isEmpty else { return }
+        var next = metadata
+        for (rawKey, rawValue) in entries {
+            let key = rawKey.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty else { continue }
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                next.removeValue(forKey: key)
+            } else {
+                next[key] = trimmed
+            }
+        }
+        if next != metadata {
+            metadata = next
+        }
+    }
+
     // MARK: - Directory Updates
 
     func updatePanelDirectory(panelId: UUID, directory: String) {

--- a/Sources/WorkspaceApplyPlan.swift
+++ b/Sources/WorkspaceApplyPlan.swift
@@ -240,9 +240,10 @@ struct ApplyFailure: Codable, Sendable, Equatable {
     /// `"validation_failed"`, `"surface_create_failed"`,
     /// `"metadata_write_failed"`, `"metadata_override"`, `"split_failed"`,
     /// `"unknown_surface_ref"`, `"duplicate_surface_id"`,
-    /// `"duplicate_surface_reference"`, `"mailbox_non_string_value"`,
-    /// `"unsupported_version"`, `"working_directory_not_applied"`,
-    /// `"divider_apply_failed"`, `"per_step_timeout_exceeded"`,
+    /// `"duplicate_surface_reference"`, `"orphan_surface"`,
+    /// `"mailbox_non_string_value"`, `"unsupported_version"`,
+    /// `"working_directory_not_applied"`, `"divider_apply_failed"`,
+    /// `"divider_clamped"`, `"per_step_timeout_exceeded"`,
     /// `"seed_panel_missing"`.
     var code: String
     /// Matches a `StepTiming.step` when possible.

--- a/Sources/WorkspaceApplyPlan.swift
+++ b/Sources/WorkspaceApplyPlan.swift
@@ -1,0 +1,287 @@
+import Foundation
+
+/// Declarative description of a workspace and its initial layout, executed
+/// app-side by `WorkspaceLayoutExecutor`. The value type is shared between
+/// Blueprints (Phase 2), Snapshots (Phase 1), and the Phase 0 debug CLI.
+///
+/// Metadata values reuse `PersistedJSONValue` so the same Codable shape that
+/// serializes through `SessionPanelSnapshot.metadata` and
+/// `SessionPaneLayoutSnapshot.metadata` serializes through a plan without a
+/// conversion layer. Per the C11-13 alignment doc, v1 only writes string
+/// values on the reserved `mailbox.*` pane-metadata namespace; non-string
+/// values surface as a warning in `ApplyResult` and are dropped on write.
+struct WorkspaceApplyPlan: Codable, Sendable, Equatable {
+    /// Schema version. Phase 0 ships `1`; bumped on breaking schema changes.
+    var version: Int
+    var workspace: WorkspaceSpec
+    /// Nested split tree; mirrors `SessionWorkspaceLayoutSnapshot` so Phase 1
+    /// Snapshot capture is a structural copy.
+    var layout: LayoutTreeSpec
+    /// Surfaces keyed by plan-local `SurfaceSpec.id`; referenced from
+    /// `LayoutTreeSpec.pane.surfaceIds`.
+    var surfaces: [SurfaceSpec]
+}
+
+struct WorkspaceSpec: Codable, Sendable, Equatable {
+    /// Applied via `Workspace.setCustomTitle` after creation.
+    var title: String?
+    /// Hex string, e.g. `"#C0392B"`. Applied via `Workspace.setCustomColor`.
+    var customColor: String?
+    /// Passed to `TabManager.addWorkspace(workingDirectory:)`.
+    var workingDirectory: String?
+    /// Operator-authored workspace-level metadata. Shape matches
+    /// `SessionWorkspaceSnapshot.metadata: [String: String]?` so Phase 1
+    /// restore is a direct assignment. Strings-only per C11-13 alignment.
+    var metadata: [String: String]?
+
+    init(
+        title: String? = nil,
+        customColor: String? = nil,
+        workingDirectory: String? = nil,
+        metadata: [String: String]? = nil
+    ) {
+        self.title = title
+        self.customColor = customColor
+        self.workingDirectory = workingDirectory
+        self.metadata = metadata
+    }
+}
+
+enum SurfaceSpecKind: String, Codable, Sendable, Equatable {
+    case terminal
+    case browser
+    case markdown
+}
+
+struct SurfaceSpec: Codable, Sendable, Equatable {
+    /// Plan-local stable id, referenced from `LayoutTreeSpec.pane.surfaceIds`.
+    /// Never persisted beyond `ApplyResult`; live refs replace it at apply time.
+    var id: String
+    var kind: SurfaceSpecKind
+    /// Applied via `Workspace.setPanelCustomTitle`, which writes the canonical
+    /// `title` key into `SurfaceMetadataStore` — no double-write.
+    var title: String?
+    /// Written via `SurfaceMetadataStore.setMetadata` under the reserved
+    /// `description` key.
+    var description: String?
+    /// Terminal: passed to the creation primitive's `workingDirectory:`.
+    var workingDirectory: String?
+    /// Terminal: sent via `TerminalPanel.sendText` once the surface is created.
+    /// Pre-surface-ready sends auto-queue and flush when the surface comes up.
+    var command: String?
+    /// Browser: passed to `newBrowserSplit(url:)` / `newBrowserSurface(url:)`.
+    var url: String?
+    /// Markdown: passed to `newMarkdownSplit(filePath:)` / `newMarkdownSurface(filePath:)`.
+    var filePath: String?
+    /// Surface metadata — routed through `SurfaceMetadataStore.setMetadata`
+    /// with `.merge` mode and `.explicit` source.
+    var metadata: [String: PersistedJSONValue]?
+    /// Pane metadata — routed through `PaneMetadataStore.setMetadata` with
+    /// `.merge` mode and `.explicit` source. The `mailbox.*` namespace is
+    /// reserved per `docs/c11-13-cmux-37-alignment.md`; the executor writes
+    /// values verbatim. v1 strings-only: non-string values on a `mailbox.*`
+    /// key surface as a warning in `ApplyResult` and are dropped.
+    var paneMetadata: [String: PersistedJSONValue]?
+
+    init(
+        id: String,
+        kind: SurfaceSpecKind,
+        title: String? = nil,
+        description: String? = nil,
+        workingDirectory: String? = nil,
+        command: String? = nil,
+        url: String? = nil,
+        filePath: String? = nil,
+        metadata: [String: PersistedJSONValue]? = nil,
+        paneMetadata: [String: PersistedJSONValue]? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.title = title
+        self.description = description
+        self.workingDirectory = workingDirectory
+        self.command = command
+        self.url = url
+        self.filePath = filePath
+        self.metadata = metadata
+        self.paneMetadata = paneMetadata
+    }
+}
+
+/// Mirrors `SessionWorkspaceLayoutSnapshot` so Phase 1 Snapshot capture is
+/// a structural copy. `SessionSplitOrientation` and Bonsplit's
+/// `SplitOrientation` are the two sides of the translation, handled inside
+/// the executor — callers stay in plan-space.
+indirect enum LayoutTreeSpec: Codable, Sendable, Equatable {
+    case pane(PaneSpec)
+    case split(SplitSpec)
+
+    private enum CodingKeys: String, CodingKey { case type, pane, split }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "pane":
+            self = .pane(try container.decode(PaneSpec.self, forKey: .pane))
+        case "split":
+            self = .split(try container.decode(SplitSpec.self, forKey: .split))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "LayoutTreeSpec: unsupported node type '\(type)'"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .pane(let pane):
+            try container.encode("pane", forKey: .type)
+            try container.encode(pane, forKey: .pane)
+        case .split(let split):
+            try container.encode("split", forKey: .type)
+            try container.encode(split, forKey: .split)
+        }
+    }
+
+    struct PaneSpec: Codable, Sendable, Equatable {
+        /// Plan-local surface ids referenced into `WorkspaceApplyPlan.surfaces`.
+        /// Order matches tab order in the pane. At least one entry required.
+        var surfaceIds: [String]
+        /// Index into `surfaceIds` of the initially selected tab. Defaults to 0.
+        var selectedIndex: Int?
+
+        init(surfaceIds: [String], selectedIndex: Int? = nil) {
+            self.surfaceIds = surfaceIds
+            self.selectedIndex = selectedIndex
+        }
+    }
+
+    struct SplitSpec: Codable, Sendable, Equatable {
+        var orientation: Orientation
+        /// 0...1. Mirrors `SessionSplitLayoutSnapshot.dividerPosition`.
+        var dividerPosition: Double
+        var first: LayoutTreeSpec
+        var second: LayoutTreeSpec
+
+        enum Orientation: String, Codable, Sendable, Equatable {
+            case horizontal
+            case vertical
+        }
+
+        init(
+            orientation: Orientation,
+            dividerPosition: Double,
+            first: LayoutTreeSpec,
+            second: LayoutTreeSpec
+        ) {
+            self.orientation = orientation
+            self.dividerPosition = dividerPosition
+            self.first = first
+            self.second = second
+        }
+    }
+}
+
+/// Caller-supplied knobs for `WorkspaceLayoutExecutor.apply`. Defaults match
+/// Phase 0's acceptance-fixture expectations.
+struct ApplyOptions: Codable, Sendable, Equatable {
+    /// Select + foreground the created workspace once ready. Defaults `true`
+    /// so the debug CLI behaves like `workspace.create`. Passed through to
+    /// `TabManager.addWorkspace(select:)`.
+    var select: Bool
+    /// Per-step deadline guard (ms). If any `StepTiming` exceeds it the
+    /// executor appends a warning but continues — partial-failure semantics,
+    /// not hard abort. A zero value disables the guard. Default: 2_000 ms,
+    /// matching the acceptance target.
+    var perStepTimeoutMs: Int
+    /// Hint for callers that want to bypass the welcome/default-grid
+    /// auto-spawn. The executor always passes `false` to
+    /// `TabManager.addWorkspace(autoWelcomeIfNeeded:)` regardless — the field
+    /// exists for future (Phase 1 restore) callers.
+    var autoWelcomeIfNeeded: Bool
+
+    init(
+        select: Bool = true,
+        perStepTimeoutMs: Int = 2_000,
+        autoWelcomeIfNeeded: Bool = false
+    ) {
+        self.select = select
+        self.perStepTimeoutMs = perStepTimeoutMs
+        self.autoWelcomeIfNeeded = autoWelcomeIfNeeded
+    }
+}
+
+/// Timing record emitted once per logical step inside `apply()`. Consumers
+/// (the acceptance fixture, a future debug CLI, eventually the v2 socket
+/// response) use these to attribute budget overruns to a named step.
+struct StepTiming: Codable, Sendable, Equatable {
+    /// Examples: `"validate"`, `"workspace.create"`, `"metadata.workspace.write"`,
+    /// `"surface[<planId>].create"`, `"layout.split[<index>].create"`,
+    /// `"metadata.surface[<planId>].write"`, `"metadata.pane[<planId>].write"`,
+    /// `"surface[<planId>].command.enqueue"`, `"refs.assemble"`, `"total"`.
+    var step: String
+    var durationMs: Double
+
+    init(step: String, durationMs: Double) {
+        self.step = step
+        self.durationMs = durationMs
+    }
+}
+
+/// Machine-readable partial-failure record. Human-readable message is carried
+/// in `message`; the code lets Phase 1 Snapshot restore branch without
+/// parsing strings.
+struct ApplyFailure: Codable, Sendable, Equatable {
+    /// Stable code. Additions are backwards-compatible. Known values:
+    /// `"validation_failed"`, `"surface_create_failed"`,
+    /// `"metadata_write_failed"`, `"metadata_override"`, `"split_failed"`,
+    /// `"unknown_surface_ref"`, `"duplicate_surface_id"`,
+    /// `"mailbox_non_string_value"`.
+    var code: String
+    /// Matches a `StepTiming.step` when possible.
+    var step: String
+    var message: String
+
+    init(code: String, step: String, message: String) {
+        self.code = code
+        self.step = step
+        self.message = message
+    }
+}
+
+struct ApplyResult: Codable, Sendable, Equatable {
+    /// Live workspace ref (`workspace:N`) assigned by the v2 ref helper after
+    /// creation. Empty string if the plan failed validation before the
+    /// workspace was created.
+    var workspaceRef: String
+    /// Plan-local surface id → live `surface:N` ref. Missing entries indicate
+    /// a creation failure whose detail surfaces in `failures`.
+    var surfaceRefs: [String: String]
+    /// Plan-local surface id → `pane:N` of the pane hosting that surface.
+    var paneRefs: [String: String]
+    var timings: [StepTiming]
+    /// Free-form human-readable warnings. Mirrored in `failures` when the
+    /// warning has a stable code.
+    var warnings: [String]
+    var failures: [ApplyFailure]
+
+    init(
+        workspaceRef: String = "",
+        surfaceRefs: [String: String] = [:],
+        paneRefs: [String: String] = [:],
+        timings: [StepTiming] = [],
+        warnings: [String] = [],
+        failures: [ApplyFailure] = []
+    ) {
+        self.workspaceRef = workspaceRef
+        self.surfaceRefs = surfaceRefs
+        self.paneRefs = paneRefs
+        self.timings = timings
+        self.warnings = warnings
+        self.failures = failures
+    }
+}

--- a/Sources/WorkspaceApplyPlan.swift
+++ b/Sources/WorkspaceApplyPlan.swift
@@ -240,7 +240,10 @@ struct ApplyFailure: Codable, Sendable, Equatable {
     /// `"validation_failed"`, `"surface_create_failed"`,
     /// `"metadata_write_failed"`, `"metadata_override"`, `"split_failed"`,
     /// `"unknown_surface_ref"`, `"duplicate_surface_id"`,
-    /// `"mailbox_non_string_value"`.
+    /// `"duplicate_surface_reference"`, `"mailbox_non_string_value"`,
+    /// `"unsupported_version"`, `"working_directory_not_applied"`,
+    /// `"divider_apply_failed"`, `"per_step_timeout_exceeded"`,
+    /// `"seed_panel_missing"`.
     var code: String
     /// Matches a `StepTiming.step` when possible.
     var step: String

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -372,6 +372,21 @@ enum WorkspaceLayoutExecutor {
             let firstPanelId: UUID
             if anchor.kind == firstSurface.kind {
                 firstPanelId = anchor.panelId
+                // Anchor reuse cannot honor an explicit workingDirectory —
+                // either the seed already launched with the workspace cwd
+                // (seedTerminal case), or the panel was created by a split
+                // primitive in the enclosing materializeSplit and its cwd
+                // is already baked in (anyExisting case). Emit a typed
+                // warning so callers see the cwd didn't apply, matching
+                // review cycle 1 I1.
+                if let cwd = firstSurface.workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !cwd.isEmpty,
+                   case .seedTerminal = anchor {
+                    reportWorkingDirectoryNotApplicable(
+                        firstSurface,
+                        context: "seed terminal reuse (cwd fixed at workspace creation)"
+                    )
+                }
             } else {
                 // Kind mismatch: replace the anchor with the target kind in
                 // the same pane, then close the old anchor. This handles the
@@ -509,8 +524,10 @@ enum WorkspaceLayoutExecutor {
 
         /// Dispatch to the right `Workspace.newXSplit` primitive. Always
         /// passes `focus: false` — the executor does not steal focus per
-        /// CLAUDE.md socket focus policy.
-        private func splitFromPanel(
+        /// CLAUDE.md socket focus policy. Terminal splits honor
+        /// `spec.workingDirectory` via the overload added in R3 of the
+        /// review cycle 1 rework.
+        private mutating func splitFromPanel(
             _ panelId: UUID,
             orientation: SplitOrientation,
             spec: SurfaceSpec
@@ -521,9 +538,13 @@ enum WorkspaceLayoutExecutor {
                     from: panelId,
                     orientation: orientation,
                     insertFirst: false,
-                    focus: false
+                    focus: false,
+                    workingDirectory: spec.workingDirectory
                 )?.id
             case .browser:
+                if spec.workingDirectory != nil {
+                    reportWorkingDirectoryNotApplicable(spec, context: "browser split")
+                }
                 let url = spec.url.flatMap { URL(string: $0) }
                 return workspace.newBrowserSplit(
                     from: panelId,
@@ -533,6 +554,9 @@ enum WorkspaceLayoutExecutor {
                     focus: false
                 )?.id
             case .markdown:
+                if spec.workingDirectory != nil {
+                    reportWorkingDirectoryNotApplicable(spec, context: "markdown split")
+                }
                 return workspace.newMarkdownSplit(
                     from: panelId,
                     orientation: orientation,
@@ -541,6 +565,25 @@ enum WorkspaceLayoutExecutor {
                     focus: false
                 )?.id
             }
+        }
+
+        /// Emit a typed ApplyFailure when a caller sets
+        /// `SurfaceSpec.workingDirectory` on a path that cannot honor it
+        /// (browser/markdown creation, or reusing a seed terminal whose
+        /// shell has already launched). Keeps cwd loss non-silent per
+        /// review cycle 1 I1.
+        mutating func reportWorkingDirectoryNotApplicable(
+            _ spec: SurfaceSpec,
+            context: String
+        ) {
+            let cwd = spec.workingDirectory ?? ""
+            let message = "surface[\(spec.id)] workingDirectory='\(cwd)' ignored: \(context) path does not accept an explicit cwd"
+            warnings.append(message)
+            failures.append(ApplyFailure(
+                code: "working_directory_not_applied",
+                step: "surface[\(spec.id)].create",
+                message: message
+            ))
         }
 
         /// Apply `spec.description`, the rest of `spec.metadata`, and

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -223,8 +223,11 @@ enum WorkspaceLayoutExecutor {
     // MARK: - Plan validation
 
     /// Returns the first validation failure encountered, or `nil` if the plan
-    /// is structurally sound. Pure; no AppKit access.
-    private static func validate(plan: WorkspaceApplyPlan) -> ApplyFailure? {
+    /// is structurally sound. Pure — safe to call off the main actor before
+    /// dispatching to `apply(_:options:dependencies:)`. Per review cycle 1 I3,
+    /// the v2 socket handler pre-checks via this entry point so validation
+    /// never rides the main actor.
+    nonisolated static func validate(plan: WorkspaceApplyPlan) -> ApplyFailure? {
         // Duplicate surface ids.
         var seen = Set<String>()
         for surface in plan.surfaces {
@@ -245,7 +248,7 @@ enum WorkspaceLayoutExecutor {
         return nil
     }
 
-    private static func validateLayout(
+    nonisolated private static func validateLayout(
         _ node: LayoutTreeSpec,
         knownSurfaceIds: Set<String>
     ) -> ApplyFailure? {

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+/// Dependencies that `WorkspaceLayoutExecutor.apply` does not own — passed in
+/// so the executor stays decoupled from the socket layer (for tests) and the
+/// v2 ref layer (for the future socket handler in commit 8b).
+///
+/// `workspaceRefMinter`/`surfaceRefMinter`/`paneRefMinter` map a live UUID to
+/// its v2 ref string (`workspace:N` / `surface:N` / `pane:N`). The socket
+/// handler wires these to `TerminalController.v2Ref`; tests can supply a
+/// synthetic minter that derives a stable string from the UUID.
+@MainActor
+struct WorkspaceLayoutExecutorDependencies {
+    var tabManager: TabManager
+    var workspaceRefMinter: (UUID) -> String
+    var surfaceRefMinter: (UUID) -> String
+    var paneRefMinter: (UUID) -> String
+
+    init(
+        tabManager: TabManager,
+        workspaceRefMinter: @escaping (UUID) -> String,
+        surfaceRefMinter: @escaping (UUID) -> String,
+        paneRefMinter: @escaping (UUID) -> String
+    ) {
+        self.tabManager = tabManager
+        self.workspaceRefMinter = workspaceRefMinter
+        self.surfaceRefMinter = surfaceRefMinter
+        self.paneRefMinter = paneRefMinter
+    }
+}
+
+/// App-side executor for `WorkspaceApplyPlan`. One `apply` call materializes
+/// an entire workspace — workspace create, layout tree, titles, descriptions,
+/// surface/pane metadata, terminal initial commands — in one transaction.
+///
+/// The executor runs on the main actor (AppKit/bonsplit state). Phase 0
+/// ships only the creation-centric path; Phase 1 adds
+/// `applyToExistingWorkspace(_:_:_:)` for Snapshot restore over a live
+/// workspace + seed panel.
+///
+/// Partial-failure semantics: validation failures short-circuit before any
+/// UI state mutates (`ApplyResult.workspaceRef` stays empty). Anything after
+/// workspace creation appends `ApplyFailure` records but leaves the workspace
+/// on-screen — matching `DefaultGridSettings.performDefaultGrid`'s
+/// truncate-on-failure behavior rather than silent disappearance.
+@MainActor
+enum WorkspaceLayoutExecutor {
+
+    /// Execute `plan`. Returns an `ApplyResult` with timings and any
+    /// partial-failure warnings. Never throws.
+    static func apply(
+        _ plan: WorkspaceApplyPlan,
+        options: ApplyOptions = ApplyOptions(),
+        dependencies: WorkspaceLayoutExecutorDependencies
+    ) async -> ApplyResult {
+        let total = Clock()
+        var timings: [StepTiming] = []
+        var warnings: [String] = []
+        var failures: [ApplyFailure] = []
+
+        // Step 1 — validate the plan locally before any AppKit state changes.
+        let validateClock = Clock()
+        if let failure = validate(plan: plan) {
+            timings.append(StepTiming(step: "validate", durationMs: validateClock.elapsedMs))
+            failures.append(failure)
+            warnings.append(failure.message)
+            timings.append(StepTiming(step: "total", durationMs: total.elapsedMs))
+            return ApplyResult(
+                workspaceRef: "",
+                surfaceRefs: [:],
+                paneRefs: [:],
+                timings: timings,
+                warnings: warnings,
+                failures: failures
+            )
+        }
+        timings.append(StepTiming(step: "validate", durationMs: validateClock.elapsedMs))
+
+        // Step 2 — create the workspace. The executor always opts out of
+        // welcome/default-grid auto-spawns so the layout walker owns the
+        // tree shape entirely; the `autoWelcomeIfNeeded` field on options
+        // is informational for future callers.
+        let createClock = Clock()
+        let workspace = dependencies.tabManager.addWorkspace(
+            workingDirectory: plan.workspace.workingDirectory,
+            initialTerminalCommand: nil,
+            select: options.select,
+            eagerLoadTerminal: false,
+            autoWelcomeIfNeeded: false
+        )
+        if let title = plan.workspace.title {
+            workspace.setCustomTitle(title)
+        }
+        if let color = plan.workspace.customColor {
+            workspace.setCustomColor(color)
+        }
+        timings.append(StepTiming(step: "workspace.create", durationMs: createClock.elapsedMs))
+
+        // Step 3 — apply workspace-level metadata (operator-authored).
+        if let entries = plan.workspace.metadata, !entries.isEmpty {
+            let metaClock = Clock()
+            workspace.setOperatorMetadata(entries)
+            timings.append(StepTiming(
+                step: "metadata.workspace.write",
+                durationMs: metaClock.elapsedMs
+            ))
+        }
+
+        // Phase 0 commit 3 stub: workspace created, layout walker and
+        // surface/pane metadata writes land in commits 4-6. `surfaceRefs`
+        // and `paneRefs` stay empty until then. The debug CLI / acceptance
+        // fixture only exercises the later commits, so the stub result
+        // here is never user-visible in shipped builds.
+        let workspaceRef = dependencies.workspaceRefMinter(workspace.id)
+        timings.append(StepTiming(step: "total", durationMs: total.elapsedMs))
+        return ApplyResult(
+            workspaceRef: workspaceRef,
+            surfaceRefs: [:],
+            paneRefs: [:],
+            timings: timings,
+            warnings: warnings,
+            failures: failures
+        )
+    }
+
+    // MARK: - Plan validation
+
+    /// Returns the first validation failure encountered, or `nil` if the plan
+    /// is structurally sound. Pure; no AppKit access.
+    private static func validate(plan: WorkspaceApplyPlan) -> ApplyFailure? {
+        // Duplicate surface ids.
+        var seen = Set<String>()
+        for surface in plan.surfaces {
+            if !seen.insert(surface.id).inserted {
+                return ApplyFailure(
+                    code: "duplicate_surface_id",
+                    step: "validate",
+                    message: "duplicate SurfaceSpec.id '\(surface.id)'"
+                )
+            }
+        }
+
+        // Every id referenced from the layout tree must exist in `surfaces`.
+        let known = Set(plan.surfaces.map(\.id))
+        if let failure = validateLayout(plan.layout, knownSurfaceIds: known) {
+            return failure
+        }
+        return nil
+    }
+
+    private static func validateLayout(
+        _ node: LayoutTreeSpec,
+        knownSurfaceIds: Set<String>
+    ) -> ApplyFailure? {
+        switch node {
+        case .pane(let pane):
+            if pane.surfaceIds.isEmpty {
+                return ApplyFailure(
+                    code: "validation_failed",
+                    step: "validate",
+                    message: "LayoutTreeSpec.pane.surfaceIds must not be empty"
+                )
+            }
+            for surfaceId in pane.surfaceIds where !knownSurfaceIds.contains(surfaceId) {
+                return ApplyFailure(
+                    code: "unknown_surface_ref",
+                    step: "validate",
+                    message: "LayoutTreeSpec references unknown surface id '\(surfaceId)'"
+                )
+            }
+            if let idx = pane.selectedIndex, idx < 0 || idx >= pane.surfaceIds.count {
+                return ApplyFailure(
+                    code: "validation_failed",
+                    step: "validate",
+                    message: "PaneSpec.selectedIndex=\(idx) out of range for \(pane.surfaceIds.count) surfaces"
+                )
+            }
+            return nil
+        case .split(let split):
+            if let failure = validateLayout(split.first, knownSurfaceIds: knownSurfaceIds) {
+                return failure
+            }
+            if let failure = validateLayout(split.second, knownSurfaceIds: knownSurfaceIds) {
+                return failure
+            }
+            return nil
+        }
+    }
+
+    // MARK: - Timing helper
+
+    /// Thin wrapper around `DispatchTime` for timing a step without the
+    /// noise of `DispatchTime.now()` arithmetic at every call site. One per
+    /// step; read `elapsedMs` when the step ends.
+    fileprivate struct Clock {
+        let start: DispatchTime = .now()
+        var elapsedMs: Double {
+            let ns = DispatchTime.now().uptimeNanoseconds &- start.uptimeNanoseconds
+            return Double(ns) / 1_000_000.0
+        }
+    }
+}

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -296,6 +296,17 @@ enum WorkspaceLayoutExecutor {
         ) {
             return failure
         }
+        // Every SurfaceSpec must be referenced from the layout tree.
+        // Orphan entries otherwise silently vanish — cycle 2 finding
+        // (Codex). Sorting keeps the error message deterministic.
+        let orphans = known.subtracting(referencedIds).sorted()
+        if !orphans.isEmpty {
+            return ApplyFailure(
+                code: "orphan_surface",
+                step: "validate",
+                message: "SurfaceSpec id(s) not referenced from layout tree: \(orphans.joined(separator: ","))"
+            )
+        }
         return nil
     }
 
@@ -797,8 +808,13 @@ enum WorkspaceLayoutExecutor {
         }
 
         /// Create an in-pane surface of the right kind. Returns the new
-        /// panel id. `focus: false` always.
-        private func createSurface(
+        /// panel id. `focus: false` always. Terminal honors
+        /// `spec.workingDirectory` via `newTerminalSurface(inPane:workingDirectory:)`;
+        /// browser/markdown cannot accept cwd and emit a typed
+        /// `working_directory_not_applied` failure when one is declared
+        /// (cycle 2: R3 left this in-pane path silent; split path was
+        /// already covered).
+        private mutating func createSurface(
             _ spec: SurfaceSpec,
             inPane paneId: PaneID,
             focus: Bool
@@ -811,6 +827,9 @@ enum WorkspaceLayoutExecutor {
                     workingDirectory: spec.workingDirectory
                 )?.id
             case .browser:
+                if spec.workingDirectory != nil {
+                    reportWorkingDirectoryNotApplicable(spec, context: "browser in-pane creation")
+                }
                 let url = spec.url.flatMap { URL(string: $0) }
                 return workspace.newBrowserSurface(
                     inPane: paneId,
@@ -818,6 +837,9 @@ enum WorkspaceLayoutExecutor {
                     focus: focus
                 )?.id
             case .markdown:
+                if spec.workingDirectory != nil {
+                    reportWorkingDirectoryNotApplicable(spec, context: "markdown in-pane creation")
+                }
                 return workspace.newMarkdownSurface(
                     inPane: paneId,
                     filePath: spec.filePath,
@@ -839,6 +861,14 @@ enum WorkspaceLayoutExecutor {
 
     // MARK: - Divider positions
 
+    /// Bonsplit enforces its own divider bounds (hard-clamped inside
+    /// `setDividerPosition`). Plan schema allows `0...1`; the executor
+    /// reports a typed warning when the plan's value falls outside this
+    /// window so the fidelity loss is visible to Phase 1 Snapshot and
+    /// Phase 2 Blueprint authors — cycle 2 IM3.
+    private static let bonsplitDividerFloor: Double = 0.1
+    private static let bonsplitDividerCeiling: Double = 0.9
+
     /// Walk plan tree and live bonsplit tree in lockstep, applying each
     /// plan-side `dividerPosition`. Same shape as
     /// `Workspace.applySessionDividerPositions` — plan tree replaces the
@@ -846,8 +876,9 @@ enum WorkspaceLayoutExecutor {
     ///
     /// Returns any `ApplyFailure` records produced when the plan and live
     /// trees disagree on shape (plan expected a split but live has a pane,
-    /// or vice versa). Pane-vs-pane is a legitimate no-op (no dividers to
-    /// apply), not a failure.
+    /// or vice versa), or when a plan-side `dividerPosition` was outside
+    /// bonsplit's acceptable `0.1...0.9` clamp. Pane-vs-pane is a
+    /// legitimate no-op (no dividers to apply), not a failure.
     private static func applyDividerPositions(
         planNode: LayoutTreeSpec,
         liveNode: ExternalTreeNode,
@@ -858,7 +889,15 @@ enum WorkspaceLayoutExecutor {
         case (.split(let planSplit), .split(let liveSplit)):
             var out: [ApplyFailure] = []
             if let splitID = UUID(uuidString: liveSplit.id) {
-                let clamped = min(max(planSplit.dividerPosition, 0), 1)
+                let requested = planSplit.dividerPosition
+                let clamped = min(max(requested, bonsplitDividerFloor), bonsplitDividerCeiling)
+                if abs(requested - clamped) > 0.0001 {
+                    out.append(ApplyFailure(
+                        code: "divider_clamped",
+                        step: "\(path).dividerPosition",
+                        message: "plan dividerPosition=\(requested) at \(path) clamped to bonsplit's acceptable range [\(bonsplitDividerFloor), \(bonsplitDividerCeiling)] (applied \(clamped))"
+                    ))
+                }
                 _ = workspace.bonsplitController.setDividerPosition(
                     CGFloat(clamped),
                     forSplit: splitID,

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Bonsplit
 
 /// Dependencies that `WorkspaceLayoutExecutor.apply` does not own — passed in
 /// so the executor stays decoupled from the socket layer (for tests) and the
@@ -105,12 +106,67 @@ enum WorkspaceLayoutExecutor {
             ))
         }
 
-        // Phase 0 commit 3 stub: workspace created, layout walker and
-        // surface/pane metadata writes land in commits 4-6. `surfaceRefs`
-        // and `paneRefs` stay empty until then. The debug CLI / acceptance
-        // fixture only exercises the later commits, so the stub result
-        // here is never user-visible in shipped builds.
+        // Index the plan's surfaces by id so the walker can look up each leaf
+        // without a linear search. Validation already rejected duplicates.
+        let surfacesById = Dictionary(
+            uniqueKeysWithValues: plan.surfaces.map { ($0.id, $0) }
+        )
+
+        // Steps 4-5 — walk the layout tree and materialize splits/surfaces.
+        //
+        // The walker maintains a `planSurfaceIdToPanelId` map so later
+        // commits can translate plan-local ids to live UUIDs for metadata
+        // writes (commit 5) and ref assembly (commit 6).
+        var walkState = WalkState(
+            workspace: workspace,
+            surfacesById: surfacesById,
+            warnings: warnings,
+            failures: failures,
+            timings: timings
+        )
+
+        // Resolve the seed panel that `addWorkspace` produced in the root
+        // pane. Every path below expects at least one seed; if it isn't
+        // available yet, record a partial failure and return what we have.
+        guard let seedPanel = workspace.focusedTerminalPanel else {
+            let failure = ApplyFailure(
+                code: "seed_panel_missing",
+                step: "layout.walk",
+                message: "TabManager.addWorkspace did not provide a seed terminal panel"
+            )
+            failures.append(failure)
+            warnings.append(failure.message)
+            let workspaceRef = dependencies.workspaceRefMinter(workspace.id)
+            timings.append(StepTiming(step: "total", durationMs: total.elapsedMs))
+            return ApplyResult(
+                workspaceRef: workspaceRef,
+                surfaceRefs: [:],
+                paneRefs: [:],
+                timings: timings,
+                warnings: warnings,
+                failures: failures
+            )
+        }
+
+        _ = walkState.materialize(plan.layout, intoAnchor: .seedTerminal(seedPanel))
+
+        // Apply divider positions by walking the plan tree alongside the
+        // live bonsplit tree. Same shape as
+        // `Workspace.applySessionDividerPositions`; a no-op for trees with
+        // only default 0.5 dividers.
+        applyDividerPositions(
+            planNode: plan.layout,
+            liveNode: workspace.bonsplitController.treeSnapshot(),
+            workspace: workspace
+        )
+
+        // Phase 0 commit 4 stub: layout built. Surface/pane metadata writes,
+        // terminal initial commands, and ref assembly arrive in commits 5-6.
+        // `surfaceRefs` / `paneRefs` stay empty here.
         let workspaceRef = dependencies.workspaceRefMinter(workspace.id)
+        timings = walkState.timings
+        warnings = walkState.warnings
+        failures = walkState.failures
         timings.append(StepTiming(step: "total", durationMs: total.elapsedMs))
         return ApplyResult(
             workspaceRef: workspaceRef,
@@ -183,6 +239,336 @@ enum WorkspaceLayoutExecutor {
                 return failure
             }
             return nil
+        }
+    }
+
+    // MARK: - Layout walk
+
+    /// Anchor passed into `materialize`. Either the workspace's seed terminal
+    /// panel (at the root call), or the panel returned by a `newXSplit` that
+    /// introduced the current subtree.
+    fileprivate enum AnchorPanel {
+        /// The seed `TerminalPanel` created by `TabManager.addWorkspace`. If
+        /// the subtree's first leaf is not a terminal, the walker replaces it
+        /// with the target kind in the same pane and closes the seed.
+        case seedTerminal(TerminalPanel)
+        /// A panel returned by `newXSplit`. Type is matched to the first leaf
+        /// of the subtree by construction — no replacement needed.
+        case anyExisting(panelId: UUID, kind: SurfaceSpecKind)
+
+        var panelId: UUID {
+            switch self {
+            case .seedTerminal(let panel): return panel.id
+            case .anyExisting(let panelId, _): return panelId
+            }
+        }
+
+        var kind: SurfaceSpecKind {
+            switch self {
+            case .seedTerminal: return .terminal
+            case .anyExisting(_, let kind): return kind
+            }
+        }
+    }
+
+    /// Mutable walk state — threaded through the DFS traversal so individual
+    /// method signatures stay small. `planSurfaceIdToPanelId` is the output
+    /// used by commits 5-6 to write metadata and mint refs.
+    @MainActor
+    fileprivate struct WalkState {
+        let workspace: Workspace
+        let surfacesById: [String: SurfaceSpec]
+        var warnings: [String]
+        var failures: [ApplyFailure]
+        var timings: [StepTiming]
+        /// plan-local SurfaceSpec.id → live panel UUID. Populated as surfaces
+        /// materialize. Commits 5-6 consume this for metadata writes and
+        /// ref assembly.
+        var planSurfaceIdToPanelId: [String: UUID] = [:]
+        /// Split-index counter used for step timing labels.
+        var splitIndex: Int = 0
+
+        /// Materialize `node`. For a pane node, the first surface lands on
+        /// `anchor`; for a split node, the walker recurses into `first` using
+        /// `anchor`, then mints a new pane via `newXSplit`, then recurses
+        /// into `second` using that new panel as its anchor.
+        ///
+        /// Returns the panel id that hosts this subtree's first leaf — used
+        /// as the split-from source for any outer split.
+        mutating func materialize(
+            _ node: LayoutTreeSpec,
+            intoAnchor anchor: AnchorPanel
+        ) -> UUID? {
+            switch node {
+            case .pane(let paneSpec):
+                return materializePane(paneSpec, intoAnchor: anchor)
+            case .split(let splitSpec):
+                return materializeSplit(splitSpec, intoAnchor: anchor)
+            }
+        }
+
+        private mutating func materializePane(
+            _ paneSpec: LayoutTreeSpec.PaneSpec,
+            intoAnchor anchor: AnchorPanel
+        ) -> UUID? {
+            guard let firstSurfaceId = paneSpec.surfaceIds.first,
+                  let firstSurface = surfacesById[firstSurfaceId] else {
+                failures.append(ApplyFailure(
+                    code: "validation_failed",
+                    step: "layout.walk",
+                    message: "PaneSpec with no surfaces reached the walker"
+                ))
+                return nil
+            }
+
+            let leafClock = Clock()
+            let firstPanelId: UUID
+            if anchor.kind == firstSurface.kind {
+                firstPanelId = anchor.panelId
+            } else {
+                // Kind mismatch only happens on the root when the plan's
+                // first leaf is browser or markdown. Replace the seed in
+                // the same pane, then close the seed terminal.
+                guard case .seedTerminal(let seed) = anchor,
+                      let paneId = workspace.paneIdForPanel(seed.id) else {
+                    failures.append(ApplyFailure(
+                        code: "seed_panel_missing",
+                        step: "layout.walk",
+                        message: "anchor kind mismatch but no seed pane available"
+                    ))
+                    return nil
+                }
+                guard let replacement = createSurface(
+                    firstSurface,
+                    inPane: paneId,
+                    focus: false
+                ) else {
+                    failures.append(ApplyFailure(
+                        code: "surface_create_failed",
+                        step: "surface[\(firstSurface.id)].create",
+                        message: "failed to replace seed terminal with \(firstSurface.kind.rawValue) surface"
+                    ))
+                    return nil
+                }
+                firstPanelId = replacement
+                _ = workspace.closePanel(seed.id, force: true)
+            }
+            timings.append(StepTiming(
+                step: "surface[\(firstSurface.id)].create",
+                durationMs: leafClock.elapsedMs
+            ))
+            planSurfaceIdToPanelId[firstSurface.id] = firstPanelId
+
+            // Apply the first surface's title via the canonical setter so
+            // SurfaceMetadataStore["title"] stays in sync.
+            if let title = firstSurface.title {
+                workspace.setPanelCustomTitle(panelId: firstPanelId, title: title)
+            }
+
+            // Additional surfaces in the same pane.
+            guard let paneId = workspace.paneIdForPanel(firstPanelId) else {
+                return firstPanelId
+            }
+            for additionalSurfaceId in paneSpec.surfaceIds.dropFirst() {
+                guard let spec = surfacesById[additionalSurfaceId] else { continue }
+                let addClock = Clock()
+                guard let newPanelId = createSurface(spec, inPane: paneId, focus: false) else {
+                    failures.append(ApplyFailure(
+                        code: "surface_create_failed",
+                        step: "surface[\(spec.id)].create",
+                        message: "failed to add \(spec.kind.rawValue) surface to pane"
+                    ))
+                    continue
+                }
+                timings.append(StepTiming(
+                    step: "surface[\(spec.id)].create",
+                    durationMs: addClock.elapsedMs
+                ))
+                planSurfaceIdToPanelId[spec.id] = newPanelId
+                if let title = spec.title {
+                    workspace.setPanelCustomTitle(panelId: newPanelId, title: title)
+                }
+            }
+
+            // Apply selectedIndex. Default is the first surface, which bonsplit
+            // selects on creation; only deviate if the plan picks another.
+            if let selectedIndex = paneSpec.selectedIndex,
+               selectedIndex > 0,
+               selectedIndex < paneSpec.surfaceIds.count,
+               let selectedSurfaceId = Optional(paneSpec.surfaceIds[selectedIndex]),
+               let selectedPanelId = planSurfaceIdToPanelId[selectedSurfaceId],
+               let selectedTabId = workspace.surfaceIdFromPanelId(selectedPanelId) {
+                workspace.bonsplitController.selectTab(selectedTabId)
+            }
+
+            return firstPanelId
+        }
+
+        private mutating func materializeSplit(
+            _ splitSpec: LayoutTreeSpec.SplitSpec,
+            intoAnchor anchor: AnchorPanel
+        ) -> UUID? {
+            // Build the first subtree using the inbound anchor.
+            guard let firstAnchorPanelId = materialize(splitSpec.first, intoAnchor: anchor) else {
+                return nil
+            }
+
+            // Determine the kind of the second subtree's first leaf so we
+            // pick the right split primitive.
+            let secondFirstSurfaceId = firstLeafSurfaceId(splitSpec.second)
+            guard let secondFirstSurfaceId,
+                  let secondFirstSurface = surfacesById[secondFirstSurfaceId] else {
+                failures.append(ApplyFailure(
+                    code: "validation_failed",
+                    step: "layout.walk",
+                    message: "split's second subtree has no discoverable first surface"
+                ))
+                return firstAnchorPanelId
+            }
+
+            let orientation: SplitOrientation = splitSpec.orientation == .vertical
+                ? .vertical
+                : .horizontal
+            let label = splitIndex
+            splitIndex += 1
+            let splitClock = Clock()
+            let newPanelId = splitFromPanel(
+                firstAnchorPanelId,
+                orientation: orientation,
+                spec: secondFirstSurface
+            )
+            timings.append(StepTiming(
+                step: "layout.split[\(label)].create",
+                durationMs: splitClock.elapsedMs
+            ))
+            guard let newPanelId else {
+                failures.append(ApplyFailure(
+                    code: "split_failed",
+                    step: "layout.split[\(label)].create",
+                    message: "newXSplit rejected split from panel for \(secondFirstSurface.kind.rawValue)"
+                ))
+                return firstAnchorPanelId
+            }
+
+            // The split returned a panel of the right kind; recurse into
+            // the second subtree with that as its anchor.
+            _ = materialize(
+                splitSpec.second,
+                intoAnchor: .anyExisting(panelId: newPanelId, kind: secondFirstSurface.kind)
+            )
+            return firstAnchorPanelId
+        }
+
+        /// Dispatch to the right `Workspace.newXSplit` primitive. Always
+        /// passes `focus: false` — the executor does not steal focus per
+        /// CLAUDE.md socket focus policy.
+        private func splitFromPanel(
+            _ panelId: UUID,
+            orientation: SplitOrientation,
+            spec: SurfaceSpec
+        ) -> UUID? {
+            switch spec.kind {
+            case .terminal:
+                return workspace.newTerminalSplit(
+                    from: panelId,
+                    orientation: orientation,
+                    insertFirst: false,
+                    focus: false
+                )?.id
+            case .browser:
+                let url = spec.url.flatMap { URL(string: $0) }
+                return workspace.newBrowserSplit(
+                    from: panelId,
+                    orientation: orientation,
+                    insertFirst: false,
+                    url: url,
+                    focus: false
+                )?.id
+            case .markdown:
+                return workspace.newMarkdownSplit(
+                    from: panelId,
+                    orientation: orientation,
+                    insertFirst: false,
+                    filePath: spec.filePath,
+                    focus: false
+                )?.id
+            }
+        }
+
+        /// Create an in-pane surface of the right kind. Returns the new
+        /// panel id. `focus: false` always.
+        private func createSurface(
+            _ spec: SurfaceSpec,
+            inPane paneId: PaneID,
+            focus: Bool
+        ) -> UUID? {
+            switch spec.kind {
+            case .terminal:
+                return workspace.newTerminalSurface(
+                    inPane: paneId,
+                    focus: focus,
+                    workingDirectory: spec.workingDirectory
+                )?.id
+            case .browser:
+                let url = spec.url.flatMap { URL(string: $0) }
+                return workspace.newBrowserSurface(
+                    inPane: paneId,
+                    url: url,
+                    focus: focus
+                )?.id
+            case .markdown:
+                return workspace.newMarkdownSurface(
+                    inPane: paneId,
+                    filePath: spec.filePath,
+                    focus: focus
+                )?.id
+            }
+        }
+    }
+
+    /// Find the first leaf's first surface id in a subtree. Returns nil only
+    /// when the tree is malformed (pre-validated away before this is called,
+    /// but the nil branch keeps the call site total).
+    fileprivate nonisolated static func firstLeafSurfaceId(_ node: LayoutTreeSpec) -> String? {
+        switch node {
+        case .pane(let pane): return pane.surfaceIds.first
+        case .split(let split): return firstLeafSurfaceId(split.first)
+        }
+    }
+
+    // MARK: - Divider positions
+
+    /// Walk plan tree and live bonsplit tree in lockstep, applying each
+    /// plan-side `dividerPosition`. Same shape as
+    /// `Workspace.applySessionDividerPositions` — plan tree replaces the
+    /// session snapshot side.
+    private static func applyDividerPositions(
+        planNode: LayoutTreeSpec,
+        liveNode: ExternalTreeNode,
+        workspace: Workspace
+    ) {
+        switch (planNode, liveNode) {
+        case (.split(let planSplit), .split(let liveSplit)):
+            if let splitID = UUID(uuidString: liveSplit.id) {
+                let clamped = min(max(planSplit.dividerPosition, 0), 1)
+                _ = workspace.bonsplitController.setDividerPosition(
+                    CGFloat(clamped),
+                    forSplit: splitID,
+                    fromExternal: true
+                )
+            }
+            applyDividerPositions(
+                planNode: planSplit.first,
+                liveNode: liveSplit.first,
+                workspace: workspace
+            )
+            applyDividerPositions(
+                planNode: planSplit.second,
+                liveNode: liveSplit.second,
+                workspace: workspace
+            )
+        default:
+            return
         }
     }
 

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -160,18 +160,51 @@ enum WorkspaceLayoutExecutor {
             workspace: workspace
         )
 
-        // Phase 0 commit 4 stub: layout built. Surface/pane metadata writes,
-        // terminal initial commands, and ref assembly arrive in commits 5-6.
-        // `surfaceRefs` / `paneRefs` stay empty here.
+        // Step 7 — terminal initial commands. TerminalPanel.sendText
+        // auto-queues pre-ready and flushes when the Ghostty surface comes
+        // up, so the executor does not need to await readiness here.
+        for surfaceSpec in plan.surfaces {
+            guard surfaceSpec.kind == .terminal,
+                  let command = surfaceSpec.command,
+                  !command.isEmpty,
+                  let panelId = walkState.planSurfaceIdToPanelId[surfaceSpec.id],
+                  let terminalPanel = workspace.panels[panelId] as? TerminalPanel else {
+                continue
+            }
+            let cmdClock = Clock()
+            terminalPanel.sendText(command)
+            walkState.timings.append(StepTiming(
+                step: "surface[\(surfaceSpec.id)].command.enqueue",
+                durationMs: cmdClock.elapsedMs
+            ))
+        }
+
+        // Step 8 — assemble refs. The executor mints refs for every surface
+        // and pane that was successfully created; plan-local surface ids map
+        // 1:1 to live `surface:N` / `pane:N` refs via the injected minters.
+        let refsClock = Clock()
+        var surfaceRefs: [String: String] = [:]
+        var paneRefs: [String: String] = [:]
+        for (planSurfaceId, panelId) in walkState.planSurfaceIdToPanelId {
+            surfaceRefs[planSurfaceId] = dependencies.surfaceRefMinter(panelId)
+            if let paneId = workspace.paneIdForPanel(panelId) {
+                paneRefs[planSurfaceId] = dependencies.paneRefMinter(paneId.id)
+            }
+        }
         let workspaceRef = dependencies.workspaceRefMinter(workspace.id)
+        walkState.timings.append(StepTiming(
+            step: "refs.assemble",
+            durationMs: refsClock.elapsedMs
+        ))
+
         timings = walkState.timings
         warnings = walkState.warnings
         failures = walkState.failures
         timings.append(StepTiming(step: "total", durationMs: total.elapsedMs))
         return ApplyResult(
             workspaceRef: workspaceRef,
-            surfaceRefs: [:],
-            paneRefs: [:],
+            surfaceRefs: surfaceRefs,
+            paneRefs: paneRefs,
             timings: timings,
             warnings: warnings,
             failures: failures

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -360,10 +360,13 @@ enum WorkspaceLayoutExecutor {
             planSurfaceIdToPanelId[firstSurface.id] = firstPanelId
 
             // Apply the first surface's title via the canonical setter so
-            // SurfaceMetadataStore["title"] stays in sync.
+            // SurfaceMetadataStore["title"] stays in sync. Description and
+            // the rest of surface + pane metadata land in a dedicated pass
+            // immediately after, during creation (no post-hoc socket loop).
             if let title = firstSurface.title {
                 workspace.setPanelCustomTitle(panelId: firstPanelId, title: title)
             }
+            writeSurfaceMetadata(firstSurface, panelId: firstPanelId)
 
             // Additional surfaces in the same pane.
             guard let paneId = workspace.paneIdForPanel(firstPanelId) else {
@@ -388,6 +391,7 @@ enum WorkspaceLayoutExecutor {
                 if let title = spec.title {
                     workspace.setPanelCustomTitle(panelId: newPanelId, title: title)
                 }
+                writeSurfaceMetadata(spec, panelId: newPanelId)
             }
 
             // Apply selectedIndex. Default is the first surface, which bonsplit
@@ -493,6 +497,136 @@ enum WorkspaceLayoutExecutor {
                     focus: false
                 )?.id
             }
+        }
+
+        /// Apply `spec.description`, the rest of `spec.metadata`, and
+        /// `spec.paneMetadata` for a just-created surface. Writes happen
+        /// during creation (not post-hoc), all with source `.explicit`.
+        /// The `mailbox.*` namespace in pane metadata is enforced
+        /// strings-only per docs/c11-13-cmux-37-alignment.md.
+        mutating func writeSurfaceMetadata(_ spec: SurfaceSpec, panelId: UUID) {
+            let surfaceClock = Clock()
+            let workspaceId = workspace.id
+
+            // Surface description — reserved key validated by the store.
+            if let raw = spec.description?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !raw.isEmpty {
+                do {
+                    _ = try SurfaceMetadataStore.shared.setMetadata(
+                        workspaceId: workspaceId,
+                        surfaceId: panelId,
+                        partial: ["description": raw],
+                        mode: .merge,
+                        source: .explicit
+                    )
+                } catch {
+                    let message = "surface[\(spec.id)] description write failed: \(error)"
+                    warnings.append(message)
+                    failures.append(ApplyFailure(
+                        code: "metadata_write_failed",
+                        step: "metadata.surface[\(spec.id)].write",
+                        message: message
+                    ))
+                }
+            }
+
+            // Rest of surface metadata. title/description collisions with
+            // the dedicated setters above emit a `metadata_override` warning
+            // but the explicit metadata value still wins (it's written last
+            // with merge mode + explicit source).
+            if let metadata = spec.metadata, !metadata.isEmpty {
+                for (key, value) in metadata {
+                    if key == "title", spec.title != nil {
+                        failures.append(ApplyFailure(
+                            code: "metadata_override",
+                            step: "metadata.surface[\(spec.id)].write",
+                            message: "surface[\(spec.id)] sets both SurfaceSpec.title and metadata[\"title\"]; metadata value wins"
+                        ))
+                    }
+                    if key == "description", spec.description != nil {
+                        failures.append(ApplyFailure(
+                            code: "metadata_override",
+                            step: "metadata.surface[\(spec.id)].write",
+                            message: "surface[\(spec.id)] sets both SurfaceSpec.description and metadata[\"description\"]; metadata value wins"
+                        ))
+                    }
+                    let decoded = PersistedMetadataBridge.decodeValues([key: value])
+                    do {
+                        _ = try SurfaceMetadataStore.shared.setMetadata(
+                            workspaceId: workspaceId,
+                            surfaceId: panelId,
+                            partial: decoded,
+                            mode: .merge,
+                            source: .explicit
+                        )
+                    } catch {
+                        let message = "surface[\(spec.id)] metadata[\"\(key)\"] write failed: \(error)"
+                        warnings.append(message)
+                        failures.append(ApplyFailure(
+                            code: "metadata_write_failed",
+                            step: "metadata.surface[\(spec.id)].write",
+                            message: message
+                        ))
+                    }
+                }
+            }
+            timings.append(StepTiming(
+                step: "metadata.surface[\(spec.id)].write",
+                durationMs: surfaceClock.elapsedMs
+            ))
+
+            // Pane metadata. mailbox.* is strings-only in v1.
+            guard let paneMetadata = spec.paneMetadata, !paneMetadata.isEmpty else {
+                return
+            }
+            let paneClock = Clock()
+            guard let paneId = workspace.paneIdForPanel(panelId) else {
+                let message = "surface[\(spec.id)] pane metadata skipped: no bonsplit pane resolved for panel"
+                warnings.append(message)
+                failures.append(ApplyFailure(
+                    code: "metadata_write_failed",
+                    step: "metadata.pane[\(spec.id)].write",
+                    message: message
+                ))
+                return
+            }
+            let paneUUID = paneId.id
+            for (key, value) in paneMetadata {
+                if key.hasPrefix("mailbox."), case .string = value {
+                    // string — OK
+                } else if key.hasPrefix("mailbox.") {
+                    let message = "surface[\(spec.id)] pane metadata[\"\(key)\"] dropped: mailbox.* values must be strings in v1"
+                    warnings.append(message)
+                    failures.append(ApplyFailure(
+                        code: "mailbox_non_string_value",
+                        step: "metadata.pane[\(spec.id)].write",
+                        message: message
+                    ))
+                    continue
+                }
+                let decoded = PersistedMetadataBridge.decodeValues([key: value])
+                do {
+                    _ = try PaneMetadataStore.shared.setMetadata(
+                        workspaceId: workspaceId,
+                        paneId: paneUUID,
+                        partial: decoded,
+                        mode: .merge,
+                        source: .explicit
+                    )
+                } catch {
+                    let message = "surface[\(spec.id)] pane metadata[\"\(key)\"] write failed: \(error)"
+                    warnings.append(message)
+                    failures.append(ApplyFailure(
+                        code: "metadata_write_failed",
+                        step: "metadata.pane[\(spec.id)].write",
+                        message: message
+                    ))
+                }
+            }
+            timings.append(StepTiming(
+                step: "metadata.pane[\(spec.id)].write",
+                durationMs: paneClock.elapsedMs
+            ))
         }
 
         /// Create an in-pane surface of the right kind. Returns the new

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -132,11 +132,12 @@ enum WorkspaceLayoutExecutor {
         // Resolve the seed panel that `addWorkspace` produced in the root
         // pane. Every path below expects at least one seed; if it isn't
         // available yet, record a partial failure and return what we have.
-        guard let seedPanel = workspace.focusedTerminalPanel else {
+        guard let seedPanel = workspace.focusedTerminalPanel,
+              let rootPaneId = workspace.paneIdForPanel(seedPanel.id) else {
             let failure = ApplyFailure(
                 code: "seed_panel_missing",
                 step: "layout.walk",
-                message: "TabManager.addWorkspace did not provide a seed terminal panel"
+                message: "TabManager.addWorkspace did not provide a resolvable seed terminal panel"
             )
             failures.append(failure)
             warnings.append(failure.message)
@@ -152,7 +153,11 @@ enum WorkspaceLayoutExecutor {
             )
         }
 
-        _ = walkState.materialize(plan.layout, intoAnchor: .seedTerminal(seedPanel))
+        walkState.materialize(
+            plan.layout,
+            intoPane: rootPaneId,
+            anchor: .seedTerminal(seedPanel)
+        )
 
         // Apply divider positions by walking the plan tree alongside the
         // live bonsplit tree. Same shape as
@@ -325,29 +330,34 @@ enum WorkspaceLayoutExecutor {
         /// Split-index counter used for step timing labels.
         var splitIndex: Int = 0
 
-        /// Materialize `node`. For a pane node, the first surface lands on
-        /// `anchor`; for a split node, the walker recurses into `first` using
-        /// `anchor`, then mints a new pane via `newXSplit`, then recurses
-        /// into `second` using that new panel as its anchor.
+        /// Materialize `node` into `paneId`. Top-down: at a split node the
+        /// walker splits the **current pane** into two sibling panes (first
+        /// stays in the original pane with the inbound anchor, second
+        /// inhabits a newly-minted pane), then recurses into each subtree
+        /// with its own pane context. Leaves populate their target pane with
+        /// the spec'd surfaces, replacing the anchor if kind doesn't match.
         ///
-        /// Returns the panel id that hosts this subtree's first leaf — used
-        /// as the split-from source for any outer split.
+        /// This mirrors `Workspace.restoreSessionLayoutNode` — the proven
+        /// top-down pattern the Snapshot restore path uses, which composes
+        /// correctly against bonsplit's leaf-only `splitPane` API.
         mutating func materialize(
             _ node: LayoutTreeSpec,
-            intoAnchor anchor: AnchorPanel
-        ) -> UUID? {
+            intoPane paneId: PaneID,
+            anchor: AnchorPanel
+        ) {
             switch node {
             case .pane(let paneSpec):
-                return materializePane(paneSpec, intoAnchor: anchor)
+                materializePane(paneSpec, intoPane: paneId, anchor: anchor)
             case .split(let splitSpec):
-                return materializeSplit(splitSpec, intoAnchor: anchor)
+                materializeSplit(splitSpec, intoPane: paneId, anchor: anchor)
             }
         }
 
         private mutating func materializePane(
             _ paneSpec: LayoutTreeSpec.PaneSpec,
-            intoAnchor anchor: AnchorPanel
-        ) -> UUID? {
+            intoPane paneId: PaneID,
+            anchor: AnchorPanel
+        ) {
             guard let firstSurfaceId = paneSpec.surfaceIds.first,
                   let firstSurface = surfacesById[firstSurfaceId] else {
                 failures.append(ApplyFailure(
@@ -355,7 +365,7 @@ enum WorkspaceLayoutExecutor {
                     step: "layout.walk",
                     message: "PaneSpec with no surfaces reached the walker"
                 ))
-                return nil
+                return
             }
 
             let leafClock = Clock()
@@ -363,18 +373,11 @@ enum WorkspaceLayoutExecutor {
             if anchor.kind == firstSurface.kind {
                 firstPanelId = anchor.panelId
             } else {
-                // Kind mismatch only happens on the root when the plan's
-                // first leaf is browser or markdown. Replace the seed in
-                // the same pane, then close the seed terminal.
-                guard case .seedTerminal(let seed) = anchor,
-                      let paneId = workspace.paneIdForPanel(seed.id) else {
-                    failures.append(ApplyFailure(
-                        code: "seed_panel_missing",
-                        step: "layout.walk",
-                        message: "anchor kind mismatch but no seed pane available"
-                    ))
-                    return nil
-                }
+                // Kind mismatch: replace the anchor with the target kind in
+                // the same pane, then close the old anchor. This handles the
+                // root case (plan's first leaf is browser/markdown) and any
+                // nested case where the anchor inherited from the enclosing
+                // split disagrees with this leaf's kind.
                 guard let replacement = createSurface(
                     firstSurface,
                     inPane: paneId,
@@ -383,12 +386,12 @@ enum WorkspaceLayoutExecutor {
                     failures.append(ApplyFailure(
                         code: "surface_create_failed",
                         step: "surface[\(firstSurface.id)].create",
-                        message: "failed to replace seed terminal with \(firstSurface.kind.rawValue) surface"
+                        message: "failed to replace anchor with \(firstSurface.kind.rawValue) surface"
                     ))
-                    return nil
+                    return
                 }
                 firstPanelId = replacement
-                _ = workspace.closePanel(seed.id, force: true)
+                _ = workspace.closePanel(anchor.panelId, force: true)
             }
             timings.append(StepTiming(
                 step: "surface[\(firstSurface.id)].create",
@@ -398,17 +401,14 @@ enum WorkspaceLayoutExecutor {
 
             // Apply the first surface's title via the canonical setter so
             // SurfaceMetadataStore["title"] stays in sync. Description and
-            // the rest of surface + pane metadata land in a dedicated pass
-            // immediately after, during creation (no post-hoc socket loop).
+            // the rest of surface + pane metadata land immediately after,
+            // during creation (no post-hoc socket loop).
             if let title = firstSurface.title {
                 workspace.setPanelCustomTitle(panelId: firstPanelId, title: title)
             }
             writeSurfaceMetadata(firstSurface, panelId: firstPanelId)
 
-            // Additional surfaces in the same pane.
-            guard let paneId = workspace.paneIdForPanel(firstPanelId) else {
-                return firstPanelId
-            }
+            // Additional surfaces in the same pane (tab-stacked).
             for additionalSurfaceId in paneSpec.surfaceIds.dropFirst() {
                 guard let spec = surfacesById[additionalSurfaceId] else { continue }
                 let addClock = Clock()
@@ -431,40 +431,41 @@ enum WorkspaceLayoutExecutor {
                 writeSurfaceMetadata(spec, panelId: newPanelId)
             }
 
-            // Apply selectedIndex. Default is the first surface, which bonsplit
-            // selects on creation; only deviate if the plan picks another.
+            // Apply selectedIndex. Default is the first surface, which
+            // bonsplit selects on creation; only deviate if the plan picks
+            // another.
             if let selectedIndex = paneSpec.selectedIndex,
                selectedIndex > 0,
-               selectedIndex < paneSpec.surfaceIds.count,
-               let selectedSurfaceId = Optional(paneSpec.surfaceIds[selectedIndex]),
-               let selectedPanelId = planSurfaceIdToPanelId[selectedSurfaceId],
-               let selectedTabId = workspace.surfaceIdFromPanelId(selectedPanelId) {
-                workspace.bonsplitController.selectTab(selectedTabId)
+               selectedIndex < paneSpec.surfaceIds.count {
+                let selectedSurfaceId = paneSpec.surfaceIds[selectedIndex]
+                if let selectedPanelId = planSurfaceIdToPanelId[selectedSurfaceId],
+                   let selectedTabId = workspace.surfaceIdFromPanelId(selectedPanelId) {
+                    workspace.bonsplitController.selectTab(selectedTabId)
+                }
             }
-
-            return firstPanelId
         }
 
         private mutating func materializeSplit(
             _ splitSpec: LayoutTreeSpec.SplitSpec,
-            intoAnchor anchor: AnchorPanel
-        ) -> UUID? {
-            // Build the first subtree using the inbound anchor.
-            guard let firstAnchorPanelId = materialize(splitSpec.first, intoAnchor: anchor) else {
-                return nil
-            }
-
-            // Determine the kind of the second subtree's first leaf so we
-            // pick the right split primitive.
-            let secondFirstSurfaceId = firstLeafSurfaceId(splitSpec.second)
-            guard let secondFirstSurfaceId,
+            intoPane paneId: PaneID,
+            anchor: AnchorPanel
+        ) {
+            // Pick the right split primitive based on `split.second`'s first
+            // leaf so the newly-minted pane is seeded with a panel of the
+            // correct kind. If second's leaf is terminal we use
+            // newTerminalSplit; browser uses newBrowserSplit; markdown uses
+            // newMarkdownSplit. This saves a replace-in-new-pane round-trip
+            // when the second subtree's first leaf matches the split's seed.
+            guard let secondFirstSurfaceId = firstLeafSurfaceId(splitSpec.second),
                   let secondFirstSurface = surfacesById[secondFirstSurfaceId] else {
                 failures.append(ApplyFailure(
                     code: "validation_failed",
                     step: "layout.walk",
                     message: "split's second subtree has no discoverable first surface"
                 ))
-                return firstAnchorPanelId
+                // Best-effort: populate first in the current pane, drop second.
+                materialize(splitSpec.first, intoPane: paneId, anchor: anchor)
+                return
             }
 
             let orientation: SplitOrientation = splitSpec.orientation == .vertical
@@ -474,7 +475,7 @@ enum WorkspaceLayoutExecutor {
             splitIndex += 1
             let splitClock = Clock()
             let newPanelId = splitFromPanel(
-                firstAnchorPanelId,
+                anchor.panelId,
                 orientation: orientation,
                 spec: secondFirstSurface
             )
@@ -482,22 +483,28 @@ enum WorkspaceLayoutExecutor {
                 step: "layout.split[\(label)].create",
                 durationMs: splitClock.elapsedMs
             ))
-            guard let newPanelId else {
+
+            guard let newPanelId,
+                  let newPaneId = workspace.paneIdForPanel(newPanelId) else {
                 failures.append(ApplyFailure(
                     code: "split_failed",
                     step: "layout.split[\(label)].create",
                     message: "newXSplit rejected split from panel for \(secondFirstSurface.kind.rawValue)"
                 ))
-                return firstAnchorPanelId
+                // Best-effort: populate first in the current pane, drop second.
+                materialize(splitSpec.first, intoPane: paneId, anchor: anchor)
+                return
             }
 
-            // The split returned a panel of the right kind; recurse into
-            // the second subtree with that as its anchor.
-            _ = materialize(
+            // Recurse:
+            //   first → current pane, inherits the inbound anchor
+            //   second → newly-minted pane, anchored on the split primitive's new panel
+            materialize(splitSpec.first, intoPane: paneId, anchor: anchor)
+            materialize(
                 splitSpec.second,
-                intoAnchor: .anyExisting(panelId: newPanelId, kind: secondFirstSurface.kind)
+                intoPane: newPaneId,
+                anchor: .anyExisting(panelId: newPanelId, kind: secondFirstSurface.kind)
             )
-            return firstAnchorPanelId
         }
 
         /// Dispatch to the right `Workspace.newXSplit` primitive. Always

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -162,12 +162,19 @@ enum WorkspaceLayoutExecutor {
         // Apply divider positions by walking the plan tree alongside the
         // live bonsplit tree. Same shape as
         // `Workspace.applySessionDividerPositions`; a no-op for trees with
-        // only default 0.5 dividers.
-        applyDividerPositions(
+        // only default 0.5 dividers. A plan/live shape mismatch (e.g., a
+        // pane on the live side where the plan expected a split — which
+        // would indicate a walker fault or an unsupported plan) now emits
+        // a typed ApplyFailure instead of being dropped silently (I4c).
+        let dividerFailures = applyDividerPositions(
             planNode: plan.layout,
             liveNode: workspace.bonsplitController.treeSnapshot(),
             workspace: workspace
         )
+        for failure in dividerFailures {
+            walkState.failures.append(failure)
+            walkState.warnings.append(failure.message)
+        }
 
         // Step 7 — terminal initial commands. TerminalPanel.sendText
         // auto-queues pre-ready and flushes when the Ghostty surface comes
@@ -209,6 +216,26 @@ enum WorkspaceLayoutExecutor {
         timings = walkState.timings
         warnings = walkState.warnings
         failures = walkState.failures
+
+        // Enforce the per-step timeout as a soft limit (I4a). Any step that
+        // exceeded options.perStepTimeoutMs emits a typed warning; the
+        // executor never aborts — partial-failure semantics per the plan's
+        // "truncate-on-failure" principle. A value of 0 disables the
+        // check. The synthetic "total" step is exempt; its budget is the
+        // acceptance fixture's concern, not per-step.
+        if options.perStepTimeoutMs > 0 {
+            let threshold = Double(options.perStepTimeoutMs)
+            for timing in timings where timing.step != "total" && timing.durationMs > threshold {
+                let message = "step '\(timing.step)' took \(String(format: "%.2f", timing.durationMs))ms, exceeding perStepTimeoutMs=\(options.perStepTimeoutMs)ms"
+                warnings.append(message)
+                failures.append(ApplyFailure(
+                    code: "per_step_timeout_exceeded",
+                    step: timing.step,
+                    message: message
+                ))
+            }
+        }
+
         timings.append(StepTiming(step: "total", durationMs: total.elapsedMs))
         return ApplyResult(
             workspaceRef: workspaceRef,
@@ -222,13 +249,31 @@ enum WorkspaceLayoutExecutor {
 
     // MARK: - Plan validation
 
+    /// Plan schema versions this executor understands. Bumping the format
+    /// (new required fields, breaking semantics) adds a version here and
+    /// at the same time updates callers that emit plans (Blueprint parser,
+    /// Snapshot reader). Phase 0 ships only version 1.
+    nonisolated static let supportedPlanVersions: Set<Int> = [1]
+
     /// Returns the first validation failure encountered, or `nil` if the plan
     /// is structurally sound. Pure — safe to call off the main actor before
     /// dispatching to `apply(_:options:dependencies:)`. Per review cycle 1 I3,
     /// the v2 socket handler pre-checks via this entry point so validation
     /// never rides the main actor.
     nonisolated static func validate(plan: WorkspaceApplyPlan) -> ApplyFailure? {
-        // Duplicate surface ids.
+        // Schema version (I4b). Unsupported versions short-circuit before
+        // we inspect surfaces or the layout tree — a mis-versioned plan has
+        // no guarantees about the rest of the shape.
+        if !supportedPlanVersions.contains(plan.version) {
+            let supported = supportedPlanVersions.sorted()
+            return ApplyFailure(
+                code: "unsupported_version",
+                step: "validate",
+                message: "WorkspaceApplyPlan.version=\(plan.version) unsupported (Phase 0 accepts \(supported))"
+            )
+        }
+
+        // Duplicate surface ids in plan.surfaces.
         var seen = Set<String>()
         for surface in plan.surfaces {
             if !seen.insert(surface.id).inserted {
@@ -240,9 +285,15 @@ enum WorkspaceLayoutExecutor {
             }
         }
 
-        // Every id referenced from the layout tree must exist in `surfaces`.
+        // Every id referenced from the layout tree must exist in `surfaces`,
+        // and no id may be referenced from more than one PaneSpec (I4d).
         let known = Set(plan.surfaces.map(\.id))
-        if let failure = validateLayout(plan.layout, knownSurfaceIds: known) {
+        var referencedIds = Set<String>()
+        if let failure = validateLayout(
+            plan.layout,
+            knownSurfaceIds: known,
+            referencedIds: &referencedIds
+        ) {
             return failure
         }
         return nil
@@ -250,7 +301,8 @@ enum WorkspaceLayoutExecutor {
 
     nonisolated private static func validateLayout(
         _ node: LayoutTreeSpec,
-        knownSurfaceIds: Set<String>
+        knownSurfaceIds: Set<String>,
+        referencedIds: inout Set<String>
     ) -> ApplyFailure? {
         switch node {
         case .pane(let pane):
@@ -261,12 +313,29 @@ enum WorkspaceLayoutExecutor {
                     message: "LayoutTreeSpec.pane.surfaceIds must not be empty"
                 )
             }
-            for surfaceId in pane.surfaceIds where !knownSurfaceIds.contains(surfaceId) {
-                return ApplyFailure(
-                    code: "unknown_surface_ref",
-                    step: "validate",
-                    message: "LayoutTreeSpec references unknown surface id '\(surfaceId)'"
-                )
+            var paneSeen = Set<String>()
+            for surfaceId in pane.surfaceIds {
+                if !knownSurfaceIds.contains(surfaceId) {
+                    return ApplyFailure(
+                        code: "unknown_surface_ref",
+                        step: "validate",
+                        message: "LayoutTreeSpec references unknown surface id '\(surfaceId)'"
+                    )
+                }
+                if !paneSeen.insert(surfaceId).inserted {
+                    return ApplyFailure(
+                        code: "duplicate_surface_reference",
+                        step: "validate",
+                        message: "LayoutTreeSpec.pane.surfaceIds contains '\(surfaceId)' twice in the same pane"
+                    )
+                }
+                if !referencedIds.insert(surfaceId).inserted {
+                    return ApplyFailure(
+                        code: "duplicate_surface_reference",
+                        step: "validate",
+                        message: "surface id '\(surfaceId)' referenced by more than one pane"
+                    )
+                }
             }
             if let idx = pane.selectedIndex, idx < 0 || idx >= pane.surfaceIds.count {
                 return ApplyFailure(
@@ -277,10 +346,18 @@ enum WorkspaceLayoutExecutor {
             }
             return nil
         case .split(let split):
-            if let failure = validateLayout(split.first, knownSurfaceIds: knownSurfaceIds) {
+            if let failure = validateLayout(
+                split.first,
+                knownSurfaceIds: knownSurfaceIds,
+                referencedIds: &referencedIds
+            ) {
                 return failure
             }
-            if let failure = validateLayout(split.second, knownSurfaceIds: knownSurfaceIds) {
+            if let failure = validateLayout(
+                split.second,
+                knownSurfaceIds: knownSurfaceIds,
+                referencedIds: &referencedIds
+            ) {
                 return failure
             }
             return nil
@@ -766,13 +843,20 @@ enum WorkspaceLayoutExecutor {
     /// plan-side `dividerPosition`. Same shape as
     /// `Workspace.applySessionDividerPositions` — plan tree replaces the
     /// session snapshot side.
+    ///
+    /// Returns any `ApplyFailure` records produced when the plan and live
+    /// trees disagree on shape (plan expected a split but live has a pane,
+    /// or vice versa). Pane-vs-pane is a legitimate no-op (no dividers to
+    /// apply), not a failure.
     private static func applyDividerPositions(
         planNode: LayoutTreeSpec,
         liveNode: ExternalTreeNode,
-        workspace: Workspace
-    ) {
+        workspace: Workspace,
+        path: String = "layout"
+    ) -> [ApplyFailure] {
         switch (planNode, liveNode) {
         case (.split(let planSplit), .split(let liveSplit)):
+            var out: [ApplyFailure] = []
             if let splitID = UUID(uuidString: liveSplit.id) {
                 let clamped = min(max(planSplit.dividerPosition, 0), 1)
                 _ = workspace.bonsplitController.setDividerPosition(
@@ -781,18 +865,33 @@ enum WorkspaceLayoutExecutor {
                     fromExternal: true
                 )
             }
-            applyDividerPositions(
+            out.append(contentsOf: applyDividerPositions(
                 planNode: planSplit.first,
                 liveNode: liveSplit.first,
-                workspace: workspace
-            )
-            applyDividerPositions(
+                workspace: workspace,
+                path: "\(path).first"
+            ))
+            out.append(contentsOf: applyDividerPositions(
                 planNode: planSplit.second,
                 liveNode: liveSplit.second,
-                workspace: workspace
-            )
-        default:
-            return
+                workspace: workspace,
+                path: "\(path).second"
+            ))
+            return out
+        case (.split, .pane):
+            return [ApplyFailure(
+                code: "divider_apply_failed",
+                step: "\(path).dividerPosition",
+                message: "plan/live tree shape mismatch at \(path); plan expected split, live has pane — dividerPosition cannot be applied"
+            )]
+        case (.pane, .split):
+            return [ApplyFailure(
+                code: "divider_apply_failed",
+                step: "\(path).dividerPosition",
+                message: "plan/live tree shape mismatch at \(path); plan expected pane, live has split — divider slot is unexpected"
+            )]
+        case (.pane, .pane):
+            return []
         }
     }
 

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -48,11 +48,15 @@ enum WorkspaceLayoutExecutor {
 
     /// Execute `plan`. Returns an `ApplyResult` with timings and any
     /// partial-failure warnings. Never throws.
+    ///
+    /// Synchronous in Phase 0 — the walk has no await points. Phase 1's
+    /// readiness pass (awaiting `ready` on each surface) will upgrade this
+    /// to `async`, at which point callers gain real backpressure.
     static func apply(
         _ plan: WorkspaceApplyPlan,
         options: ApplyOptions = ApplyOptions(),
         dependencies: WorkspaceLayoutExecutorDependencies
-    ) async -> ApplyResult {
+    ) -> ApplyResult {
         let total = Clock()
         var timings: [StepTiming] = []
         var warnings: [String] = []

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -3996,6 +3996,13 @@ enum WelcomeSettings {
     ///
     /// Newly-created terminal panels auto-queue `sendText` before their surfaces
     /// finish initializing and flush on ready, so we can issue commands immediately.
+    ///
+    // TODO(CMUX-37 Phase 0+): express the quad as a WorkspaceApplyPlan and
+    // apply via WorkspaceLayoutExecutor. The current implementation runs on
+    // an already-created workspace with a live terminal panel; the executor
+    // assumes workspace-creation responsibility. Migration path: extend
+    // WorkspaceLayoutExecutor with an `applyToExistingWorkspace(_:workspace:
+    // seedPanel:)` overload that skips step 2 and reuses the seed panel.
     @MainActor
     static func performQuadLayout(on workspace: Workspace, initialPanel: TerminalPanel) {
         let initialPanelId = initialPanel.id
@@ -4078,6 +4085,12 @@ enum DefaultGridSettings {
     /// Auto-spawns a 2×2 terminal grid rooted at `initialPanel`. Silently
     /// truncates the build if any split fails (partial grid is acceptable).
     /// Callers decide when the initial panel's Ghostty surface is ready.
+    ///
+    // TODO(CMUX-37 Phase 0+): express the 2x2 grid as a WorkspaceApplyPlan
+    // driven by DefaultGridSettings.gridSplitOperations(). Gated on the
+    // apply-to-existing-workspace overload (same gate as performQuadLayout).
+    // The remote-workspace guard below must move into the executor or stay
+    // at the call site post-migration.
     @MainActor
     static func performDefaultGrid(
         on workspace: Workspace,

--- a/c11Tests/Fixtures/workspace-apply-plans/deep-nested-splits.json
+++ b/c11Tests/Fixtures/workspace-apply-plans/deep-nested-splits.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "workspace": {
+    "title": "Deep Nested"
+  },
+  "layout": {
+    "type": "split",
+    "split": {
+      "orientation": "horizontal",
+      "dividerPosition": 0.3,
+      "first": { "type": "pane", "pane": { "surfaceIds": ["a"] } },
+      "second": {
+        "type": "split",
+        "split": {
+          "orientation": "vertical",
+          "dividerPosition": 0.4,
+          "first": { "type": "pane", "pane": { "surfaceIds": ["b"] } },
+          "second": {
+            "type": "split",
+            "split": {
+              "orientation": "horizontal",
+              "dividerPosition": 0.5,
+              "first": { "type": "pane", "pane": { "surfaceIds": ["c"] } },
+              "second": {
+                "type": "split",
+                "split": {
+                  "orientation": "vertical",
+                  "dividerPosition": 0.7,
+                  "first": { "type": "pane", "pane": { "surfaceIds": ["d"] } },
+                  "second": { "type": "pane", "pane": { "surfaceIds": ["e"] } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "surfaces": [
+    { "id": "a", "kind": "terminal", "title": "a" },
+    { "id": "b", "kind": "terminal", "title": "b" },
+    { "id": "c", "kind": "terminal", "title": "c" },
+    { "id": "d", "kind": "terminal", "title": "d" },
+    { "id": "e", "kind": "terminal", "title": "e" }
+  ]
+}

--- a/c11Tests/Fixtures/workspace-apply-plans/default-grid.json
+++ b/c11Tests/Fixtures/workspace-apply-plans/default-grid.json
@@ -30,8 +30,8 @@
   },
   "surfaces": [
     { "id": "tl", "kind": "terminal" },
-    { "id": "tr", "kind": "terminal" },
-    { "id": "bl", "kind": "terminal" },
+    { "id": "tr", "kind": "terminal", "workingDirectory": "/tmp" },
+    { "id": "bl", "kind": "terminal", "workingDirectory": "/var/tmp" },
     { "id": "br", "kind": "terminal" }
   ]
 }

--- a/c11Tests/Fixtures/workspace-apply-plans/default-grid.json
+++ b/c11Tests/Fixtures/workspace-apply-plans/default-grid.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "workspace": {
+    "title": "Default Grid"
+  },
+  "layout": {
+    "type": "split",
+    "split": {
+      "orientation": "horizontal",
+      "dividerPosition": 0.5,
+      "first": {
+        "type": "split",
+        "split": {
+          "orientation": "vertical",
+          "dividerPosition": 0.5,
+          "first": { "type": "pane", "pane": { "surfaceIds": ["tl"] } },
+          "second": { "type": "pane", "pane": { "surfaceIds": ["bl"] } }
+        }
+      },
+      "second": {
+        "type": "split",
+        "split": {
+          "orientation": "vertical",
+          "dividerPosition": 0.5,
+          "first": { "type": "pane", "pane": { "surfaceIds": ["tr"] } },
+          "second": { "type": "pane", "pane": { "surfaceIds": ["br"] } }
+        }
+      }
+    }
+  },
+  "surfaces": [
+    { "id": "tl", "kind": "terminal" },
+    { "id": "tr", "kind": "terminal" },
+    { "id": "bl", "kind": "terminal" },
+    { "id": "br", "kind": "terminal" }
+  ]
+}

--- a/c11Tests/Fixtures/workspace-apply-plans/mixed-browser-markdown.json
+++ b/c11Tests/Fixtures/workspace-apply-plans/mixed-browser-markdown.json
@@ -1,0 +1,37 @@
+{
+  "version": 1,
+  "workspace": {
+    "title": "Docs + Tests"
+  },
+  "layout": {
+    "type": "split",
+    "split": {
+      "orientation": "vertical",
+      "dividerPosition": 0.6,
+      "first": {
+        "type": "split",
+        "split": {
+          "orientation": "horizontal",
+          "dividerPosition": 0.5,
+          "first": { "type": "pane", "pane": { "surfaceIds": ["docs"] } },
+          "second": { "type": "pane", "pane": { "surfaceIds": ["notes"] } }
+        }
+      },
+      "second": {
+        "type": "split",
+        "split": {
+          "orientation": "horizontal",
+          "dividerPosition": 0.5,
+          "first": { "type": "pane", "pane": { "surfaceIds": ["tests"] } },
+          "second": { "type": "pane", "pane": { "surfaceIds": ["build"] } }
+        }
+      }
+    }
+  },
+  "surfaces": [
+    { "id": "docs", "kind": "browser", "title": "docs", "url": "https://stage11.ai/docs" },
+    { "id": "notes", "kind": "markdown", "title": "plan" },
+    { "id": "tests", "kind": "terminal", "title": "vitest", "command": "vitest --watch\n" },
+    { "id": "build", "kind": "terminal", "title": "build" }
+  ]
+}

--- a/c11Tests/Fixtures/workspace-apply-plans/single-large-with-metadata.json
+++ b/c11Tests/Fixtures/workspace-apply-plans/single-large-with-metadata.json
@@ -1,0 +1,32 @@
+{
+  "version": 1,
+  "workspace": {
+    "title": "Driver",
+    "metadata": {
+      "description": "single-pane driver session with mailbox config"
+    }
+  },
+  "layout": {
+    "type": "pane",
+    "pane": { "surfaceIds": ["main"] }
+  },
+  "surfaces": [
+    {
+      "id": "main",
+      "kind": "terminal",
+      "title": "driver",
+      "description": "cc session with mailbox.* subscription",
+      "metadata": {
+        "role": "driver",
+        "status": "ready",
+        "task": "cmux-37",
+        "model": "claude-opus-4-7"
+      },
+      "paneMetadata": {
+        "mailbox.delivery": "stdin,watch",
+        "mailbox.subscribe": "build.*,deploy.green",
+        "mailbox.retention_days": "7"
+      }
+    }
+  ]
+}

--- a/c11Tests/Fixtures/workspace-apply-plans/welcome-quad.json
+++ b/c11Tests/Fixtures/workspace-apply-plans/welcome-quad.json
@@ -1,0 +1,41 @@
+{
+  "version": 1,
+  "workspace": {
+    "title": "Welcome Quad",
+    "customColor": "#C0392B"
+  },
+  "layout": {
+    "type": "split",
+    "split": {
+      "orientation": "horizontal",
+      "dividerPosition": 0.5,
+      "first": {
+        "type": "split",
+        "split": {
+          "orientation": "vertical",
+          "dividerPosition": 0.5,
+          "first": { "type": "pane", "pane": { "surfaceIds": ["tl"] } },
+          "second": { "type": "pane", "pane": { "surfaceIds": ["bl"] } }
+        }
+      },
+      "second": {
+        "type": "split",
+        "split": {
+          "orientation": "vertical",
+          "dividerPosition": 0.5,
+          "first": { "type": "pane", "pane": { "surfaceIds": ["tr"] } },
+          "second": { "type": "pane", "pane": { "surfaceIds": ["br"] } }
+        }
+      }
+    }
+  },
+  "surfaces": [
+    { "id": "tl", "kind": "terminal", "title": "welcome",
+      "command": "c11 welcome\n" },
+    { "id": "tr", "kind": "browser", "title": "spike",
+      "url": "https://stage11.ai" },
+    { "id": "bl", "kind": "markdown", "title": "welcome.md" },
+    { "id": "br", "kind": "terminal", "title": "claude",
+      "command": "command -v claude >/dev/null 2>&1 && claude --dangerously-skip-permissions\n" }
+  ]
+}

--- a/c11Tests/WorkspaceApplyPlanCodableTests.swift
+++ b/c11Tests/WorkspaceApplyPlanCodableTests.swift
@@ -1,0 +1,233 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Codable round-trip tests for the `WorkspaceApplyPlan` value types.
+/// Phase 1 Snapshot capture and Phase 2 Blueprint parsing both serialize
+/// through this schema; these tests lock the wire shape so either can land
+/// without a compat layer.
+final class WorkspaceApplyPlanCodableTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(value)
+    }
+
+    private func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        return try JSONDecoder().decode(type, from: data)
+    }
+
+    private func roundTrip<T: Codable & Equatable>(_ value: T) throws {
+        let data = try encode(value)
+        let decoded = try decode(T.self, from: data)
+        XCTAssertEqual(decoded, value)
+    }
+
+    // MARK: - WorkspaceSpec
+
+    func testWorkspaceSpecRoundTripsFullyPopulated() throws {
+        let spec = WorkspaceSpec(
+            title: "Debug Auth",
+            customColor: "#C0392B",
+            workingDirectory: "/Users/op/repo",
+            metadata: ["description": "auth module work", "icon": "shield"]
+        )
+        try roundTrip(spec)
+    }
+
+    func testWorkspaceSpecRoundTripsEmpty() throws {
+        try roundTrip(WorkspaceSpec())
+    }
+
+    // MARK: - SurfaceSpec
+
+    func testSurfaceSpecTerminalRoundTrips() throws {
+        let spec = SurfaceSpec(
+            id: "main",
+            kind: .terminal,
+            title: "driver",
+            description: "cc on auth",
+            workingDirectory: "/Users/op/repo",
+            command: "cc --resume abc123",
+            metadata: [
+                "role": .string("driver"),
+                "status": .string("ready"),
+                "model": .string("claude-opus-4-7")
+            ],
+            paneMetadata: [
+                "mailbox.delivery": .string("stdin,watch"),
+                "mailbox.subscribe": .string("build.*,deploy.green"),
+                "mailbox.retention_days": .string("7")
+            ]
+        )
+        try roundTrip(spec)
+    }
+
+    func testSurfaceSpecBrowserRoundTrips() throws {
+        let spec = SurfaceSpec(
+            id: "docs",
+            kind: .browser,
+            title: "docs",
+            url: "https://stage11.ai"
+        )
+        try roundTrip(spec)
+    }
+
+    func testSurfaceSpecMarkdownRoundTrips() throws {
+        let spec = SurfaceSpec(
+            id: "notes",
+            kind: .markdown,
+            title: "plan",
+            filePath: "/Users/op/notes/plan.md"
+        )
+        try roundTrip(spec)
+    }
+
+    func testSurfaceSpecPreservesMailboxStarKeysVerbatim() throws {
+        // Per docs/c11-13-cmux-37-alignment.md: the mailbox.* namespace
+        // round-trips without normalization. The string-value type guard
+        // lives in the executor, not the Codable layer, so a non-string value
+        // must still decode cleanly on the wire.
+        let spec = SurfaceSpec(
+            id: "watcher",
+            kind: .terminal,
+            paneMetadata: [
+                "mailbox.delivery": .string("silent"),
+                "mailbox.advertises": .array([.string("build.*"), .string("deploy.*")]),
+                "mailbox.retention_days": .number(14)
+            ]
+        )
+        let data = try encode(spec)
+        let decoded = try decode(SurfaceSpec.self, from: data)
+        XCTAssertEqual(decoded.paneMetadata?["mailbox.delivery"], .string("silent"))
+        XCTAssertEqual(
+            decoded.paneMetadata?["mailbox.advertises"],
+            .array([.string("build.*"), .string("deploy.*")])
+        )
+        XCTAssertEqual(decoded.paneMetadata?["mailbox.retention_days"], .number(14))
+    }
+
+    // MARK: - LayoutTreeSpec
+
+    func testLayoutTreeSpecSinglePaneRoundTrips() throws {
+        let tree = LayoutTreeSpec.pane(
+            .init(surfaceIds: ["main"], selectedIndex: 0)
+        )
+        try roundTrip(tree)
+    }
+
+    func testLayoutTreeSpecNestedSplitRoundTrips() throws {
+        let tree = LayoutTreeSpec.split(
+            .init(
+                orientation: .horizontal,
+                dividerPosition: 0.5,
+                first: .pane(.init(surfaceIds: ["tl"])),
+                second: .split(
+                    .init(
+                        orientation: .vertical,
+                        dividerPosition: 0.5,
+                        first: .pane(.init(surfaceIds: ["tr"])),
+                        second: .pane(.init(surfaceIds: ["br"], selectedIndex: 0))
+                    )
+                )
+            )
+        )
+        try roundTrip(tree)
+    }
+
+    func testLayoutTreeSpecDiscriminatorIsTypeKey() throws {
+        let tree = LayoutTreeSpec.pane(.init(surfaceIds: ["s"]))
+        let data = try encode(tree)
+        let string = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(string.contains("\"type\":\"pane\""))
+    }
+
+    func testLayoutTreeSpecRejectsUnknownType() throws {
+        let bogus = Data("""
+        {"type":"triple-pane","extra":{}}
+        """.utf8)
+        XCTAssertThrowsError(try decode(LayoutTreeSpec.self, from: bogus)) { error in
+            guard case DecodingError.dataCorrupted = error else {
+                XCTFail("expected .dataCorrupted, got \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Full plan
+
+    func testWorkspaceApplyPlanRoundTripsMixedLayout() throws {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(
+                title: "Welcome Quad",
+                workingDirectory: "/Users/op"
+            ),
+            layout: .split(
+                .init(
+                    orientation: .horizontal,
+                    dividerPosition: 0.5,
+                    first: .split(
+                        .init(
+                            orientation: .vertical,
+                            dividerPosition: 0.5,
+                            first: .pane(.init(surfaceIds: ["tl"])),
+                            second: .pane(.init(surfaceIds: ["bl"]))
+                        )
+                    ),
+                    second: .split(
+                        .init(
+                            orientation: .vertical,
+                            dividerPosition: 0.5,
+                            first: .pane(.init(surfaceIds: ["tr"])),
+                            second: .pane(.init(surfaceIds: ["br"]))
+                        )
+                    )
+                )
+            ),
+            surfaces: [
+                SurfaceSpec(id: "tl", kind: .terminal, title: "driver", command: "c11 welcome\n"),
+                SurfaceSpec(id: "tr", kind: .browser, title: "spike", url: "https://stage11.ai"),
+                SurfaceSpec(id: "bl", kind: .markdown, title: "welcome", filePath: "/tmp/welcome.md"),
+                SurfaceSpec(id: "br", kind: .terminal, title: "claude", command: "claude\n")
+            ]
+        )
+        try roundTrip(plan)
+    }
+
+    // MARK: - ApplyOptions / ApplyResult
+
+    func testApplyOptionsDefaultsRoundTrip() throws {
+        try roundTrip(ApplyOptions())
+        try roundTrip(ApplyOptions(select: false, perStepTimeoutMs: 0, autoWelcomeIfNeeded: true))
+    }
+
+    func testApplyResultRoundTripsWithWarningsAndFailures() throws {
+        let result = ApplyResult(
+            workspaceRef: "workspace:1",
+            surfaceRefs: ["main": "surface:1", "logs": "surface:2"],
+            paneRefs: ["main": "pane:1", "logs": "pane:2"],
+            timings: [
+                StepTiming(step: "validate", durationMs: 0.3),
+                StepTiming(step: "workspace.create", durationMs: 12.1),
+                StepTiming(step: "total", durationMs: 180.5)
+            ],
+            warnings: ["mailbox.retention_days dropped: non-string value"],
+            failures: [
+                ApplyFailure(
+                    code: "mailbox_non_string_value",
+                    step: "metadata.pane[main].write",
+                    message: "mailbox.retention_days must be a string in v1"
+                )
+            ]
+        )
+        try roundTrip(result)
+    }
+}

--- a/c11Tests/WorkspaceApplyPlanCodableTests.swift
+++ b/c11Tests/WorkspaceApplyPlanCodableTests.swift
@@ -230,4 +230,95 @@ final class WorkspaceApplyPlanCodableTests: XCTestCase {
         )
         try roundTrip(result)
     }
+
+    // MARK: - Validation (review cycle 1 R6: I4a/I4b/I4d)
+
+    /// Helper: build a plan with the minimum valid layout (one terminal).
+    private func minimalPlan(
+        version: Int = 1,
+        surfaces: [SurfaceSpec]? = nil,
+        layout: LayoutTreeSpec? = nil
+    ) -> WorkspaceApplyPlan {
+        let resolvedSurfaces = surfaces ?? [SurfaceSpec(id: "a", kind: .terminal)]
+        let resolvedLayout = layout ?? .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["a"]))
+        return WorkspaceApplyPlan(
+            version: version,
+            workspace: WorkspaceSpec(),
+            layout: resolvedLayout,
+            surfaces: resolvedSurfaces
+        )
+    }
+
+    func testValidateAcceptsVersionOne() {
+        XCTAssertNil(WorkspaceLayoutExecutor.validate(plan: minimalPlan(version: 1)))
+    }
+
+    func testValidateRejectsUnsupportedVersion() {
+        let failure = WorkspaceLayoutExecutor.validate(plan: minimalPlan(version: 2))
+        XCTAssertEqual(failure?.code, "unsupported_version")
+        XCTAssertEqual(failure?.step, "validate")
+    }
+
+    func testValidateRejectsDuplicateSurfaceId() {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(),
+            layout: .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["a"])),
+            surfaces: [
+                SurfaceSpec(id: "a", kind: .terminal),
+                SurfaceSpec(id: "a", kind: .terminal)
+            ]
+        )
+        let failure = WorkspaceLayoutExecutor.validate(plan: plan)
+        XCTAssertEqual(failure?.code, "duplicate_surface_id")
+    }
+
+    func testValidateRejectsDuplicateSurfaceReferenceAcrossPanes() {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(),
+            layout: .split(LayoutTreeSpec.SplitSpec(
+                orientation: .horizontal,
+                dividerPosition: 0.5,
+                first: .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["a"])),
+                second: .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["a"]))
+            )),
+            surfaces: [SurfaceSpec(id: "a", kind: .terminal)]
+        )
+        let failure = WorkspaceLayoutExecutor.validate(plan: plan)
+        XCTAssertEqual(failure?.code, "duplicate_surface_reference")
+    }
+
+    func testValidateRejectsDuplicateSurfaceReferenceWithinSinglePane() {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(),
+            layout: .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["a", "a"])),
+            surfaces: [SurfaceSpec(id: "a", kind: .terminal)]
+        )
+        let failure = WorkspaceLayoutExecutor.validate(plan: plan)
+        XCTAssertEqual(failure?.code, "duplicate_surface_reference")
+    }
+
+    func testValidateRejectsUnknownSurfaceReference() {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(),
+            layout: .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["ghost"])),
+            surfaces: [SurfaceSpec(id: "a", kind: .terminal)]
+        )
+        let failure = WorkspaceLayoutExecutor.validate(plan: plan)
+        XCTAssertEqual(failure?.code, "unknown_surface_ref")
+    }
+
+    func testValidateRejectsOutOfRangeSelectedIndex() {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(),
+            layout: .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["a"], selectedIndex: 5)),
+            surfaces: [SurfaceSpec(id: "a", kind: .terminal)]
+        )
+        let failure = WorkspaceLayoutExecutor.validate(plan: plan)
+        XCTAssertEqual(failure?.code, "validation_failed")
+    }
 }

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Bonsplit
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -8,8 +9,16 @@ import XCTest
 
 /// Acceptance fixture for `WorkspaceLayoutExecutor`. Runs each of five
 /// `WorkspaceApplyPlan` JSON fixtures through the executor on a real
-/// `TabManager` and asserts the workspace materializes in under 2 s —
-/// the per-fixture budget from the Phase 0 plan.
+/// `TabManager` and verifies three things:
+///
+/// 1. Every plan-local surface id appears in `result.surfaceRefs` and
+///    `result.paneRefs`.
+/// 2. The live bonsplit tree shape — split orientations, divider positions,
+///    pane tab ordering, selected tab — matches the fixture's `LayoutTreeSpec`.
+///    Without this assertion, a broken layout walker can produce malformed
+///    geometry and still satisfy surface-ref coverage (review cycle 1 B1/B2).
+/// 3. Every `SurfaceSpec.metadata` / `SurfaceSpec.paneMetadata` entry in the
+///    fixture round-trips through `SurfaceMetadataStore` / `PaneMetadataStore`.
 ///
 /// Per `CLAUDE.md`, tests are never run locally by the impl agent; this file
 /// is committed and exercised only in CI.
@@ -18,17 +27,13 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
 
     // MARK: - Fixtures
 
-    private static let fixtureNames = [
-        "welcome-quad",
-        "default-grid",
-        "single-large-with-metadata",
-        "mixed-browser-markdown",
-        "deep-nested-splits"
-    ]
-
     /// Budget per fixture in milliseconds. Matches `ApplyOptions.perStepTimeoutMs`
     /// default and the plan's acceptance target.
     private static let perFixtureBudgetMs: Double = 2_000
+
+    /// Divider positions are floating-point; allow a small tolerance when
+    /// comparing plan value vs. live bonsplit value.
+    private static let dividerTolerance: Double = 0.001
 
     // MARK: - Setup
 
@@ -55,36 +60,10 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
     }
 
     func testAppliesSingleLargeWithMetadataFixture() throws {
-        let result = try runFixture(
+        try runFixture(
             named: "single-large-with-metadata",
             expectedSurfaceIds: ["main"]
         )
-        // Workspace-level metadata should land on the workspace.
-        let workspaceId = try XCTUnwrap(UUID(uuidString: result.workspaceRef.replacingOccurrences(of: "workspace:", with: "")))
-        let workspace = try XCTUnwrap(tabManager.tabs.first { $0.id == workspaceId })
-        XCTAssertEqual(workspace.metadata["description"], "single-pane driver session with mailbox config")
-
-        // Surface metadata round-trips through SurfaceMetadataStore.
-        let mainPanelId = try XCTUnwrap(
-            panelId(forSurfaceRef: result.surfaceRefs["main"], workspace: workspace)
-        )
-        let (surfaceMetadata, _) = SurfaceMetadataStore.shared.getMetadata(
-            workspaceId: workspace.id,
-            surfaceId: mainPanelId
-        )
-        XCTAssertEqual(surfaceMetadata["role"] as? String, "driver")
-        XCTAssertEqual(surfaceMetadata["status"] as? String, "ready")
-        XCTAssertEqual(surfaceMetadata["description"] as? String, "cc session with mailbox.* subscription")
-
-        // mailbox.* pane metadata round-trips verbatim through PaneMetadataStore.
-        let paneId = try XCTUnwrap(workspace.paneIdForPanel(mainPanelId)?.id)
-        let (paneMetadata, _) = PaneMetadataStore.shared.getMetadata(
-            workspaceId: workspace.id,
-            paneId: paneId
-        )
-        XCTAssertEqual(paneMetadata["mailbox.delivery"] as? String, "stdin,watch")
-        XCTAssertEqual(paneMetadata["mailbox.subscribe"] as? String, "build.*,deploy.green")
-        XCTAssertEqual(paneMetadata["mailbox.retention_days"] as? String, "7")
     }
 
     func testAppliesMixedBrowserMarkdownFixture() throws {
@@ -121,6 +100,7 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
             dependencies: deps
         )
 
+        // 1. Surface / pane ref coverage.
         XCTAssertFalse(result.workspaceRef.isEmpty, "workspaceRef populated for \(name)")
         XCTAssertEqual(
             Set(result.surfaceRefs.keys),
@@ -137,6 +117,36 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
             "no validation_failed entries in \(name): \(result.failures)"
         )
 
+        let workspace = try XCTUnwrap(
+            resolveWorkspace(from: result.workspaceRef),
+            "workspaceRef \(result.workspaceRef) resolves to a live Workspace"
+        )
+
+        // 2. Structural assertion against bonsplit treeSnapshot.
+        let liveTree = workspace.bonsplitController.treeSnapshot()
+        let planSurfaceIdToPanelUUID = Dictionary(uniqueKeysWithValues: result.surfaceRefs
+            .compactMap { (planId, ref) -> (String, UUID)? in
+                guard let uuid = parseUUIDSuffix(ref) else { return nil }
+                return (planId, uuid)
+            })
+        compareStructure(
+            fixtureName: name,
+            path: "layout",
+            plan: plan.layout,
+            live: liveTree,
+            planSurfaceIdToPanelUUID: planSurfaceIdToPanelUUID,
+            workspace: workspace
+        )
+
+        // 3. Metadata round-trip for every fixture that declares metadata.
+        assertMetadataRoundTrip(
+            fixtureName: name,
+            plan: plan,
+            result: result,
+            workspace: workspace
+        )
+
+        // 4. Timing budget.
         let totalMs = result.timings.first { $0.step == "total" }?.durationMs ?? .infinity
         XCTAssertLessThan(
             totalMs,
@@ -156,12 +166,276 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
         return try JSONDecoder().decode(WorkspaceApplyPlan.self, from: data)
     }
 
-    private func panelId(forSurfaceRef ref: String?, workspace: Workspace) -> UUID? {
+    // MARK: - Workspace lookup
+
+    private func resolveWorkspace(from ref: String) -> Workspace? {
+        guard let uuid = parseUUIDSuffix(ref) else { return nil }
+        return tabManager.tabs.first { $0.id == uuid }
+    }
+
+    private func parseUUIDSuffix(_ ref: String?) -> UUID? {
         guard let ref = ref,
-              let uuidString = ref.split(separator: ":").last,
-              let uuid = UUID(uuidString: String(uuidString)) else {
+              let uuidString = ref.split(separator: ":").last else {
             return nil
         }
-        return workspace.panels[uuid] != nil ? uuid : nil
+        return UUID(uuidString: String(uuidString))
+    }
+
+    // MARK: - Structural comparison
+
+    /// Walk plan and live trees in lockstep. Every divergence (shape,
+    /// orientation, divider position, tab order, selected tab) fails the
+    /// test with a fixture-and-path-qualified message so breakage points at
+    /// the specific subtree that disagrees.
+    private func compareStructure(
+        fixtureName: String,
+        path: String,
+        plan: LayoutTreeSpec,
+        live: ExternalTreeNode,
+        planSurfaceIdToPanelUUID: [String: UUID],
+        workspace: Workspace
+    ) {
+        switch (plan, live) {
+        case (.split(let planSplit), .split(let liveSplit)):
+            XCTAssertEqual(
+                planSplit.orientation.rawValue,
+                liveSplit.orientation,
+                "[\(fixtureName) @ \(path)] split orientation mismatch"
+            )
+            XCTAssertEqual(
+                planSplit.dividerPosition,
+                liveSplit.dividerPosition,
+                accuracy: Self.dividerTolerance,
+                "[\(fixtureName) @ \(path)] dividerPosition mismatch"
+            )
+            compareStructure(
+                fixtureName: fixtureName,
+                path: "\(path).first",
+                plan: planSplit.first,
+                live: liveSplit.first,
+                planSurfaceIdToPanelUUID: planSurfaceIdToPanelUUID,
+                workspace: workspace
+            )
+            compareStructure(
+                fixtureName: fixtureName,
+                path: "\(path).second",
+                plan: planSplit.second,
+                live: liveSplit.second,
+                planSurfaceIdToPanelUUID: planSurfaceIdToPanelUUID,
+                workspace: workspace
+            )
+        case (.pane(let planPane), .pane(let livePane)):
+            comparePane(
+                fixtureName: fixtureName,
+                path: path,
+                planPane: planPane,
+                livePane: livePane,
+                planSurfaceIdToPanelUUID: planSurfaceIdToPanelUUID,
+                workspace: workspace
+            )
+        case (.split, .pane):
+            XCTFail("[\(fixtureName) @ \(path)] plan expected split, live is pane")
+        case (.pane, .split):
+            XCTFail("[\(fixtureName) @ \(path)] plan expected pane, live is split")
+        }
+    }
+
+    private func comparePane(
+        fixtureName: String,
+        path: String,
+        planPane: LayoutTreeSpec.PaneSpec,
+        livePane: ExternalPaneNode,
+        planSurfaceIdToPanelUUID: [String: UUID],
+        workspace: Workspace
+    ) {
+        // Resolve the bonsplit tab ids back to plan-local surface ids so the
+        // assertion compares like for like. Tabs whose panel id doesn't
+        // resolve to a plan surface are surfaced as "unknown" in the
+        // assertion message — they indicate a stray seed or leaked panel.
+        let panelUUIDToPlanId = Dictionary(
+            uniqueKeysWithValues: planSurfaceIdToPanelUUID.map { ($0.value, $0.key) }
+        )
+        let livePlanIds: [String] = livePane.tabs.map { tab in
+            guard let panelId = workspace.panelIdFromSurfaceId(tab.id),
+                  let planId = panelUUIDToPlanId[panelId] else {
+                return "unknown(\(tab.id))"
+            }
+            return planId
+        }
+        XCTAssertEqual(
+            livePlanIds,
+            planPane.surfaceIds,
+            "[\(fixtureName) @ \(path)] pane tab ordering mismatch"
+        )
+
+        let expectedSelectedIndex = planPane.selectedIndex ?? 0
+        if expectedSelectedIndex >= 0, expectedSelectedIndex < planPane.surfaceIds.count {
+            let expectedSurfaceId = planPane.surfaceIds[expectedSelectedIndex]
+            guard let expectedPanelId = planSurfaceIdToPanelUUID[expectedSurfaceId],
+                  let expectedTabId = workspace.surfaceIdFromPanelId(expectedPanelId) else {
+                XCTFail("[\(fixtureName) @ \(path)] could not resolve expected selected surface \(expectedSurfaceId)")
+                return
+            }
+            XCTAssertEqual(
+                livePane.selectedTabId,
+                expectedTabId,
+                "[\(fixtureName) @ \(path)] selectedTabId mismatch (expected surface \(expectedSurfaceId))"
+            )
+        }
+    }
+
+    // MARK: - Metadata round-trip
+
+    /// For every `SurfaceSpec` in the plan, verify that declared surface and
+    /// pane metadata landed in the respective stores. Absent metadata is a
+    /// no-op — fixtures don't need entries they don't care about.
+    private func assertMetadataRoundTrip(
+        fixtureName: String,
+        plan: WorkspaceApplyPlan,
+        result: ApplyResult,
+        workspace: Workspace
+    ) {
+        // Workspace-level metadata.
+        if let entries = plan.workspace.metadata {
+            for (key, expected) in entries {
+                XCTAssertEqual(
+                    workspace.metadata[key],
+                    expected,
+                    "[\(fixtureName)] workspace.metadata[\"\(key)\"] round-trip"
+                )
+            }
+        }
+        if let expectedTitle = plan.workspace.title {
+            XCTAssertEqual(
+                workspace.customTitle,
+                expectedTitle,
+                "[\(fixtureName)] workspace customTitle matches plan.workspace.title"
+            )
+        }
+
+        for surfaceSpec in plan.surfaces {
+            guard let panelId = parseUUIDSuffix(result.surfaceRefs[surfaceSpec.id]) else {
+                continue
+            }
+            let paneUUID = workspace.paneIdForPanel(panelId)?.id
+
+            // Surface-level metadata.
+            let (surfaceMetadata, _) = SurfaceMetadataStore.shared.getMetadata(
+                workspaceId: workspace.id,
+                surfaceId: panelId
+            )
+            if let title = surfaceSpec.title {
+                XCTAssertEqual(
+                    surfaceMetadata["title"] as? String,
+                    title,
+                    "[\(fixtureName)] surface[\(surfaceSpec.id)] title in SurfaceMetadataStore"
+                )
+            }
+            if let description = surfaceSpec.description?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !description.isEmpty {
+                XCTAssertEqual(
+                    surfaceMetadata["description"] as? String,
+                    description,
+                    "[\(fixtureName)] surface[\(surfaceSpec.id)] description in SurfaceMetadataStore"
+                )
+            }
+            if let metadata = surfaceSpec.metadata {
+                for (key, expected) in metadata {
+                    assertMetadataValueMatches(
+                        fixtureName: fixtureName,
+                        storeName: "SurfaceMetadataStore",
+                        surfaceId: surfaceSpec.id,
+                        key: key,
+                        expected: expected,
+                        actual: surfaceMetadata[key]
+                    )
+                }
+            }
+
+            // Pane-level metadata (including the reserved `mailbox.*` namespace).
+            if let paneMetadata = surfaceSpec.paneMetadata,
+               !paneMetadata.isEmpty,
+               let paneUUID {
+                let (livePaneMetadata, _) = PaneMetadataStore.shared.getMetadata(
+                    workspaceId: workspace.id,
+                    paneId: paneUUID
+                )
+                for (key, expected) in paneMetadata {
+                    // v1 strings-only: non-string values on `mailbox.*` are
+                    // intentionally dropped with an ApplyFailure. The round-trip
+                    // assertion skips those; presence of the matching failure
+                    // is verified separately.
+                    if key.hasPrefix("mailbox."), case .string = expected {
+                        // fall through to the assertion
+                    } else if key.hasPrefix("mailbox.") {
+                        XCTAssertTrue(
+                            result.failures.contains {
+                                $0.code == "mailbox_non_string_value"
+                                    && $0.message.contains("[\(key)")
+                            },
+                            "[\(fixtureName)] surface[\(surfaceSpec.id)] non-string mailbox.\(key) emits ApplyFailure"
+                        )
+                        XCTAssertNil(
+                            livePaneMetadata[key],
+                            "[\(fixtureName)] surface[\(surfaceSpec.id)] non-string mailbox.\(key) dropped from store"
+                        )
+                        continue
+                    }
+                    assertMetadataValueMatches(
+                        fixtureName: fixtureName,
+                        storeName: "PaneMetadataStore",
+                        surfaceId: surfaceSpec.id,
+                        key: key,
+                        expected: expected,
+                        actual: livePaneMetadata[key]
+                    )
+                }
+            }
+        }
+    }
+
+    /// Compare a `PersistedJSONValue` expected value to whatever the store
+    /// returned (the store speaks `[String: Any]`). Scalars are matched
+    /// directly; containers are normalized through JSON to avoid leaking
+    /// Swift-specific equality rules into the assertion.
+    private func assertMetadataValueMatches(
+        fixtureName: String,
+        storeName: String,
+        surfaceId: String,
+        key: String,
+        expected: PersistedJSONValue,
+        actual: Any?
+    ) {
+        let qualifier = "[\(fixtureName)] \(storeName) surface[\(surfaceId)] \(key)"
+        switch expected {
+        case .string(let value):
+            XCTAssertEqual(actual as? String, value, "\(qualifier): string")
+        case .bool(let value):
+            XCTAssertEqual(actual as? Bool, value, "\(qualifier): bool")
+        case .number(let value):
+            if let actualDouble = (actual as? NSNumber)?.doubleValue ?? (actual as? Double) {
+                XCTAssertEqual(actualDouble, value, accuracy: 0.0001, "\(qualifier): number")
+            } else {
+                XCTFail("\(qualifier): expected number \(value), got \(String(describing: actual))")
+            }
+        case .null:
+            XCTAssertNil(actual, "\(qualifier): null")
+        case .array, .object:
+            // Containers: compare JSON round-trips. This keeps the assertion
+            // honest without enumerating every container layout.
+            guard let actual = actual,
+                  let expectedData = try? JSONEncoder().encode(expected),
+                  let actualData = try? JSONSerialization.data(withJSONObject: actual),
+                  let expectedJSON = try? JSONSerialization.jsonObject(with: expectedData),
+                  let actualJSON = try? JSONSerialization.jsonObject(with: actualData) else {
+                XCTFail("\(qualifier): container comparison failed; expected=\(expected), actual=\(String(describing: actual))")
+                return
+            }
+            XCTAssertEqual(
+                String(describing: actualJSON),
+                String(describing: expectedJSON),
+                "\(qualifier): container round-trip"
+            )
+        }
     }
 }

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -146,6 +146,18 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
             workspace: workspace
         )
 
+        // 3b. Terminal working-directory plumb — explicit cwd on a
+        //     split-created terminal should either land on the panel
+        //     (requestedWorkingDirectory matches) or emit a typed
+        //     working_directory_not_applied failure. Silent drop is the
+        //     bug review cycle 1 I1 flagged.
+        assertWorkingDirectoriesApplied(
+            fixtureName: name,
+            plan: plan,
+            result: result,
+            workspace: workspace
+        )
+
         // 4. Timing budget.
         let totalMs = result.timings.first { $0.step == "total" }?.durationMs ?? .infinity
         XCTAssertLessThan(
@@ -280,6 +292,45 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
                 livePane.selectedTabId,
                 expectedTabId,
                 "[\(fixtureName) @ \(path)] selectedTabId mismatch (expected surface \(expectedSurfaceId))"
+            )
+        }
+    }
+
+    // MARK: - Working directory
+
+    /// For each terminal `SurfaceSpec` that declares a `workingDirectory`,
+    /// assert it either landed on the live panel or emitted a typed
+    /// `working_directory_not_applied` failure. Silent drop (pre-rework B1/I1)
+    /// now fails the test.
+    private func assertWorkingDirectoriesApplied(
+        fixtureName: String,
+        plan: WorkspaceApplyPlan,
+        result: ApplyResult,
+        workspace: Workspace
+    ) {
+        for spec in plan.surfaces {
+            guard spec.kind == .terminal,
+                  let expectedCwd = spec.workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !expectedCwd.isEmpty else {
+                continue
+            }
+            guard let panelId = parseUUIDSuffix(result.surfaceRefs[spec.id]),
+                  let terminalPanel = workspace.panels[panelId] as? TerminalPanel else {
+                XCTFail("[\(fixtureName)] terminal surface[\(spec.id)] with workingDirectory did not produce a resolvable panel")
+                continue
+            }
+            let landed = terminalPanel.requestedWorkingDirectory?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if landed == expectedCwd {
+                continue
+            }
+            let reported = result.failures.contains {
+                $0.code == "working_directory_not_applied"
+                    && $0.message.contains("surface[\(spec.id)]")
+            }
+            XCTAssertTrue(
+                reported,
+                "[\(fixtureName)] surface[\(spec.id)] workingDirectory='\(expectedCwd)' neither landed ('\(landed)') nor emitted working_directory_not_applied ApplyFailure"
             )
         }
     }

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -419,12 +419,17 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
                     if key.hasPrefix("mailbox."), case .string = expected {
                         // fall through to the assertion
                     } else if key.hasPrefix("mailbox.") {
+                        // Executor emits: `... pane metadata["<key>"] dropped ...`.
+                        // The `["<key>"]` substring is distinctive enough to scope
+                        // the assertion to the right key without false positives
+                        // from other failures sharing the same code.
+                        let keyMatch = "[\"\(key)\"]"
                         XCTAssertTrue(
                             result.failures.contains {
                                 $0.code == "mailbox_non_string_value"
-                                    && $0.message.contains("[\(key)")
+                                    && $0.message.contains(keyMatch)
                             },
-                            "[\(fixtureName)] surface[\(surfaceSpec.id)] non-string mailbox.\(key) emits ApplyFailure"
+                            "[\(fixtureName)] surface[\(surfaceSpec.id)] non-string mailbox.\(key) emits ApplyFailure (looking for '\(keyMatch)' in failure messages)"
                         )
                         XCTAssertNil(
                             livePaneMetadata[key],

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Acceptance fixture for `WorkspaceLayoutExecutor`. Runs each of five
+/// `WorkspaceApplyPlan` JSON fixtures through the executor on a real
+/// `TabManager` and asserts the workspace materializes in under 2 s —
+/// the per-fixture budget from the Phase 0 plan.
+///
+/// Per `CLAUDE.md`, tests are never run locally by the impl agent; this file
+/// is committed and exercised only in CI.
+@MainActor
+final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private static let fixtureNames = [
+        "welcome-quad",
+        "default-grid",
+        "single-large-with-metadata",
+        "mixed-browser-markdown",
+        "deep-nested-splits"
+    ]
+
+    /// Budget per fixture in milliseconds. Matches `ApplyOptions.perStepTimeoutMs`
+    /// default and the plan's acceptance target.
+    private static let perFixtureBudgetMs: Double = 2_000
+
+    // MARK: - Setup
+
+    private var tabManager: TabManager!
+
+    override func setUp() {
+        super.setUp()
+        tabManager = TabManager()
+    }
+
+    override func tearDown() {
+        tabManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Per-fixture tests
+
+    func testAppliesWelcomeQuadFixture() async throws {
+        try await runFixture(named: "welcome-quad", expectedSurfaceIds: ["tl", "tr", "bl", "br"])
+    }
+
+    func testAppliesDefaultGridFixture() async throws {
+        try await runFixture(named: "default-grid", expectedSurfaceIds: ["tl", "tr", "bl", "br"])
+    }
+
+    func testAppliesSingleLargeWithMetadataFixture() async throws {
+        let result = try await runFixture(
+            named: "single-large-with-metadata",
+            expectedSurfaceIds: ["main"]
+        )
+        // Workspace-level metadata should land on the workspace.
+        let workspaceId = try XCTUnwrap(UUID(uuidString: result.workspaceRef.replacingOccurrences(of: "workspace:", with: "")))
+        let workspace = try XCTUnwrap(tabManager.tabs.first { $0.id == workspaceId })
+        XCTAssertEqual(workspace.metadata["description"], "single-pane driver session with mailbox config")
+
+        // Surface metadata round-trips through SurfaceMetadataStore.
+        let mainPanelId = try XCTUnwrap(
+            panelId(forSurfaceRef: result.surfaceRefs["main"], workspace: workspace)
+        )
+        let (surfaceMetadata, _) = SurfaceMetadataStore.shared.getMetadata(
+            workspaceId: workspace.id,
+            surfaceId: mainPanelId
+        )
+        XCTAssertEqual(surfaceMetadata["role"] as? String, "driver")
+        XCTAssertEqual(surfaceMetadata["status"] as? String, "ready")
+        XCTAssertEqual(surfaceMetadata["description"] as? String, "cc session with mailbox.* subscription")
+
+        // mailbox.* pane metadata round-trips verbatim through PaneMetadataStore.
+        let paneId = try XCTUnwrap(workspace.paneIdForPanel(mainPanelId)?.id)
+        let (paneMetadata, _) = PaneMetadataStore.shared.getMetadata(
+            workspaceId: workspace.id,
+            paneId: paneId
+        )
+        XCTAssertEqual(paneMetadata["mailbox.delivery"] as? String, "stdin,watch")
+        XCTAssertEqual(paneMetadata["mailbox.subscribe"] as? String, "build.*,deploy.green")
+        XCTAssertEqual(paneMetadata["mailbox.retention_days"] as? String, "7")
+    }
+
+    func testAppliesMixedBrowserMarkdownFixture() async throws {
+        try await runFixture(
+            named: "mixed-browser-markdown",
+            expectedSurfaceIds: ["docs", "notes", "tests", "build"]
+        )
+    }
+
+    func testAppliesDeepNestedSplitsFixture() async throws {
+        try await runFixture(
+            named: "deep-nested-splits",
+            expectedSurfaceIds: ["a", "b", "c", "d", "e"]
+        )
+    }
+
+    // MARK: - Harness
+
+    @discardableResult
+    private func runFixture(
+        named name: String,
+        expectedSurfaceIds: [String]
+    ) async throws -> ApplyResult {
+        let plan = try loadFixture(named: name)
+        let deps = WorkspaceLayoutExecutorDependencies(
+            tabManager: tabManager,
+            workspaceRefMinter: { "workspace:\($0.uuidString)" },
+            surfaceRefMinter: { "surface:\($0.uuidString)" },
+            paneRefMinter: { "pane:\($0.uuidString)" }
+        )
+        let result = await WorkspaceLayoutExecutor.apply(
+            plan,
+            options: ApplyOptions(select: true),
+            dependencies: deps
+        )
+
+        XCTAssertFalse(result.workspaceRef.isEmpty, "workspaceRef populated for \(name)")
+        XCTAssertEqual(
+            Set(result.surfaceRefs.keys),
+            Set(expectedSurfaceIds),
+            "surfaceRefs cover all expected plan surface ids for \(name)"
+        )
+        XCTAssertEqual(
+            Set(result.paneRefs.keys),
+            Set(expectedSurfaceIds),
+            "paneRefs cover all expected plan surface ids for \(name)"
+        )
+        XCTAssertTrue(
+            result.failures.allSatisfy { $0.code != "validation_failed" },
+            "no validation_failed entries in \(name): \(result.failures)"
+        )
+
+        let totalMs = result.timings.first { $0.step == "total" }?.durationMs ?? .infinity
+        XCTAssertLessThan(
+            totalMs,
+            Self.perFixtureBudgetMs,
+            "fixture \(name) exceeded \(Self.perFixtureBudgetMs) ms budget; total=\(totalMs)"
+        )
+        return result
+    }
+
+    private func loadFixture(named name: String) throws -> WorkspaceApplyPlan {
+        let fixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("workspace-apply-plans")
+            .appendingPathComponent("\(name).json")
+        let data = try Data(contentsOf: fixtureURL)
+        return try JSONDecoder().decode(WorkspaceApplyPlan.self, from: data)
+    }
+
+    private func panelId(forSurfaceRef ref: String?, workspace: Workspace) -> UUID? {
+        guard let ref = ref,
+              let uuidString = ref.split(separator: ":").last,
+              let uuid = UUID(uuidString: String(uuidString)) else {
+            return nil
+        }
+        return workspace.panels[uuid] != nil ? uuid : nil
+    }
+}

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -46,16 +46,16 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
 
     // MARK: - Per-fixture tests
 
-    func testAppliesWelcomeQuadFixture() async throws {
-        try await runFixture(named: "welcome-quad", expectedSurfaceIds: ["tl", "tr", "bl", "br"])
+    func testAppliesWelcomeQuadFixture() throws {
+        try runFixture(named: "welcome-quad", expectedSurfaceIds: ["tl", "tr", "bl", "br"])
     }
 
-    func testAppliesDefaultGridFixture() async throws {
-        try await runFixture(named: "default-grid", expectedSurfaceIds: ["tl", "tr", "bl", "br"])
+    func testAppliesDefaultGridFixture() throws {
+        try runFixture(named: "default-grid", expectedSurfaceIds: ["tl", "tr", "bl", "br"])
     }
 
-    func testAppliesSingleLargeWithMetadataFixture() async throws {
-        let result = try await runFixture(
+    func testAppliesSingleLargeWithMetadataFixture() throws {
+        let result = try runFixture(
             named: "single-large-with-metadata",
             expectedSurfaceIds: ["main"]
         )
@@ -87,15 +87,15 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
         XCTAssertEqual(paneMetadata["mailbox.retention_days"] as? String, "7")
     }
 
-    func testAppliesMixedBrowserMarkdownFixture() async throws {
-        try await runFixture(
+    func testAppliesMixedBrowserMarkdownFixture() throws {
+        try runFixture(
             named: "mixed-browser-markdown",
             expectedSurfaceIds: ["docs", "notes", "tests", "build"]
         )
     }
 
-    func testAppliesDeepNestedSplitsFixture() async throws {
-        try await runFixture(
+    func testAppliesDeepNestedSplitsFixture() throws {
+        try runFixture(
             named: "deep-nested-splits",
             expectedSurfaceIds: ["a", "b", "c", "d", "e"]
         )
@@ -107,7 +107,7 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
     private func runFixture(
         named name: String,
         expectedSurfaceIds: [String]
-    ) async throws -> ApplyResult {
+    ) throws -> ApplyResult {
         let plan = try loadFixture(named: name)
         let deps = WorkspaceLayoutExecutorDependencies(
             tabManager: tabManager,
@@ -115,7 +115,7 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
             surfaceRefMinter: { "surface:\($0.uuidString)" },
             paneRefMinter: { "pane:\($0.uuidString)" }
         )
-        let result = await WorkspaceLayoutExecutor.apply(
+        let result = WorkspaceLayoutExecutor.apply(
             plan,
             options: ApplyOptions(select: true),
             dependencies: deps


### PR DESCRIPTION
## Summary

Phase 0 of **CMUX-37** — Workspace persistence: Blueprints + Snapshots + session resume. Lands the app-side primitive that later phases (Snapshots, Blueprints, restart registry) build on.

- **`WorkspaceApplyPlan`** — new `Codable, Sendable, Equatable` value type at `Sources/WorkspaceApplyPlan.swift` with `WorkspaceSpec`, `LayoutTreeSpec` (nested split tree, indirect enum), `SurfaceSpec`, `ApplyOptions`, `ApplyResult`, `StepTiming`, `ApplyFailure`. Metadata values reuse `PersistedJSONValue` so the schema flows through `SessionPersistence` snapshots without a conversion layer.
- **`WorkspaceLayoutExecutor`** at `Sources/WorkspaceLayoutExecutor.swift` — one `@MainActor static func apply(_:options:dependencies:) -> ApplyResult` entry point. Creates the workspace via `TabManager.addWorkspace`, walks the layout tree top-down (mirrors `Workspace.restoreSessionLayoutNode`), calls existing `newTerminalSplit` / `newBrowserSplit` / `newMarkdownSplit` primitives, writes titles / descriptions / surface metadata / pane metadata during creation (no post-hoc socket loop), returns refs + timings + warnings + typed `ApplyFailure` records.
- **v2 socket method `workspace.apply`** at `Sources/TerminalController.swift` + CLI `c11 workspace apply --file <path>` (plus back-compat alias `c11 workspace-apply`).
- **5-fixture acceptance harness** at `c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift` covering welcome-quad, default-grid, single-large-with-metadata, mixed-browser-markdown, deep-nested-splits. Harness asserts structural fidelity (orientation, dividerPosition, tab order, selectedTab), metadata round-trip, terminal cwd plumb, and a 2 s per-fixture budget. Plus Codable round-trip + validation-path tests at `c11Tests/WorkspaceApplyPlanCodableTests.swift`.
- **Welcome-quad and default-grid** unchanged; TODO comments at both call sites (`Sources/c11App.swift`) documenting the Phase 0+ `applyToExistingWorkspace` migration path.

## Alignment with C11-13

Honors the locked contract in `docs/c11-13-cmux-37-alignment.md`:
- Surface names are the stable addressing primitive; `surface:N` refs are live-only.
- `mailbox.*` pane-metadata namespace round-trips verbatim through `SurfaceSpec.paneMetadata`; executor emits a typed `mailbox_non_string_value` failure when a non-string value is declared and drops it (v1 strings-only).
- `c11 mailbox configure` (C11-13) stays on the existing `set_metadata` runtime path — not routed through `workspace.apply`.

## Phase 0 scope (what's NOT here)

- No `cmux snapshot` / `cmux restore` (Phase 1)
- No Blueprint Markdown parser or picker (Phase 2)
- No browser/markdown Snapshot capture (Phase 3)
- No SessionStart hook (Phase 4)
- No codex/kimi/opencode restart registry rows (Phase 5)
- No welcome-quad / default-grid migration through the executor (left with TODOs; `applyToExistingWorkspace` follow-up)

## Review history

Two Trident cycles on this branch:

- **Cycle 1** returned FAIL-IMPL-REWORK (unanimous 3-model consensus) — broken bottom-up layout walker against bonsplit's leaf-only `splitPane` API + test harness that couldn't detect it, plus four importants (cwd plumb, CLI subcommand drift, off-main validate, silent-failure gaps). Addressed in R1–R7 commits.
- **Cycle 2** returned MINOR FIXES — no blockers, no plan rework. Six small findings (focus-policy gate on `workspace.apply`, cwd silently dropped in in-pane createSurface path, validation envelope returning `ok:true`, divider clamp divergence, orphan `SurfaceSpec` validation, mailbox regression-test substring mismatch) landed inline in the cycle-2-fixes commit.

Review packs at `notes/trident-review-CMUX-37-pack-*` (both cycles archived in the branch). Full plan + cycle-1 findings + rework directive at `.lattice/plans/task_01KPMTEY4WGECM9MNZ4XARN7Y6.md`.

## Test plan

Per `CLAUDE.md` at the repo root: **never run tests locally**. Validation is CI-only.

- [ ] CI: `c11-unit` scheme builds green on macos-15 runner
- [ ] CI: `WorkspaceApplyPlanCodableTests` passes (Codable round-trip + 7 validation cases)
- [ ] CI: `WorkspaceLayoutExecutorAcceptanceTests` passes all 5 fixtures (structural + metadata + cwd assertions, 2 s per-fixture budget)
- [ ] No new warnings introduced
- [ ] No typing-latency hot-path touches (`TerminalWindowPortal.hitTest`, `TabItemView`, `GhosttyTerminalView.forceRefresh`) — verified by diff
- [ ] No `Resources/bin/claude` touch, no `c11 install` revival — verified by diff
- [ ] No local test runs committed to history (build-only checkpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)