### PR TITLE
Pane-close: in-pane confirmation overlay with destructive emphasis

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		A5C101A0 /* PaneInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B0 /* PaneInteraction.swift */; };
 		A5C101A1 /* PaneInteractionCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B1 /* PaneInteractionCardView.swift */; };
 		A5C101A2 /* PaneInteractionOverlayHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B2 /* PaneInteractionOverlayHost.swift */; };
+		A5C101A3 /* PaneInteractionOverlayHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B3 /* PaneInteractionOverlayHostView.swift */; };
+		A5C101A4 /* PaneCloseOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B4 /* PaneCloseOverlayController.swift */; };
 		A5C102A0 /* PaneInteractionRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C102B0 /* PaneInteractionRuntimeTests.swift */; };
 		A58689DE /* MermaidRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C229 /* MermaidRenderer.swift */; };
 		A58689DF /* FencedCodeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A537C22A /* FencedCodeRenderer.swift */; };
@@ -387,6 +389,8 @@
 		A5C101B0 /* PaneInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteraction.swift; sourceTree = "<group>"; };
 		A5C101B1 /* PaneInteractionCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteractionCardView.swift; sourceTree = "<group>"; };
 		A5C101B2 /* PaneInteractionOverlayHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteractionOverlayHost.swift; sourceTree = "<group>"; };
+		A5C101B3 /* PaneInteractionOverlayHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneInteractionOverlayHostView.swift; sourceTree = "<group>"; };
+		A5C101B4 /* PaneCloseOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PaneCloseOverlayController.swift; sourceTree = "<group>"; };
 		A5C102B0 /* PaneInteractionRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInteractionRuntimeTests.swift; sourceTree = "<group>"; };
 		A537C229 /* MermaidRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MermaidRenderer.swift; sourceTree = "<group>"; };
 		A537C22A /* FencedCodeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FencedCodeRenderer.swift; sourceTree = "<group>"; };
@@ -701,6 +705,8 @@
 				A5C101B0 /* PaneInteraction.swift */,
 				A5C101B1 /* PaneInteractionCardView.swift */,
 				A5C101B2 /* PaneInteractionOverlayHost.swift */,
+				A5C101B3 /* PaneInteractionOverlayHostView.swift */,
+				A5C101B4 /* PaneCloseOverlayController.swift */,
 				A537C229 /* MermaidRenderer.swift */,
 				A537C22A /* FencedCodeRenderer.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
@@ -1089,6 +1095,8 @@
 				A5C101A0 /* PaneInteraction.swift in Sources */,
 				A5C101A1 /* PaneInteractionCardView.swift in Sources */,
 				A5C101A2 /* PaneInteractionOverlayHost.swift in Sources */,
+				A5C101A3 /* PaneInteractionOverlayHostView.swift in Sources */,
+				A5C101A4 /* PaneCloseOverlayController.swift in Sources */,
 				A58689DE /* MermaidRenderer.swift in Sources */,
 				A58689DF /* FencedCodeRenderer.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,

--- a/Sources/Panels/PaneCloseOverlayController.swift
+++ b/Sources/Panels/PaneCloseOverlayController.swift
@@ -1,0 +1,87 @@
+import AppKit
+import Combine
+import Foundation
+
+/// Owns the AppKit overlay layer that renders the pane-close confirmation card.
+/// One instance per workspace. The controller mounts `PaneInteractionOverlayHost`
+/// instances directly into the window's themeFrame so they sit above the
+/// `WindowTerminalPortal` host view (and above all SwiftUI content). Anchor
+/// frames are pushed in from `PaneInteractionOverlayHostView`, which is
+/// rendered inside each Bonsplit pane via the pane-overlay environment value.
+@MainActor
+final class PaneCloseOverlayController {
+    let runtime: PaneInteractionRuntime
+    private var anchors: [UUID: AnchorRecord] = [:]
+    private var hosts: [UUID: PaneInteractionOverlayHost] = [:]
+    private var activeIds: Set<UUID> = []
+    private var subscription: AnyCancellable?
+
+    private struct AnchorRecord {
+        var frameInWindow: NSRect
+        weak var window: NSWindow?
+    }
+
+    init(runtime: PaneInteractionRuntime) {
+        self.runtime = runtime
+        subscription = runtime.$active
+            .receive(on: RunLoop.main)
+            .sink { [weak self] active in
+                self?.activeIds = Set(active.keys)
+                self?.synchronize()
+            }
+        activeIds = Set(runtime.active.keys)
+    }
+
+    func updateAnchor(paneIdentity: UUID, frameInWindow: NSRect, window: NSWindow) {
+        anchors[paneIdentity] = AnchorRecord(frameInWindow: frameInWindow, window: window)
+        synchronize()
+    }
+
+    func removeAnchor(paneIdentity: UUID) {
+        anchors.removeValue(forKey: paneIdentity)
+        if let host = hosts.removeValue(forKey: paneIdentity) {
+            host.removeFromSuperview()
+        }
+    }
+
+    func cleanup() {
+        for host in hosts.values {
+            host.removeFromSuperview()
+        }
+        hosts.removeAll()
+        anchors.removeAll()
+        activeIds.removeAll()
+    }
+
+    private func synchronize() {
+        // Drop hosts for panes that are no longer active.
+        for (id, host) in hosts where !activeIds.contains(id) {
+            host.removeFromSuperview()
+            hosts.removeValue(forKey: id)
+        }
+
+        for id in activeIds {
+            guard let anchor = anchors[id],
+                  let window = anchor.window,
+                  let themeFrame = window.contentView?.superview
+            else { continue }
+
+            let host: PaneInteractionOverlayHost
+            if let existing = hosts[id] {
+                host = existing
+            } else {
+                host = PaneInteractionOverlayHost(panelId: id, runtime: runtime)
+                hosts[id] = host
+            }
+
+            // themeFrame and the window share the same coordinate system (themeFrame
+            // is the window's outermost view at origin (0,0), full window size).
+            // `convert(_:to: nil)` from any descendant gives window-coords directly.
+            host.frame = anchor.frameInWindow
+
+            // Re-add as the topmost subview so we sit above the portal hostView,
+            // the file-drop overlay, and any SwiftUI hosting view.
+            themeFrame.addSubview(host, positioned: .above, relativeTo: nil)
+        }
+    }
+}

--- a/Sources/Panels/PaneInteraction.swift
+++ b/Sources/Panels/PaneInteraction.swift
@@ -39,9 +39,15 @@ public struct ConfirmContent: Identifiable {
     public let id = UUID()
     public let title: String
     public let message: String?
+    /// Optional list of items the action will affect, rendered as a bullet
+    /// list under the message. Use for high-stakes destructive flows where
+    /// the user needs to see exactly what's about to be removed (e.g.
+    /// pane-close listing each tab being closed).
+    public let detailLines: [String]
     public let confirmLabel: String
     public let cancelLabel: String
     public let role: ConfirmRole
+    public let style: ConfirmStyle
     public let source: InteractionSource
     public let completion: (ConfirmResult) -> Void
 
@@ -50,20 +56,34 @@ public struct ConfirmContent: Identifiable {
         case destructive
     }
 
+    /// Visual treatment of the card. `.standard` is the default look used by
+    /// every existing call site. `.criticalDestructive` is the emphasised
+    /// treatment used when an irreversible multi-item action is at stake —
+    /// red glow on the card, pulsing destructive button, larger title — so
+    /// the operator can't fat-finger their way through it.
+    public enum ConfirmStyle {
+        case standard
+        case criticalDestructive
+    }
+
     public init(
         title: String,
         message: String?,
+        detailLines: [String] = [],
         confirmLabel: String,
         cancelLabel: String,
         role: ConfirmRole,
+        style: ConfirmStyle = .standard,
         source: InteractionSource,
         completion: @escaping (ConfirmResult) -> Void
     ) {
         self.title = title
         self.message = message
+        self.detailLines = detailLines
         self.confirmLabel = confirmLabel
         self.cancelLabel = cancelLabel
         self.role = role
+        self.style = style
         self.source = source
         self.completion = completion
     }

--- a/Sources/Panels/PaneInteractionCardView.swift
+++ b/Sources/Panels/PaneInteractionCardView.swift
@@ -45,21 +45,70 @@ private struct ConfirmCard: View {
     let panelId: UUID
     let content: ConfirmContent
     @ObservedObject var runtime: PaneInteractionRuntime
+    @State private var pulse: Bool = false
 
     private var selected: ConfirmSelectionField {
         runtime.confirmSelection[panelId] ?? .confirm
     }
 
+    private var isCritical: Bool {
+        content.style == .criticalDestructive
+    }
+
+    private var titleFont: Font {
+        isCritical
+            ? .system(size: 18, weight: .bold)
+            : .system(size: 15, weight: .semibold)
+    }
+
+    private var confirmFont: Font {
+        isCritical
+            ? .system(size: 14, weight: .bold)
+            : .system(size: 13, weight: .regular)
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text(content.title)
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundStyle(BrandColors.whiteSwiftUI)
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                if isCritical {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(Color.red)
+                        .accessibilityHidden(true)
+                }
+                Self.emphasizedText(content.title)
+                    .font(titleFont)
+                    .foregroundStyle(BrandColors.whiteSwiftUI)
+            }
 
             if let message = content.message, !message.isEmpty {
                 Text(message)
                     .font(.system(size: 13))
                     .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.85))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if !content.detailLines.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(content.detailLines.enumerated()), id: \.offset) { _, line in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text("•")
+                                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.65))
+                            Text(line)
+                                .font(.system(size: 12, design: .monospaced))
+                                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.95))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                }
+                .padding(.vertical, 8)
+                .padding(.horizontal, 10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.black.opacity(0.35))
+                )
             }
 
             HStack(spacing: 8) {
@@ -77,30 +126,57 @@ private struct ConfirmCard: View {
 
                 Button(role: content.role == .destructive ? .destructive : nil,
                        action: confirm) {
-                    Text(content.confirmLabel)
+                    Self.emphasizedText(content.confirmLabel)
+                        .font(confirmFont)
                         .foregroundColor(content.role == .destructive
                                          ? BrandColors.whiteSwiftUI
                                          : BrandColors.blackSwiftUI)
-                        .frame(minWidth: 64)
+                        .frame(minWidth: isCritical ? 96 : 64)
                 }
                 .buttonStyle(.borderedProminent)
+                .controlSize(isCritical ? .large : .regular)
                 .tint(content.role == .destructive ? .red : BrandColors.goldSwiftUI)
                 .selectionBox(isActive: selected == .confirm)
                 .accessibilityAddTraits(selected == .confirm ? .isSelected : [])
+                .scaleEffect(isCritical && pulse ? 1.04 : 1.0)
+                .shadow(color: isCritical
+                        ? Color.red.opacity(pulse ? 0.85 : 0.4)
+                        : .clear,
+                        radius: isCritical ? (pulse ? 14 : 6) : 0)
+                .animation(
+                    isCritical
+                        ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true)
+                        : .default,
+                    value: pulse
+                )
             }
         }
         .padding(24)
-        .frame(minWidth: 260, maxWidth: 420, alignment: .leading)
+        .frame(
+            minWidth: isCritical ? 320 : 260,
+            maxWidth: isCritical ? 480 : 420,
+            alignment: .leading
+        )
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(BrandColors.surfaceSwiftUI)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(BrandColors.ruleSwiftUI, lineWidth: 1)
+                        .strokeBorder(
+                            isCritical ? Color.red.opacity(0.85) : BrandColors.ruleSwiftUI,
+                            lineWidth: isCritical ? 2 : 1
+                        )
+                )
+                .shadow(
+                    color: isCritical ? Color.red.opacity(0.45) : .clear,
+                    radius: isCritical ? 20 : 0
                 )
         )
         .environment(\.colorScheme, .dark)
         .accessibilityIdentifier("PaneInteraction.confirm.card")
+        .onAppear {
+            if isCritical { pulse = true }
+        }
     }
 
     private func confirm() {
@@ -116,6 +192,38 @@ private struct ConfirmCard: View {
             result: .cancelled,
             ifInteractionId: content.id
         )
+    }
+
+    /// Underline standalone occurrences of "entire" / "Entire" / "ENTIRE" in
+    /// the supplied string. We use this to make the pane-close title and
+    /// button visibly distinct from a tab close at a glance — the differentiating
+    /// word is what catches the eye, not the sentence as a whole.
+    private static func emphasizedText(_ string: String) -> Text {
+        let pattern = #"\b(entire|Entire|ENTIRE)\b"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return Text(string)
+        }
+        let nsString = string as NSString
+        let fullRange = NSRange(location: 0, length: nsString.length)
+        let matches = regex.matches(in: string, range: fullRange)
+        guard !matches.isEmpty else { return Text(string) }
+
+        var cursor = 0
+        var result = Text("")
+        for match in matches {
+            if match.range.location > cursor {
+                let plainRange = NSRange(location: cursor, length: match.range.location - cursor)
+                result = result + Text(nsString.substring(with: plainRange))
+            }
+            let emphasized = nsString.substring(with: match.range)
+            result = result + Text(emphasized).underline().bold()
+            cursor = match.range.location + match.range.length
+        }
+        if cursor < nsString.length {
+            let tailRange = NSRange(location: cursor, length: nsString.length - cursor)
+            result = result + Text(nsString.substring(with: tailRange))
+        }
+        return result
     }
 }
 

--- a/Sources/Panels/PaneInteractionOverlayHostView.swift
+++ b/Sources/Panels/PaneInteractionOverlayHostView.swift
@@ -1,0 +1,90 @@
+import AppKit
+import Bonsplit
+import SwiftUI
+
+/// SwiftUI anchor that reports a pane's bounds (in window coordinates) to a
+/// workspace-level overlay controller.
+///
+/// We can't render the pane-close confirmation as a SwiftUI overlay because
+/// portal-hosted terminal/browser content is reparented into an AppKit layer
+/// that sits above the workspace's SwiftUI tree (see `WindowTerminalPortal`).
+/// Anything we draw inside the pane in SwiftUI ends up behind the terminal.
+///
+/// Instead, this view stays invisible and just publishes its window-coord
+/// frame; `PaneCloseOverlayController` mounts an AppKit overlay (the existing
+/// `PaneInteractionOverlayHost`) at the matching frame in the window's
+/// themeFrame, which is above the portal layer.
+struct PaneInteractionOverlayHostView: View {
+    let paneId: PaneID
+    let controller: PaneCloseOverlayController
+
+    var body: some View {
+        AnchorRepresentable(
+            paneIdentity: paneId.id,
+            controller: controller
+        )
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private struct AnchorRepresentable: NSViewRepresentable {
+        let paneIdentity: UUID
+        let controller: PaneCloseOverlayController
+
+        func makeNSView(context: Context) -> AnchorView {
+            let v = AnchorView()
+            v.paneIdentity = paneIdentity
+            v.controller = controller
+            return v
+        }
+
+        func updateNSView(_ nsView: AnchorView, context: Context) {
+            nsView.paneIdentity = paneIdentity
+            nsView.controller = controller
+            nsView.reportFrame()
+        }
+
+        static func dismantleNSView(_ nsView: AnchorView, coordinator: ()) {
+            if let id = nsView.paneIdentity {
+                nsView.controller?.removeAnchor(paneIdentity: id)
+            }
+        }
+    }
+
+    final class AnchorView: NSView {
+        var paneIdentity: UUID?
+        weak var controller: PaneCloseOverlayController?
+
+        override var isOpaque: Bool { false }
+        override func hitTest(_ point: NSPoint) -> NSView? { nil }
+        override var acceptsFirstResponder: Bool { false }
+
+        override var frame: NSRect {
+            didSet { reportFrame() }
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            reportFrame()
+        }
+
+        override func viewDidEndLiveResize() {
+            super.viewDidEndLiveResize()
+            reportFrame()
+        }
+
+        func reportFrame() {
+            guard let id = paneIdentity, let controller else { return }
+            guard let window else {
+                controller.removeAnchor(paneIdentity: id)
+                return
+            }
+            let frameInWindow = convert(bounds, to: nil)
+            controller.updateAnchor(
+                paneIdentity: id,
+                frameInWindow: frameInWindow,
+                window: window
+            )
+        }
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5028,6 +5028,22 @@ final class Workspace: Identifiable, ObservableObject {
     /// queue + soft cap lives inside the runtime. Views observe `.active`.
     let paneInteractionRuntime = PaneInteractionRuntime()
 
+    /// Pane-scoped (rather than panel-scoped) presenter. Shares the same runtime
+    /// implementation, but its overlays mount over the entire pane — tab strip
+    /// included — so a pane-close confirmation visibly spans every tab it's
+    /// about to remove. Keyed by `PaneID.id` (the runtime's `panelId` argument
+    /// is just an opaque UUID; using a separate instance keeps panel teardown
+    /// from clearing pane-scoped state and vice versa).
+    let paneCloseInteractionRuntime = PaneInteractionRuntime()
+
+    /// Mounts pane-scoped overlays as AppKit subviews of the workspace window's
+    /// themeFrame so they render above the `WindowTerminalPortal` host (and
+    /// thus above terminal/browser portal content). Driven by anchor frames
+    /// pushed in from `PaneInteractionOverlayHostView` per pane.
+    lazy var paneCloseOverlayController = PaneCloseOverlayController(
+        runtime: paneCloseInteractionRuntime
+    )
+
 
     // Closing tabs mutates split layout immediately; terminal views handle their own AppKit
     // layout/size synchronization.
@@ -5421,7 +5437,12 @@ final class Workspace: Identifiable, ObservableObject {
         let config = BonsplitConfiguration(
             allowSplits: true,
             allowCloseTabs: true,
-            allowCloseLastPane: false,
+            // Keep Bonsplit's X enabled even when this is the only pane —
+            // the workspace handler intercepts the request and resets the
+            // pane (close all tabs + open a fresh terminal) instead of
+            // tearing the workspace down. Bonsplit refuses to actually
+            // remove the last pane, which is the right contract.
+            allowCloseLastPane: true,
             allowTabReordering: true,
             allowCrossPaneTabMove: true,
             autoCloseEmptyPanes: true,
@@ -7769,6 +7790,8 @@ final class Workspace: Identifiable, ObservableObject {
         // leaks CheckedContinuations and blocks socket worker threads forever
         // (synthesis-standard §1.1, synthesis-critical §1.3).
         paneInteractionRuntime.clearAll()
+        paneCloseInteractionRuntime.clearAll()
+        paneCloseOverlayController.cleanup()
 
         let panelEntries = Array(panels)
         for (panelId, panel) in panelEntries {
@@ -10415,6 +10438,11 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didClosePane paneId: PaneID) {
+        // The pane is gone — drop any pending pane-scoped overlay (e.g. a stale
+        // pane-close confirmation that survived the close path) so its
+        // continuation resolves with .dismissed instead of leaking.
+        paneCloseInteractionRuntime.clear(panelId: paneId.id)
+
         let closedPanelIds = pendingPaneClosePanelIds.removeValue(forKey: paneId.id) ?? []
         let shouldScheduleFocusReconcile = !isDetachingCloseTransaction
 
@@ -10725,35 +10753,123 @@ extension Workspace: BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, didRequestClosePane pane: PaneID) {
         let tabs = controller.tabs(inPane: pane)
         let paneCount = controller.allPaneIds.count
-        guard paneCount > 1 else { return }
+        let isOnlyPane = paneCount <= 1
 
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = String(
-            localized: "workspace.closePane.alert.title",
-            defaultValue: "Close this pane?"
-        )
-        alert.informativeText = Self.closePaneConfirmationMessage(tabCount: tabs.count)
-        alert.addButton(withTitle: String(
-            localized: "workspace.closePane.alert.confirm",
-            defaultValue: "Close Pane"
-        ))
-        alert.addButton(withTitle: String(
+        let tabTitles = tabs.map { Self.paneCloseTabTitle(for: $0) }
+        let title = Self.closePaneConfirmationTitle(tabCount: tabs.count, isOnlyPane: isOnlyPane)
+        let message = Self.closePaneConfirmationMessage(tabCount: tabs.count, isOnlyPane: isOnlyPane)
+        let confirmLabel = Self.closePaneConfirmLabel(tabCount: tabs.count, isOnlyPane: isOnlyPane)
+        let cancelLabel = String(
             localized: "workspace.closePane.alert.cancel",
             defaultValue: "Cancel"
-        ))
+        )
 
-        // First button is the default/accept; make it the destructive role visually
-        if let confirmButton = alert.buttons.first {
-            confirmButton.hasDestructiveAction = true
+        let runtime = paneCloseInteractionRuntime
+        let paneKey = pane.id
+        Task { @MainActor [weak self] in
+            let confirmed = await withCheckedContinuation { (cont: CheckedContinuation<Bool, Never>) in
+                let content = ConfirmContent(
+                    title: title,
+                    message: message,
+                    detailLines: tabTitles,
+                    confirmLabel: confirmLabel,
+                    cancelLabel: cancelLabel,
+                    role: .destructive,
+                    style: .criticalDestructive,
+                    source: .local,
+                    completion: { result in
+                        cont.resume(returning: result == .confirmed)
+                    }
+                )
+                runtime.present(
+                    panelId: paneKey,
+                    interaction: .confirm(content),
+                    dedupeToken: "workspace.closePane"
+                )
+            }
+            guard confirmed, let self else { return }
+
+            if isOnlyPane {
+                // The pane structure stays (Bonsplit refuses to remove the
+                // last pane and the workspace must always have one). Close
+                // every tab in it without per-tab confirmation — the user
+                // already accepted the bigger "close entire pane" action —
+                // then drop a fresh terminal in so the operator isn't left
+                // staring at the empty-pane chooser. Matches the user's ask:
+                // X always does something, even on the root pane.
+                let tabsNow = self.bonsplitController.tabs(inPane: pane)
+                for tab in tabsNow {
+                    self.forceCloseTabIds.insert(tab.id)
+                    _ = self.bonsplitController.closeTab(tab.id)
+                }
+                _ = self.newTerminalSurface(inPane: pane)
+            } else {
+                guard self.bonsplitController.allPaneIds.contains(pane) else { return }
+                _ = self.bonsplitController.closePane(pane)
+            }
         }
-
-        let response = alert.runModal()
-        guard response == .alertFirstButtonReturn else { return }
-        _ = bonsplitController.closePane(pane)
     }
 
-    private static func closePaneConfirmationMessage(tabCount: Int) -> String {
+    private static func paneCloseTabTitle(for tab: Bonsplit.Tab) -> String {
+        let trimmed = tab.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        return String(
+            localized: "workspace.closePane.alert.tab.untitled",
+            defaultValue: "Untitled tab"
+        )
+    }
+
+    private static func closePaneConfirmationTitle(tabCount: Int, isOnlyPane: Bool) -> String {
+        // Always "entire pane" — the differentiator vs Close Tab is the
+        // word "entire" (rendered with emphasis in the card view), so the
+        // wording stays uniform across tab counts.
+        _ = tabCount
+        if isOnlyPane {
+            return String(
+                localized: "workspace.closePane.alert.title.only",
+                defaultValue: "Reset entire pane?"
+            )
+        }
+        return String(
+            localized: "workspace.closePane.alert.title",
+            defaultValue: "Close entire pane?"
+        )
+    }
+
+    private static func closePaneConfirmLabel(tabCount: Int, isOnlyPane: Bool) -> String {
+        _ = tabCount
+        if isOnlyPane {
+            return String(
+                localized: "workspace.closePane.alert.confirm.only",
+                defaultValue: "Reset Entire Pane"
+            )
+        }
+        return String(
+            localized: "workspace.closePane.alert.confirm",
+            defaultValue: "Close Entire Pane"
+        )
+    }
+
+    private static func closePaneConfirmationMessage(tabCount: Int, isOnlyPane: Bool) -> String {
+        if isOnlyPane {
+            if tabCount <= 0 {
+                return String(
+                    localized: "workspace.closePane.alert.body.only.empty",
+                    defaultValue: "This pane has no tabs. A new terminal will replace it."
+                )
+            }
+            if tabCount == 1 {
+                return String(
+                    localized: "workspace.closePane.alert.body.only.one",
+                    defaultValue: "Current tab that will be closed (a new terminal will replace it):"
+                )
+            }
+            return String(
+                localized: "workspace.closePane.alert.body.only.many",
+                defaultValue: "Current tabs that will be closed (a new terminal will replace them):"
+            )
+        }
+
         if tabCount <= 0 {
             return String(
                 localized: "workspace.closePane.alert.body.empty",
@@ -10763,14 +10879,13 @@ extension Workspace: BonsplitDelegate {
         if tabCount == 1 {
             return String(
                 localized: "workspace.closePane.alert.body.one",
-                defaultValue: "This will close 1 tab in this pane. This cannot be undone."
+                defaultValue: "Current tab that will be closed:"
             )
         }
-        let template = String(
+        return String(
             localized: "workspace.closePane.alert.body.many",
-            defaultValue: "This will close %lld tabs in this pane. This cannot be undone."
+            defaultValue: "Current tabs that will be closed:"
         )
-        return String(format: template, locale: Locale.current, tabCount)
     }
 
     /// Handle the "+" toolbar button: create a new tab in the given pane of

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -129,6 +129,21 @@ struct WorkspaceContentView: View {
                 }
         }
         .internalOnlyTabDrag()
+        // Inject a per-pane anchor view. The anchor itself draws nothing; it
+        // reports its window-coord frame to the workspace's overlay controller
+        // so the controller can mount the pane-close confirmation card in the
+        // window's themeFrame (above the WindowTerminalPortal layer). Drawing
+        // the overlay inside the SwiftUI tree leaves it stranded behind
+        // portal-hosted terminals/browsers, which is why we route through an
+        // AppKit overlay layer instead.
+        .environment(\.paneOverlayBuilder, { paneId in
+            AnyView(
+                PaneInteractionOverlayHostView(
+                    paneId: paneId,
+                    controller: workspace.paneCloseOverlayController
+                )
+            )
+        })
         // Split zoom swaps Bonsplit between the full split tree and a single pane view.
         // Recreate the Bonsplit subtree on zoom enter/exit so stale pre-zoom pane chrome
         // cannot remain stacked above portal-hosted browser content.

--- a/Sources/WorkspaceSnapshotCapture.swift
+++ b/Sources/WorkspaceSnapshotCapture.swift
@@ -69,8 +69,10 @@ struct LiveWorkspaceSnapshotSource: WorkspaceSnapshotSource {
     }
 
     /// Default bundle version + build number, e.g. `"0.01.123+42"`. Lives on
-    /// the type so tests can inject a deterministic string.
-    static func defaultVersionString() -> String {
+    /// the type so tests can inject a deterministic string. Nonisolated so it
+    /// can be evaluated as a default argument of `init` (Swift 6 won't let a
+    /// main-actor-isolated method run in the synchronous default-arg context).
+    nonisolated static func defaultVersionString() -> String {
         let info = Bundle.main.infoDictionary
         let short = (info?["CFBundleShortVersionString"] as? String) ?? "0.0.0"
         let build = (info?["CFBundleVersion"] as? String) ?? "0"


### PR DESCRIPTION
## Summary

- Replaces the window-centered NSAlert that fired when closing a pane with an inline overlay anchored to the pane being closed (covers the tab bar AND content together).
- Underscores the difference between *pane close* and *tab close*: title says "Close <u>**entire**</u> pane?", destructive button says "Close <u>**Entire**</u> Pane", and the body lists every tab title that's about to disappear. Card gets a red border + glow, ⚠️, and a subtly pulsing destructive button.
- Makes the X work on the only pane too — it now resets the pane (force-close every tab, drop in a fresh terminal in place) instead of being a no-op. Wording switches to "Reset entire pane?" with a parenthetical so the operator knows what to expect.

## Why the AppKit dance
The portal layer (`WindowTerminalPortal`) sits above the workspace's SwiftUI tree, so any pane-level overlay drawn in SwiftUI ends up behind the terminal/browser content. The fix routes through a workspace-scoped `PaneCloseOverlayController` that mounts an AppKit overlay in the window's themeFrame above the portal, sized via an invisible SwiftUI anchor view inside each pane.

## Bonsplit changes (separate commit on submodule `main`)
- New public `paneOverlayBuilder` SwiftUI environment value.
- `TabBarView` honours the existing `BonsplitConfiguration.allowCloseLastPane` flag instead of hardcoding `paneCount > 1`.

Both are generic — could go upstream.

## Out-of-scope build fix
First commit (`f4149714`): `WorkspaceSnapshotCapture.defaultVersionString()` is now `nonisolated`. The `@MainActor`-isolated form was breaking the build on `main` under Swift 6 strict concurrency when used as a default `init` argument.

## Test plan
- [x] Multi-pane workspace: X on a pane shows the overlay covering tab bar + content; card lists each tab; Cancel leaves everything intact; Confirm closes the pane.
- [x] Single-pane workspace: X on the only pane shows "Reset entire pane?"; Confirm closes every tab and opens a fresh terminal in place.
- [x] Esc / Enter keyboard routing works via the existing `PaneInteractionOverlayHost` first-responder capture.
- [x] Build succeeds with `./scripts/reload.sh --tag pane-close-overlay`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)