### PR TITLE
C11-21: Input handling, keyboard, IME, paste (8 upstream picks)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11086,7 +11086,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if hasEventChars,
            flags.contains(.command),
            !flags.contains(.control),
-           shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey) {
+           shortcutKey.count == 1,
+           let scalar = shortcutKey.unicodeScalars.first,
+           CharacterSet.letters.contains(scalar) {
             return false
         }
 
@@ -11107,6 +11109,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // only fall back to ANSI keyCodes when neither AppKit nor the active layout produced a
         // usable character: otherwise the physical-key match clobbers a working character match
         // on layouts where punctuation is remapped (e.g. JIS Cmd+Shift+[ misrouting to ]).
+        //
+        // Tradeoff: ANSI fallback is now gated on both event-character and layout-character
+        // lookup failing. This fixes JIS Cmd+Shift+[ clobbering prevSurface (cmux#3061) but
+        // means Cmd+punct on layouts where AppKit returns a non-matching character (e.g.
+        // AZERTY Cmd+1 produces '&') will not fire the shortcut. Users on those layouts
+        // should rebind via the keyboard shortcut settings. Validate manually on US, JIS,
+        // AZERTY, and Dvorak before merge.
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)
@@ -11116,13 +11125,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return event.keyCode == expectedKeyCode
         }
         return false
-    }
-
-    private func shouldRequireCharacterMatchForCommandShortcut(shortcutKey: String) -> Bool {
-        guard shortcutKey.count == 1, let scalar = shortcutKey.unicodeScalars.first else {
-            return false
-        }
-        return CharacterSet.letters.contains(scalar)
     }
 
     private func shortcutCharacterMatches(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11103,16 +11103,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         // Control-key combos can surface as ASCII control characters (e.g. Ctrl+H => backspace),
-        // so keep ANSI keyCode fallback for control-modified shortcuts. Also allow fallback for
-        // command punctuation shortcuts, since some non-US layouts report different characters
-        // for the same physical key even when menu-equivalent semantics should still apply.
+        // so keep ANSI keyCode fallback for control-modified shortcuts. For command shortcuts
+        // only fall back to ANSI keyCodes when neither AppKit nor the active layout produced a
+        // usable character: otherwise the physical-key match clobbers a working character match
+        // on layouts where punctuation is remapped (e.g. JIS Cmd+Shift+[ misrouting to ]).
         let allowANSIKeyCodeFallback = flags.contains(.control)
             || (flags.contains(.command)
                 && !flags.contains(.control)
-                && (
-                    !shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || (!hasEventChars && (layoutCharacter?.isEmpty ?? true))
-                ))
+                && !hasEventChars
+                && (layoutCharacter?.isEmpty ?? true))
         if allowANSIKeyCodeFallback, let expectedKeyCode = keyCodeForShortcutKey(shortcutKey) {
             return event.keyCode == expectedKeyCode
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -103,7 +103,11 @@ private enum GhosttyPasteboardHelper {
         // Latin-1/ASCII-truncated `.string` value alongside a clean UTF-8
         // entry; reading UTF-8 first preserves bytes >= 0x80 (Hangul,
         // Cyrillic, Qt-emitted non-ASCII). See cmux#3069 / #2756 / #2891.
-        if let value = pasteboard.string(forType: utf8PlainTextType) {
+        //
+        // Skip an empty UTF-8 entry so a pathological producer that registers
+        // utf8PlainTextType with an empty value but populates `.string`
+        // doesn't cause us to return empty.
+        if let value = pasteboard.string(forType: utf8PlainTextType), !value.isEmpty {
             return value
         }
 
@@ -4864,8 +4868,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     // can compute press/release deltas. AppKit fires flagsChanged on every
     // modifier transition without telling us whether the bit was set or
     // cleared; diffing against this snapshot is how we know which to send.
-    // Stack value (NSEvent.ModifierFlags is OptionSet) so this stays
-    // allocation-free in the typing-latency hot path.
+    // OptionSet operations on NSEvent.ModifierFlags are allocation-free, so
+    // updating and diffing this snapshot stays cheap on the typing-latency
+    // hot path.
     private var lastModifierFlags: NSEvent.ModifierFlags = []
     private struct SelectionSnapshot {
         let range: NSRange
@@ -5223,6 +5228,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
             keyEvent.keycode = UInt32(event.keyCode)
             keyEvent.mods = modsFromEvent(event)
+            // consumed_mods intentionally NONE: Delete has no glyph form, so
+            // macos-option-as-alt doesn't apply. Copying this pattern to a
+            // glyph keycode would silently break option-as-alt; route those
+            // through ghostty_surface_key_translation_mods instead.
             keyEvent.consumed_mods = GHOSTTY_MODS_NONE
             keyEvent.composing = false
             keyEvent.unshifted_codepoint = unshiftedCodepointFromEvent(event)
@@ -5561,13 +5570,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Option releases (cmux#1153) and breaks IME composition flows where
         // Shift/Cmd are tapped during preedit (cmux#2949).
         //
-        // Diff against the previous snapshot (stack value, allocation-free
-        // since NSEvent.ModifierFlags is OptionSet) and emit the appropriate
-        // action. New bits = PRESS, cleared bits = RELEASE. When the
-        // aggregate diff is empty (e.g. holding left Option, then pressing
-        // and releasing right Option -- the .option bit stays set both
-        // times), disambiguate via the side-specific NX device mask in the
-        // raw modifier flags. Mirrors Ghostty's upstream AppKit handler.
+        // Diff against the previous snapshot (allocation-free OptionSet
+        // operations) and emit the appropriate action. New bits = PRESS,
+        // cleared bits = RELEASE. When the aggregate diff is empty (e.g.
+        // holding left Option, then pressing and releasing right Option --
+        // the .option bit stays set both times), disambiguate via the
+        // side-specific NX device mask in the raw modifier flags. Mirrors
+        // Ghostty's upstream AppKit handler.
         let newFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let oldFlags = lastModifierFlags
         lastModifierFlags = newFlags
@@ -5592,10 +5601,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             let sideHeld = (event.modifierFlags.rawValue & sideMask) != 0
             keyEvent.action = sideHeld ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
         } else {
-            // No deviceIndependent bit toggled and the event's keyCode isn't
-            // a recognized modifier. Reachable for mask-stripped bits (e.g.
-            // numericPad, function) and synthetic events. Preserve the prior
-            // unconditional PRESS for backwards compat.
+            // No recognized modifier bit changed. Covers numericPad/function
+            // flags stripped by deviceIndependentFlagsMask and synthetic
+            // events from accessibility. Default to PRESS for backwards
+            // compatibility: these transitions are rare and Ghostty ignores
+            // unknown keycodes gracefully.
             keyEvent.action = GHOSTTY_ACTION_PRESS
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -97,11 +97,17 @@ private enum GhosttyPasteboardHelper {
                 .joined(separator: " ")
         }
 
-        if let value = pasteboard.string(forType: .string) {
+        // Prefer the explicit UTF-8 plain-text type when available. On modern
+        // macOS `.string` is aliased to `public.utf8-plain-text`, but legacy
+        // pasteboard producers (or apps writing both types) can leave a
+        // Latin-1/ASCII-truncated `.string` value alongside a clean UTF-8
+        // entry; reading UTF-8 first preserves bytes >= 0x80 (Hangul,
+        // Cyrillic, Qt-emitted non-ASCII). See cmux#3069 / #2756 / #2891.
+        if let value = pasteboard.string(forType: utf8PlainTextType) {
             return value
         }
 
-        if let value = pasteboard.string(forType: utf8PlainTextType) {
+        if let value = pasteboard.string(forType: .string) {
             return value
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4765,6 +4765,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             // If we become first responder before the ghostty surface exists (e.g. during
             // split/tab creation while the surface is still being created), record the desired focus.
             desiredFocus = true
+            // Re-snapshot modifier state from the global accessor on focus gain
+            // so the next flagsChanged diff is against ground truth, not the
+            // stale snapshot from before focus loss. Closes a stuck-modifier
+            // window where Option held during focus transitions could
+            // misclassify the subsequent press/release.
+            lastModifierFlags = NSEvent.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
             // During programmatic splits, SwiftUI reparents the old NSView which triggers
             // becomeFirstResponder. Suppress onFocus + ghostty_surface_set_focus to prevent
@@ -4834,6 +4840,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let result = super.resignFirstResponder()
         if result {
             desiredFocus = false
+            // Drop the modifier snapshot so we don't diff a future flagsChanged
+            // against stale state. While focus lives elsewhere, modifier
+            // transitions go to another responder; the next event we see should
+            // be treated as a fresh PRESS against an empty baseline (or the
+            // baseline re-established in becomeFirstResponder below).
+            lastModifierFlags = []
         }
         if result, let surface = surface {
             let now = CACurrentMediaTime()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -131,7 +131,7 @@ private enum GhosttyPasteboardHelper {
     static func hasString(for location: ghostty_clipboard_e) -> Bool {
         guard let pasteboard = pasteboard(for: location) else { return false }
         let types = pasteboard.types ?? []
-        if types.contains(.fileURL) || types.contains(.string) || types.contains(utf8PlainTextType)
+        if types.contains(.fileURL) || types.contains(utf8PlainTextType) || types.contains(.string)
             || types.contains(.html) || types.contains(.rtf) || types.contains(.rtfd) {
             return true
         }
@@ -5201,7 +5201,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         //
         // Mirrors the Ctrl fast path above. See cmux#1153 (@sldx report,
         // @judekim0507 diagnosis, @pandec PR #2246 root-cause).
-        if event.keyCode == 51,
+        if event.keyCode == 51, // kVK_ANSI_Delete (Backspace)
            flags.contains(.option),
            !flags.contains(.command),
            !flags.contains(.control),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4842,6 +4842,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var keyTextAccumulator: [String]? = nil
     private var markedText = NSMutableAttributedString()
     private var lastPerformKeyEvent: TimeInterval?
+    // Snapshot of modifier flags from the most recent flagsChanged event so we
+    // can compute press/release deltas. AppKit fires flagsChanged on every
+    // modifier transition without telling us whether the bit was set or
+    // cleared; diffing against this snapshot is how we know which to send.
+    // Stack value (NSEvent.ModifierFlags is OptionSet) so this stays
+    // allocation-free in the typing-latency hot path.
+    private var lastModifierFlags: NSEvent.ModifierFlags = []
     private struct SelectionSnapshot {
         let range: NSRange
         let string: String
@@ -5177,6 +5184,34 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             if handled { return }
         }
 
+        // Fast path for Option+Delete (alt+backspace).
+        //
+        // AppKit's interpretKeyEvents would translate Option+Delete to a
+        // deleteWordBackward: action selector or to insertText with a
+        // pre-deleted string, both of which strip the alt prefix Ghostty
+        // needs to encode the backward-kill-word escape sequence
+        // (ESC DEL = \x1b\x7f) that lazygit, vim, fish, zsh, Claude Code,
+        // and Codex all expect for word-deletion in TUI input fields.
+        //
+        // Mirrors the Ctrl fast path above. See cmux#1153 (@sldx report,
+        // @judekim0507 diagnosis, @pandec PR #2246 root-cause).
+        if event.keyCode == 51,
+           flags.contains(.option),
+           !flags.contains(.command),
+           !flags.contains(.control),
+           !hasMarkedText() {
+            ghostty_surface_set_focus(surface, true)
+            var keyEvent = ghostty_input_key_s()
+            keyEvent.action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
+            keyEvent.keycode = UInt32(event.keyCode)
+            keyEvent.mods = modsFromEvent(event)
+            keyEvent.consumed_mods = GHOSTTY_MODS_NONE
+            keyEvent.composing = false
+            keyEvent.unshifted_codepoint = unshiftedCodepointFromEvent(event)
+            keyEvent.text = nil
+            if ghostty_surface_key(surface, keyEvent) { return }
+        }
+
         let action = event.isARepeat ? GHOSTTY_ACTION_REPEAT : GHOSTTY_ACTION_PRESS
 
         // Translate mods to respect Ghostty config (e.g., macos-option-as-alt)
@@ -5501,13 +5536,38 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
+        // AppKit's flagsChanged fires on every modifier transition without
+        // telling us whether the bit was set or cleared. Without a press/
+        // release distinction Ghostty's input state always thinks modifiers
+        // are held: that breaks alt+backspace word-delete in TUI apps after
+        // Option releases (cmux#1153) and breaks IME composition flows where
+        // Shift/Cmd are tapped during preedit (cmux#2949).
+        //
+        // Diff against the previous snapshot (stack value, allocation-free
+        // since NSEvent.ModifierFlags is OptionSet) and emit the appropriate
+        // action. New bits = PRESS, cleared bits = RELEASE.
+        let newFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let oldFlags = lastModifierFlags
+        lastModifierFlags = newFlags
+
         var keyEvent = ghostty_input_key_s()
-        keyEvent.action = GHOSTTY_ACTION_PRESS
         keyEvent.keycode = UInt32(event.keyCode)
         keyEvent.mods = modsFromEvent(event)
         keyEvent.consumed_mods = GHOSTTY_MODS_NONE
         keyEvent.text = nil
         keyEvent.composing = false
+
+        if !newFlags.subtracting(oldFlags).isEmpty {
+            keyEvent.action = GHOSTTY_ACTION_PRESS
+        } else if !oldFlags.subtracting(newFlags).isEmpty {
+            keyEvent.action = GHOSTTY_ACTION_RELEASE
+        } else {
+            // No bit changed (e.g. caps lock toggle on a layout where the
+            // diff cancels out). Default to PRESS for backwards compat with
+            // anything that relied on the previous unconditional behavior.
+            keyEvent.action = GHOSTTY_ACTION_PRESS
+        }
+
         _ = ghostty_surface_key(surface, keyEvent)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5563,7 +5563,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         //
         // Diff against the previous snapshot (stack value, allocation-free
         // since NSEvent.ModifierFlags is OptionSet) and emit the appropriate
-        // action. New bits = PRESS, cleared bits = RELEASE.
+        // action. New bits = PRESS, cleared bits = RELEASE. When the
+        // aggregate diff is empty (e.g. holding left Option, then pressing
+        // and releasing right Option -- the .option bit stays set both
+        // times), disambiguate via the side-specific NX device mask in the
+        // raw modifier flags. Mirrors Ghostty's upstream AppKit handler.
         let newFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let oldFlags = lastModifierFlags
         lastModifierFlags = newFlags
@@ -5579,14 +5583,42 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEvent.action = GHOSTTY_ACTION_PRESS
         } else if !oldFlags.subtracting(newFlags).isEmpty {
             keyEvent.action = GHOSTTY_ACTION_RELEASE
+        } else if let sideMask = Self.sideMaskForModifierKeyCode(event.keyCode) {
+            // Aggregate diff is empty but a known modifier keyCode fired:
+            // same-modifier opposite-side transition. The post-event raw
+            // modifierFlags carry the side-specific NX bit; use it to pick
+            // PRESS (this side now held) vs RELEASE (this side now cleared,
+            // other side still held).
+            let sideHeld = (event.modifierFlags.rawValue & sideMask) != 0
+            keyEvent.action = sideHeld ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
         } else {
-            // No bit changed (e.g. caps lock toggle on a layout where the
-            // diff cancels out). Default to PRESS for backwards compat with
-            // anything that relied on the previous unconditional behavior.
+            // No deviceIndependent bit toggled and the event's keyCode isn't
+            // a recognized modifier. Reachable for mask-stripped bits (e.g.
+            // numericPad, function) and synthetic events. Preserve the prior
+            // unconditional PRESS for backwards compat.
             keyEvent.action = GHOSTTY_ACTION_PRESS
         }
 
         _ = ghostty_surface_key(surface, keyEvent)
+    }
+
+    // Side-specific NX device mask for a left/right modifier keycode, or nil
+    // for non-modifier or single-side keys (e.g. caps lock, function). Used
+    // by flagsChanged to disambiguate same-modifier opposite-side transitions
+    // when the aggregate deviceIndependentFlagsMask diff is empty. Mirrors
+    // upstream Ghostty's AppKit handler in SurfaceView_AppKit.swift.
+    private static func sideMaskForModifierKeyCode(_ keyCode: UInt16) -> UInt? {
+        switch keyCode {
+        case 0x38: return UInt(NX_DEVICELSHIFTKEYMASK) // kVK_Shift
+        case 0x3C: return UInt(NX_DEVICERSHIFTKEYMASK) // kVK_RightShift
+        case 0x3B: return UInt(NX_DEVICELCTLKEYMASK)   // kVK_Control
+        case 0x3E: return UInt(NX_DEVICERCTLKEYMASK)   // kVK_RightControl
+        case 0x3A: return UInt(NX_DEVICELALTKEYMASK)   // kVK_Option
+        case 0x3D: return UInt(NX_DEVICERALTKEYMASK)   // kVK_RightOption
+        case 0x37: return UInt(NX_DEVICELCMDKEYMASK)   // kVK_Command
+        case 0x36: return UInt(NX_DEVICERCMDKEYMASK)   // kVK_RightCommand
+        default: return nil
+        }
     }
 
     private func modsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {


### PR DESCRIPTION
## Summary

8 upstream cmux issues affecting input handling, keyboard layouts, IME, and paste. Disproportionately important for c11's 6-locale shipping story (ja, uk, ko, zh-Hans, zh-Hant, ru).

**Substantive code changes (3 commits):**

- `2a0c92d8` — **Pick 1 (cmux#3061):** Tighten `allowANSIKeyCodeFallback` in `matchShortcut` so physical-keycode fallback only fires when both AppKit and the active layout returned no character. Fixes JIS `Cmd+Shift+[` routing to `nextSurface` instead of `prevSurface`. Note: AZERTY `Cmd+punct` shortcuts where AppKit returns a non-matching glyph will not fire (documented tradeoff; see comment at AppDelegate.swift:11113-11118). Manual smoke on US/JIS/AZERTY/Dvorak required before merge.
  - Reported-by: @wada811 (upstream cmux#3061)

- `4baf4b06` — **Pick 6+8 (cmux#1153 + cmux#2949):** Two changes in `GhosttyTerminalView.swift`: (A) Option+Delete (keyCode 51) fast path before `interpretKeyEvents`, mirroring the existing Ctrl fast path — fixes alt+backspace word-deletion in TUI apps (lazygit, vim, Claude Code, Codex). (B) `flagsChanged` now tracks `lastModifierFlags` and emits `GHOSTTY_ACTION_PRESS` for newly-set bits and `GHOSTTY_ACTION_RELEASE` for cleared bits — fixes modifier events dropped during IME marked text. Both changes are allocation-free (OptionSet stack ops).
  - Reported-by: @sldx (cmux#1153); Diagnosed-by: @judekim0507 (cmux#1424); First-attempt: @shouryamaanjain (PR #1438, closed unmerged); Root-cause: @pandec (PR #2246, closed unmerged); Reference: manaflow-ai/cmux@ab46c557 + fda8daad + 151075f7 by @austinywang
  - Reported-by: @shaun0927 (cmux#2949)

- `9028edab` — **Pick 4 (cmux#3069):** Reorder `stringContents(from:)` to prefer `NSPasteboard.utf8PlainTextType` over `.string`. Addresses the Hangul/Cyrillic/Qt non-ASCII paste corruption class. Ghostty's clipboard pipeline is already byte-clean for non-ASCII at the current submodule pin; this is defensive insurance against legacy pasteboard producers. S3 hardening included: falls back to `.string` if UTF-8 entry is non-nil but empty.
  - Reported-by: @jewel-sallylab (cmux#3069); Also-closes: cmux#2756 (reported by @AndreySoloviev); Also-closes: cmux#2891 (reported by @pankrusheff) — pending manual validation

**Drift-confirmed picks (5 commits — no code changes, traces in commit bodies):**

- `6bbb0cb7` — Pick 5 (cmux#1469): `macos-option-as-alt` already unset in c11-default.conf; option-key glyphs already reach shell on non-US layouts.
- `55ff8da9` — Pick 3 (cmux#3096): Ghostty's selection-to-string already omits `\n` at soft-wrap boundaries at current submodule pin.
- `d478e287` — Pick 7 (cmux#2105): PTY termios inherits `ISIG`/`VSUSP` from `openpty` defaults; ctrl-z already routes to SIGTSTP.
- `69abae46` — Pick 2 (cmux#1456): Ghostty default bindings cover both `super+equal` and `super+shift+equal=increase_font_size`; zoom-in symmetry intact.
- `3f91e3f2` — Pick 8 (cmux#2949): Credit commit; behavioral fix landed in 4baf4b06.

**Trident review follow-ups (4 commits applied by review pass):**

- `64c763b5` — UTF-8 type ordering parity in `hasString`; `kVK_ANSI_Delete` label on fast path.
- `b89be99d` — Reset `lastModifierFlags` on `resignFirstResponder`; re-snapshot on `becomeFirstResponder`. Closes stuck-modifier hole on focus transitions.
- `a413f80d` — Side-aware press/release fallback for same-modifier opposite-side `flagsChanged` transitions (left-Shift vs right-Shift etc.), via `sideMaskForModifierKeyCode` lookup.
- `8913426c` — Post-review comment hardening: S1 AZERTY tradeoff, S2 PRESS-fallback explanation, S3 empty-UTF8 fallback guard, S4 `consumed_mods=NONE` rationale.

## Test matrix

| Test | Result |
|------|--------|
| `xcodebuild -scheme c11-unit` | PASS |
| E2E `gh workflow run test-e2e.yml` | Pre-existing infrastructure failure (heredoc syntax in test runner, confirmed on sibling branch c11-23 run 24976041837). Not a C11-21 regression. |
| Tagged build `c11-21-input-handling` | CLEAN — socket at `/tmp/c11-debug-c11-21-input-handling.sock` |
| Pick 1 code audit (AppDelegate.swift matchShortcut) | PASS |
| Pick 6 code audit (GhosttyTerminalView.swift fast path + flagsChanged) | PASS |
| Pick 4 code audit (stringContents UTF-8 preference) | PASS |
| Post-review comments (S1-S4) | PRESENT |

**Manual smoke required before merge (tagged build + non-US input):**

- JIS: `Cmd+Shift+[` → prevSurface fires (not nextSurface)
- DE: `Option+L` → `@` arrives in terminal
- KR: IME composition, `Shift+Arrow` during marked text → selection extends; `Option+Delete` after commit → word deleted
- RU/UK: `Cmd+V` paste of Cyrillic → correct characters (not `?`)
- TUI alt+backspace (lazygit, vim, Claude Code, Codex): `Option+Delete` → last word deleted; no stuck-modifier after double-Option-tap

## Follow-on tickets

- E1: `c11 send-key` socket command — unlocks `tests_v2` behavioral tests for input fast paths (~half-day). Multiple Trident reviewers flagged this as highest-leverage follow-up.
- E2: `makeGhosttyKeyEvent(from:action:text:unshiftedCodepoint:)` helper consolidating Ctrl + Option+Delete fast paths and flagsChanged body. Touches typing-latency hot path — needs tagged-build validation before landing.
- S5: Behavioral test coverage for fast paths via tests_v2 socket harness once E1 ships.

## Tagged build

`c11 DEV-c11-21-input-handling.app` — socket: `/tmp/c11-debug-c11-21-input-handling.sock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)