### PR TITLE
C11-20: CLI hygiene & focus policy sweep (7 upstream picks)

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -3997,14 +3997,26 @@ struct CMUXCLI {
             throw CLIError(message: "Invalid workspace handle: \(trimmed) (expected UUID, ref like workspace:1, or index)")
         }
 
-        var params: [String: Any] = [:]
         if let windowHandle {
-            params["window_id"] = windowHandle
-        }
-        let listed = try client.sendV2(method: "workspace.list", params: params)
-        let items = listed["workspaces"] as? [[String: Any]] ?? []
-        for item in items where intFromAny(item["index"]) == wantedIndex {
-            return (item["ref"] as? String) ?? (item["id"] as? String)
+            // Caller scoped to a specific window — list only that window's workspaces.
+            let listed = try client.sendV2(method: "workspace.list", params: ["window_id": windowHandle])
+            let items = listed["workspaces"] as? [[String: Any]] ?? []
+            for item in items where intFromAny(item["index"]) == wantedIndex {
+                return (item["ref"] as? String) ?? (item["id"] as? String)
+            }
+        } else {
+            // No window filter: scan all windows so --workspace 1 finds the correct workspace
+            // even if it lives in a different window than the socket's default context.
+            let windowsPayload = try client.sendV2(method: "window.list")
+            let windows = windowsPayload["windows"] as? [[String: Any]] ?? []
+            for window in windows {
+                guard let windowId = window["id"] as? String else { continue }
+                let listed = try client.sendV2(method: "workspace.list", params: ["window_id": windowId])
+                let items = listed["workspaces"] as? [[String: Any]] ?? []
+                for item in items where intFromAny(item["index"]) == wantedIndex {
+                    return (item["ref"] as? String) ?? (item["id"] as? String)
+                }
+            }
         }
         throw CLIError(message: "Workspace index not found")
     }

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2326,10 +2326,10 @@ struct CMUXCLI {
             let surfaceArg = sfArg ?? (wsArg == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
             // Require explicit surface targeting. Shell-integrated callers inside a c11
             // surface have CMUX_SURFACE_ID set automatically. External callers must pass
-            // --surface. Routing to the focused surface by default silently misdirects.
+            // --surface. The windowId path is excluded: --window without --surface still
+            // routes to ws.focusedPanelId, which is the ambient misdirection we're removing.
             guard sfArg != nil
-                || ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil
-                || windowId != nil else {
+                || ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil else {
                 throw CLIError(message: "send requires --surface <id|ref> (or run inside a c11 surface so CMUX_SURFACE_ID is set)")
             }
             let rawText = rem1.dropFirst(rem1.first == "--" ? 1 : 0).joined(separator: " ")
@@ -2349,9 +2349,9 @@ struct CMUXCLI {
             let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceArg = sfArg ?? (wsArg == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
             // Require explicit surface targeting (same policy as send).
+            // windowId alone is excluded for the same reason: it still routes to focusedPanelId.
             guard sfArg != nil
-                || ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil
-                || windowId != nil else {
+                || ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil else {
                 throw CLIError(message: "send-key requires --surface <id|ref> (or run inside a c11 surface so CMUX_SURFACE_ID is set)")
             }
             let keyArgs = rem1.first == "--" ? Array(rem1.dropFirst()) : rem1
@@ -2986,10 +2986,16 @@ struct CMUXCLI {
     /// `{plan: ...}` suitable for `workspace.create`'s `layout` param.
     private func resolveBlueprintPlan(_ ref: String, client: SocketClient) throws -> [String: Any] {
         let pathToTry = resolvePath(ref)
-        if FileManager.default.fileExists(atPath: pathToTry),
-           let data = FileManager.default.contents(atPath: pathToTry),
-           let file = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-           let plan = file["plan"] {
+        if FileManager.default.fileExists(atPath: pathToTry) {
+            guard let data = FileManager.default.contents(atPath: pathToTry) else {
+                throw CLIError(message: "new-workspace: could not read blueprint file '\(pathToTry)'")
+            }
+            guard let file = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+                throw CLIError(message: "new-workspace: blueprint file '\(pathToTry)' is not a valid JSON object")
+            }
+            guard let plan = file["plan"] else {
+                throw CLIError(message: "new-workspace: blueprint file '\(pathToTry)' does not contain a 'plan' key")
+            }
             return ["plan": plan]
         }
         // Not a direct path — search by name in the blueprint store.
@@ -7667,18 +7673,21 @@ struct CMUXCLI {
             """
         case "new-workspace":
             return """
-            Usage: c11 new-workspace [--cwd <path>] [--command <text>]
+            Usage: c11 new-workspace [--cwd <path>] [--command <text>] [--layout <path|name>]
 
             Create a new workspace in the current window.
 
             Flags:
-              --cwd <path>      Set the working directory for the new workspace
-              --command <text>   Send text+Enter to the new workspace after creation
+              --cwd <path>           Set the working directory for the new workspace
+              --command <text>       Send text+Enter to the new workspace after creation
+              --layout <path|name>   Apply a blueprint plan (file path or blueprint name)
 
             Example:
               c11 new-workspace
               c11 new-workspace --cwd ~/projects/myapp
               c11 new-workspace --cwd . --command "npm test"
+              c11 new-workspace --layout my-review-room
+              c11 new-workspace --layout /path/to/blueprint.json
             """
         case "list-workspaces":
             return """

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -14408,6 +14408,17 @@ struct CMUXTermMain {
     static func main() {
         // CLI tools should ignore SIGPIPE so closed stdout pipes do not terminate the process.
         _ = signal(SIGPIPE, SIG_IGN)
+        NSSetUncaughtExceptionHandler { exception in
+            // NSFileHandle.writeData: raises NSFileHandleOperationException when writing to a
+            // closed pipe. SIGPIPE is already SIG_IGN; treat a broken-pipe write as a clean exit.
+            if exception.name.rawValue == NSFileHandleOperationException {
+                exit(0)
+            }
+            FileHandle.standardError.write(
+                Data("c11: uncaught exception \(exception.name): \(exception.reason ?? "(none)")\n".utf8)
+            )
+            exit(1)
+        }
         mirrorC11CmuxEnv()
         let cli = CMUXCLI(args: CommandLine.arguments)
         do {

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -14466,7 +14466,7 @@ struct CMUXTermMain {
         NSSetUncaughtExceptionHandler { exception in
             // NSFileHandle.writeData: raises NSFileHandleOperationException when writing to a
             // closed pipe. SIGPIPE is already SIG_IGN; treat a broken-pipe write as a clean exit.
-            if exception.name.rawValue == NSFileHandleOperationException {
+            if exception.name == .fileHandleOperationException {
                 exit(0)
             }
             FileHandle.standardError.write(

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2317,6 +2317,14 @@ struct CMUXCLI {
             let (sfArg, rem1) = parseOption(rem0, name: "--surface")
             let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceArg = sfArg ?? (wsArg == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+            // Require explicit surface targeting. Shell-integrated callers inside a c11
+            // surface have CMUX_SURFACE_ID set automatically. External callers must pass
+            // --surface. Routing to the focused surface by default silently misdirects.
+            guard sfArg != nil
+                || ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil
+                || windowId != nil else {
+                throw CLIError(message: "send requires --surface <id|ref> (or run inside a c11 surface so CMUX_SURFACE_ID is set)")
+            }
             let rawText = rem1.dropFirst(rem1.first == "--" ? 1 : 0).joined(separator: " ")
             guard !rawText.isEmpty else { throw CLIError(message: "send requires text") }
             let text = unescapeSendText(rawText)
@@ -2333,6 +2341,12 @@ struct CMUXCLI {
             let (sfArg, rem1) = parseOption(rem0, name: "--surface")
             let workspaceArg = wsArg ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceArg = sfArg ?? (wsArg == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+            // Require explicit surface targeting (same policy as send).
+            guard sfArg != nil
+                || ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] != nil
+                || windowId != nil else {
+                throw CLIError(message: "send-key requires --surface <id|ref> (or run inside a c11 surface so CMUX_SURFACE_ID is set)")
+            }
             let keyArgs = rem1.first == "--" ? Array(rem1.dropFirst()) : rem1
             guard let key = keyArgs.first else { throw CLIError(message: "send-key requires a key") }
             var params: [String: Any] = ["key": key]

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2048,6 +2048,7 @@ struct CMUXCLI {
             let paneRaw = optionValue(commandArgs, name: "--pane")
             let url = optionValue(commandArgs, name: "--url")
             let file = optionValue(commandArgs, name: "--file")
+            let noFocus = commandArgs.contains("--no-focus")
             var params: [String: Any] = [:]
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
@@ -2056,6 +2057,7 @@ struct CMUXCLI {
             if let type { params["type"] = type }
             if let url { params["url"] = url }
             if let file { params["file"] = file }
+            if noFocus { params["focus"] = false }
             let payload = try client.sendV2(method: "surface.create", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
@@ -7806,11 +7808,13 @@ struct CMUXCLI {
               --workspace <id|ref>                Target workspace (default: $CMUX_WORKSPACE_ID)
               --url <url>                         URL for browser surfaces
               --file <path>                       File path for markdown surfaces
+              --no-focus                          Create surface without stealing focus
 
             Example:
               c11 new-surface
               c11 new-surface --type browser --pane pane:1 --url https://example.com
               c11 new-surface --type markdown --file ~/docs/notes.md
+              c11 new-surface --no-focus
             """
         case "close-surface":
             return """

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -1921,14 +1921,19 @@ struct CMUXCLI {
 
         case "new-workspace":
             let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
-            let (cwdOpt, remaining) = parseOption(rem0, name: "--cwd")
+            let (cwdOpt, rem1) = parseOption(rem0, name: "--cwd")
+            let (layoutOpt, remaining) = parseOption(rem1, name: "--layout")
             if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --command <text>, --cwd <path>")
+                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --command <text>, --cwd <path>, --layout <path|name>")
             }
             var params: [String: Any] = [:]
             if let cwdOpt {
                 let resolved = resolvePath(cwdOpt)
                 params["cwd"] = resolved
+            }
+            if let layoutRef = layoutOpt {
+                // Resolve blueprint path or name -> {plan: ...} dict for workspace.create layout param.
+                params["layout"] = try resolveBlueprintPlan(layoutRef, client: client)
             }
             let response = try client.sendV2(method: "workspace.create", params: params)
             let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
@@ -2975,6 +2980,31 @@ struct CMUXCLI {
             throw CLIError(message: "workspace new: '\(resolved)' is not a valid blueprint file (missing 'plan' key)")
         }
         return plan
+    }
+
+    /// Resolve a blueprint reference (file path or name) to a layout dict
+    /// `{plan: ...}` suitable for `workspace.create`'s `layout` param.
+    private func resolveBlueprintPlan(_ ref: String, client: SocketClient) throws -> [String: Any] {
+        let pathToTry = resolvePath(ref)
+        if FileManager.default.fileExists(atPath: pathToTry),
+           let data = FileManager.default.contents(atPath: pathToTry),
+           let file = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let plan = file["plan"] {
+            return ["plan": plan]
+        }
+        // Not a direct path — search by name in the blueprint store.
+        let cwd = FileManager.default.currentDirectoryPath
+        let payload = try client.sendV2(method: "workspace.list_blueprints", params: ["cwd": cwd])
+        let blueprints = payload["blueprints"] as? [[String: Any]] ?? []
+        let trimmed = ref.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let match = blueprints.first(where: { ($0["name"] as? String) == trimmed }),
+              let url = match["url"] as? String,
+              let data = FileManager.default.contents(atPath: resolvePath(url)),
+              let file = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let plan = file["plan"] else {
+            throw CLIError(message: "new-workspace: blueprint '\(ref)' not found (tried as path and name)")
+        }
+        return ["plan": plan]
     }
 
     /// `c11 workspace export-blueprint --name <name> [--workspace <ref>]

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3075,7 +3075,8 @@ class TerminalController {
                 "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id]),
                 "pane_id": v2OrNull(paneUUID?.uuidString),
                 "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
-                "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id])
+                "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id]),
+                "tty": v2OrNull(workspace.surfaceTTYNames[panel.id])
             ]
 
             if panel.panelType == .browser, let browserPanel = panel as? BrowserPanel {
@@ -5537,7 +5538,8 @@ class TerminalController {
                     "pane_id": v2OrNull(paneUUID?.uuidString),
                     "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
                     "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id]),
-                    "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id])
+                    "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id]),
+                    "tty": v2OrNull(ws.surfaceTTYNames[panel.id])
                 ]
                 if let browserPanel = panel as? BrowserPanel {
                     item["developer_tools_visible"] = browserPanel.isDeveloperToolsVisible()

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3768,6 +3768,11 @@ class TerminalController {
                 if let windowId = v2ResolveWindowId(tabManager: tabManager) {
                     _ = AppDelegate.shared?.focusMainWindow(windowId: windowId)
                     setActiveTabManager(tabManager)
+                    // Bring c11 to the macOS foreground for explicit focus-intent commands.
+                    // workspace.select is in focusIntentV2Methods, so this is intentional.
+                    DispatchQueue.main.async {
+                        NSApp.activate(ignoringOtherApps: true)
+                    }
                 }
                 tabManager.selectWorkspace(ws)
                 success = true

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6437,7 +6437,9 @@ class TerminalController {
             let sendStart = ProcessInfo.processInfo.systemUptime
             #endif
             let queued: Bool
-            if let surface = terminalPanel.surface.surface {
+            let surface = terminalPanel.surface.surface
+                ?? waitForTerminalSurface(terminalPanel, waitUpTo: 2.0)
+            if let surface {
                 sendSocketText(text, surface: surface)
                 // Ensure we present a new frame after injecting input so snapshot-based tests (and
                 // socket-driven agents) can observe the updated terminal without requiring a focus
@@ -6445,9 +6447,9 @@ class TerminalController {
                 terminalPanel.surface.forceRefresh(reason: "terminalController.v2SurfaceSendText")
                 queued = false
             } else {
-                // Avoid blocking the main actor waiting for view/surface attachment.
+                // Surface not available within 2s (e.g., terminal not yet attached to any window).
+                // Fall back to the pending queue as a last resort.
                 terminalPanel.sendText(text)
-                terminalPanel.surface.requestBackgroundSurfaceStartIfNeeded()
                 queued = true
             }
 #if DEBUG

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3726,6 +3726,48 @@ class TerminalController {
             cwd = nil
         }
 
+        // Layout path: let WorkspaceLayoutExecutor own creation so exactly one workspace is created.
+        // Pre-creating a workspace here causes a ghost tab on every successful layout apply (B1).
+        if let layoutDict = params["layout"] as? [String: Any], !layoutDict.isEmpty {
+            let layoutResult = v2WorkspaceApply(params: layoutDict)
+
+            if case .err = layoutResult {
+                return layoutResult
+            }
+
+            guard case .ok(let resultAny) = layoutResult,
+                  let resultDict = resultAny as? [String: Any] else {
+                return .err(code: "internal_error", message: "Unexpected apply result", data: nil)
+            }
+
+            // Transactional: non-empty failures mean partial apply — roll back the workspace.
+            let failures = resultDict["failures"] as? [[String: Any]] ?? []
+            if !failures.isEmpty {
+                if let refStr = resultDict["workspaceRef"] as? String,
+                   let wsUUID = v2ResolveHandleRef(refStr) {
+                    v2MainSync {
+                        if let ws = tabManager.tabs.first(where: { $0.id == wsUUID }) {
+                            tabManager.closeWorkspace(ws)
+                        }
+                    }
+                }
+                return .err(code: "apply_failed", message: "Layout application partially failed", data: resultDict)
+            }
+
+            // Normalize to the standard snake_case workspace creation envelope (B2).
+            let workspaceRef = resultDict["workspaceRef"] as? String ?? ""
+            let wsUUID = v2ResolveHandleRef(workspaceRef)
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            return .ok([
+                "workspace_id": v2OrNull(wsUUID?.uuidString),
+                "workspace_ref": workspaceRef as Any,
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId),
+                "layout_result": resultAny
+            ])
+        }
+
+        // No layout: create workspace normally.
         var newId: UUID?
         let shouldFocus = v2FocusAllowed()
         guard v2MainSyncWithDeadline({
@@ -3746,33 +3788,13 @@ class TerminalController {
             return .err(code: "internal_error", message: "Failed to create workspace", data: nil)
         }
 
-        // If no layout param, return immediately (existing behavior unchanged).
-        guard let layoutDict = params["layout"] as? [String: Any], !layoutDict.isEmpty else {
-            let windowId = v2ResolveWindowId(tabManager: tabManager)
-            return .ok([
-                "window_id": v2OrNull(windowId?.uuidString),
-                "window_ref": v2Ref(kind: .window, uuid: windowId),
-                "workspace_id": newId.uuidString,
-                "workspace_ref": v2Ref(kind: .workspace, uuid: newId)
-            ])
-        }
-
-        // Attempt layout application. Inject the new workspace ID so v2WorkspaceApply
-        // targets the freshly created workspace.
-        var layoutParams = layoutDict
-        layoutParams["workspace_id"] = newId.uuidString
-        let layoutResult = v2WorkspaceApply(params: layoutParams)
-
-        if case .err = layoutResult {
-            // Rollback: close the workspace to prevent orphan state.
-            v2MainSync {
-                if let ws = tabManager.tabs.first(where: { $0.id == newId }) {
-                    tabManager.closeWorkspace(ws)
-                }
-            }
-            return layoutResult
-        }
-        return layoutResult
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "workspace_id": newId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: newId)
+        ])
     }
     private func v2WorkspaceSelect(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
@@ -5739,7 +5761,9 @@ class TerminalController {
                 return
             }
             // Caller may pass focus: false to opt out of focus (--no-focus in CLI).
-            // When the param is absent, default focus-allowed since surface.create is a focusIntent method.
+            // surface.create is NOT in focusIntentV2Methods, so v2FocusAllowed returns false
+            // regardless of callerWantsFocus. The focus param is accepted for forward-compatibility
+            // if surface.create is added to focusIntentV2Methods in the future.
             let callerWantsFocus = self.v2Bool(params, "focus") ?? true
             let focus = self.v2FocusAllowed(requested: callerWantsFocus)
             if focus {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3745,13 +3745,34 @@ class TerminalController {
         guard let newId else {
             return .err(code: "internal_error", message: "Failed to create workspace", data: nil)
         }
-        let windowId = v2ResolveWindowId(tabManager: tabManager)
-        return .ok([
-            "window_id": v2OrNull(windowId?.uuidString),
-            "window_ref": v2Ref(kind: .window, uuid: windowId),
-            "workspace_id": newId.uuidString,
-            "workspace_ref": v2Ref(kind: .workspace, uuid: newId)
-        ])
+
+        // If no layout param, return immediately (existing behavior unchanged).
+        guard let layoutDict = params["layout"] as? [String: Any], !layoutDict.isEmpty else {
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            return .ok([
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId),
+                "workspace_id": newId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: newId)
+            ])
+        }
+
+        // Attempt layout application. Inject the new workspace ID so v2WorkspaceApply
+        // targets the freshly created workspace.
+        var layoutParams = layoutDict
+        layoutParams["workspace_id"] = newId.uuidString
+        let layoutResult = v2WorkspaceApply(params: layoutParams)
+
+        if case .err = layoutResult {
+            // Rollback: close the workspace to prevent orphan state.
+            v2MainSync {
+                if let ws = tabManager.tabs.first(where: { $0.id == newId }) {
+                    tabManager.closeWorkspace(ws)
+                }
+            }
+            return layoutResult
+        }
+        return layoutResult
     }
     private func v2WorkspaceSelect(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5712,8 +5712,14 @@ class TerminalController {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return
             }
-            self.v2MaybeFocusWindow(for: tabManager)
-            self.v2MaybeSelectWorkspace(tabManager, workspace: ws)
+            // Caller may pass focus: false to opt out of focus (--no-focus in CLI).
+            // When the param is absent, default focus-allowed since surface.create is a focusIntent method.
+            let callerWantsFocus = self.v2Bool(params, "focus") ?? true
+            let focus = self.v2FocusAllowed(requested: callerWantsFocus)
+            if focus {
+                self.v2MaybeFocusWindow(for: tabManager)
+                self.v2MaybeSelectWorkspace(tabManager, workspace: ws)
+            }
 
             let paneUUID = self.v2UUID(params, "pane_id")
             let paneId: PaneID? = {
@@ -5731,11 +5737,11 @@ class TerminalController {
             let newPanelId: UUID?
             switch panelType {
             case .browser:
-                newPanelId = ws.newBrowserSurface(inPane: paneId, url: url, focus: self.v2FocusAllowed())?.id
+                newPanelId = ws.newBrowserSurface(inPane: paneId, url: url, focus: focus)?.id
             case .markdown:
-                newPanelId = ws.newMarkdownSurface(inPane: paneId, filePath: resolvedMarkdownPath!, focus: self.v2FocusAllowed())?.id
+                newPanelId = ws.newMarkdownSurface(inPane: paneId, filePath: resolvedMarkdownPath!, focus: focus)?.id
             case .terminal:
-                newPanelId = ws.newTerminalSurface(inPane: paneId, focus: self.v2FocusAllowed())?.id
+                newPanelId = ws.newTerminalSurface(inPane: paneId, focus: focus)?.id
             }
 
             guard let newPanelId else {

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -148,6 +148,8 @@ c11 send-key --workspace workspace:2 --surface surface:5 enter
 
 When talking to your own surface, omit both — env vars default them correctly.
 
+**`send` and `send-key` now require explicit surface targeting.** Callers outside a c11 shell integration context must pass `--surface`. The `CMUX_SURFACE_ID` env var satisfies the requirement for callers already inside a c11 surface. Passing `--window` alone is not sufficient — the command errors rather than falling back to whatever surface happens to be focused in that window.
+
 ## Send text to a surface
 
 ```bash
@@ -185,9 +187,14 @@ c11 read-screen --scrollback --lines 200        # include scrollback buffer
 c11 new-split <left|right|up|down>             # Split any pane; the NEW pane is always a terminal
 c11 new-pane --type browser --url <url>        # New pane of any surface type; --direction is relative to focus
 c11 new-surface --pane <pane-ref>              # Add a tab to an existing pane
+c11 new-surface --no-focus                     # Create without stealing focus (safe for background agents)
+c11 new-workspace                              # Create a new workspace
+c11 new-workspace --layout <path|name>         # Create a workspace from a blueprint plan
 ```
 
 - **`new-split` clarified.** Source can be a pane of any surface type — terminal, browser, or markdown. Only the *new* pane is constrained to terminal. Use `new-pane` when the new pane should be a browser or markdown viewer.
+- **`--no-focus` on `new-surface`.** Pass `--no-focus` to create a terminal, browser, or markdown surface without the workspace switching focus to it. Useful when an agent is building out a layout in the background.
+- **`--layout` on `new-workspace`.** Pass a blueprint file path or blueprint name to create a workspace pre-populated with the plan's pane/surface topology. Response includes `workspace_id`, `workspace_ref`, `window_id`, and `window_ref` (same envelope as a plain `new-workspace`), plus a `layout_result` field with apply details.
 - **Direction is relative to the focused pane.** `new-pane` has no `--pane` flag; it operates on the currently focused pane. Call `c11 focus-pane --pane <ref> --workspace <ref>` first if you need to target a different one.
 - **`new-split` does NOT return the new pane ref** — output is `OK surface:<N> workspace:<M>` only. Follow with `c11 tree --no-layout` (or `--json`) to discover the newly created pane. `new-pane` *does* return the pane ref (`OK surface:<N> pane:<P> workspace:<M>`).
 - **Default targets differ.** `new-split` defaults to the **caller's** pane; `new-surface` defaults to the **focused** pane (often different). To add a tab to your own pane, read `caller.pane_ref` from `c11 identify` and pass it via `--pane`.
@@ -229,6 +236,8 @@ c11 tree --no-layout                    # suppress the floor plan, keep hierarch
 ```
 
 Read `c11 tree` before planning layouts — splitting blind leads to cramped panes. For programmatic layout decisions use `--json`: every pane carries its rect in pixels and percent, the workspace content-area dimensions, and its split path.
+
+**`tty` field.** `c11 tree --json` and `c11 surface list` now include a `tty` field on each terminal surface (e.g., `/dev/ttys004`). Use this to correlate a c11 surface with a shell process, process listings, or agent detection — useful for "which surface is running that codex?" lookups.
 
 ## Title and description
 

--- a/tests_v2/test_cli_sigpipe_clean.py
+++ b/tests_v2/test_cli_sigpipe_clean.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Pick #2984: c11 <cmd> | head -1 exits cleanly, no SIGABRT on broken pipe."""
+
+from __future__ import annotations
+
+import glob
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+    candidates: List[str] = []
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11 DEV *.app/Contents/Resources/bin/c11")
+    candidates += glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11 DEV*.app/Contents/Resources/bin/c11"
+    ), recursive=True)
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _broken_pipe_exit(cli: str, args: List[str]) -> Tuple[int, str]:
+    """Run CLI, read only one line from stdout, then close the pipe. Return (returncode, one_line)."""
+    env = dict(os.environ)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_TAB_ID", None)
+    env["CMUX_SOCKET"] = SOCKET_PATH
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+    line = b""
+    try:
+        line = proc.stdout.readline()
+    finally:
+        proc.stdout.close()
+    proc.wait(timeout=5)
+    return proc.returncode, line.decode("utf-8", errors="replace").strip()
+
+
+def test_list_workspaces_sigpipe_clean(cli: str) -> None:
+    """c11 list-workspaces | head -1: CLI must not abort on broken pipe."""
+    rc, first_line = _broken_pipe_exit(cli, ["list-workspaces"])
+    _must(
+        rc != -signal.SIGABRT,
+        f"c11 list-workspaces got SIGABRT (rc={rc}) on broken pipe — fix didn't land",
+    )
+    _must(
+        rc in (0, -signal.SIGPIPE, 141),
+        f"c11 list-workspaces unexpected exit code {rc} on broken pipe (expected 0, SIGPIPE, or 141)",
+    )
+    print(f"PASS: test_list_workspaces_sigpipe_clean (rc={rc}, first_line={first_line!r})")
+
+
+def test_tree_sigpipe_clean(cli: str) -> None:
+    """c11 tree | head -1: CLI must not abort on broken pipe."""
+    rc, first_line = _broken_pipe_exit(cli, ["tree"])
+    _must(
+        rc != -signal.SIGABRT,
+        f"c11 tree got SIGABRT (rc={rc}) on broken pipe — fix didn't land",
+    )
+    _must(
+        rc in (0, -signal.SIGPIPE, 141),
+        f"c11 tree unexpected exit code {rc} on broken pipe (expected 0, SIGPIPE, or 141)",
+    )
+    print(f"PASS: test_tree_sigpipe_clean (rc={rc}, first_line={first_line!r})")
+
+
+def test_shell_pipeline_exit_code(cli: str) -> None:
+    """Shell pipeline 'c11 list-workspaces | head -1' must exit with overall code 0."""
+    env = dict(os.environ)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env["CMUX_SOCKET"] = SOCKET_PATH
+    cmd = f"{cli!r} --socket {SOCKET_PATH!r} list-workspaces | head -1"
+    proc = subprocess.run(["bash", "-c", cmd], capture_output=True, text=True, check=False, env=env)
+    _must(
+        proc.returncode == 0,
+        f"Shell pipeline 'c11 list-workspaces | head -1' exited {proc.returncode}: {proc.stderr!r}",
+    )
+    print("PASS: test_shell_pipeline_exit_code")
+
+
+def main() -> int:
+    cli = _find_cli()
+    test_list_workspaces_sigpipe_clean(cli)
+    test_tree_sigpipe_clean(cli)
+    test_shell_pipeline_exit_code(cli)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_focus_no_new_window.py
+++ b/tests_v2/test_focus_no_new_window.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Pick #3065: workspace.select (focus intent) does not increment the window count."""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+    candidates: List[str] = []
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11 DEV *.app/Contents/Resources/bin/c11")
+    candidates += glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11 DEV*.app/Contents/Resources/bin/c11"
+    ), recursive=True)
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _run_cli(cli: str, args: List[str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_TAB_ID", None)
+    env["CMUX_SOCKET"] = SOCKET_PATH
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+
+
+def _window_count(c: cmux) -> int:
+    windows = c.list_windows()
+    return len(windows)
+
+
+def test_select_workspace_no_new_window_socket(c: cmux) -> None:
+    """workspace.select must not increase window count."""
+    count_before = _window_count(c)
+    new_ws_res = c._call("workspace.create") or {}
+    new_ws = str(new_ws_res.get("workspace_id") or "")
+    _must(bool(new_ws), f"workspace.create returned no workspace_id: {new_ws_res}")
+    try:
+        baseline_ws = str((c._call("workspace.current") or {}).get("workspace_id") or "")
+        c._call("workspace.select", {"workspace_id": new_ws})
+        time.sleep(0.2)
+        count_after = _window_count(c)
+        _must(
+            count_after == count_before,
+            f"workspace.select increased window count from {count_before} to {count_after} (spawned a new window)",
+        )
+        c._call("workspace.select", {"workspace_id": baseline_ws})
+        time.sleep(0.1)
+        count_restore = _window_count(c)
+        _must(
+            count_restore == count_before,
+            f"Second workspace.select changed window count from {count_before} to {count_restore}",
+        )
+    finally:
+        try:
+            c.close_workspace(new_ws)
+        except Exception:
+            pass
+    print("PASS: test_select_workspace_no_new_window_socket")
+
+
+def test_select_workspace_no_new_window_cli(c: cmux, cli: str) -> None:
+    """c11 workspace.select / c11 list-workspaces must not increase window count."""
+    count_before = _window_count(c)
+    new_ws_res = c._call("workspace.create") or {}
+    new_ws = str(new_ws_res.get("workspace_id") or "")
+    _must(bool(new_ws), f"workspace.create returned no workspace_id: {new_ws_res}")
+    try:
+        proc = _run_cli(cli, ["select-workspace", "--workspace", new_ws])
+        _must(proc.returncode == 0, f"c11 select-workspace failed: {proc.stderr!r}")
+        time.sleep(0.2)
+        count_after = _window_count(c)
+        _must(
+            count_after == count_before,
+            f"c11 select-workspace increased window count from {count_before} to {count_after}",
+        )
+        list_proc = _run_cli(cli, ["list-workspaces"])
+        _must(list_proc.returncode == 0, f"c11 list-workspaces failed: {list_proc.stderr!r}")
+        count_list = _window_count(c)
+        _must(
+            count_list == count_before,
+            f"c11 list-workspaces changed window count from {count_before} to {count_list}",
+        )
+    finally:
+        try:
+            c.close_workspace(new_ws)
+        except Exception:
+            pass
+    print("PASS: test_select_workspace_no_new_window_cli")
+
+
+def main() -> int:
+    cli = _find_cli()
+    with cmux(SOCKET_PATH) as c:
+        test_select_workspace_no_new_window_socket(c)
+        test_select_workspace_no_new_window_cli(c, cli)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_new_surface_no_focus.py
+++ b/tests_v2/test_new_surface_no_focus.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Pick #1418: surface.create with focus:false / c11 new-surface --no-focus preserves selected workspace."""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+    candidates: List[str] = []
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11 DEV *.app/Contents/Resources/bin/c11")
+    candidates += glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11 DEV*.app/Contents/Resources/bin/c11"
+    ), recursive=True)
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _run_cli(cli: str, args: List[str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_TAB_ID", None)
+    env["CMUX_SOCKET"] = SOCKET_PATH
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+
+
+def _current_workspace(c: cmux) -> str:
+    payload = c._call("workspace.current") or {}
+    ws_id = str(payload.get("workspace_id") or "")
+    _must(bool(ws_id), f"workspace.current returned no workspace_id: {payload}")
+    return ws_id
+
+
+def test_socket_no_focus(c: cmux) -> None:
+    """surface.create with focus:false must not change the selected workspace."""
+    baseline_ws = _current_workspace(c)
+    other_ws = c._call("workspace.create") or {}
+    bg_ws = str(other_ws.get("workspace_id") or "")
+    _must(bool(bg_ws), f"workspace.create returned no workspace_id: {other_ws}")
+    try:
+        _must(
+            _current_workspace(c) == baseline_ws,
+            "workspace.create already changed selected workspace (pre-condition failed)",
+        )
+        res = c._call("surface.create", {"workspace_id": bg_ws, "type": "terminal", "focus": False}) or {}
+        sid = str(res.get("surface_id") or "")
+        _must(bool(sid), f"surface.create returned no surface_id: {res}")
+        time.sleep(0.2)
+        _must(
+            _current_workspace(c) == baseline_ws,
+            f"surface.create focus:false changed selected workspace to {_current_workspace(c)!r} (expected {baseline_ws!r})",
+        )
+    finally:
+        try:
+            c.close_workspace(bg_ws)
+        except Exception:
+            pass
+    print("PASS: test_socket_no_focus")
+
+
+def test_cli_no_focus_flag(c: cmux, cli: str) -> None:
+    """c11 new-surface --no-focus must not change the selected workspace."""
+    baseline_ws = _current_workspace(c)
+    other_ws = c._call("workspace.create") or {}
+    bg_ws = str(other_ws.get("workspace_id") or "")
+    _must(bool(bg_ws), f"workspace.create returned no workspace_id: {other_ws}")
+    try:
+        proc = _run_cli(cli, ["new-surface", "--workspace", bg_ws, "--no-focus"])
+        _must(proc.returncode == 0, f"c11 new-surface --no-focus failed: {proc.stderr!r}")
+        time.sleep(0.2)
+        _must(
+            _current_workspace(c) == baseline_ws,
+            f"c11 new-surface --no-focus changed selected workspace to {_current_workspace(c)!r} (expected {baseline_ws!r})",
+        )
+    finally:
+        try:
+            c.close_workspace(bg_ws)
+        except Exception:
+            pass
+    print("PASS: test_cli_no_focus_flag")
+
+
+def main() -> int:
+    cli = _find_cli()
+    with cmux(SOCKET_PATH) as c:
+        test_socket_no_focus(c)
+        test_cli_no_focus_flag(c, cli)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_send_requires_surface.py
+++ b/tests_v2/test_send_requires_surface.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Pick #2839: c11 send / send-key without --surface and no CMUX_SURFACE_ID exits non-zero with error."""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+    candidates: List[str] = []
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11 DEV *.app/Contents/Resources/bin/c11")
+    candidates += glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11 DEV*.app/Contents/Resources/bin/c11"
+    ), recursive=True)
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _run_cli_no_surface(cli: str, args: List[str]) -> subprocess.CompletedProcess:
+    """Run CLI with surface env vars explicitly stripped."""
+    env = dict(os.environ)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_TAB_ID", None)
+    env.pop("C11_SURFACE_ID", None)
+    env["CMUX_SOCKET"] = SOCKET_PATH
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+
+
+def test_send_without_surface_fails(cli: str) -> None:
+    """c11 send without --surface and no env target must exit non-zero with an error message."""
+    proc = _run_cli_no_surface(cli, ["send", "hello"])
+    _must(proc.returncode != 0, "c11 send without --surface should exit non-zero, but exited 0")
+    merged = (proc.stdout + proc.stderr).lower()
+    _must(
+        "surface" in merged or "target" in merged or "required" in merged,
+        f"c11 send without --surface expected error mentioning surface/target/required, got: {merged!r}",
+    )
+    print("PASS: test_send_without_surface_fails")
+
+
+def test_send_key_without_surface_fails(cli: str) -> None:
+    """c11 send-key without --surface and no env target must exit non-zero with an error message."""
+    proc = _run_cli_no_surface(cli, ["send-key", "ctrl-c"])
+    _must(proc.returncode != 0, "c11 send-key without --surface should exit non-zero, but exited 0")
+    merged = (proc.stdout + proc.stderr).lower()
+    _must(
+        "surface" in merged or "target" in merged or "required" in merged,
+        f"c11 send-key without --surface expected error mentioning surface/target/required, got: {merged!r}",
+    )
+    print("PASS: test_send_key_without_surface_fails")
+
+
+def test_send_with_surface_succeeds(cli: str, c: cmux) -> None:
+    """c11 send --surface <id> should succeed (guard doesn't fire when surface is explicit)."""
+    created = c._call("workspace.create") or {}
+    ws_id = str(created.get("workspace_id") or "")
+    _must(bool(ws_id), f"workspace.create returned no workspace_id: {created}")
+    try:
+        import time; time.sleep(0.2)
+        surfaces = (c._call("surface.list", {"workspace_id": ws_id}) or {}).get("surfaces") or []
+        _must(bool(surfaces), f"No surfaces in new workspace: {surfaces}")
+        sid = str(surfaces[0].get("id") or "")
+        _must(bool(sid), f"surface.list returned surface without id: {surfaces}")
+        proc = _run_cli_no_surface(cli, ["send", "--workspace", ws_id, "--surface", sid, "echo c11_send_guard_test\n"])
+        _must(proc.returncode == 0, f"c11 send with --surface failed unexpectedly: {proc.stderr!r}")
+    finally:
+        try:
+            c.close_workspace(ws_id)
+        except Exception:
+            pass
+    print("PASS: test_send_with_surface_succeeds")
+
+
+def main() -> int:
+    cli = _find_cli()
+    with cmux(SOCKET_PATH) as c:
+        test_send_without_surface_fails(cli)
+        test_send_key_without_surface_fails(cli)
+        test_send_with_surface_succeeds(cli, c)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_send_text_non_focused_tab.py
+++ b/tests_v2/test_send_text_non_focused_tab.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Pick #3129: surface.send_text delivers to a non-focused, non-selected surface."""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+    candidates: List[str] = []
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11 DEV *.app/Contents/Resources/bin/c11")
+    candidates += glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11 DEV*.app/Contents/Resources/bin/c11"
+    ), recursive=True)
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _wait_for(pred: Callable[[], bool], timeout_s: float = 8.0) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if pred():
+            return
+        time.sleep(0.1)
+    raise cmuxError("Timed out waiting for condition")
+
+
+def test_send_text_non_focused_surface(c: cmux, cli: str) -> None:
+    """Send text to a non-selected workspace surface and confirm delivery via read-screen."""
+    baseline_ws = (c._call("workspace.current") or {}).get("workspace_id", "")
+    _must(bool(baseline_ws), "Could not determine current workspace")
+
+    target_ws_res = c._call("workspace.create") or {}
+    target_ws = str(target_ws_res.get("workspace_id") or "")
+    _must(bool(target_ws), f"workspace.create returned no workspace_id: {target_ws_res}")
+
+    other_ws_res = c._call("workspace.create") or {}
+    other_ws = str(other_ws_res.get("workspace_id") or "")
+    _must(bool(other_ws), f"workspace.create returned no workspace_id: {other_ws_res}")
+
+    try:
+        time.sleep(0.3)
+        surfaces_res = c._call("surface.list", {"workspace_id": target_ws}) or {}
+        surfaces = surfaces_res.get("surfaces") or []
+        _must(bool(surfaces), f"No surfaces in target workspace {target_ws}")
+        target_surface_id = str(surfaces[0].get("id") or "")
+        _must(bool(target_surface_id), f"surface.list returned surface without id: {surfaces}")
+
+        c._call("workspace.select", {"workspace_id": other_ws})
+        time.sleep(0.1)
+
+        current = str((c._call("workspace.current") or {}).get("workspace_id") or "")
+        _must(current == other_ws, f"Expected selected workspace to be {other_ws!r}, got {current!r}")
+
+        token = f"C11_SEND_NONFOCUS_{int(time.time() * 1000)}"
+        c._call("surface.send_text", {
+            "workspace_id": target_ws,
+            "surface_id": target_surface_id,
+            "text": f"echo {token}\n",
+        })
+
+        def token_visible() -> bool:
+            payload = c._call("surface.read_text", {
+                "workspace_id": target_ws,
+                "surface_id": target_surface_id,
+            }) or {}
+            return token in str(payload.get("text") or "")
+
+        _wait_for(token_visible, timeout_s=8.0)
+
+        env = dict(os.environ)
+        env.pop("CMUX_SURFACE_ID", None)
+        env.pop("CMUX_WORKSPACE_ID", None)
+        env["CMUX_SOCKET"] = SOCKET_PATH
+        proc = subprocess.run(
+            [cli, "--socket", SOCKET_PATH, "read-screen",
+             "--workspace", target_ws, "--surface", target_surface_id],
+            capture_output=True, text=True, check=False, env=env,
+        )
+        _must(proc.returncode == 0, f"c11 read-screen failed: {proc.stderr!r}")
+        _must(token in proc.stdout, f"c11 read-screen missing token {token!r}: {proc.stdout!r}")
+
+        _must(
+            str((c._call("workspace.current") or {}).get("workspace_id") or "") == other_ws,
+            "send_text to non-focused workspace changed the selected workspace (focus stolen)",
+        )
+    finally:
+        for ws in (target_ws, other_ws):
+            try:
+                c.close_workspace(ws)
+            except Exception:
+                pass
+
+    print("PASS: test_send_text_non_focused_surface")
+
+
+def main() -> int:
+    cli = _find_cli()
+    with cmux(SOCKET_PATH) as c:
+        test_send_text_non_focused_surface(c, cli)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_tree_tty_field.py
+++ b/tests_v2/test_tree_tty_field.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Pick #3098: c11 tree --json and surface.list return non-null tty for terminal surfaces."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+    candidates: List[str] = []
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11 DEV *.app/Contents/Resources/bin/c11")
+    candidates += glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11 DEV*.app/Contents/Resources/bin/c11"
+    ), recursive=True)
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _register_tty(socket_path: str, ws_id: str, surface_id: str, tty_name: str) -> None:
+    """Send a report_tty command via the raw CLI socket protocol."""
+    raw_cmd = f"report_tty {tty_name} --tab={ws_id} --panel={surface_id}\n"
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.connect(socket_path)
+    try:
+        sock.sendall(raw_cmd.encode())
+        sock.settimeout(2.0)
+        resp = sock.recv(4096).decode(errors="replace").strip()
+        if not resp.startswith("OK"):
+            raise cmuxError(f"report_tty failed: {resp!r}")
+    finally:
+        sock.close()
+
+
+def _all_surfaces_from_tree(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    out: List[Dict[str, Any]] = []
+    for win in payload.get("windows", []):
+        for ws in win.get("workspaces", []):
+            for pane in ws.get("panes", []):
+                out.extend(pane.get("surfaces", []))
+    return out
+
+
+def _run_cli(cli: str, args: List[str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env["CMUX_SOCKET"] = SOCKET_PATH
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+
+
+def test_tty_key_present_in_surface_list(c: cmux) -> None:
+    """surface.list must include a 'tty' key for every terminal surface (may be null)."""
+    created = c._call("workspace.create") or {}
+    ws_id = str(created.get("workspace_id") or "")
+    _must(bool(ws_id), f"workspace.create returned no workspace_id: {created}")
+    try:
+        time.sleep(0.3)
+        res = c._call("surface.list", {"workspace_id": ws_id}) or {}
+        surfaces = res.get("surfaces") or []
+        _must(bool(surfaces), f"surface.list returned no surfaces for ws {ws_id}")
+        for s in surfaces:
+            _must("tty" in s, f"surface.list response missing 'tty' key for terminal surface: {s}")
+    finally:
+        try:
+            c.close_workspace(ws_id)
+        except Exception:
+            pass
+    print("PASS: test_tty_key_present_in_surface_list")
+
+
+def test_surface_list_tty_non_null_after_register(c: cmux) -> None:
+    """After registering a TTY via report_tty, surface.list must return a non-null tty."""
+    created = c._call("workspace.create") or {}
+    ws_id = str(created.get("workspace_id") or "")
+    _must(bool(ws_id), f"workspace.create returned no workspace_id: {created}")
+    try:
+        time.sleep(0.3)
+        surfaces_res = c._call("surface.list", {"workspace_id": ws_id}) or {}
+        surfaces = surfaces_res.get("surfaces") or []
+        _must(bool(surfaces), f"No surfaces in workspace {ws_id}")
+        surface_id = str(surfaces[0].get("id") or "")
+        _must(bool(surface_id), f"Surface missing id: {surfaces}")
+
+        fake_tty = "/dev/ttys099"
+        _register_tty(SOCKET_PATH, ws_id, surface_id, fake_tty)
+        time.sleep(0.2)
+
+        surfaces_after = (c._call("surface.list", {"workspace_id": ws_id}) or {}).get("surfaces") or []
+        found = next((s for s in surfaces_after if s.get("id") == surface_id), None)
+        _must(found is not None, f"Surface {surface_id!r} disappeared after TTY register")
+        _must(
+            found.get("tty") == fake_tty,
+            f"surface.list tty expected {fake_tty!r}, got {found.get('tty')!r}",
+        )
+    finally:
+        try:
+            c.close_workspace(ws_id)
+        except Exception:
+            pass
+    print("PASS: test_surface_list_tty_non_null_after_register")
+
+
+def test_tree_json_tty_non_null_after_register(c: cmux, cli: str) -> None:
+    """After registering a TTY, c11 tree --json must include the non-null tty."""
+    created = c._call("workspace.create") or {}
+    ws_id = str(created.get("workspace_id") or "")
+    _must(bool(ws_id), f"workspace.create returned no workspace_id: {created}")
+    try:
+        time.sleep(0.3)
+        surfaces_res = c._call("surface.list", {"workspace_id": ws_id}) or {}
+        surfaces = surfaces_res.get("surfaces") or []
+        _must(bool(surfaces), f"No surfaces in workspace {ws_id}")
+        surface = surfaces[0]
+        surface_id = str(surface.get("id") or "")
+        surface_ref = str(surface.get("ref") or "")
+
+        fake_tty = "/dev/ttys098"
+        _register_tty(SOCKET_PATH, ws_id, surface_id, fake_tty)
+        time.sleep(0.2)
+
+        proc = _run_cli(cli, ["--json", "tree", "--workspace", ws_id])
+        _must(proc.returncode == 0, f"c11 --json tree failed: {proc.stderr!r}")
+        payload = json.loads(proc.stdout or "{}")
+        tree_surfaces = _all_surfaces_from_tree(payload)
+        _must(bool(tree_surfaces), f"No surfaces in c11 tree --json output: {payload}")
+
+        # Tree output uses 'ref' for matching (not 'id').
+        found = next((s for s in tree_surfaces if s.get("ref") == surface_ref), None)
+        if found is None:
+            # Fallback: if only one surface in workspace, use it.
+            _must(len(tree_surfaces) == 1, f"Surface ref {surface_ref!r} not in tree; multiple surfaces: {[s.get('ref') for s in tree_surfaces]}")
+            found = tree_surfaces[0]
+        _must("tty" in found, f"tree --json surface missing 'tty' key: {found}")
+        _must(
+            found.get("tty") == fake_tty,
+            f"tree --json tty expected {fake_tty!r}, got {found.get('tty')!r}",
+        )
+    finally:
+        try:
+            c.close_workspace(ws_id)
+        except Exception:
+            pass
+    print("PASS: test_tree_json_tty_non_null_after_register")
+
+
+def main() -> int:
+    cli = _find_cli()
+    with cmux(SOCKET_PATH) as c:
+        test_tty_key_present_in_surface_list(c)
+        test_surface_list_tty_non_null_after_register(c)
+        test_tree_json_tty_non_null_after_register(c, cli)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_workspace_create_layout_orphan.py
+++ b/tests_v2/test_workspace_create_layout_orphan.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Pick #2951: workspace.create with invalid layout rolls back — no orphan workspace left."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+    candidates: List[str] = []
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11 DEV *.app/Contents/Resources/bin/c11")
+    candidates += glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11 DEV*.app/Contents/Resources/bin/c11"
+    ), recursive=True)
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _all_workspace_ids(c: cmux) -> List[str]:
+    workspaces = c.list_workspaces()
+    return [ws_id for (_, ws_id, _, _) in workspaces]
+
+
+def test_bad_plan_version_no_orphan_socket(c: cmux) -> None:
+    """workspace.create with an unsupported plan version must error and leave no new workspace."""
+    ids_before = set(_all_workspace_ids(c))
+
+    try:
+        result = c._call("workspace.create", {
+            "layout": {
+                "plan": {
+                    "version": 9999,
+                    "workspace": {},
+                    "layout": {"type": "pane", "pane": {"surfaceIds": ["s1"]}},
+                    "surfaces": [{"id": "s1", "kind": "terminal"}],
+                },
+            },
+        })
+        raise cmuxError(
+            f"workspace.create with invalid plan version should have failed, but returned: {result}"
+        )
+    except cmuxError as exc:
+        if "should have failed" in str(exc):
+            raise
+
+    time.sleep(0.3)
+    ids_after = set(_all_workspace_ids(c))
+    new_ids = ids_after - ids_before
+    _must(
+        len(new_ids) == 0,
+        f"workspace.create with invalid plan left {len(new_ids)} orphan workspace(s): {new_ids}",
+    )
+    print("PASS: test_bad_plan_version_no_orphan_socket")
+
+
+def test_bad_blueprint_no_orphan_cli(cli: str, c: cmux) -> None:
+    """c11 new-workspace --layout <bad-file> must error and leave no new workspace."""
+    ids_before = set(_all_workspace_ids(c))
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, prefix="c11-test-bad-blueprint-"
+    ) as f:
+        # Blueprint file with no 'plan' key triggers CLI error before socket call.
+        json.dump({"version": "bad", "not_a_plan": True}, f)
+        bad_path = f.name
+
+    try:
+        env = dict(os.environ)
+        env.pop("CMUX_SURFACE_ID", None)
+        env.pop("CMUX_WORKSPACE_ID", None)
+        env.pop("CMUX_TAB_ID", None)
+        env["CMUX_SOCKET"] = SOCKET_PATH
+        proc = subprocess.run(
+            [cli, "--socket", SOCKET_PATH, "new-workspace", "--layout", bad_path],
+            capture_output=True, text=True, check=False, env=env,
+        )
+        _must(
+            proc.returncode != 0,
+            f"c11 new-workspace --layout <bad> should exit non-zero, got 0. stdout={proc.stdout!r}",
+        )
+    finally:
+        try:
+            os.unlink(bad_path)
+        except OSError:
+            pass
+
+    time.sleep(0.3)
+    ids_after = set(_all_workspace_ids(c))
+    new_ids = ids_after - ids_before
+    _must(
+        len(new_ids) == 0,
+        f"c11 new-workspace with bad blueprint left {len(new_ids)} orphan workspace(s): {new_ids}",
+    )
+    print("PASS: test_bad_blueprint_no_orphan_cli")
+
+
+def test_valid_plan_creates_workspace(c: cmux) -> None:
+    """workspace.create with a valid plan must succeed and workspace appears in list."""
+    ids_before = set(_all_workspace_ids(c))
+    new_ws_res = c._call("workspace.create", {
+        "layout": {
+            "plan": {
+                "version": 1,
+                "workspace": {},
+                "layout": {"type": "pane", "pane": {"surfaceIds": ["s1"]}},
+                "surfaces": [{"id": "s1", "kind": "terminal"}],
+            },
+        },
+    }) or {}
+    new_ws = str(new_ws_res.get("workspace_id") or "")
+    _must(bool(new_ws), f"workspace.create with valid plan returned no workspace_id: {new_ws_res}")
+    try:
+        time.sleep(0.2)
+        ids_after = set(_all_workspace_ids(c))
+        _must(
+            new_ws in ids_after,
+            f"workspace.create with valid plan returned {new_ws!r} but it's not in workspace list",
+        )
+    finally:
+        try:
+            c.close_workspace(new_ws)
+        except Exception:
+            pass
+    print("PASS: test_valid_plan_creates_workspace")
+
+
+def main() -> int:
+    cli = _find_cli()
+    with cmux(SOCKET_PATH) as c:
+        test_bad_plan_version_no_orphan_socket(c)
+        test_bad_blueprint_no_orphan_cli(cli, c)
+        test_valid_plan_creates_workspace(c)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements 7 CLI hygiene and focus policy fixes, each inspired by an upstream manaflow-ai/cmux issue and written fresh for c11. All changes are in `CLI/c11.swift` and `Sources/TerminalController.swift`.

## Picks

| # | Fix | File(s) | Credits |
|---|-----|---------|---------|
| #3098 | Populate `tty` field in `surface.list` and `system.tree` responses | TerminalController.swift | Reported-by: @andy5090 |
| #2839 | `c11 send` / `send-key` error when `--surface` omitted and no `CMUX_SURFACE_ID` | CLI/c11.swift | Reported-by: @hummer98 |
| #2984 | Suppress SIGABRT on broken pipe (NSFileHandleOperationException catch) | CLI/c11.swift | Reported-by: @nengqi |
| #1418 | `c11 new-surface --no-focus` flag; `surface.create` accepts `focus:false` param | CLI/c11.swift + TerminalController.swift | Reported-by: @jasonkuhrt |
| #3129 | `surface.send_text` delivers to non-focused/non-selected tabs via `waitForTerminalSurface` | TerminalController.swift | Reported-by: @EtanHey |
| #3065 | Focus/workspace select brings existing window to foreground; cross-window index resolution | CLI/c11.swift + TerminalController.swift | Reported-by: @austinywang |
| #2951 | `workspace.create --layout` rolls back orphan workspace on layout failure | CLI/c11.swift + TerminalController.swift | Reported-by: @shaun0927 |

## Trident review findings applied

Post-implementation Trident review caught and fixed:
- **B1**: workspace.create + layout path double-created workspace; executor now owns creation
- **B2**: layout path returned camelCase response; normalized to standard snake_case creation envelope
- **I1**: rollback scope extended to `ApplyResult.failures`, not just `.err`
- **I2**: SKILL.md updated for 4 new agent-facing CLI changes
- **I3**: `--layout` added to `new-workspace` help text
- **I4**: `--window`-only invocation of `send`/`send-key` no longer bypasses the explicit-surface guard
- **M1**: `resolveBlueprintPlan` silent fallthrough on malformed blueprints replaced with descriptive errors
- **M2**: Misleading comment claiming `surface.create` is a `focusIntentV2Methods` member corrected

## Test matrix — all green

| Pick | Test | Result |
|------|------|--------|
| #3098 | `tests_v2/test_tree_tty_field.py` | PASS |
| #1418 | `tests_v2/test_new_surface_no_focus.py` | PASS |
| #2839 | `tests_v2/test_send_requires_surface.py` | PASS |
| #2984 | `tests_v2/test_cli_sigpipe_clean.py` | PASS |
| #3129 | `tests_v2/test_send_text_non_focused_tab.py` | PASS |
| #3065 | `tests_v2/test_focus_no_new_window.py` | PASS |
| #2951 | `tests_v2/test_workspace_create_layout_orphan.py` | PASS |

`xcodebuild -scheme c11-unit`: PASS

**Tagged build:** `c11 DEV-c11-20-cli-hygiene.app`
**Socket:** `/tmp/c11-debug-c11-20-cli-hygiene.sock`

## Upstream references

- manaflow-ai/cmux#3098 — tty null in tree output
- manaflow-ai/cmux#1418 — new-surface --no-focus
- manaflow-ai/cmux#2839 — send requires explicit surface
- manaflow-ai/cmux#2984 — CLI SIGABRT on broken pipe
- manaflow-ai/cmux#3129 — send_text drops to non-focused tab
- manaflow-ai/cmux#3065 — focus actions spawn new window
- manaflow-ai/cmux#2951 — workspace.create orphan on layout failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)