### PR TITLE
C11-7: Automation socket reliability — bounded waits, named timeouts, trace mode, main-actor bridge

### DIFF
--- a/.lattice/notes/task_01KPS4FBHSSCCJC3EP43YJ7XMZ.md
+++ b/.lattice/notes/task_01KPS4FBHSSCCJC3EP43YJ7XMZ.md
@@ -1,0 +1,190 @@
+# Implementation Plan: C11-7 — Automation socket reliability
+
+**Ticket:** task_01KPS4FBHSSCCJC3EP43YJ7XMZ
+**Branch:** c11-7/bounded-waits
+**Plan author:** agent:opus-c11-7-plan
+**Date:** 2026-04-24
+
+---
+
+## Status of prior work
+
+### Items 1-3 (commit 3d0b8257)
+
+Audited via `git show 3d0b8257 --stat`, `git diff main HEAD -- CLI/c11.swift`, and `git diff main HEAD -- tests/test_cli_socket_deadline.py`.
+
+**Item 1: Bounded CLI waits — CONFIRMED.**
+- `SocketDeadline` enum added to CLI: `.default` (10s, env-tunable), `.none` (unbounded), `.custom(TimeInterval)`.
+- Default reads `C11_DEFAULT_SOCKET_DEADLINE_MS` (primary) then `CMUX_DEFAULT_SOCKET_DEADLINE_MS` (compat) then legacy `CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC`, falls back to 10s.
+- `send(command:responseTimeout:)` overload plumbed through `configureReceiveTimeout` which correctly clears `SO_RCVTIMEO` when `timeout == nil`.
+- Opt-outs with `deadline: .none`: `pane.confirm` (line 1989), `browser.wait` (line 5338), `browser.download.wait` (line 5873). Correct; these are governed by server-side timeouts.
+
+**Item 2: Named timeout errors — CONFIRMED.**
+- Stable `c11: timeout:` prefix present.
+- Fields: `method=`, `workspace=`, `surface=`, `pane=`, `panel=` (when present in params), `socket=`, `elapsed_ms=`.
+- Exits non-zero on timeout.
+- `traceStatus = "timeout"` set before the re-throw so trace output also reflects the timeout.
+
+**Item 3: Trace mode — CONFIRMED.**
+- `C11_TRACE=1` and `CMUX_TRACE=1` both set `SocketClient.traceEnabled = true`.
+- `[c11-trace] -> <method> (<refs>) socket=<path>` emitted to stderr before send.
+- `[c11-trace] <- <method> elapsed=<N>ms status=<ok|timeout|error>` emitted after, via `defer`.
+- `traceRefs(from:)` helper extracts workspace/surface/pane/panel refs from params.
+
+**Tests in tests/test_cli_socket_deadline.py — SOLID.**
+Three tests, all using a real deaf-socket harness (accepts but never writes). Verifies observable behavior (exit code, stderr content, timing). Correctly skips if CLI binary not found. Does not inspect source code or file structure. Appropriately designed for CI.
+
+**One minor removal in the diff not called out in the commit message:**
+The diff removes `isAdvisoryHookConnectivityError` and the `claude-hook` connect-failure suppression path. This appears intentional (simplification — the advisory no-op was fragile), but is undocumented. Not a blocker; note for review.
+
+### Item 4 (notify v2, PR #66)
+
+DONE. Landed on main via commit `8ffcae8f`.
+
+---
+
+## Remaining work
+
+### Item 5: Main-thread audit doc
+
+- **Status:** DONE (this plan session).
+- **Output file:** `notes/c11-7-mainthread-audit-2026-04-24.md`
+- **Summary:** 105 total `DispatchQueue.main.sync` occurrences across Sources/. 48 SAFE, 38 RISKY, 19 NEEDS_ASYNC. The 19 NEEDS_ASYNC occurrences are in workspace/surface/pane/window creation handlers — the paths agents call most under rapid automation. Full table and migration priority in the audit file.
+
+### Item 6: Deadline-aware main actor bridge
+
+**Problem:** Items 1-3 fix the CLI side — the CLI now exits with a named error after 10s. But the server-side socket handler is still blocked: `DispatchQueue.main.sync` inside the background accept-thread blocks indefinitely waiting for main. Under rapid multi-agent automation (many `workspace.create` / `surface.create` calls), the main thread queues up many sync dispatches. Each one blocks the socket thread until the previous finishes, which can be seconds. The 10s CLI deadline fires before the server has responded, but the server handler is still blocking.
+
+**Approach:** Two implementation options; recommend Option A.
+
+**Option A (minimal change — recommended for this ticket):** Replace `DispatchQueue.main.sync` in Tier 1 handlers with a semaphore+deadline pattern. Keeps the existing background-thread accept loop architecture; no Swift Concurrency rearchitecture needed.
+
+```swift
+// In TerminalController.swift, alongside v2MainSync:
+private func v2MainSyncWithDeadline<T>(
+    seconds: TimeInterval = 10.0,
+    _ body: @escaping () -> T
+) -> T? {
+    if Thread.isMainThread { return body() }
+    var result: T?
+    let sema = DispatchSemaphore(value: 0)
+    DispatchQueue.main.async {
+        result = body()
+        sema.signal()
+    }
+    let waited = sema.wait(timeout: .now() + seconds)
+    return waited == .success ? result : nil
+}
+```
+
+Callers that currently use `v2MainSync { ... }` for creation paths switch to `v2MainSyncWithDeadline { ... }`. If nil is returned, the handler returns a `v2Error` with `code: "main_thread_timeout"`. The CLI caller receives the error JSON within the deadline window instead of waiting for the full 10s `SO_RCVTIMEO`.
+
+**Option B (full async refactor — defer to C11-4):** Rearchitect the accept loop to use Swift Concurrency (`async`/`await`, `Task { @MainActor }`). Cleaner long-term but requires restructuring `handleClient`, `processCommand`, and `processV2Command` to be async. Scope: ~500 lines. Better for C11-4 which owns the full bounded-dispatch work.
+
+**Decision for C11-7:** Apply Option A to Tier 1 handlers only (workspace.create, surface.create, pane.create, window.create, new_workspace, new_split, drag_surface_to_split). This closes the "server side can still hang" gap. C11-4 then owns the full async refactor.
+
+**Files to change:**
+- `Sources/TerminalController.swift`: add `v2MainSyncWithDeadline`, update 7 Tier 1 handler call sites
+- `CLI/c11.swift`: no changes needed (already done by items 1-3)
+
+**Key decision:** The deadline passed to `v2MainSyncWithDeadline` should be slightly shorter than the CLI deadline (e.g., 8s) so the server-side error propagates before `SO_RCVTIMEO` fires. This gives the CLI a clean JSON error response rather than a bare timeout.
+
+**What this does NOT fix:**
+- The 38 RISKY handlers that are fast under normal load but block under heavy concurrency. Those are C11-4 scope.
+- The `appendLog` RISKY path (telemetry hotpath). Fix is trivial (switch to `.async`) but out of scope for this item.
+
+### Item 7: Regression stress test
+
+**Goal:** Assert that no CLI process can hang indefinitely during rapid mixed-surface creation. Tests run in CI only (per CLAUDE.md testing policy).
+
+**File:** `tests_v2/test_socket_reliability_stress.py`
+
+**Approach:**
+- Use the `cmux` Python client from `tests_v2/cmux.py` to connect to a running c11 debug instance.
+- Rapidly issue `workspace.create`, `surface.create` (terminal, browser, markdown), `pane.create`, and `surface.set_metadata` commands concurrently via `threading.Thread`.
+- Each CLI call via `subprocess.run` is given a hard timeout of 12s (above the 10s CLI deadline).
+- Assert all calls complete within that timeout (no hung processes).
+- Assert CLI processes that do timeout exit with the `c11: timeout:` prefix, not hang indefinitely.
+- Clean up created workspaces/surfaces after the test.
+
+**Key design constraints:**
+- Must connect to a real running c11 instance (uses `CMUX_SOCKET` / `C11_SOCKET` env var). Skips gracefully if socket not found.
+- Does NOT inspect source code or count `DispatchQueue.main.sync` occurrences.
+- Tests observable timing behavior: "all 20 CLI calls completed within 12s" is the assertion.
+- Uses the `C11_DEFAULT_SOCKET_DEADLINE_MS=9000` env var to set a known CLI deadline for the stress test.
+
+**Test sketch:**
+
+```python
+def test_no_cli_hangs_under_rapid_surface_creation(c11: cmux, cli_path: str) -> None:
+    """Rapid mixed surface creation must not cause any CLI call to hang indefinitely."""
+    CONCURRENT_CALLS = 20
+    PER_CALL_TIMEOUT_S = 12.0  # well above 10s CLI deadline
+    CLI_DEADLINE_MS = "9000"   # leaves 3s for the server to propagate the error
+
+    results = []
+    threads = []
+
+    def create_workspace():
+        proc = subprocess.run(
+            [cli_path, "workspace.create"],
+            env={**os.environ, "C11_DEFAULT_SOCKET_DEADLINE_MS": CLI_DEADLINE_MS},
+            capture_output=True, text=True, timeout=PER_CALL_TIMEOUT_S, check=False,
+        )
+        results.append((proc.returncode, proc.stderr))
+
+    for _ in range(CONCURRENT_CALLS):
+        t = threading.Thread(target=create_workspace, daemon=True)
+        threads.append(t)
+
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=PER_CALL_TIMEOUT_S + 2.0)
+
+    hung = [t for t in threads if t.is_alive()]
+    assert not hung, f"{len(hung)} CLI calls hung past the deadline+grace period"
+
+    # Any failed calls should carry the named timeout prefix, not be silent failures
+    for returncode, stderr in results:
+        if returncode != 0:
+            assert "c11: timeout:" in stderr or "error" in stderr.lower(), \
+                f"Non-zero exit without named error: {stderr!r}"
+```
+
+---
+
+## Implementation order
+
+1. **Item 5 (audit doc):** Done in this plan session. File is at `notes/c11-7-mainthread-audit-2026-04-24.md`. No further work needed; C11-4 can cite it directly.
+
+2. **Item 6 (deadline-aware main actor bridge):** Implement `v2MainSyncWithDeadline` and wire it into the 7 Tier 1 creation handlers. Commit separately from item 7.
+
+3. **Item 7 (stress test):** Write `tests_v2/test_socket_reliability_stress.py` after item 6 is in, so the test exercises the fixed code paths. Commit to the same branch.
+
+4. **PR:** Squash items 6-7 into logical commits, push to `c11-7/bounded-waits`, open PR targeting main.
+
+---
+
+## Do NOT ship
+
+- A full Swift Concurrency refactor of the accept loop (C11-4 scope).
+- Changes to the 38 RISKY-but-not-creation handlers (appendLog, notifyCurrent, etc.) — C11-4 scope.
+- Any changes to `CLI/c11.swift` beyond what landed in commit 3d0b8257.
+- Reverting or modifying the `claude-hook` connect-failure suppression removal (it's gone, leave it gone).
+- Any `install`-style hooks or writes to external tool config files (per CLAUDE.md principle: c11 is unopinionated about the terminal).
+
+---
+
+## Acceptance criteria verification
+
+| Criterion | How met |
+|-----------|---------|
+| CLI socket commands have a default 10s deadline | `SocketDeadline.default` → `configuredDefaultDeadlineSeconds` = 10s. Confirmed in audit of commit 3d0b8257. |
+| Timeout exits non-zero with parseable named error | `c11: timeout: method=... socket=... elapsed_ms=...`. Confirmed. |
+| Long-runners opt out | `pane.confirm`, `browser.wait`, `browser.download.wait` use `deadline: .none`. Confirmed. |
+| `C11_TRACE=1` emits bracketing lines | `[c11-trace] ->` / `<-` with status and elapsed. Confirmed. |
+| Tests cover the above | Three tests in `tests/test_cli_socket_deadline.py`, behavioral not structural. Confirmed. |
+| Main-thread audit doc exists | `notes/c11-7-mainthread-audit-2026-04-24.md`. Written this session. |
+| Server side has bounded dispatch for creation handlers | Item 6 (pending): `v2MainSyncWithDeadline` wired into Tier 1 handlers. |
+| Stress test covers concurrent surface creation | Item 7 (pending): `tests_v2/test_socket_reliability_stress.py`. |

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -869,7 +869,7 @@ final class SocketClient {
 
     // Default deadline: 10 s, tunable via env. Dual-read: C11_* primary, CMUX_* compat.
     // Legacy CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC (seconds) honoured for backward compat.
-    static let configuredDefaultDeadlineSeconds: TimeInterval = {
+    private static let configuredDefaultDeadlineSeconds: TimeInterval = {
         let env = ProcessInfo.processInfo.environment
         for key in ["C11_DEFAULT_SOCKET_DEADLINE_MS", "CMUX_DEFAULT_SOCKET_DEADLINE_MS"] {
             if let raw = env[key], let ms = Double(raw), ms > 0 { return ms / 1000 }
@@ -879,7 +879,7 @@ final class SocketClient {
     }()
 
     // C11_TRACE=1 (or CMUX_TRACE=1) prints per-request start/end/timing lines to stderr.
-    static let traceEnabled: Bool = {
+    private static let traceEnabled: Bool = {
         let env = ProcessInfo.processInfo.environment
         return env["C11_TRACE"] == "1" || env["CMUX_TRACE"] == "1"
     }()
@@ -1163,7 +1163,7 @@ final class SocketClient {
         var traceStatus = "ok"
 
         if Self.traceEnabled {
-            let refs = traceRefs(from: params)
+            let refs = refTokens(from: params).joined(separator: " ")
             let refsStr = refs.isEmpty ? "" : "(\(refs)) "
             FileHandle.standardError.write(
                 Data("[c11-trace] -> \(method) \(refsStr)socket=\(path)\n".utf8)
@@ -1200,14 +1200,7 @@ final class SocketClient {
         } catch let err as CLIError where err.message == "Command timed out" {
             traceStatus = "timeout"
             let elapsedMs = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
-            var parts = ["method=\(method)"]
-            if let ws = params["workspace_id"] as? String { parts.append("workspace=\(ws)") }
-            if let surf = params["surface_id"] as? String { parts.append("surface=\(surf)") }
-            if let pane = params["pane_id"] as? String { parts.append("pane=\(pane)") }
-            if let panel = params["panel_id"] as? String { parts.append("panel=\(panel)") }
-            parts.append("socket=\(path)")
-            parts.append("elapsed_ms=\(elapsedMs)")
-            throw CLIError(message: "c11: timeout: \(parts.joined(separator: " "))")
+            throw CLIError(message: timeoutMessage(method: method, params: params, elapsedMs: elapsedMs))
         } catch {
             traceStatus = "error"
             throw error
@@ -1235,9 +1228,18 @@ final class SocketClient {
         }
 
         if let error = response["error"] as? [String: Any] {
-            traceStatus = "error"
             let code = (error["code"] as? String) ?? "error"
             let message = (error["message"] as? String) ?? "Unknown v2 error"
+            // Normalize server-side main_thread_timeout to the same parseable c11: timeout:
+            // envelope as a client-side SO_RCVTIMEO, so automation can parse both paths uniformly.
+            // The 8 s server deadline is intentionally shorter than the 10 s CLI deadline, so this
+            // is the expected production timeout path under a saturated main thread.
+            if code == "main_thread_timeout" {
+                traceStatus = "timeout"
+                let elapsedMs = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
+                throw CLIError(message: timeoutMessage(method: method, params: params, elapsedMs: elapsedMs))
+            }
+            traceStatus = "error"
             throw CLIError(message: "\(code): \(message)")
         }
 
@@ -1245,13 +1247,22 @@ final class SocketClient {
         throw CLIError(message: "v2 request failed")
     }
 
-    private func traceRefs(from params: [String: Any]) -> String {
+    // Shared builder for both trace output and timeout error messages.
+    // Extracts workspace/surface/pane/panel refs from params into "key=value" tokens.
+    private func refTokens(from params: [String: Any]) -> [String] {
         var parts: [String] = []
         if let ws = params["workspace_id"] as? String { parts.append("workspace=\(ws)") }
         if let surf = params["surface_id"] as? String { parts.append("surface=\(surf)") }
         if let pane = params["pane_id"] as? String { parts.append("pane=\(pane)") }
         if let panel = params["panel_id"] as? String { parts.append("panel=\(panel)") }
-        return parts.joined(separator: " ")
+        return parts
+    }
+
+    private func timeoutMessage(method: String, params: [String: Any], elapsedMs: Int) -> String {
+        var parts = ["method=\(method)"] + refTokens(from: params)
+        parts.append("socket=\(path)")
+        parts.append("elapsed_ms=\(elapsedMs)")
+        return "c11: timeout: \(parts.joined(separator: " "))"
     }
 }
 
@@ -4168,7 +4179,9 @@ struct CMUXCLI {
                 "sshOptions=\(remoteSSHOptions.joined(separator: "|"))"
             )
             let configureStartedAt = Date()
-            configuredPayload = try client.sendV2(method: "workspace.remote.configure", params: configureParams)
+            // deadline: .none — SSH handshake and relay negotiation can exceed 10 s on slow
+            // VPNs or distant hosts; the server governs the timeout for this operation.
+            configuredPayload = try client.sendV2(method: "workspace.remote.configure", params: configureParams, deadline: .none)
             var selectParams: [String: Any] = ["workspace_id": workspaceId]
             if let workspaceWindowId, !workspaceWindowId.isEmpty {
                 selectParams["window_id"] = workspaceWindowId

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -854,20 +854,37 @@ private enum CLISocketPathResolver {
     }
 }
 
+// Policy a sendV2 caller declares for how long the CLI will wait for the server response.
+// Long-running operations (browser.wait, browser.download.wait, pane.confirm) use .none so
+// their server-side timeouts control the wall-clock bound without a competing CLI deadline.
+enum SocketDeadline {
+    case `default`            // C11_DEFAULT_SOCKET_DEADLINE_MS / CMUX_ fallback / 10 s hard default
+    case none                 // No CLI-side deadline; server timeout governs
+    case custom(TimeInterval) // Explicit seconds (reserved for future use)
+}
+
 final class SocketClient {
     private let path: String
     private var socketFD: Int32 = -1
-    private static let defaultResponseTimeoutSeconds: TimeInterval = 15.0
-    private static let multilineResponseIdleTimeoutSeconds: TimeInterval = 0.12
-    private static let responseTimeoutSeconds: TimeInterval = {
+
+    // Default deadline: 10 s, tunable via env. Dual-read: C11_* primary, CMUX_* compat.
+    // Legacy CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC (seconds) honoured for backward compat.
+    static let configuredDefaultDeadlineSeconds: TimeInterval = {
         let env = ProcessInfo.processInfo.environment
-        if let raw = env["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"],
-           let seconds = Double(raw),
-           seconds > 0 {
-            return seconds
+        for key in ["C11_DEFAULT_SOCKET_DEADLINE_MS", "CMUX_DEFAULT_SOCKET_DEADLINE_MS"] {
+            if let raw = env[key], let ms = Double(raw), ms > 0 { return ms / 1000 }
         }
-        return defaultResponseTimeoutSeconds
+        if let raw = env["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"], let s = Double(raw), s > 0 { return s }
+        return 10.0
     }()
+
+    // C11_TRACE=1 (or CMUX_TRACE=1) prints per-request start/end/timing lines to stderr.
+    static let traceEnabled: Bool = {
+        let env = ProcessInfo.processInfo.environment
+        return env["C11_TRACE"] == "1" || env["CMUX_TRACE"] == "1"
+    }()
+
+    private static let multilineResponseIdleTimeoutSeconds: TimeInterval = 0.12
 
     init(path: String) {
         self.path = path
@@ -889,7 +906,13 @@ final class SocketClient {
         }
     }
 
+    // Backward-compat overload: uses the configured default deadline.
     func send(command: String) throws -> String {
+        try send(command: command, responseTimeout: Self.configuredDefaultDeadlineSeconds)
+    }
+
+    // responseTimeout: nil = no SO_RCVTIMEO (unbounded); >0 = initial-read deadline in seconds.
+    func send(command: String, responseTimeout: TimeInterval?) throws -> String {
         guard socketFD >= 0 else { throw CLIError(message: "Not connected") }
         let payload = command + "\n"
         try payload.withCString { ptr in
@@ -904,7 +927,7 @@ final class SocketClient {
 
         while true {
             try configureReceiveTimeout(
-                sawNewline ? Self.multilineResponseIdleTimeoutSeconds : Self.responseTimeoutSeconds
+                sawNewline ? Self.multilineResponseIdleTimeoutSeconds : responseTimeout
             )
 
             var buffer = [UInt8](repeating: 0, count: 8192)
@@ -984,11 +1007,17 @@ final class SocketClient {
         )
     }
 
-    private func configureReceiveTimeout(_ timeout: TimeInterval) throws {
-        var interval = timeval(
-            tv_sec: Int(timeout.rounded(.down)),
-            tv_usec: __darwin_suseconds_t((timeout - floor(timeout)) * 1_000_000)
-        )
+    // timeout == nil clears SO_RCVTIMEO (no deadline). timeout > 0 sets the deadline.
+    private func configureReceiveTimeout(_ timeout: TimeInterval?) throws {
+        var interval: timeval
+        if let t = timeout, t > 0 {
+            interval = timeval(
+                tv_sec: Int(t.rounded(.down)),
+                tv_usec: __darwin_suseconds_t((t - floor(t)) * 1_000_000)
+            )
+        } else {
+            interval = timeval(tv_sec: 0, tv_usec: 0)
+        }
         let result = withUnsafePointer(to: &interval) { ptr in
             setsockopt(
                 socketFD,
@@ -1122,34 +1151,82 @@ final class SocketClient {
         return nil
     }
 
-    func sendV2(method: String, params: [String: Any] = [:]) throws -> [String: Any] {
+    func sendV2(method: String, params: [String: Any] = [:], deadline: SocketDeadline = .default) throws -> [String: Any] {
+        let effectiveTimeout: TimeInterval?
+        switch deadline {
+        case .default: effectiveTimeout = Self.configuredDefaultDeadlineSeconds
+        case .none: effectiveTimeout = nil
+        case .custom(let t): effectiveTimeout = t > 0 ? t : nil
+        }
+
+        let startTime = Date()
+        var traceStatus = "ok"
+
+        if Self.traceEnabled {
+            let refs = traceRefs(from: params)
+            let refsStr = refs.isEmpty ? "" : "(\(refs)) "
+            FileHandle.standardError.write(
+                Data("[c11-trace] -> \(method) \(refsStr)socket=\(path)\n".utf8)
+            )
+        }
+        defer {
+            if Self.traceEnabled {
+                let ms = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
+                FileHandle.standardError.write(
+                    Data("[c11-trace] <- \(method) elapsed=\(ms)ms status=\(traceStatus)\n".utf8)
+                )
+            }
+        }
+
         let request: [String: Any] = [
             "id": UUID().uuidString,
             "method": method,
             "params": params
         ]
         guard JSONSerialization.isValidJSONObject(request) else {
+            traceStatus = "error"
             throw CLIError(message: "Failed to encode v2 request")
         }
 
         let requestData = try JSONSerialization.data(withJSONObject: request, options: [])
         guard let requestLine = String(data: requestData, encoding: .utf8) else {
+            traceStatus = "error"
             throw CLIError(message: "Failed to encode v2 request")
         }
 
-        let raw = try send(command: requestLine)
+        let raw: String
+        do {
+            raw = try send(command: requestLine, responseTimeout: effectiveTimeout)
+        } catch let err as CLIError where err.message == "Command timed out" {
+            traceStatus = "timeout"
+            let elapsedMs = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
+            var parts = ["method=\(method)"]
+            if let ws = params["workspace_id"] as? String { parts.append("workspace=\(ws)") }
+            if let surf = params["surface_id"] as? String { parts.append("surface=\(surf)") }
+            if let pane = params["pane_id"] as? String { parts.append("pane=\(pane)") }
+            if let panel = params["panel_id"] as? String { parts.append("panel=\(panel)") }
+            parts.append("socket=\(path)")
+            parts.append("elapsed_ms=\(elapsedMs)")
+            throw CLIError(message: "c11: timeout: \(parts.joined(separator: " "))")
+        } catch {
+            traceStatus = "error"
+            throw error
+        }
 
         // The server may return plain-text errors (e.g., "ERROR: Access denied ...")
         // before the JSON protocol starts. Surface these directly instead of letting
         // JSONSerialization throw a confusing parse error.
         if raw.hasPrefix("ERROR:") {
+            traceStatus = "error"
             throw CLIError(message: raw)
         }
 
         guard let responseData = raw.data(using: .utf8) else {
+            traceStatus = "error"
             throw CLIError(message: "Invalid UTF-8 v2 response")
         }
         guard let response = try JSONSerialization.jsonObject(with: responseData, options: []) as? [String: Any] else {
+            traceStatus = "error"
             throw CLIError(message: "Invalid v2 response: \(raw)")
         }
 
@@ -1158,12 +1235,23 @@ final class SocketClient {
         }
 
         if let error = response["error"] as? [String: Any] {
+            traceStatus = "error"
             let code = (error["code"] as? String) ?? "error"
             let message = (error["message"] as? String) ?? "Unknown v2 error"
             throw CLIError(message: "\(code): \(message)")
         }
 
+        traceStatus = "error"
         throw CLIError(message: "v2 request failed")
+    }
+
+    private func traceRefs(from params: [String: Any]) -> String {
+        var parts: [String] = []
+        if let ws = params["workspace_id"] as? String { parts.append("workspace=\(ws)") }
+        if let surf = params["surface_id"] as? String { parts.append("surface=\(surf)") }
+        if let pane = params["pane_id"] as? String { parts.append("pane=\(pane)") }
+        if let panel = params["panel_id"] as? String { parts.append("panel=\(panel)") }
+        return parts.joined(separator: " ")
     }
 }
 
@@ -1898,7 +1986,7 @@ struct CMUXCLI {
             if let cancelLabel = optionValue(commandArgs, name: "--cancel-label") {
                 params["cancel_label"] = cancelLabel
             }
-            let payload = try client.sendV2(method: "pane.confirm", params: params)
+            let payload = try client.sendV2(method: "pane.confirm", params: params, deadline: .none)
             // Exit code maps to outcome: 0=ok, 2=cancel, 3=dismissed, 1=error.
             // Note: socket reports timeout as "dismissed" (exit 3); the user
             // cannot distinguish a timeout from a panel-teardown from the CLI.
@@ -5247,7 +5335,7 @@ struct CMUXCLI {
                 params["timeout_ms"] = max(1, Int(seconds * 1000.0))
             }
 
-            let payload = try client.sendV2(method: "browser.wait", params: params)
+            let payload = try client.sendV2(method: "browser.wait", params: params, deadline: .none)
             output(payload, fallback: "OK")
             return
         }
@@ -5782,7 +5870,7 @@ struct CMUXCLI {
                 params["timeout_ms"] = max(1, Int(seconds * 1000.0))
             }
 
-            let payload = try client.sendV2(method: "browser.download.wait", params: params)
+            let payload = try client.sendV2(method: "browser.download.wait", params: params, deadline: .none)
             output(payload, fallback: "OK")
             return
         }

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -864,6 +864,11 @@ enum SocketDeadline {
 }
 
 final class SocketClient {
+    // Stable string used at both the throw site and the catch site in sendV2.
+    // Extracting it prevents the catch clause from silently missing the timeout
+    // if the throw-site message is ever edited.
+    fileprivate static let commandTimedOutMessage = "Command timed out"
+
     private let path: String
     private var socketFD: Int32 = -1
 
@@ -940,7 +945,7 @@ final class SocketClient {
                     if sawNewline {
                         break
                     }
-                    throw CLIError(message: "Command timed out")
+                    throw CLIError(message: SocketClient.commandTimedOutMessage)
                 }
                 throw CLIError(message: "Socket read error")
             }
@@ -1197,7 +1202,7 @@ final class SocketClient {
         let raw: String
         do {
             raw = try send(command: requestLine, responseTimeout: effectiveTimeout)
-        } catch let err as CLIError where err.message == "Command timed out" {
+        } catch let err as CLIError where err.message == SocketClient.commandTimedOutMessage {
             traceStatus = "timeout"
             let elapsedMs = Int((Date().timeIntervalSince(startTime) * 1000).rounded())
             throw CLIError(message: timeoutMessage(method: method, params: params, elapsedMs: elapsedMs))

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3228,15 +3228,26 @@ class TerminalController {
 
     // 8 s is slightly under the CLI 10 s deadline so the server-side error
     // propagates before SO_RCVTIMEO fires on the caller side.
-    private func v2MainSyncWithDeadline<T>(seconds: TimeInterval = 8.0, _ body: @escaping () -> T) -> T? {
+    // Must stay strictly less than SocketClient.configuredDefaultDeadlineSeconds (10 s).
+    private static let kTier1MainThreadDeadlineSeconds: TimeInterval = 8.0
+
+    private func v2MainSyncWithDeadline<T>(seconds: TimeInterval = kTier1MainThreadDeadlineSeconds, _ body: @escaping () -> T) -> T? {
         if Thread.isMainThread { return body() }
         var result: T?
+        // Cancellation flag: written by the calling (socket) thread after a timeout, read by the
+        // main-thread closure. Prevents ghost mutations when the main queue drains after the
+        // caller has already received a timeout error and the operation has been declared failed.
+        // On Darwin, GCD memory ordering makes this safe in practice. C11-4 can harden further
+        // if needed (e.g., os_unfair_lock) for strict memory-model correctness.
+        var cancelled = false
         let sema = DispatchSemaphore(value: 0)
         DispatchQueue.main.async {
-            result = body()
+            if !cancelled { result = body() }
             sema.signal()
         }
-        return sema.wait(timeout: .now() + seconds) == .success ? result : nil
+        if sema.wait(timeout: .now() + seconds) == .success { return result }
+        cancelled = true
+        return nil
     }
 
     private func v2Ok(id: Any?, result: Any) -> String {
@@ -3602,8 +3613,13 @@ class TerminalController {
     }
 
     private func v2WindowCreate(params _: [String: Any]) -> V2CallResult {
-        guard let windowId = v2MainSyncWithDeadline(seconds: 8.0, { AppDelegate.shared?.createMainWindow() }) ?? nil else {
+        // Two-step unwrap: outer nil = deadline fired; inner nil = AppDelegate.shared unavailable.
+        let rawWindowId = v2MainSyncWithDeadline({ AppDelegate.shared?.createMainWindow() })
+        guard let rawWindowId else {
             return .err(code: "main_thread_timeout", message: "main thread did not respond within deadline", data: nil)
+        }
+        guard let windowId = rawWindowId else {
+            return .err(code: "internal_error", message: "Failed to create window", data: nil)
         }
         // The new window should become key, but setActiveTabManager defensively.
         if let tm = v2MainSync({ AppDelegate.shared?.tabManagerFor(windowId: windowId) }) {
@@ -3694,7 +3710,7 @@ class TerminalController {
 
         var newId: UUID?
         let shouldFocus = v2FocusAllowed()
-        guard v2MainSyncWithDeadline(seconds: 8.0, {
+        guard v2MainSyncWithDeadline({
             let ws = tabManager.addWorkspace(
                 workingDirectory: cwd,
                 initialTerminalCommand: initialCommand,
@@ -5175,7 +5191,7 @@ class TerminalController {
         }
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create surface", data: nil)
-        guard v2MainSyncWithDeadline(seconds: 8.0, {
+        guard v2MainSyncWithDeadline({
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
@@ -6749,7 +6765,7 @@ class TerminalController {
         let insertFirst = direction.insertFirst
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create pane", data: nil)
-        guard v2MainSyncWithDeadline(seconds: 8.0, {
+        guard v2MainSyncWithDeadline({
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
@@ -13537,7 +13553,7 @@ class TerminalController {
 
         var newTabId: UUID?
         let focus = socketCommandAllowsInAppFocusMutations()
-        guard v2MainSyncWithDeadline(seconds: 8.0, {
+        guard v2MainSyncWithDeadline({
             let workspace = tabManager.addTab(select: focus, eagerLoadTerminal: !focus)
             newTabId = workspace.id
         }) != nil else {
@@ -13563,7 +13579,7 @@ class TerminalController {
         }
 
         var result = "ERROR: Failed to create split"
-        guard v2MainSyncWithDeadline(seconds: 8.0, {
+        guard v2MainSyncWithDeadline({
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -15317,7 +15333,7 @@ class TerminalController {
 	        let insertFirst = (direction == .left || direction == .up)
 	
 	        var result = "ERROR: Failed to move surface"
-	        guard v2MainSyncWithDeadline(seconds: 8.0, {
+	        guard v2MainSyncWithDeadline({
 	            guard let tabId = tabManager.selectedTabId,
 	                  let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
 	                result = "ERROR: No tab selected"

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3226,6 +3226,19 @@ class TerminalController {
         return DispatchQueue.main.sync(execute: body)
     }
 
+    // 8 s is slightly under the CLI 10 s deadline so the server-side error
+    // propagates before SO_RCVTIMEO fires on the caller side.
+    private func v2MainSyncWithDeadline<T>(seconds: TimeInterval = 8.0, _ body: @escaping () -> T) -> T? {
+        if Thread.isMainThread { return body() }
+        var result: T?
+        let sema = DispatchSemaphore(value: 0)
+        DispatchQueue.main.async {
+            result = body()
+            sema.signal()
+        }
+        return sema.wait(timeout: .now() + seconds) == .success ? result : nil
+    }
+
     private func v2Ok(id: Any?, result: Any) -> String {
         return v2Encode([
             "id": v2OrNull(id),
@@ -3589,8 +3602,8 @@ class TerminalController {
     }
 
     private func v2WindowCreate(params _: [String: Any]) -> V2CallResult {
-        guard let windowId = v2MainSync({ AppDelegate.shared?.createMainWindow() }) else {
-            return .err(code: "internal_error", message: "Failed to create window", data: nil)
+        guard let windowId = v2MainSyncWithDeadline(seconds: 8.0, { AppDelegate.shared?.createMainWindow() }) ?? nil else {
+            return .err(code: "main_thread_timeout", message: "main thread did not respond within deadline", data: nil)
         }
         // The new window should become key, but setActiveTabManager defensively.
         if let tm = v2MainSync({ AppDelegate.shared?.tabManagerFor(windowId: windowId) }) {
@@ -3681,7 +3694,7 @@ class TerminalController {
 
         var newId: UUID?
         let shouldFocus = v2FocusAllowed()
-        v2MainSync {
+        guard v2MainSyncWithDeadline(seconds: 8.0, {
             let ws = tabManager.addWorkspace(
                 workingDirectory: cwd,
                 initialTerminalCommand: initialCommand,
@@ -3690,6 +3703,8 @@ class TerminalController {
                 eagerLoadTerminal: !shouldFocus
             )
             newId = ws.id
+        }) != nil else {
+            return .err(code: "main_thread_timeout", message: "main thread did not respond within deadline", data: nil)
         }
 
         guard let newId else {
@@ -5160,7 +5175,7 @@ class TerminalController {
         }
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create surface", data: nil)
-        v2MainSync {
+        guard v2MainSyncWithDeadline(seconds: 8.0, {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
@@ -5208,6 +5223,8 @@ class TerminalController {
                 "surface_ref": v2Ref(kind: .surface, uuid: newPanelId),
                 "type": panelType.rawValue
             ])
+        }) != nil else {
+            return .err(code: "main_thread_timeout", message: "main thread did not respond within deadline", data: nil)
         }
         return result
     }
@@ -6732,7 +6749,7 @@ class TerminalController {
         let insertFirst = direction.insertFirst
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create pane", data: nil)
-        v2MainSync {
+        guard v2MainSyncWithDeadline(seconds: 8.0, {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
@@ -6792,6 +6809,8 @@ class TerminalController {
                 "surface_ref": v2Ref(kind: .surface, uuid: newPanelId),
                 "type": panelType.rawValue
             ])
+        }) != nil else {
+            return .err(code: "main_thread_timeout", message: "main thread did not respond within deadline", data: nil)
         }
         return result
     }
@@ -13518,9 +13537,11 @@ class TerminalController {
 
         var newTabId: UUID?
         let focus = socketCommandAllowsInAppFocusMutations()
-        DispatchQueue.main.sync {
+        guard v2MainSyncWithDeadline(seconds: 8.0, {
             let workspace = tabManager.addTab(select: focus, eagerLoadTerminal: !focus)
             newTabId = workspace.id
+        }) != nil else {
+            return "ERROR: main thread did not respond within deadline"
         }
         return "OK \(newTabId?.uuidString ?? "unknown")"
     }
@@ -13542,7 +13563,7 @@ class TerminalController {
         }
 
         var result = "ERROR: Failed to create split"
-        DispatchQueue.main.sync {
+        guard v2MainSyncWithDeadline(seconds: 8.0, {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -13568,6 +13589,8 @@ class TerminalController {
             if let newPanelId = tabManager.newSplit(tabId: tabId, surfaceId: targetSurface, direction: direction) {
                 result = "OK \(newPanelId.uuidString)"
             }
+        }) != nil else {
+            return "ERROR: main thread did not respond within deadline"
         }
         return result
     }
@@ -15294,7 +15317,7 @@ class TerminalController {
 	        let insertFirst = (direction == .left || direction == .up)
 	
 	        var result = "ERROR: Failed to move surface"
-	        DispatchQueue.main.sync {
+	        guard v2MainSyncWithDeadline(seconds: 8.0, {
 	            guard let tabId = tabManager.selectedTabId,
 	                  let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
 	                result = "ERROR: No tab selected"
@@ -15317,6 +15340,8 @@ class TerminalController {
 	            }
 	
 	            result = "OK \(newPaneId.id.uuidString)"
+	        }) != nil else {
+	            return "ERROR: main thread did not respond within deadline"
 	        }
 	        return result
 	    }

--- a/notes/c11-7-mainthread-audit-2026-04-24.md
+++ b/notes/c11-7-mainthread-audit-2026-04-24.md
@@ -1,0 +1,192 @@
+# Main-Thread Audit: DispatchQueue.main.sync in Socket Handlers
+
+**Date:** 2026-04-24
+**Branch:** c11-7/bounded-waits
+**Author:** agent:opus-c11-7-plan
+**Purpose:** Input for C11-4 (deadline-aware main actor bridge). Identifies which socket command handlers use `DispatchQueue.main.sync` in ways that block CLI callers indefinitely when the main thread is busy.
+
+---
+
+## Methodology
+
+Grepped all `Sources/*.swift` files for `DispatchQueue.main.sync`. Each occurrence was traced back to its enclosing function and classified by call context:
+
+- **SAFE**: The `main.sync` is either inside a debug-only code path, performs a read-only operation that completes in microseconds, or the enclosing function is not on the direct socket-handler call path.
+- **RISKY**: The `main.sync` is in a live socket command handler invoked from the background accept-thread. The main thread may be busy (SwiftUI animations, workspace creation, window operations), causing the background thread to block indefinitely — the CLI caller blocks until `SO_RCVTIMEO` fires (10s default).
+- **NEEDS_ASYNC**: RISKY and the fix path is clear: the mutation can be dispatched via a deadline-aware async + continuation pattern rather than a blocking sync. These are the highest-priority targets for C11-4.
+
+**Threading context:** The socket accept loop runs on a detached thread (`Thread.detachNewThread` at line 1040). `processCommand` and `processV2Command` are called on that background thread. Every `DispatchQueue.main.sync` in a socket handler is a synchronous block of that thread waiting for the main thread — with no timeout.
+
+---
+
+## Summary
+
+| File | Total occurrences | SAFE | RISKY | NEEDS_ASYNC |
+|------|------------------|------|-------|-------------|
+| Sources/TerminalController.swift | 103 | 46 | 38 | 19 |
+| Sources/GhosttyTerminalView.swift | 1 | 1 | 0 | 0 |
+| Sources/TabManager.swift | 1 | 1 | 0 | 0 |
+| **Total** | **105** | **48** | **38** | **19** |
+
+---
+
+## Detail Table
+
+### Non-socket-handler occurrences (SAFE)
+
+| File:Line | Context | Classification | Reason |
+|-----------|---------|----------------|--------|
+| GhosttyTerminalView.swift:1881 | `performOnMain<T>` helper | SAFE | Called from internal UI paths (surface view), not socket handlers. |
+| TabManager.swift:586 | VSync IOSurface timeline callback | SAFE | CoreVideo display link callback. Not a socket command path. |
+| TerminalController.swift:3226 | `v2MainSync<T>` helper | SAFE | The helper itself; risk is in callers, classified below. |
+
+### v2 handlers: workspace / window / surface / pane creation (NEEDS_ASYNC — Priority 1)
+
+These are the highest-priority targets. They use `v2MainSync {}` to call `tabManager.addWorkspace`, `NSWindow` creation, and `Workspace.new*Surface/Split` methods. All of these can trigger SwiftUI layout passes, NSWindow creation, and Ghostty surface initialization — easily 50-500ms of main-thread time. Concurrent CLI calls (agent spinning up many workspaces) will queue behind each other on the main thread indefinitely.
+
+| File:Line | Socket method | Classification | Reason |
+|-----------|--------------|----------------|--------|
+| TerminalController.swift:3592 | `window.create` | NEEDS_ASYNC | Calls `AppDelegate.createMainWindow()` — creates NSWindow, attaches tab manager, triggers layout. |
+| TerminalController.swift:3629 | `workspace.list` | RISKY | Reads `tabManager.tabs`; fast when main is idle, blocks when main is busy with creation. |
+| TerminalController.swift:3684 | `workspace.create` | NEEDS_ASYNC | Calls `tabManager.addWorkspace()` — creates a new tab, initializes terminal/UI state. Most expensive creation path. |
+| TerminalController.swift:3715 | `workspace.select` | RISKY | Calls `tabManager.selectWorkspace()` — triggers sidebar re-render. |
+| TerminalController.swift:3772 | `workspace.close` | RISKY | Calls `tabManager.closeWorkspace()` — triggers layout and cleanup. |
+| TerminalController.swift:5163 | `surface.create` | NEEDS_ASYNC | Calls `ws.newTerminalSurface/newBrowserSurface/newMarkdownSurface` — creates bonsplit tab, allocates Ghostty surface or WKWebView. |
+| TerminalController.swift:5221 | `surface.close` | RISKY | Calls bonsplit close + Ghostty/WebView teardown. |
+| TerminalController.swift:6735 | `pane.create` | NEEDS_ASYNC | Calls `ws.newTerminalSplit/newBrowserSplit/newMarkdownSplit` — creates new bonsplit pane + surface. |
+
+### v2 handlers: reads and simpler mutations (RISKY)
+
+These block the background thread while waiting for main, but the main-thread work is fast when the main thread is actually available. They become a problem under load when the main thread is occupied with creation/animation work from concurrent commands.
+
+| File:Line | Socket method | Classification | Reason |
+|-----------|--------------|----------------|--------|
+| TerminalController.swift:7693 | `notification.list` | RISKY | Reads notification store. Fast, but blocks if main is occupied. |
+| TerminalController.swift:7710 | `notification.clear` | RISKY | Clears notification store. Fast mutation but synchronous. |
+
+### Debug-mode-only v2 handlers (SAFE)
+
+All `v2Debug*` handlers (lines 11743–12059) gate themselves on DEBUG builds or explicit debug API access. Not reached in production automation.
+
+| File:Line | Handler group | Classification | Reason |
+|-----------|--------------|----------------|--------|
+| 11743–12059 | `v2DebugType`, `v2DebugToggleCommandPalette`, `v2DebugCommandPalette*`, etc. | SAFE | DEBUG-only handlers; not in production socket handler hot path. |
+
+### v1 (legacy) handlers: workspace and surface mutations (NEEDS_ASYNC — Priority 2)
+
+| File:Line | v1 command | Classification | Reason |
+|-----------|-----------|----------------|--------|
+| TerminalController.swift:13521 | `new_workspace` | NEEDS_ASYNC | Calls `tabManager.addTab` — same risk as `workspace.create`. |
+| TerminalController.swift:13545 | `new_split` | NEEDS_ASYNC | Calls `tabManager.newSplit` — creates bonsplit pane. |
+| TerminalController.swift:16848 | `new_surface` | NEEDS_ASYNC | Creates new surface in current pane. |
+| TerminalController.swift:14493 | `close_workspace` | RISKY | Calls `tabManager.closeTab`. |
+| TerminalController.swift:14506 | `select_workspace` | RISKY | Calls `tabManager.selectTab`. |
+| TerminalController.swift:13600 | `focus_surface` | RISKY | Calls `tabManager.focusSurface`. |
+| TerminalController.swift:15234 | `focus_pane` | RISKY | Calls `bonsplitController.focusPane`. |
+| TerminalController.swift:15262 | `focus_surface_by_panel` | RISKY | Calls `tabManager.focusSurface`. |
+| TerminalController.swift:15297 | `drag_surface_to_split` | NEEDS_ASYNC | Calls `bonsplitController.splitPane` — creates new pane. |
+
+### v1 handlers: input injection (RISKY)
+
+Terminal input injection calls Ghostty surface APIs on main. Not creation-heavy, but can block if main is rendering or processing events.
+
+| File:Line | v1 command | Classification | Reason |
+|-----------|-----------|----------------|--------|
+| TerminalController.swift:14697 | `send_input` | RISKY | Calls `ghostty_surface_key` — must be on main, fast but blocks under load. |
+| TerminalController.swift:14771 | `send_workspace` | RISKY | Input to workspace terminal. Main.sync to resolve target, then async for the actual inject. |
+| TerminalController.swift:14858 | `send_surface` | RISKY | Input to specific surface. Same pattern. |
+
+### v1 handlers: sidebar telemetry (RISKY — special case)
+
+The `set-metadata`, `set-status`, `report_*` commands correctly use `DispatchQueue.main.async` for the actual mutation (fire-and-forget, returns "OK" immediately). These are **SAFE** for the CLI blocking problem. However, a few telemetry commands still use `main.sync` for the mutation:
+
+| File:Line | v1 command | Classification | Reason |
+|-----------|-----------|----------------|--------|
+| TerminalController.swift:15986 | `log` / `append_log` | RISKY | Uses `main.sync` to append a log entry. This is a hotpath for agents. Should use `main.async`. |
+| TerminalController.swift:16003 | `clear_log` | RISKY | Uses `main.sync` for log clear. Low-frequency, acceptable risk. |
+| TerminalController.swift:15944 | `clear_meta_block` | RISKY | Uses `main.sync` for metadata block removal. |
+| TerminalController.swift:15958 | `list_meta_blocks` | SAFE | Read-only, fast. |
+
+### v1 handlers: read-only queries (SAFE)
+
+| File:Line | v1 command | Classification | Reason |
+|-----------|-----------|----------------|--------|
+| TerminalController.swift:13506 | `list_workspaces` | SAFE | Read-only workspace list. |
+| TerminalController.swift:13578 | `list_surfaces` | SAFE | Read-only surface list. |
+| TerminalController.swift:13723 | `list_notifications` | SAFE | Read-only notification list. |
+| TerminalController.swift:14527 | `current_workspace` | SAFE | Read UUID, fast. |
+| TerminalController.swift:15154 | `list_panes` | SAFE | Read-only pane list. |
+| TerminalController.swift:15178 | `list_pane_surfaces` | SAFE | Read-only surface list in pane. |
+| TerminalController.swift:12344 | `read_screen` | SAFE | Reads terminal buffer. Fast unless scrollback is huge. |
+
+### v1 handlers: drag/overlay/pasteboard (SAFE)
+
+| File:Line | v1 command | Classification | Reason |
+|-----------|-----------|----------------|--------|
+| TerminalController.swift:12783 | `set_drag_pasteboard` | SAFE | Fast NSPasteboard operation. |
+| TerminalController.swift:12790 | `clear_drag_pasteboard` | SAFE | Fast NSPasteboard clear. |
+| TerminalController.swift:12809 | `overlay_hit_gate` | SAFE | Reads DragOverlayRoutingPolicy. Fast. |
+| TerminalController.swift:12833 | `overlay_drop_gate` | SAFE | Same. |
+| TerminalController.swift:12855 | `portal_hit_gate` | SAFE | Same. |
+| TerminalController.swift:12878 | `sidebar_overlay_gate` | SAFE | Same. |
+
+---
+
+## Recommended Migration Priority for C11-4
+
+### Tier 1: Fix immediately (blocking automation workflows)
+
+These are the handlers that agents call in rapid succession when setting up workspaces. A single busy main-thread event can cause a cascade of CLI timeouts.
+
+1. **`workspace.create`** (TC:3684) — most-called creation path, highest blast radius
+2. **`surface.create`** (TC:5163) — second most-called, creates terminal/browser/markdown surfaces
+3. **`pane.create`** (TC:6735) — split creation, often called right after workspace/surface create
+4. **`window.create`** (TC:3592) — less frequent but creates an NSWindow (expensive)
+5. **`new_workspace` / `new_split`** (TC:13521, 13545) — v1 equivalents used by older agents
+
+### Tier 2: Fix as part of the same pass (low-friction wins)
+
+6. **`log` / `append_log`** (TC:15986) — telemetry hotpath; should already be using `.async` like `set-status` does
+7. **`workspace.select` / `workspace.close`** (TC:3715, 3772) — commonly called; mutations are fast but sync-blocked under load
+
+### Tier 3: Low priority (read-only or low-frequency)
+
+8. Notification list/clear, sidebar metadata reads — already fast; migrate in a cleanup pass
+
+---
+
+## Recommended Approach for NEEDS_ASYNC Handlers
+
+The cleanest solution for Tier 1 handlers is a `withCheckedContinuation` / `Task { @MainActor }` pattern with a caller-side deadline:
+
+```swift
+// Pattern: deadline-aware main actor dispatch (server side)
+func v2MainAsync<T: Sendable>(
+    deadline: TimeInterval = 10.0,
+    _ body: @MainActor @Sendable () -> T
+) async throws -> T {
+    try await withTimeout(seconds: deadline) {
+        await MainActor.run { body() }
+    }
+}
+```
+
+The socket handler then becomes an `async` function dispatched onto a Swift Concurrency executor with a deadline, and the accept-loop spawns a `Task` per connection rather than blocking the thread.
+
+The minimal change that doesn't require restructuring the entire accept loop is to keep the background-thread handler but replace `DispatchQueue.main.sync` with a semaphore+timeout pattern:
+
+```swift
+func v2MainSyncWithDeadline<T>(seconds: TimeInterval = 10.0, _ body: () -> T) -> T? {
+    if Thread.isMainThread { return body() }
+    var result: T?
+    let sema = DispatchSemaphore(value: 0)
+    DispatchQueue.main.async {
+        result = body()
+        sema.signal()
+    }
+    let waited = sema.wait(timeout: .now() + seconds)
+    return waited == .success ? result : nil
+}
+```
+
+This is the "minimal change" path. The full Swift Concurrency refactor is cleaner but requires rearchitecting the accept loop. C11-4 should decide between these two approaches.

--- a/tests/test_cli_socket_deadline.py
+++ b/tests/test_cli_socket_deadline.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""C11-7: CLI socket deadline — named timeouts and trace mode.
+
+Tests verify observable behavior:
+- A command sent to a socket that never responds exits non-zero within the deadline.
+- stderr contains the stable "c11: timeout:" prefix with method/socket/elapsed fields.
+- C11_TRACE=1 emits [c11-trace] start/end lines bracketing the request.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+
+
+# ---------------------------------------------------------------------------
+# CLI binary resolution
+# ---------------------------------------------------------------------------
+
+def resolve_c11_cli() -> str:
+    explicit = os.environ.get("C11_CLI_BIN") or os.environ.get("CMUX_CLI_BIN") or os.environ.get("CMUX_CLI")
+    if explicit and os.path.exists(explicit) and os.access(explicit, os.X_OK):
+        return explicit
+
+    # Prefer the path written by scripts/reload.sh --tag.
+    last_cli_path_file = "/tmp/c11-last-cli-path"
+    if os.path.isfile(last_cli_path_file) and not os.path.islink(last_cli_path_file):
+        try:
+            candidate = open(last_cli_path_file).read().strip()
+            if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        except OSError:
+            pass
+
+    # Xcode DerivedData — both project names (historical: cmux, current: c11)
+    candidates: list[str] = []
+    for binary_name in ("c11", "cmux"):
+        candidates.extend(glob.glob(
+            os.path.expanduser(f"~/Library/Developer/Xcode/DerivedData/*/Build/Products/Debug/{binary_name}")
+        ))
+        candidates.extend(glob.glob(f"/tmp/cmux-*/Build/Products/Debug/{binary_name}"))
+        candidates.extend(glob.glob(f"/tmp/c11-*/Build/Products/Debug/{binary_name}"))
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if candidates:
+        candidates.sort(key=os.path.getmtime, reverse=True)
+        return candidates[0]
+
+    for binary_name in ("c11", "cmux"):
+        found = shutil.which(binary_name)
+        if found:
+            return found
+
+    raise RuntimeError(
+        "Unable to find c11 CLI binary. "
+        "Run ./scripts/reload.sh --tag <name> first, or set C11_CLI_BIN."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deaf socket server: accepts connections, reads input, never writes back.
+# ---------------------------------------------------------------------------
+
+class DeafSocketServer:
+    """Unix socket server that accepts connections but never responds."""
+
+    def __init__(self, socket_path: str):
+        self.socket_path = socket_path
+        self.ready = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def wait_ready(self, timeout: float = 2.0) -> bool:
+        return self.ready.wait(timeout)
+
+    def _run(self) -> None:
+        if os.path.exists(self.socket_path):
+            os.remove(self.socket_path)
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            srv.bind(self.socket_path)
+            srv.listen(8)
+            srv.settimeout(30.0)
+            self.ready.set()
+            while True:
+                try:
+                    conn, _ = srv.accept()
+                    # Accept the connection, drain input, but never send a byte back.
+                    threading.Thread(target=self._drain, args=(conn,), daemon=True).start()
+                except socket.timeout:
+                    break
+        finally:
+            srv.close()
+            try:
+                os.remove(self.socket_path)
+            except OSError:
+                pass
+
+    @staticmethod
+    def _drain(conn: socket.socket) -> None:
+        try:
+            conn.settimeout(60.0)
+            while conn.recv(4096):
+                pass
+        except OSError:
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_cli(
+    cli_path: str,
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+    timeout: float = 15.0,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CMUX_CLI_SENTRY_DISABLED"] = "1"
+    env["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [cli_path, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_deadline_fires_and_names_timeout(cli_path: str, sock_path: str) -> tuple[bool, str]:
+    """CLI exits non-zero with 'c11: timeout: method=...' when server never responds."""
+    server = DeafSocketServer(sock_path)
+    server.start()
+    if not server.wait_ready():
+        return False, "deaf server did not become ready"
+
+    start = time.monotonic()
+    proc = _run_cli(
+        cli_path,
+        "capabilities",
+        extra_env={
+            "CMUX_SOCKET_PATH": sock_path,
+            # 600 ms deadline — fast enough for the test, long enough for slow CI.
+            "C11_DEFAULT_SOCKET_DEADLINE_MS": "600",
+        },
+    )
+    elapsed = time.monotonic() - start
+
+    if proc.returncode == 0:
+        return False, f"expected non-zero exit; got 0; stdout={proc.stdout!r}"
+
+    # Must complete well within 2x the deadline.
+    if elapsed > 5.0:
+        return False, f"CLI took {elapsed:.1f}s — deadline did not fire in time"
+
+    # stderr must contain the stable parseable prefix.
+    if "c11: timeout:" not in proc.stderr:
+        return False, f"expected 'c11: timeout:' in stderr; got {proc.stderr!r}"
+
+    # Must name the method.
+    if "method=system.capabilities" not in proc.stderr:
+        return False, f"expected 'method=system.capabilities' in stderr; got {proc.stderr!r}"
+
+    # Must include the socket path.
+    if "socket=" not in proc.stderr:
+        return False, f"expected 'socket=...' field in stderr; got {proc.stderr!r}"
+
+    # Must include elapsed_ms.
+    if "elapsed_ms=" not in proc.stderr:
+        return False, f"expected 'elapsed_ms=...' field in stderr; got {proc.stderr!r}"
+
+    return True, ""
+
+
+def test_trace_mode_emits_start_and_end(cli_path: str, sock_path: str) -> tuple[bool, str]:
+    """C11_TRACE=1 emits bracketing [c11-trace] -> / <- lines around the request."""
+    server = DeafSocketServer(sock_path)
+    server.start()
+    if not server.wait_ready():
+        return False, "deaf server did not become ready"
+
+    proc = _run_cli(
+        cli_path,
+        "capabilities",
+        extra_env={
+            "CMUX_SOCKET_PATH": sock_path,
+            "C11_DEFAULT_SOCKET_DEADLINE_MS": "600",
+            "C11_TRACE": "1",
+        },
+    )
+
+    if "[c11-trace] ->" not in proc.stderr:
+        return False, f"expected '[c11-trace] ->' in stderr; got {proc.stderr!r}"
+
+    if "[c11-trace] <-" not in proc.stderr:
+        return False, f"expected '[c11-trace] <-' in stderr; got {proc.stderr!r}"
+
+    if "status=timeout" not in proc.stderr:
+        return False, f"expected 'status=timeout' in trace end line; got {proc.stderr!r}"
+
+    if "elapsed=" not in proc.stderr:
+        return False, f"expected 'elapsed=...' in trace end line; got {proc.stderr!r}"
+
+    return True, ""
+
+
+def test_no_deadline_for_browser_wait_command(cli_path: str, sock_path: str) -> tuple[bool, str]:
+    """'browser wait' uses deadline:.none — the CLI default deadline does not apply.
+
+    The deaf server will hold the connection open. With a 200ms default deadline
+    and no explicit cli-side deadline for browser.wait, the CLI should NOT exit
+    within 200ms. We give it 600ms and assert it is still running — then we kill it.
+    """
+    server = DeafSocketServer(sock_path)
+    server.start()
+    if not server.wait_ready():
+        return False, "deaf server did not become ready"
+
+    env = os.environ.copy()
+    env["CMUX_SOCKET_PATH"] = sock_path
+    env["C11_DEFAULT_SOCKET_DEADLINE_MS"] = "200"
+    env["CMUX_CLI_SENTRY_DISABLED"] = "1"
+    env["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+    proc = subprocess.Popen(
+        [cli_path, "browser", "wait", "--load-state", "complete"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    # Wait 600ms — well past the 200ms default deadline. browser.wait should still be alive.
+    time.sleep(0.6)
+    still_running = proc.poll() is None
+    proc.terminate()
+    try:
+        proc.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+    if not still_running:
+        stderr = proc.stderr.read() if proc.stderr else ""
+        return (
+            False,
+            f"'browser wait' exited early (deadline:.none was not applied). stderr={stderr!r}",
+        )
+
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    try:
+        cli_path = resolve_c11_cli()
+    except RuntimeError as exc:
+        print(f"SKIP: {exc}")
+        return 0  # Not a test failure; CLI not built yet.
+
+    tmpdir = tempfile.mkdtemp(prefix="c11-deadline-test-")
+    failures: list[str] = []
+
+    tests = [
+        ("deadline fires and names timeout", test_deadline_fires_and_names_timeout),
+        ("trace mode emits start and end lines", test_trace_mode_emits_start_and_end),
+        ("browser wait bypasses default deadline", test_no_deadline_for_browser_wait_command),
+    ]
+
+    for name, fn in tests:
+        sock_path = os.path.join(tmpdir, f"{name.replace(' ', '_')}.sock")
+        try:
+            ok, msg = fn(cli_path, sock_path)
+        except Exception as exc:
+            ok, msg = False, f"unexpected exception: {exc}"
+        finally:
+            try:
+                os.remove(sock_path)
+            except OSError:
+                pass
+
+        status = "PASS" if ok else "FAIL"
+        print(f"{status}: {name}")
+        if not ok:
+            print(f"  detail: {msg}")
+            failures.append(name)
+
+    try:
+        os.rmdir(tmpdir)
+    except OSError:
+        pass
+
+    if failures:
+        print(f"\n{len(failures)} test(s) failed.")
+        return 1
+
+    print(f"\nAll {len(tests)} tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_socket_reliability_stress.py
+++ b/tests_v2/test_socket_reliability_stress.py
@@ -34,29 +34,49 @@ def _must(cond: bool, msg: str) -> None:
         raise cmuxError(msg)
 
 
-def _find_cli_binary() -> str:
-    env_cli = os.environ.get("CMUXTERM_CLI")
-    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
-        return env_cli
+def _find_cli_binary() -> Optional[str]:
+    """Return path to c11/cmux CLI binary, or None if not found (caller should skip)."""
+    import shutil
 
-    fixed = os.path.expanduser(
-        "~/Library/Developer/Xcode/DerivedData/cmux-tests-v2/Build/Products/Debug/cmux"
-    )
-    if os.path.isfile(fixed) and os.access(fixed, os.X_OK):
-        return fixed
+    # Prefer explicit env vars (c11-style first, then legacy cmux compat).
+    for env_key in ("C11_CLI_BIN", "CMUX_CLI_BIN", "CMUX_CLI", "CMUXTERM_CLI"):
+        val = os.environ.get(env_key)
+        if val and os.path.isfile(val) and os.access(val, os.X_OK):
+            return val
 
-    candidates = glob.glob(
-        os.path.expanduser(
-            "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/cmux"
-        ),
-        recursive=True,
-    )
-    candidates += glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux")
+    # Prefer the path written by scripts/reload.sh --tag.
+    last_cli_path_file = "/tmp/c11-last-cli-path"
+    if os.path.isfile(last_cli_path_file) and not os.path.islink(last_cli_path_file):
+        try:
+            candidate = open(last_cli_path_file).read().strip()
+            if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+                return candidate
+        except OSError:
+            pass
+
+    # Xcode DerivedData — search both project names (c11 current, cmux historical).
+    candidates: list[str] = []
+    for binary_name in ("c11", "cmux"):
+        candidates.extend(glob.glob(
+            os.path.expanduser(
+                f"~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/{binary_name}"
+            ),
+            recursive=True,
+        ))
+        candidates.extend(glob.glob(f"/tmp/c11-*/Build/Products/Debug/{binary_name}"))
+        candidates.extend(glob.glob(f"/tmp/cmux-*/Build/Products/Debug/{binary_name}"))
     candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
-    if not candidates:
-        raise cmuxError("Could not locate cmux CLI binary; set CMUXTERM_CLI")
-    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
-    return candidates[0]
+    if candidates:
+        candidates.sort(key=os.path.getmtime, reverse=True)
+        return candidates[0]
+
+    # PATH fallback.
+    for binary_name in ("c11", "cmux"):
+        found = shutil.which(binary_name)
+        if found:
+            return found
+
+    return None
 
 
 def _cli_env() -> dict[str, str]:
@@ -86,6 +106,9 @@ def test_no_cli_hangs_under_rapid_surface_creation() -> int:
         return 0
 
     cli = _find_cli_binary()
+    if cli is None:
+        print("SKIP: c11/cmux CLI binary not found. Run ./scripts/reload.sh --tag <name>, or set C11_CLI_BIN.")
+        return 0
     env = _cli_env()
 
     # Seed workspace and surface IDs to use for surface.create and set-metadata.

--- a/tests_v2/test_socket_reliability_stress.py
+++ b/tests_v2/test_socket_reliability_stress.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Stress test: 20 concurrent CLI calls complete within wall-clock deadline.
+
+Covers the original dogfood failure shape: batch automation that fires many
+surface/metadata commands back-to-back could hang indefinitely before
+3d0b8257 + this ticket's Tier 1 deadline bridge.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("C11_SOCKET") or os.environ.get("CMUX_SOCKET", "")
+WALL_CLOCK_LIMIT = 15.0
+SUBPROCESS_TIMEOUT = 15.0
+CALL_COUNT = 20
+DEADLINE_ENV_MS = "9000"
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli_binary() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+
+    fixed = os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/cmux-tests-v2/Build/Products/Debug/cmux"
+    )
+    if os.path.isfile(fixed) and os.access(fixed, os.X_OK):
+        return fixed
+
+    candidates = glob.glob(
+        os.path.expanduser(
+            "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/cmux"
+        ),
+        recursive=True,
+    )
+    candidates += glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux")
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate cmux CLI binary; set CMUXTERM_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _cli_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env["C11_DEFAULT_SOCKET_DEADLINE_MS"] = DEADLINE_ENV_MS
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_TAB_ID", None)
+    return env
+
+
+def _run(cli: str, args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=SUBPROCESS_TIMEOUT,
+        env=env,
+    )
+
+
+def test_no_cli_hangs_under_rapid_surface_creation() -> int:
+    if not SOCKET_PATH:
+        print("SKIP: C11_SOCKET / CMUX_SOCKET not set — no live c11 instance")
+        return 0
+
+    cli = _find_cli_binary()
+    env = _cli_env()
+
+    # Seed workspace and surface IDs to use for surface.create and set-metadata.
+    # We need at least one workspace+surface already live; create one via the
+    # Python client so it's available before the stress loop starts.
+    seed_ws_id: Optional[str] = None
+    seed_surface_id: Optional[str] = None
+    stress_ws_ids: list[str] = []
+
+    with cmux(SOCKET_PATH) as c:
+        created = c._call("workspace.create", {}) or {}
+        seed_ws_id = str(created.get("workspace_id") or "")
+        _must(bool(seed_ws_id), f"seed workspace.create returned no workspace_id: {created}")
+
+        surfaces = c.list_surfaces(seed_ws_id)
+        if surfaces:
+            seed_surface_id = str(surfaces[0][1])
+
+    results: list[subprocess.CompletedProcess[str]] = [None] * CALL_COUNT  # type: ignore[list-item]
+
+    def worker(idx: int) -> None:
+        # Distribute call types across the 20 workers.
+        call_type = idx % 4
+        try:
+            if call_type == 0:
+                # workspace.create via new-workspace
+                results[idx] = _run(cli, ["new-workspace"], env)
+            elif call_type == 1:
+                # surface.create via new-surface (terminal type in existing workspace)
+                args = ["new-surface", "--type", "terminal"]
+                if seed_ws_id:
+                    args += ["--workspace", seed_ws_id]
+                results[idx] = _run(cli, args, env)
+            elif call_type == 2:
+                # pane.create via new-pane (split right in existing workspace)
+                args = ["new-pane", "--direction", "right"]
+                if seed_ws_id:
+                    args += ["--workspace", seed_ws_id]
+                results[idx] = _run(cli, args, env)
+            else:
+                # surface.set_metadata via set-metadata
+                args = ["set-metadata", "--key", "stress_test", "--value", f"v{idx}"]
+                if seed_surface_id:
+                    args += ["--surface", seed_surface_id]
+                elif seed_ws_id:
+                    args += ["--workspace", seed_ws_id]
+                results[idx] = _run(cli, args, env)
+        except subprocess.TimeoutExpired:
+            # Replace with a synthetic result so assertion below can check it.
+            results[idx] = subprocess.CompletedProcess(
+                args=[],
+                returncode=124,
+                stdout="",
+                stderr="c11: timeout: subprocess.TimeoutExpired (hard wall timeout hit)",
+            )
+
+    start = time.monotonic()
+    threads = [threading.Thread(target=worker, args=(i,), daemon=True) for i in range(CALL_COUNT)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=WALL_CLOCK_LIMIT + 1.0)
+    elapsed = time.monotonic() - start
+
+    _must(
+        elapsed < WALL_CLOCK_LIMIT,
+        f"20 concurrent CLI calls took {elapsed:.1f}s, exceeding {WALL_CLOCK_LIMIT}s wall-clock limit",
+    )
+
+    # Collect workspace IDs created during the run so we can clean up.
+    for i, proc in enumerate(results):
+        if proc is None:
+            raise cmuxError(f"Worker {i} never completed (thread join timed out)")
+        if proc.returncode == 0 and (i % 4) == 0:
+            # new-workspace output: "OK workspace:..." or "OK <uuid>"
+            out = (proc.stdout or "").strip()
+            if out.startswith("OK "):
+                stress_ws_ids.append(out[3:].strip())
+
+    # Assertion: any non-zero result must carry the named timeout prefix, not silence.
+    failed_silently = []
+    for i, proc in enumerate(results):
+        if proc.returncode != 0:
+            combined = (proc.stdout or "") + (proc.stderr or "")
+            has_timeout_prefix = "c11: timeout:" in combined
+            has_error_label = (
+                "error" in combined.lower()
+                or "timeout" in combined.lower()
+                or "ERROR" in combined
+            )
+            if not (has_timeout_prefix or has_error_label):
+                failed_silently.append((i, proc.returncode, combined[:200]))
+
+    _must(
+        not failed_silently,
+        f"Some CLI calls exited non-zero without a named error/timeout prefix: {failed_silently}",
+    )
+
+    # Clean up: close workspaces created during stress run + the seed workspace.
+    cleanup_ids = stress_ws_ids[:]
+    if seed_ws_id:
+        cleanup_ids.append(seed_ws_id)
+
+    if cleanup_ids:
+        with cmux(SOCKET_PATH) as c:
+            for ws_id in cleanup_ids:
+                try:
+                    c._call("workspace.close", {"workspace_id": ws_id})
+                except Exception:
+                    pass
+
+    passed = sum(1 for p in results if p.returncode == 0)
+    timed_out = sum(1 for p in results if "c11: timeout:" in ((p.stdout or "") + (p.stderr or "")))
+    print(
+        f"PASS: {CALL_COUNT} concurrent CLI calls completed in {elapsed:.2f}s "
+        f"({passed} ok, {timed_out} named-timeout, "
+        f"{CALL_COUNT - passed - timed_out} other-nonzero)"
+    )
+    return 0
+
+
+def main() -> int:
+    return test_no_cli_hangs_under_rapid_surface_creation()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Hardens the c11 CLI/socket layer so automated scripts cannot hang indefinitely. Two complementary sides:

**CLI side** — `CLI/c11.swift`:
- 10 s default deadline on all ordinary socket commands (`SocketDeadline.default`); env-tunable via `C11_DEFAULT_SOCKET_DEADLINE_MS`
- Named timeout errors: `c11: timeout: method=... workspace=... socket=... elapsed_ms=...` on stderr, non-zero exit
- `C11_TRACE=1` / `CMUX_TRACE=1` emits bracketing `[c11-trace] ->` / `<-` lines with elapsed and status per request
- Long-runners opt out with `deadline: .none` (`pane.confirm`, `browser.wait`, `browser.download.wait`, `workspace.remote.configure`)
- `c11 notify` already migrated to v2 in PR #66

**App (server) side** — `Sources/TerminalController.swift`:
- `v2MainSyncWithDeadline` (semaphore + 8 s deadline) alongside existing `v2MainSync`
- Wired into 7 Tier 1 creation handlers: `window.create`, `workspace.create`, `surface.create`, `pane.create`, `new_workspace`, `new_split`, `drag_surface_to_split`
- Server-side timeout normalised to the same parseable `c11: timeout:` envelope as CLI-side SO_RCVTIMEO
- Cancellation flag prevents ghost-mutating UI state after the caller already received a timeout error

**Audit doc** — `notes/c11-7-mainthread-audit-2026-04-24.md`:
- 105 total `DispatchQueue.main.sync` occurrences: 48 SAFE / 38 RISKY / 19 NEEDS_ASYNC
- C11-4 (deadline-aware main actor bridge — full async refactor) is sequenced behind this ticket and can cite the audit doc directly

**Tests**:
- `tests/test_cli_socket_deadline.py` — deaf-socket harness, verifies exit code / stderr / timing for CLI deadline and trace mode (CI only, per CLAUDE.md)
- `tests_v2/test_socket_reliability_stress.py` — 20 concurrent CLI calls during rapid surface creation, asserts no hangs past deadline (CI only)

## Deferred to C11-4

- Full Swift Concurrency refactor of the socket accept loop (38 RISKY + remaining 12 NEEDS_ASYNC handlers)
- Ghost-creation long-term design (operation IDs + idempotency keys for safe retry semantics) — S1 from trident review
- Stress-test assertion tightening (acceptable failure rates under concurrent load) — S3
- `SocketDeadline.humanInput` semantic case (E1)
- Main-thread latency telemetry in `v2MainSyncWithDeadline` (E2)
- `main_thread_timeout` execution_state field for retry logic (E3)

## traceStatus S5 — resolved, no action

critical-codex claimed `traceStatus` might emit `status=ok` on malformed responses. Code review confirms all parse-failure paths set `traceStatus = "error"` before throwing; standard-claude was correct. No change needed.

## Test plan

- [ ] CI: `test_cli_socket_deadline.py` and `test_socket_reliability_stress.py` pass
- [ ] Smoke: `C11_TRACE=1 c11 set-metadata --surface surface:1 --key foo --value bar` shows `[c11-trace] ->` / `<-` lines
- [ ] Smoke: CLI against a deaf socket exits within ~10 s with `c11: timeout:` on stderr
- [ ] Smoke: `c11 notify` returns quickly (v2 path already landed in #66)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)