### PR TITLE
Flash extends to top-bar tab strip and sidebar workspace row

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8485,7 +8485,8 @@ struct VerticalTabsSidebar: View {
                                     themedRailColor: themedColors.rail,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuTargets.map(\.id),
                                     allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
-                                    allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected }
+                                    allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected },
+                                    sidebarFlashToken: tab.sidebarFlashToken
                                 )
                                 .equatable()
                             }
@@ -10905,6 +10906,11 @@ enum SidebarWorkspaceShortcutHintMetrics {
 // main thread during typing). If you add new properties, update == below.
 // Do NOT add @EnvironmentObject or new @Binding without updating ==.
 // Do NOT remove .equatable() from the ForEach call site in VerticalTabsSidebar.
+//
+// Note on `sidebarFlashToken`: it's a precomputed `let` (Int), threaded from
+// the parent ForEach via `tab.sidebarFlashToken`. Keeping it in `==` is what
+// causes ONLY the targeted workspace's row to re-render (and therefore
+// re-fire its `.onChange`) when a flash arrives — sibling rows skip body.
 private struct TabItemView: View, Equatable {
     // Closures, Bindings, and object references are excluded from ==
     // because they're recreated every parent eval but don't affect rendering.
@@ -10924,7 +10930,8 @@ private struct TabItemView: View, Equatable {
         lhs.themedRailColor?.hexString(includeAlpha: true) == rhs.themedRailColor?.hexString(includeAlpha: true) &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
-        lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected
+        lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
+        lhs.sidebarFlashToken == rhs.sidebarFlashToken
     }
 
     // Use plain references instead of @EnvironmentObject to avoid subscribing
@@ -10955,8 +10962,15 @@ private struct TabItemView: View, Equatable {
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
+    /// Per-workspace flash signal. Bumped by `Workspace.triggerFocusFlash`
+    /// whenever any panel in the workspace is flashed. The row reacts by
+    /// running a single, gentle pulse in the same accent color used for
+    /// other workspace affordances. Visual-only; never selects.
+    let sidebarFlashToken: Int
     @State private var isHovering = false
     @State private var rowHeight: CGFloat = 1
+    @State private var sidebarFlashOpacity: Double = 0
+    @State private var lastObservedSidebarFlashToken: Int = 0
     @AppStorage(ShortcutHintDebugSettings.sidebarHintXKey) private var sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
     @AppStorage(ShortcutHintDebugSettings.sidebarHintYKey) private var sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey) private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
@@ -11494,7 +11508,21 @@ private struct TabItemView: View, Equatable {
                             .offset(x: -1)
                     }
                 }
+                .overlay {
+                    // Sidebar flash pulse. Single, gentle accent fill that
+                    // signals "a panel in this workspace was flashed" without
+                    // shouting from the sidebar. Hit testing is disabled so
+                    // the pulse never intercepts clicks/drags.
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(cmuxAccentColor().opacity(sidebarFlashOpacity))
+                        .allowsHitTesting(false)
+                }
         )
+        .onChange(of: sidebarFlashToken) { _, newValue in
+            guard newValue != lastObservedSidebarFlashToken else { return }
+            lastObservedSidebarFlashToken = newValue
+            runSidebarFlashAnimation(token: newValue)
+        }
         .padding(.horizontal, 6)
         .background {
             GeometryReader { proxy in
@@ -11571,6 +11599,27 @@ private struct TabItemView: View, Equatable {
 
     private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {
         isMulti ? multi : single
+    }
+
+    private func runSidebarFlashAnimation(token: Int) {
+        // Reset to the envelope start in case a prior flash is mid-flight.
+        sidebarFlashOpacity = SidebarFlashPattern.values.first ?? 0
+        for segment in SidebarFlashPattern.segments {
+            DispatchQueue.main.asyncAfter(deadline: .now() + segment.delay) {
+                // Bail if a newer flash superseded this run.
+                guard token == lastObservedSidebarFlashToken else { return }
+                let animation: Animation
+                switch segment.curve {
+                case .easeIn:
+                    animation = .easeIn(duration: segment.duration)
+                case .easeOut:
+                    animation = .easeOut(duration: segment.duration)
+                }
+                withAnimation(animation) {
+                    sidebarFlashOpacity = segment.targetOpacity
+                }
+            }
+        }
     }
 
     private func remoteContextMenuWorkspaces() -> [Workspace] {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6636,11 +6636,11 @@ final class GhosttySurfaceScrollView: NSView {
         flashOverlayView.layer?.masksToBounds = false
         flashOverlayView.autoresizingMask = [.width, .height]
         flashLayer.fillColor = NSColor.clear.cgColor
-        flashLayer.strokeColor = NSColor.systemBlue.cgColor
+        flashLayer.strokeColor = cmuxAccentNSColor().cgColor
         flashLayer.lineWidth = 3
         flashLayer.lineJoin = .round
         flashLayer.lineCap = .round
-        flashLayer.shadowColor = NSColor.systemBlue.cgColor
+        flashLayer.shadowColor = cmuxAccentNSColor().cgColor
         flashLayer.shadowOpacity = 0.6
         flashLayer.shadowRadius = 6
         flashLayer.shadowOffset = .zero

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -61,6 +61,31 @@ enum FocusFlashPattern {
     }
 }
 
+/// Single-pulse, low-peak envelope used for the sidebar workspace row flash.
+/// Calibrated to be a polite ambient nudge: noticeable enough to draw the eye,
+/// gentle enough not to startle when it fires from a workspace the operator
+/// is not actively viewing.
+enum SidebarFlashPattern {
+    static let values: [Double] = [0, 0.18, 0]
+    static let keyTimes: [Double] = [0, 0.5, 1]
+    static let duration: TimeInterval = 0.6
+    static let curves: [FocusFlashCurve] = [.easeOut, .easeIn]
+
+    static var segments: [FocusFlashSegment] {
+        let stepCount = min(curves.count, values.count - 1, keyTimes.count - 1)
+        return (0..<stepCount).map { index in
+            let startTime = keyTimes[index]
+            let endTime = keyTimes[index + 1]
+            return FocusFlashSegment(
+                delay: startTime * duration,
+                duration: (endTime - startTime) * duration,
+                targetOpacity: values[index + 1],
+                curve: curves[index]
+            )
+        }
+    }
+}
+
 /// Protocol for all panel types (terminal, browser, etc.)
 @MainActor
 public protocol Panel: AnyObject, Identifiable, ObservableObject where ID == UUID {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5099,6 +5099,13 @@ final class Workspace: Identifiable, ObservableObject {
     /// Mapping from bonsplit TabID to our Panel instances
     @Published private(set) var panels: [UUID: any Panel] = [:]
 
+    /// Monotonically incrementing token used by the sidebar workspace row to
+    /// observe focus flashes targeting any panel in this workspace. Bumped
+    /// from `triggerFocusFlash(panelId:)` so a single fan-out drives the
+    /// pane content flash, the Bonsplit tab strip flash, and the sidebar
+    /// row pulse together. Visual-only; never affects selection.
+    @Published private(set) var sidebarFlashToken: Int = 0
+
     /// Subscriptions for panel updates (e.g., browser title changes)
     private var panelSubscriptions: [UUID: AnyCancellable] = [:]
 
@@ -8793,8 +8800,21 @@ final class Workspace: Identifiable, ObservableObject {
 
     // MARK: - Flash/Notification Support
 
+    /// Single fan-out for a focus flash. Drives, in order:
+    ///   (a) the targeted panel's pane-content flash (existing behavior),
+    ///   (b) the Bonsplit tab strip — scrolls the matching tab into view and
+    ///       plays a brief pulse on it (visual-only; selection is unchanged),
+    ///   (c) the sidebar workspace row — gentle accent pulse so the operator
+    ///       can locate the workspace at a glance even when viewing another.
+    /// Gated on `NotificationPaneFlashSettings` so disabling the user-facing
+    /// "Pane Flash" toggle silences all three channels consistently.
     func triggerFocusFlash(panelId: UUID) {
+        guard NotificationPaneFlashSettings.isEnabled() else { return }
         panels[panelId]?.triggerFlash()
+        if let tabId = surfaceIdFromPanelId(panelId) {
+            bonsplitController.flashTab(tabId)
+        }
+        sidebarFlashToken &+= 1
     }
 
     func triggerNotificationFocusFlash(
@@ -8802,7 +8822,7 @@ final class Workspace: Identifiable, ObservableObject {
         requiresSplit: Bool = false,
         shouldFocus: Bool = true
     ) {
-        guard let terminalPanel = terminalPanel(for: panelId) else { return }
+        guard terminalPanel(for: panelId) != nil else { return }
         if shouldFocus {
             focusPanel(panelId)
         }
@@ -8810,7 +8830,7 @@ final class Workspace: Identifiable, ObservableObject {
         if requiresSplit && !isSplit {
             return
         }
-        terminalPanel.triggerFlash()
+        triggerFocusFlash(panelId: panelId)
     }
 
     func triggerDebugFlash(panelId: UUID) {

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -5681,7 +5681,7 @@ struct SettingsView: View {
 
             SettingsCardRow(
                 String(localized: "settings.notifications.paneFlash.title", defaultValue: "Pane Flash"),
-                subtitle: String(localized: "settings.notifications.paneFlash.subtitle", defaultValue: "Briefly flash a blue outline when c11 highlights a pane.")
+                subtitle: String(localized: "settings.notifications.paneFlash.subtitle", defaultValue: "Briefly flash a yellow outline when c11 highlights a pane.")
             ) {
                 Toggle("", isOn: $notificationPaneFlashEnabled)
                     .labelsHidden()

--- a/notes/flash-extension-plan.md
+++ b/notes/flash-extension-plan.md
@@ -1,0 +1,290 @@
+# Flash Extension Plan — Tab strip + Sidebar workspace
+
+Branch: `c11-flash-tab-and-workspace` (off `origin/main`).
+Worktree: `/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace`.
+
+## Confirmed setup notes
+
+- `vendor/bonsplit/` is a **git submodule** (`Stage-11-Agentics/bonsplit`). It was empty in this fresh worktree until `git submodule update --init vendor/bonsplit` ran. Bonsplit changes must follow CLAUDE.md "Submodule safety": commit + push the submodule HEAD to `bonsplit/main` BEFORE committing the parent pointer bump.
+- `typealias Tab = Workspace` (`Sources/TabManager.swift:10`). The sidebar's `TabItemView` parameter named `tab: Tab` is a `Workspace`. Adding `@Published var sidebarFlashToken: Int = 0` to `Workspace` is exactly the right hook.
+- `PaneState` is `@Observable` (Swift's new observation, not `ObservableObject`). Adding `var flashTabId: UUID?` and `var flashTabGeneration: Int = 0` is sufficient — observation is automatic.
+- `BonsplitController.findTabInternal(_:)` at `vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift:822` is the right helper to reuse for the new `flashTab(_:)` API.
+- `FocusFlashPattern` lives at `Sources/Panels/Panel.swift:41` and is module-internal — accessible from `ContentView.swift` without re-export.
+- `cmuxAccentColor()` at `Sources/ContentView.swift:61` is the host accent color.
+
+## 1. Architecture summary
+
+Single fan-out point stays `Workspace.triggerFocusFlash(panelId:)` (`Sources/Workspace.swift:8918`). Today:
+
+```swift
+panels[panelId]?.triggerFlash()       // (a) pane content flash
+```
+
+Extend to three channels:
+
+```swift
+panels[panelId]?.triggerFlash()                                    // (a) pane content
+if let tabId = surfaceIdFromPanelId(panelId) {                     // (b) bonsplit tab
+    bonsplitController.flashTab(tabId)
+}
+sidebarFlashToken &+= 1                                            // (c) sidebar row
+```
+
+All four existing trigger paths (keyboard shortcut, right-click "Trigger Flash" via `triggerDebugFlash`, v2 socket `surface.trigger_flash`, notification routing via `triggerNotificationFocusFlash`) collapse onto this one fan-out by changing `triggerNotificationFocusFlash` to call `triggerFocusFlash(panelId:)` instead of `terminalPanel.triggerFlash()` directly.
+
+Per channel:
+
+- **(a) Pane content (unchanged).** Existing `Panel.triggerFlash()` impl: `CAKeyframeAnimation` for terminal, segmented `withAnimation` for SwiftUI panels.
+- **(b) Bonsplit tab strip.** New public Bonsplit API `BonsplitController.flashTab(_:)` writes `flashTabId` + `flashTabGeneration` on `PaneState`. `TabBarView`'s `ScrollViewReader` listens via `.onChange(of: pane.flashTabGeneration)` and calls `proxy.scrollTo(flashId, anchor: .center)`. `TabItemView` reads the matching generation and runs a SwiftUI segment animation against a fill overlay.
+- **(c) Sidebar row.** `Workspace.sidebarFlashToken` increments. The c11 sidebar `TabItemView` receives the token as a precomputed `let` parameter from the parent `ForEach`, fires `.onChange(of:)`, runs a single-pulse segment animation. The `==` comparator gets one new `Int` field.
+
+Both new flashes are intentionally **non-selecting**.
+
+## 2. Public seam in Bonsplit
+
+Add to `vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift` after `selectTab(_:)` (line 290):
+
+```swift
+/// Trigger a transient visual flash on the tab matching `tabId`.
+/// Visual-only: does NOT change selection or focus.
+/// Composes with the tab strip's existing scroll-into-view machinery.
+public func flashTab(_ tabId: TabID) {
+    guard let (pane, _) = findTabInternal(tabId) else { return }
+    pane.flashTabId = tabId.id
+    pane.flashTabGeneration &+= 1
+}
+```
+
+Add to `vendor/bonsplit/Sources/Bonsplit/Internal/Models/PaneState.swift` near `selectedTabId`:
+
+```swift
+/// Last-flashed tab id (visual-only signal, does not affect selection).
+var flashTabId: UUID?
+/// Monotonic generation that increments on every flash request.
+/// Observers key animations off changes to this counter so back-to-back
+/// flash calls cleanly restart the animation rather than stacking.
+var flashTabGeneration: Int = 0
+```
+
+**Why this seam.** Composes with `TabBarView`'s existing `ScrollViewReader` and `proxy.scrollTo(tabId, anchor: .center)` machinery. Same conceptual layer as `selectTab(_:)`, `togglePaneZoom()`, etc. on the public controller. No new delegate calls. Self-contained — generic enough to upstream to `almonk/bonsplit` later.
+
+**Alternative considered:** put the token on `TabItem`. Rejected — `TabItem` is `Codable` and round-trips via drag/drop pasteboards; transient UI flags do not belong there. Pane-keyed approach also lets us flash a non-selected tab without touching `selectedTabId`.
+
+## 3. File-by-file change list
+
+### Bonsplit submodule
+
+1. **`vendor/bonsplit/Sources/Bonsplit/Internal/Models/PaneState.swift`** — add `flashTabId`, `flashTabGeneration` properties (~5 lines).
+
+2. **`vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift`** — add `flashTab(_:)` after `selectTab(_:)` (~8 lines).
+
+3. **`vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift`**
+   - Inside `ScrollViewReader { proxy in ... }` block (line 471), add a new `.onChange(of: pane.flashTabGeneration)` after the four existing `scrollToPreferredTarget` change handlers (after line 548):
+     ```swift
+     .onChange(of: pane.flashTabGeneration) { _, _ in
+         guard let flashId = pane.flashTabId else { return }
+         withTransaction(Transaction(animation: nil)) {
+             proxy.scrollTo(flashId, anchor: .center)
+         }
+     }
+     ```
+   - In `tabItem(for:at:)` (around line 677), thread the flash signal:
+     ```swift
+     TabItemView(
+         tab: tab,
+         isSelected: pane.selectedTabId == tab.id,
+         flashGeneration: (pane.flashTabId == tab.id) ? pane.flashTabGeneration : 0,
+         ...
+     )
+     ```
+     Only the matching tab sees a non-zero generation; others stay at 0 and ignore.
+
+4. **`vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift`**
+   - Add `let flashGeneration: Int` (default 0).
+   - Add `@State private var flashOpacity: Double = 0` and `@State private var lastObservedFlashGen: Int = 0`.
+   - Add a fill overlay on the tab background:
+     ```swift
+     .overlay {
+         RoundedRectangle(cornerRadius: tabCornerRadius)
+             .fill(appearance.activeIndicatorColor.opacity(flashOpacity))
+             .allowsHitTesting(false)
+     }
+     ```
+     Tint with the host's accent (`appearance.activeIndicatorColor` already used for selected-tab styling — keeps Bonsplit standalone).
+   - Add `.onChange(of: flashGeneration) { _, newGen in if newGen > lastObservedFlashGen { lastObservedFlashGen = newGen; runFlashAnimation() } }`.
+   - Define a Bonsplit-internal `FlashPattern` mirroring `FocusFlashPattern`'s constants verbatim (peak 0.55, two pulses, 0.9s) — keeps Bonsplit self-contained for upstream-friendly diffs.
+
+### c11 sources
+
+5. **`Sources/Workspace.swift`**
+   - Add property near other published state: `@Published private(set) var sidebarFlashToken: Int = 0`
+   - Modify `triggerFocusFlash(panelId:)` (line 8918):
+     ```swift
+     func triggerFocusFlash(panelId: UUID) {
+         guard NotificationPaneFlashSettings.isEnabled() else { return }
+         panels[panelId]?.triggerFlash()                                  // (a)
+         if let tabId = surfaceIdFromPanelId(panelId) {                   // (b)
+             bonsplitController.flashTab(tabId)
+         }
+         sidebarFlashToken &+= 1                                          // (c)
+     }
+     ```
+     (Verify `NotificationPaneFlashSettings.isEnabled()` exists; if it's only `@AppStorage`, read `UserDefaults.standard.bool(forKey: NotificationPaneFlashSettings.enabledKey)` directly — see step 9.)
+   - Modify `triggerNotificationFocusFlash(panelId:requiresSplit:shouldFocus:)` (line 8922) to delegate through the fan-out:
+     ```swift
+     // was: terminalPanel.triggerFlash()
+     triggerFocusFlash(panelId: panelId)
+     ```
+   - `triggerDebugFlash(panelId:)` (line 8938) already calls `triggerNotificationFocusFlash`; no change needed.
+
+6. **`Sources/ContentView.swift`** — sidebar `TabItemView` (line 10908)
+   - Add `let sidebarFlashToken: Int` to the struct.
+   - Add to `==` comparator (line 10911) — **critical, otherwise unrelated parent re-evals replay the animation**:
+     ```swift
+     lhs.sidebarFlashToken == rhs.sidebarFlashToken &&
+     ```
+     Update the warning comment block at line 10902 to mention the new field.
+   - Add `@State private var lastObservedSidebarFlash: Int = 0` and `@State private var sidebarFlashOpacity: Double = 0`.
+   - Add a fill overlay in the row body (sized to the row container, low corner radius matching existing row chrome):
+     ```swift
+     .overlay {
+         RoundedRectangle(cornerRadius: 8)
+             .fill(cmuxAccentColor().opacity(sidebarFlashOpacity))
+             .allowsHitTesting(false)
+     }
+     .onChange(of: sidebarFlashToken) { _, newValue in
+         guard newValue != lastObservedSidebarFlash else { return }
+         lastObservedSidebarFlash = newValue
+         runSidebarFlashAnimation()
+     }
+     ```
+   - `runSidebarFlashAnimation()` is a `@MainActor` helper using a single-pulse pattern (see §4) and a generation guard mirroring `MarkdownPanelView.triggerFocusFlashAnimation`.
+   - At the parent ForEach call site (line 8453), pass `sidebarFlashToken: tab.sidebarFlashToken` as a constructor parameter. The parent already re-evaluates because `tab` is `@ObservedObject`; updating the field triggers the `==` mismatch and body runs.
+
+7. **No changes to** `Sources/Panels/MarkdownPanelView.swift`, `Sources/Panels/BrowserPanelView.swift`, `Sources/AppDelegate.swift`, `Sources/TabManager.swift`, `Sources/TerminalController.swift`, `Sources/c11App.swift`. They all reach the new fan-out via `triggerFocusFlash`/`triggerNotificationFocusFlash`.
+
+## 4. Animation reuse — exact values
+
+Use `FocusFlashPattern` (`Sources/Panels/Panel.swift:41`) as the c11-side source of truth. Bonsplit gets a self-contained mirror with identical numeric constants so visuals match by construction.
+
+| Channel | Envelope source | Peak opacity | Pulses | Duration |
+|---|---|---|---|---|
+| (a) Pane content | `FocusFlashPattern` (existing) | 1.0 (stroke at full) | 2 | 0.9s |
+| (b) Bonsplit tab fill | mirrored pattern in Bonsplit | 0.55 (accent fill) | 2 | 0.9s |
+| (c) Sidebar row fill | new `SidebarFlashPattern` in c11 | 0.18 (accent fill) | **1** | 0.6s |
+
+**Why fill not stroke** for (b) and (c): the pane content stroke is ring-inset by 6pt at 10pt corner radius — fine for a content-area-sized rect with internal padding. The Bonsplit tab strip applies `mask(combinedMask)` (line 552) to fade tabs at the bar's leading/trailing edges. A stroke would clip oddly under the mask; a fill fades naturally with the tab. The sidebar row is similarly small/rounded — a fill reads as "polite glow" instead of "alert ring."
+
+**Sidebar single-pulse pattern (defined adjacent to `FocusFlashPattern` in `Panel.swift` for discoverability):**
+
+```swift
+enum SidebarFlashPattern {
+    static let values: [Double] = [0, 0.18, 0]
+    static let keyTimes: [Double] = [0, 0.5, 1]
+    static let duration: TimeInterval = 0.6
+    static let curves: [FocusFlashCurve] = [.easeOut, .easeIn]
+    static var segments: [FocusFlashSegment] {
+        let stepCount = min(curves.count, values.count - 1, keyTimes.count - 1)
+        return (0..<stepCount).map { index in
+            let startTime = keyTimes[index]
+            let endTime = keyTimes[index + 1]
+            return FocusFlashSegment(
+                delay: startTime * duration,
+                duration: (endTime - startTime) * duration,
+                targetOpacity: values[index + 1],
+                curve: curves[index]
+            )
+        }
+    }
+}
+```
+
+## 5. Equatability preservation (sidebar `TabItemView`)
+
+The c11 sidebar `TabItemView` is `Equatable` because every `TabManager`/`NotificationStore` publish would otherwise re-evaluate every row's body (~18% of main thread per the in-source comment at line 10902).
+
+**Mechanism — same pattern as the existing `unreadCount`, `latestNotificationText`, `agentChip`, etc.:**
+
+1. `Workspace.sidebarFlashToken` (`@Published`) increments on each fan-out call.
+2. The parent `ForEach` at `ContentView.swift:8425` is already re-evaluated whenever any `tab`'s published state changes (because `tab` is `@ObservedObject`).
+3. The new ForEach iteration constructs `TabItemView(..., sidebarFlashToken: tab.sidebarFlashToken)`.
+4. SwiftUI invokes `==`. The new `lhs.sidebarFlashToken == rhs.sidebarFlashToken` line fails for the targeted row; body runs.
+5. Inside the body, `.onChange(of: sidebarFlashToken)` fires once and runs `runSidebarFlashAnimation`.
+6. **Other** ForEach iterations (other workspaces) get the same `sidebarFlashToken` they had before; `==` still holds; body skipped. Typing-latency invariant preserved.
+
+**Anti-patterns to avoid** (each would silently break the contract):
+- `@ObservedObject` on a separate flash store — every store change touches every row.
+- `@EnvironmentObject` — bypasses the `==` short-circuit.
+- Closures that capture flash state — closures are excluded from `==`.
+
+The `==` update is one line, but call it out in the patch with a comment because the warning at line 10902 is load-bearing.
+
+## 6. Edge cases
+
+1. **Surface in a closed/hidden pane.** `panels[panelId]` is nil ⇒ (a) no-ops. `surfaceIdFromPanelId(panelId)` returns nil ⇒ (b) no-ops. Workspace still exists ⇒ (c) fires. Correct: "you asked for a flash on something gone, but the workspace highlights so you know where it was."
+
+2. **Non-active tab in pane.** This is the load-bearing new affordance. `proxy.scrollTo(flashId, anchor: .center)` brings the tab into view, the tab pulses, **selection does NOT change**. Operator can click to actually switch.
+
+3. **`notificationPaneFlashEnabled` disabled.** Single guard at top of `triggerFocusFlash` — disables all three channels consistently. Keeps the per-panel internal guards for defense-in-depth (harmless redundancy).
+
+4. **Multiple flashes within animation window.** Generation counters at every layer:
+   - Bonsplit `pane.flashTabGeneration` increments → animation in `TabItemView` cleanly restarts via `lastObservedFlashGen` guard.
+   - c11 `sidebarFlashToken` increments → `lastObservedSidebarFlash` guard restarts the row animation cleanly.
+   - Pane content uses existing `focusFlashAnimationGeneration` machinery.
+
+5. **Workspace switch during animation.** Sidebar row lives in `LazyVStack` outside any per-workspace tree — animation continues through switches. Bonsplit tab strip lives inside the workspace view tree; SwiftUI may throttle offscreen work but resumes on return. Not a correctness issue.
+
+6. **Sidebar scroll-into-view for workspace row.** The sidebar's outer `ScrollView` (line 8418) lacks a `ScrollViewReader`. **Out of scope** for this change — adds complexity, sidebar typically shows all workspaces. Leave as documented follow-up.
+
+## 7. Validation plan
+
+Tagged build + relaunch (per `skills/c11-hotload/SKILL.md`):
+
+```bash
+./scripts/reload.sh --tag flash
+```
+
+Manual checks (operator must eyeball — no UI automation can validate a 0.9s opacity pulse):
+
+1. **Keyboard shortcut "Flash Focused Pane".** Verify pane ring flashes (existing), top-bar tab flashes with accent tint, sidebar row gets a faint accent pulse. Selection unchanged.
+2. **Right-click → Trigger Flash** on a terminal surface. Same expected behavior. Verifies the `triggerNotificationFocusFlash` → `triggerFocusFlash` collapse.
+3. **CLI / v2 socket.** `c11 v2 surface.trigger_flash --workspace_ref … --surface_ref …` (or via Python `tests_v2/`). Eyeball the same three flashes. The existing `flash_count` (debug.flash.count) still increments for the pane channel — tests_v2/test_trigger_flash.py should still pass.
+4. **Non-active tab in pane.** Split a pane, two tabs, focus a different pane. Trigger flash via v2 with the non-selected tab's surface_id. Tab strip scrolls inactive tab into view, tab pulses, **selection does NOT change**. (Most important new behavior.)
+5. **Different workspace.** Trigger flash on a surface in a workspace other than the active one. That workspace's sidebar row pulses; active workspace's row does not.
+6. **Setting toggled off.** Settings → Notifications → "Pane Flash" off. Trigger via any path. Nothing visible.
+7. **Rapid repeated triggers.** Fire shortcut 5x fast. Animations restart cleanly without stacking — generation guards do their job.
+
+**No new headless tests.** Per CLAUDE.md "Test quality policy", source-text/assertion-only tests are discouraged. The new channels are visual-only; existing pane-flash regression coverage (`tests_v2/test_trigger_flash.py`) suffices.
+
+## 8. Risks
+
+1. **Typing-latency hot path.** Sidebar `TabItemView`'s `==` is load-bearing (CLAUDE.md). The change adds exactly one `Int` comparison and one `Int` parameter. Validation: type rapidly into a focused terminal while flashing repeatedly; if latency degrades, suspect comparator is mis-coded.
+
+2. **Bonsplit submodule push order.** Per CLAUDE.md "Submodule safety": commit + push the submodule HEAD to `bonsplit/main` BEFORE committing the parent pointer bump. Workflow:
+   1. In `vendor/bonsplit/`: branch, commit, push to `Stage-11-Agentics/bonsplit` `main` (or PR + merge).
+   2. Verify: `cd vendor/bonsplit && git merge-base --is-ancestor HEAD origin/main`.
+   3. In c11 root: `git add vendor/bonsplit && git commit -m "..."`.
+
+3. **Upstream-friendly diff.** Keep Bonsplit changes self-contained (~80 LoC), one public API, no host coupling. Standalone enough to PR to `almonk/bonsplit` later as "Add public `flashTab(_:)` for transient tab attention."
+
+4. **Bonsplit tab strip mask.** `mask(combinedMask)` (line 552) fades tabs at edges. Fill overlay (chosen) fades naturally with the tab. Stroke would clip — confirms §4 choice.
+
+5. **Portal layering.** Tab strip lives above pane content in SwiftUI tree, but pane content is portal-hosted by AppKit. Tab strip overlay does not intersect portal layer (tabs sit above panes, not over them). Verify by triggering a flash while a browser surface occupies most of the workspace.
+
+6. **Dead per-panel guards.** Adding the `NotificationPaneFlashSettings.isEnabled()` early-return at fan-out makes the per-panel `triggerFlash` setting checks redundant. Leave them — defense-in-depth, zero cost.
+
+## 9. Open verification before coding
+
+- [ ] Confirm `NotificationPaneFlashSettings` has an `isEnabled()` static method or expose one (otherwise read `UserDefaults.standard.bool(forKey: NotificationPaneFlashSettings.enabledKey)` in `Workspace`).
+- [ ] Confirm `appearance.activeIndicatorColor` exists in Bonsplit (sample existing usage in `TabItemView.swift` for selected-tab styling).
+- [ ] Confirm sidebar row body has a stable corner-radius / clip shape we can match in the overlay (visually inspect existing `themedSidebarTabColors` background).
+
+## Critical files for implementation
+
+- `Sources/Workspace.swift`
+- `Sources/ContentView.swift`
+- `Sources/Panels/Panel.swift` (for `SidebarFlashPattern` definition)
+- `vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift`
+- `vendor/bonsplit/Sources/Bonsplit/Internal/Models/PaneState.swift`
+- `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift`
+- `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift`

--- a/notes/trident-review-flash-tab-pack-20260428-0035/critical-claude.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/critical-claude.md
@@ -1,0 +1,280 @@
+## Critical Code Review
+- **Date:** 2026-04-27T00:35:00Z
+- **Model:** Claude Opus 4.7 (claude-opus-4-7)
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62d4b47e83ec54427d43d95f633deb38ed
+- **Linear Story:** flash-tab
+- **Review Type:** Critical/Adversarial
+---
+
+## The Ugly Truth
+
+This is, honestly, a small and well-shaped change. The author chose a single fan-out point, used a generation-token pattern that already exists in the codebase, and updated the load-bearing `==` invariant on the sidebar `TabItemView` with a comment that explicitly calls out the contract. Submodule push order is correct (`78d09a44` is an ancestor of `Stage-11-Agentics/bonsplit/main`). The Bonsplit diff is ~113 LoC, single-purpose, host-decoupled, and self-evidently upstreamable to `almonk/bonsplit`.
+
+That's the good news. The bad news is that the design has a **silent behavioral expansion** that nobody flagged in the context document, and the test coverage has a real gap. The expansion: **terminal-notification-routed flashes (Zulip-style "agent finished" notifications) now also drive the sidebar workspace pulse and the Bonsplit tab pulse**, where previously they only flashed the pane ring. That's the documented intent — but it changes the visual character of every notification that lands while you're heads-down in a different workspace, on every workspace, every time. Whether that's "polite ambient nudge" or "now my whole sidebar is twitching when an agent in workspace #14 finishes a build" is a calibration question that should be eyeballed under realistic notification load before this lands. Peak 0.18 opacity is gentle; peak 0.18 opacity firing 30 times per minute across a 12-workspace sidebar may not be.
+
+Two real implementation concerns underneath that:
+
+1. **`surfaceIdFromPanelId` is O(n) over `surfaceIdToPanelId`** (Workspace.swift:5793 — `first { $0.value == panelId }`). Every flash now pays this cost. Fine for small workspaces, but it's silently quadratic-shaped relative to surface count and it's now on the v2 socket hot path for `surface.trigger_flash`. Not a bug, but worth a one-line fix (reverse-lookup dict or pass tabId from the call sites that already have it).
+
+2. **The Bonsplit `flashGeneration` guard `newValue > 0`** breaks correctly on overflow. `&+= 1` wraps Int from `Int.max` to `Int.min`, which is negative. After overflow, the `newValue > 0` guard fails forever and the tab flash silently stops working. Practically unreachable (9 quintillion flashes), but the c11 sidebar uses just `!=` so the wrap is handled there — the inconsistency is the smell, not the unreachability.
+
+The change is **almost ready**, with one design-intent ambiguity to settle (notification fan-out scope) and a couple of cleanups.
+
+## What Will Break
+
+### W1. Notification-volume blast radius is unbounded.
+**File:** `Sources/Workspace.swift:8820-8834` (`triggerNotificationFocusFlash`)
+
+`triggerNotificationFocusFlash` is called by `TabManager.swift:2982, 2995, 3175` and `AppDelegate.swift:2760` — these are **terminal notification routing paths** (an agent finishes, a Zulip ping arrives, a remote daemon emits an event). Previously these only fired the per-pane ring flash. Now they fan out to all three channels including the sidebar workspace row pulse.
+
+When an operator has 8-12 active workspaces with agents working in parallel — the explicit target user in the project's CLAUDE.md ("eight, ten, thirty agents at once") — every notification now produces a sidebar pulse. If 5 agents emit notifications in a 0.6s window, 5 different sidebar rows are pulsing simultaneously. Peak opacity is 0.18 (gentle), but 5 simultaneous gentle pulses across a 12-row sidebar reads differently than one.
+
+The plan document calls this out in §6.5 ("Workspace switch during animation") but only for correctness, not perceived noise. **Whether the sidebar fan-out should be on the `triggerFocusFlash` path or only on the explicit user-action paths (keyboard, right-click, v2 socket) is a calibration question the implementer made unilaterally without surfacing the tradeoff.**
+
+### W2. `surfaceIdFromPanelId` is O(n) per flash.
+**File:** `Sources/Workspace.swift:5793-5795`
+
+```swift
+func surfaceIdFromPanelId(_ panelId: UUID) -> TabID? {
+    surfaceIdToPanelId.first { $0.value == panelId }?.key
+}
+```
+
+This is a linear scan through the dictionary's values. It's now on the flash hot path. With the bonsplit `flashTab` callsites that already have `tabId` in hand, this is unnecessary work. For small workspaces (<10 surfaces) it's nothing. For workspaces with many tabs across panes, every flash pays it. It also means the v2 socket `surface.trigger_flash` does a linear scan on every call (it has the `surfaceId` already and could pass it directly).
+
+Not a blocker. Worth fixing as part of this change rather than letting it accumulate.
+
+### W3. `flashGeneration > 0` guard breaks on Int wrap.
+**File:** `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:236-241`
+
+```swift
+.onChange(of: flashGeneration) { _, newValue in
+    guard newValue > 0, newValue != lastObservedFlashGeneration else { return }
+    ...
+}
+```
+
+After `Int.max` flashes, `pane.flashTabGeneration &+= 1` wraps to `Int.min`. The `newValue > 0` guard then fails forever and the tab flash silently stops working. The c11 sidebar handles this correctly (uses `!=` only).
+
+In practice unreachable. The reason to flag it: the inconsistency between Bonsplit's guard (`newValue > 0`) and c11 sidebar's guard (just `!=`) means a future maintainer copy-pasting one pattern gets a subtly different contract. Pick one. Either drop `> 0` in Bonsplit, or use `!=` everywhere with a separate "skip 0→0" sentinel. The `> 0` was probably defensive against the parent passing 0 to a non-targeted tab, but the parent already guarantees that via `(pane.flashTabId == tab.id) ? pane.flashTabGeneration : 0` — and the resulting 0→0 transition doesn't fire `.onChange` anyway because the value didn't change.
+
+### W4. Overlay covers the active-row leading rail during the pulse.
+**File:** `Sources/ContentView.swift:11494-11520`
+
+The flash overlay sits **after** the leading rail overlay in the modifier chain:
+
+```swift
+.background(
+    RoundedRectangle(...)
+        .fill(backgroundColor)
+        .overlay { strokeBorder }
+        .overlay(alignment: .leading) { Capsule(railColor) }   // active workspace rail
+        .overlay { RoundedRectangle.fill(accent.opacity(...)) } // flash, on top of rail
+)
+```
+
+When the active workspace's row receives a flash, the accent fill briefly tints the leading rail. Peak 0.18 opacity makes this minor, but it's still a layering bug — the rail is the active-state signal, and tinting it during an unrelated flash event muddles the signal. Reorder so the rail overlay sits on top of the flash, or use `.compositingGroup()` and a blend mode that doesn't tint solid fills.
+
+Visual nit, not a blocker.
+
+### W5. Sibling tab body re-evaluates on every flash (Bonsplit).
+**File:** `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift:698`
+
+```swift
+flashGeneration: (pane.flashTabId == tab.id) ? pane.flashTabGeneration : 0,
+```
+
+Every Bonsplit `tabItem(for:at:)` call reads `pane.flashTabId` and `pane.flashTabGeneration` from the `@Observable` `PaneState`. When either changes, the parent `tabItem` ViewBuilder re-evaluates for **every tab in the pane**, not just the targeted one. SwiftUI then reconciles each `TabItemView` and computes a body diff.
+
+`TabItemView` in Bonsplit is **not** Equatable (unlike c11's sidebar `TabItemView`). So sibling tabs do go through body re-evaluation when a flash fires.
+
+For pane tab counts (typically 1-15), this is negligible. But it's also unnecessary — siblings get `flashGeneration: 0` and don't animate. Flagging because:
+- The c11 sidebar version was carefully designed to skip sibling re-eval via `Equatable`. Bonsplit's tab strip version drops that discipline.
+- If any future Bonsplit-tab observable property is added that touches per-tab body, this becomes a real cost.
+
+Acceptable for now; document the tradeoff or add `Equatable` to Bonsplit's `TabItemView`.
+
+### W6. Sidebar `LazyVStack` defers row creation; flashes during scroll are lost.
+**File:** `Sources/ContentView.swift:8424` (LazyVStack)
+
+The sidebar uses `LazyVStack`. Workspaces scrolled out of view aren't materialized as views. If a flash fires for a workspace whose sidebar row hasn't been created yet, `Workspace.sidebarFlashToken` increments, but no `TabItemView.onChange` observer exists. When the user later scrolls that row into view, `@State sidebarFlashOpacity` initializes to 0, `lastObservedSidebarFlashToken` to 0, and the flash never replays.
+
+This is **probably correct behavior** (you don't want a 5-second-old flash to replay when scrolling), but it's worth noting because it means the sidebar pulse is a "best-effort, observable-while-mounted" signal, not a reliable "this workspace had a flash" indicator. Operators who scroll their sidebar regularly may miss flashes entirely. The plan §6.6 notes this for scroll-into-view but doesn't note the lost-flash consequence.
+
+Mitigation: a separate "has unseen flash" sticky indicator, or treating flashes as part of the existing notification-store stack. Out of scope for this PR but worth filing as a follow-up.
+
+### W7. `triggerNotificationFocusFlash` calls `focusPanel` even when flash is gated off.
+**File:** `Sources/Workspace.swift:8820-8834`
+
+```swift
+func triggerNotificationFocusFlash(panelId: UUID, requiresSplit: Bool = false, shouldFocus: Bool = true) {
+    guard terminalPanel(for: panelId) != nil else { return }
+    if shouldFocus {
+        focusPanel(panelId)        // <-- happens even when NotificationPaneFlashSettings is OFF
+    }
+    let isSplit = bonsplitController.allPaneIds.count > 1 || panels.count > 1
+    if requiresSplit && !isSplit { return }
+    triggerFocusFlash(panelId: panelId)  // <-- gated inside
+}
+```
+
+This is **pre-existing behavior** (the prior code also focused before the flash gate inside `terminalPanel.triggerFlash`). I'm flagging it not as a regression but as a documentation gap: the `NotificationPaneFlashSettings.isEnabled()` toggle silences flashes but does NOT silence focus-stealing. An operator who turned the flash OFF expecting "stop yanking focus on notifications" will be surprised. Not introduced by this PR; worth surfacing because the new fan-out makes the flash setting more visible to users who may revisit it.
+
+## What's Missing
+
+### M1. No regression test for the fan-out invariant.
+The implementer explicitly notes "no new headless tests added" per the test quality policy. The pane-content channel is covered by `tests_v2/test_trigger_flash.py` via `flash_count`. Channels (b) and (c) have **no observable counter**.
+
+The CLAUDE.md test policy permits skipping "fake regression tests" but requires tests "through executable paths (unit/integration/e2e/CLI)" when feasible. A small extension is feasible:
+- Expose `Workspace.sidebarFlashToken` and `pane.flashTabGeneration` via a debug socket command (analogous to `debug.flash.count`).
+- `tests_v2/test_trigger_flash.py` asserts both counters increment when `surface.trigger_flash` fires.
+
+This catches regressions like "fan-out point gets refactored and skips channel (b) on Tuesdays" without testing visual envelopes. ~30 lines of test code, real behavioral coverage.
+
+### M2. No test for the `requiresSplit` path through the fan-out.
+`triggerNotificationFocusFlash` bails before `triggerFocusFlash` when `requiresSplit && !isSplit`. The fan-out should NOT fire in that case. The existing test covers the "split exists" path. Add one assertion for the "no split, requiresSplit=true" path that confirms no channel fires.
+
+### M3. No test for the non-terminal panel guard.
+Browser/Markdown panel notification flashes still bail at `terminalPanel(for: panelId) != nil`. The implementer's risk #4 says this is preserved. Worth a 5-line test: open a browser surface, fire `triggerNotificationFocusFlash`, assert no flash on any channel.
+
+### M4. No verification that `NotificationPaneFlashSettings.isEnabled() == false` silences ALL three channels.
+Trivially testable via the same socket counters proposed in M1 plus a `defaults write notificationPaneFlashEnabled false` step. The implementer relies on visual confirmation; this is exactly the kind of "did the gate move correctly" regression that an automated test catches and a smoke test misses.
+
+### M5. The CLAUDE.md "Socket command threading policy" check.
+The new code at `Workspace.swift:8811-8818` runs on `@MainActor`. Good. But `triggerFocusFlash` is now called from socket telemetry paths via `triggerNotificationFocusFlash`. The CLAUDE.md policy says "Schedule minimal UI/model mutation with `DispatchQueue.main.async` only when needed" for telemetry hot paths. The fan-out runs three UI mutations synchronously on main. For a single notification this is fine. Under burst load (e.g., 20 notifications in 100ms from a chatty agent), this could cause main-thread stalls during typing.
+
+Not a blocker — the existing pane flash already had this shape — but add a comment that the fan-out is intentionally synchronous on main, or coalesce bursts at the fan-out (already done implicitly via the generation guard in animation, but the AppKit/SwiftUI mutation of `panels[panelId]?.triggerFlash()` and `bonsplitController.flashTab(tabId)` still happens once per notification).
+
+### M6. Plan §9 verification checklist was filed but the plan doesn't say all three items were verified.
+The plan's "Open verification before coding" checklist lists three boxes that are not checked off in the context document:
+- [ ] `NotificationPaneFlashSettings.isEnabled()` confirmed
+- [ ] `appearance.activeIndicatorColor` confirmed
+- [ ] sidebar row corner-radius confirmed
+
+The code shows all three were resolved correctly in the implementation (`isEnabled()` is real at `TerminalNotificationStore.swift:539`; the Bonsplit code uses `TabBarColors.activeIndicator(for:)`; sidebar uses `cornerRadius: 6` matching the row background). But the plan's checklist is now misleading documentation. Tick the boxes or remove the section before merging.
+
+## The Nits
+
+### N1. `runSidebarFlashAnimation(token:)` reset is theatrical.
+**File:** `Sources/ContentView.swift:11604-11606`
+
+```swift
+private func runSidebarFlashAnimation(token: Int) {
+    sidebarFlashOpacity = SidebarFlashPattern.values.first ?? 0
+    ...
+}
+```
+
+`SidebarFlashPattern.values.first` is `0`. Setting `sidebarFlashOpacity` to 0 synchronously before scheduling the easeOut-to-0.18 segment is a no-op visually (the next animation closure overrides it within one runloop). The same pattern exists in Bonsplit's `runFlashAnimation` and in `MarkdownPanelView.triggerFocusFlashAnimation`. Documented as defensive against mid-flight prior animations, which is correct, but the `?? 0` fallback on a constant array is unreachable. Either drop the `??`, or hardcode `sidebarFlashOpacity = 0` and ditch the lookup.
+
+### N2. `triggerNotificationFocusFlash` discards `terminalPanel` reference.
+**File:** `Sources/Workspace.swift:8825`
+
+```swift
+guard terminalPanel(for: panelId) != nil else { return }
+```
+
+Was previously `guard let terminalPanel = ...`. The binding is dropped because the new flow goes through `triggerFocusFlash(panelId:)` which re-resolves via `panels[panelId]`. So `terminalPanel(for:)` is now called once just to check existence, and `panels[panelId]` is called again inside `triggerFocusFlash`. Two lookups where one would do. Trivial.
+
+### N3. Documentation comment at `Workspace.swift:8803-8810` is excellent.
+Good prose, names the three channels clearly, names the gate. Keep this style for future fan-outs.
+
+### N4. The plan's `flashTabId == tab.id` per-tab gate is conceptually clean but allocates a new `flashGeneration: Int` argument on every tab parameter list re-eval.
+**File:** `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift:698`
+
+`Int` is a value type so this is not a heap allocation, just a stack arg. Negligible. Flagging because the plan §3 step 4 says "default 0" but the actual code requires it as a positional argument. Make the default explicit (`let flashGeneration: Int = 0`) so the public-ish struct (`internal struct TabItemView`) can be initialized without it for any call site that doesn't care. Defensive, costs nothing.
+
+### N5. `&+=` on `sidebarFlashToken` is fine, but `private(set)` is good — make the same field on PaneState similarly access-controlled.
+**File:** `vendor/bonsplit/Sources/Bonsplit/Internal/Models/PaneState.swift:11-15`
+
+```swift
+var flashTabId: UUID?
+var flashTabGeneration: Int = 0
+```
+
+These are `internal` (the default for a class-internal property in a `final class` with no access modifier). The only writer is `BonsplitController.flashTab(_:)`. Since `PaneState` is `internal` to the Bonsplit module, this is effectively module-internal. Fine. Consider `private(set) var flashTabId: UUID?` and an internal setter helper to make the contract explicit in case future Bonsplit code is tempted to write directly. Minor.
+
+### N6. Minor inconsistency in the SidebarFlashPattern.curves type.
+**File:** `Sources/Panels/Panel.swift:72`
+
+c11's `SidebarFlashPattern` uses `[FocusFlashCurve]` (the c11-side enum). Bonsplit's `TabFlashPattern` uses its own internal `Curve` enum because Bonsplit is decoupled. Two enums for the same two cases (`easeIn`, `easeOut`) is the cost of the upstream-friendly seam and acceptable. Worth a short comment on either side acknowledging the duplication is intentional.
+
+## Numbered List
+
+### Blockers
+*(None.)*
+
+### Important
+
+1. **W1 — Notification fan-out scope is unilateral and possibly miscalibrated.** [Sources/Workspace.swift:8820-8834] Confirm with the operator whether terminal-notification-routed flashes (Zulip pings, agent-completion, remote daemon events) should drive the sidebar workspace pulse. Today's behavior is a unilateral expansion with a "polite peak 0.18" assumption that hasn't been validated under realistic notification load on a 8-12 workspace sidebar. Either (a) accept the expansion explicitly with a calibration note, or (b) bypass channel (c) for `triggerNotificationFocusFlash` calls (only fire on explicit-user-action paths). If you ship as-is, plan a follow-up to gather operator feedback after a week.
+
+2. **M1 — Add a debug socket counter for channels (b) and (c) and extend `tests_v2/test_trigger_flash.py`.** ~30 lines of code. Catches the most likely regression mode: "future refactor accidentally breaks one of the two new channels and nobody notices because the visual is hard to eyeball." This is exactly the case the test quality policy permits ("verify the runtime behavior that depends on that metadata, not the checked-in source file").
+
+### Potential
+
+3. **W2 — `surfaceIdFromPanelId` is O(n).** [Sources/Workspace.swift:5793] Either add a reverse-lookup dict alongside `surfaceIdToPanelId`, or pass `tabId` directly from call sites that have it (the v2 socket `surface.trigger_flash` already has `surfaceId` in scope at TerminalController.swift:6967).
+
+4. **W3 — Bonsplit guard `newValue > 0` is inconsistent with c11 sidebar's `!=` and breaks on Int wrap.** [vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:237] Drop the `> 0`; the parent's `(pane.flashTabId == tab.id) ? gen : 0` already guarantees the targeted-tab semantic, and `.onChange` doesn't fire on 0→0.
+
+5. **W4 — Sidebar flash overlay sits on top of the active-row leading rail.** [Sources/ContentView.swift:11494-11520] Reorder overlays so the rail stays on top of the flash, or accept the brief tint at peak 0.18 as a non-issue.
+
+6. **W5 — Bonsplit `TabItemView` is not Equatable; siblings re-evaluate body on every flash.** [vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift] Add `Equatable` conformance using the existing prop list, mirroring c11 sidebar. Or document the tradeoff.
+
+7. **W6 — Lazy-mounted sidebar rows lose flashes that fire while scrolled out of view.** [Sources/ContentView.swift:8424 LazyVStack + TabItemView] File a follow-up for a "has unseen flash" sticky indicator. Current behavior is acceptable but should be intentional, not accidental.
+
+8. **W7 — `NotificationPaneFlashSettings` toggle disables flash but not focus-stealing.** [Sources/Workspace.swift:8820-8828] Pre-existing; worth a docstring update on the setting describing its actual scope.
+
+9. **M2-M3 — Add tests for `requiresSplit && !isSplit` and non-terminal-panel notification paths.** Both bail early before the fan-out; both regressions are silent without a counter.
+
+10. **M5 — Document the synchronous-on-main fan-out at the comment block.** Add one sentence: "Three channels mutate UI state synchronously on `@MainActor`. If notification burst rates climb, consider coalescing here."
+
+11. **M6 — Tick or remove plan §9 "Open verification before coding" checklist.** Currently misleading documentation.
+
+12. **N1 — Drop the `?? 0` fallback on a known-non-empty constant array.** Cosmetic.
+
+13. **N4 — Make `flashGeneration: Int = 0` a default arg in Bonsplit's `TabItemView`.** Defensive.
+
+## Phase 5: Validation Pass
+
+- ✅ **W1 confirmed.** Verified `triggerNotificationFocusFlash` (Workspace.swift:8820) now delegates to `triggerFocusFlash` which fans out to all three channels. Verified callsites in `TabManager.swift:2982, 2995, 3175` and `AppDelegate.swift:2760` are notification-routing paths. The expansion is real and unflagged in the context document.
+
+- ✅ **W2 confirmed.** Read `surfaceIdFromPanelId` at `Workspace.swift:5793-5795`: `surfaceIdToPanelId.first { $0.value == panelId }?.key`. Linear scan. Now on the flash hot path.
+
+- ✅ **W3 confirmed.** Read `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:236-241`. The `newValue > 0` guard combined with `&+= 1` overflow gives the silent-stop behavior described. Sidebar `ContentView.swift:11521-11525` uses `!=` only — confirmed inconsistency.
+
+- ❓ **W4 likely.** Read modifier chain at `ContentView.swift:11494-11520`. The overlay ordering is as described, but SwiftUI `.overlay` rendering order may interact with `compositingGroup`s I didn't trace. Needs visual eyeball under flash on the active workspace row.
+
+- ✅ **W5 confirmed.** Bonsplit `TabItemView` (vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:50+) is `struct TabItemView: View` — no `Equatable` conformance. Confirmed by reading the struct declaration and the parent `tabItem(for:at:)` call at `TabBarView.swift:698`.
+
+- ✅ **W6 confirmed.** Read `LazyVStack` declaration at `ContentView.swift:8424`. SwiftUI semantics for LazyVStack defer creation. `@State` on `lastObservedSidebarFlashToken: Int = 0` initializes to 0 on first mount, and `.onChange` does not retroactively fire for changes that occurred pre-mount.
+
+- ✅ **W7 confirmed.** Verified `triggerNotificationFocusFlash` calls `focusPanel(panelId)` at `Workspace.swift:8827` before the gate check. Pre-existing. Documented gap.
+
+- ✅ **M1-M3 confirmed.** Searched for `flash_count` in `tests_v2/`; only the existing pane-channel counter exists. No counter for sidebar or tab.
+
+- ⬇️ **M4 lower priority than initial** — given test quality policy, this is mostly covered by M1's broader proposal.
+
+- ✅ **M5 confirmed.** `Workspace` is `@MainActor` (Workspace.swift:5071). The fan-out runs three sync ui-mutating calls on main per flash. Pre-existing pattern for the pane channel.
+
+- ✅ **M6 confirmed.** Plan §9 has three unchecked boxes; code shows all three were resolved correctly.
+
+- ✅ **N1 confirmed.** `SidebarFlashPattern.values.first ?? 0` and `TabFlashPattern.values.first ?? 0` — both arrays start with literal `0`. The `??` is dead.
+
+- ✅ **N4 confirmed.** Bonsplit `TabItemView.flashGeneration` (line 95-ish) has no default value.
+
+## Closing
+
+**Would I mass-deploy this to 100k users? Yes — with the W1 calibration question explicitly resolved by the operator first, and with M1 (the ~30-line socket-counter test extension) added.**
+
+The change is small, well-scoped, and reuses established patterns. The load-bearing typing-latency invariant on the sidebar `TabItemView` is preserved correctly (one `Int` parameter, one `Int` comparison, comment updated). The submodule push order is correct. Build was verified by the implementer. The Bonsplit changes are genuinely upstream-friendly (one public method, no host coupling, ~113 LoC).
+
+What stops it from being a no-brainer:
+
+1. **The notification-routed fan-out (W1) is a unilateral product decision.** Whether sidebar pulses on every Zulip ping is "polite ambient nudge" or "twitchy" depends on operator workflow, and the implementer didn't flag it as a tradeoff. Get a five-second eyeball under realistic notification volume before merging.
+
+2. **No automated coverage for two of three channels (M1).** The test policy permits the gap, but the gap exists. A small socket-counter extension closes it cheaply and pays for itself the first time someone refactors the fan-out.
+
+3. **The smaller items (W2-W7, N1-N6)** are cleanups and consistency fixes. None block. All would improve the code if rolled into this PR rather than left for "someday."
+
+**Net:** ship after W1 is acknowledged and M1 is added. The other items can land here or as follow-ups depending on the operator's appetite for scope.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/critical-codex.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/critical-codex.md
@@ -1,0 +1,50 @@
+## Critical Code Review
+- **Date:** 2026-04-28T04:40:53Z
+- **Model:** GPT-5 Codex (MODEL=ucodex)
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62d4b4
+- **Linear Story:** flash-tab
+- **Review Type:** Critical/Adversarial
+---
+
+## The Ugly Truth
+
+This is a small, coherent visual fan-out change. The core implementation is not fragile: it reuses the existing flash entry point, preserves the terminal-only notification guard, keeps the Bonsplit API generic, and threads one integer through the sidebar's load-bearing `Equatable` row path.
+
+The weakest part is not the animation machinery. It is the product contract around the setting and validation. The user-facing "Pane Flash" copy still describes only a blue outline, while the implementation now gates the pane ring, Bonsplit tab pulse, and sidebar row pulse together. That is exactly how confusing settings regressions ship.
+
+Branch sync was not performed because the requested prompt explicitly made this a read-only review and prohibited actions beyond writing this file. I reviewed local `HEAD` against local `origin/main`. I did not run local tests because this repo's instructions say tests run in CI or VM, not locally.
+
+## What Will Break
+
+1. When a user disables "Pane Flash" in Settings, they are disabling all three flash channels, but the UI still says only "Briefly flash a blue outline when c11 highlights a pane." The implementation at `Sources/Workspace.swift:8811-8817` now gates the Bonsplit tab strip pulse and sidebar workspace pulse too. The copy at `Sources/c11App.swift:5683-5684` is stale and will mislead users.
+
+2. If a future internal caller invokes `Workspace.triggerFocusFlash(panelId:)` with a stale or invalid panel id, the workspace sidebar still pulses because `sidebarFlashToken &+= 1` is unconditional at `Sources/Workspace.swift:8817`. Current socket and focused-panel callers validate before entry, so this is not a present production bug, but the fan-out API itself is not defensive.
+
+## What's Missing
+
+The new visual channels are not covered by a runtime or artifact-level assertion. I agree that source-grep tests would be fake coverage, but the current branch depends on manual/CI confidence for the Bonsplit pulse and sidebar pulse. The existing `tests_v2/test_trigger_flash.py` only proves the terminal pane channel increments its flash count.
+
+The settings copy and translations are missing from the change. The behavior changed, so the user-facing description should change with it, followed by the normal localization pass.
+
+## The Nits
+
+`Sources/Workspace.swift:8803-8810` documents the fan-out well, but `triggerFocusFlash(panelId:)` should either early-return when `panels[panelId] == nil` or explicitly document that a workspace-level flash is allowed without a panel flash. Today the implementation says "panel flash" but can produce only a sidebar pulse if miscalled.
+
+## Blockers
+
+None found.
+
+## Important
+
+1. ✅ Confirmed — `Sources/c11App.swift:5683-5684` still describes the setting as a blue outline only, while `Sources/Workspace.swift:8811-8817` now uses that same setting to silence all three channels. Update the English default copy and run the localization sync. This will not crash, but it is a real settings-contract bug.
+
+## Potential
+
+1. ✅ Confirmed — `Sources/Workspace.swift:8811-8817` pulses the sidebar even when `panelId` is invalid. Existing reviewed callers validate first (`Sources/TerminalController.swift:6954-6967`, `Sources/TabManager.swift:3856-3860`, and the context-menu path passes an existing panel), so this is lower priority. A guard on `panels[panelId]` would make the fan-out safer.
+
+2. ❓ Likely but hard to verify here — the new Bonsplit and sidebar channels are visual-only and not covered by an automated behavioral assertion. CI can catch compilation failures, but it will not catch a regression where the pulse does not appear, scroll-to-center silently stops working, or the setting copy drifts again.
+
+## Closing
+
+I would not block this code on the animation implementation. I would fix the settings copy before broad release because the branch changed what the toggle means. After that and CI, this is reasonable to ship; the remaining risk is visual regression coverage, not a structural defect in the fan-out path.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/critical-gemini.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/critical-gemini.md
@@ -1,0 +1,38 @@
+## Critical Code Review
+- **Date:** 2026-04-28T04:44:24Z
+- **Model:** ugemini
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62
+- **Linear Story:** flash-tab
+- **Review Type:** Critical/Adversarial
+---
+
+**The Ugly Truth**: You attempted an elegant three-channel synchronized flash, but channel (c) is completely dead in the water. You tried to thread a `let` parameter to bypass SwiftUI's rendering hot-paths, but forgot that the child view also directly `@ObservedObject var tab: Workspace`. This leads to a classic SwiftUI state desync where the child view re-evaluates but with stale `let` values, causing the animation trigger to silently fail. Furthermore, you deviated from your own plan and slapped a square `Rectangle` over a rounded Bonsplit tab, which is going to look terrible.
+
+**What Will Break**:
+- **Channel (c) (Sidebar Flash) is Dead**: The `sidebarFlashToken` parameter will never update its internal `let` value because the parent `VerticalTabsSidebar` doesn't observe the `Workspace`. `TabItemView` will re-render from the `objectWillChange` emission, but `.onChange` will see the stale `let` value.
+- **Tab Flash Overflow**: The generation token uses `&+=` which wraps to a negative value at `Int.max`. `guard newValue > 0` will permanently fail, bricking the tab flash for the rest of the session.
+- **Tab Flash Visual Glitch**: The Bonsplit tab background uses rounded corners. The new overlay uses `Rectangle()`, meaning sharp square corners will visibly bleed over the rounded tab geometry.
+
+**What's Missing**:
+- The `SidebarFlashPattern` and `TabFlashPattern` compute their segments array on every access because `static var segments` is a computed property, not a `static let`. This does unnecessary array mapping on the main thread during an animation frame.
+- A functional unit test for the sidebar flash logic. Because you are orchestrating state through a complex `Equatable` SwiftUI view, it is highly brittle and warrants a basic test to prove the `.onChange` trigger actually fires.
+
+**The Nits**:
+- `lastObservedSidebarFlashToken` isn't strictly necessary if you just use a `.onReceive(tab.$sidebarFlashToken)` modifier that triggers on emission directly instead of manually threading variables.
+
+1. **Blocker** — `TabItemView` in c11 sidebar will never trigger its flash animation. The threaded `let sidebarFlashToken` never updates when `Workspace` emits a change because the parent view (`VerticalTabsSidebar`) does not observe `Workspace` and does not re-evaluate to pass the new value. (Sources/ContentView.swift:10906)
+2. **Important** — `TabItemView` in Bonsplit uses a square `Rectangle()` for its flash overlay, which will bleed over the rounded corners of `tabBackground`. It must use `RoundedRectangle(cornerRadius: tabCornerRadius)` as originally detailed in the plan. (vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:229)
+3. **Important** — `newValue > 0` guard in Bonsplit `TabItemView` will permanently break tab flashes once `flashTabGeneration` overflows (`&+= 1`) into negative numbers. (vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:237)
+4. **Potential** — `segments` in both `SidebarFlashPattern` and `TabFlashPattern` are computed properties (`static var`). Change to `static let` so you don't re-allocate and map arrays on the main thread during hot path renders. (Sources/Panels/Panel.swift:75)
+
+## Validation Pass
+
+- ✅ Confirmed — **Blocker 1**: I explicitly wrote a SwiftUI test script mimicking your exact `ObservableObject` and `Equatable` structure. The parent view does not re-evaluate, so the child retains the stale `let` value. `onChange` never fires.
+- ✅ Confirmed — **Important 2**: Verified in the codebase that `tabBackground` has rounded geometry and `Rectangle()` will produce sharp edges that don't respect the mask.
+- ✅ Confirmed — **Important 3**: Standard Swift `Int` overflow behavior with `&+=` leads to negative `Int.min`.
+- ✅ Confirmed — **Potential 4**: Swift `static var` is evaluated every time unless marked `lazy` or converted to `let`.
+
+## Closing
+
+This code is absolutely **NOT** ready for production. While the Bonsplit integration (channel b) works well, the c11 Sidebar integration (channel c) is completely broken and requires a fundamental fix to how the `sidebarFlashToken` is observed. You also need to fix the visual glitch with the square `Rectangle` overlay in Bonsplit and address the integer overflow bug before this ships to users.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/evolutionary-claude.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/evolutionary-claude.md
@@ -1,0 +1,127 @@
+## Evolutionary Code Review
+- **Date:** 2026-04-28T00:35:00Z
+- **Model:** Claude (claude-opus-4-7)
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62
+- **Linear Story:** flash-tab (Stage 11; no AUT-### id)
+- **Review Type:** Evolutionary/Exploratory
+---
+
+### What's Really Being Built
+
+Read narrowly, this PR adds two visual ornaments next to an existing pane flash. Read at the right altitude, it does something more interesting: it elevates *flash* from "ring around one pane" to **a workspace-scope locator event** that fans out across every layer where the operator might be looking — pane content, tab strip, sidebar workspace row.
+
+What is actually being birthed here, even if nobody has named it yet:
+
+- **A spatial routing primitive for "look here" signals.** The fan-out at `Workspace.triggerFocusFlash(panelId:)` (Sources/Workspace.swift:8811) is the first place in c11 where a single id is exploded into "draw the operator's eye to the pane *and* the tab *and* the workspace row, simultaneously, without changing focus." That's not a flash feature. That's the **attention bus** — a non-intrusive, non-selecting way for the system (and, soon, agents) to point at a surface.
+- **A discipline split between "alert" and "ambient."** The three channels deliberately differ in peak opacity (1.0 / 0.55 / 0.18) and pulse count (2 / 2 / 1). That's not animation aesthetics — that's an emerging *intensity vocabulary* keyed to spatial distance from the operator's gaze. The further from where the operator is currently looking, the gentler the signal. This is exactly the right gradient. It just hasn't been formalized as a vocabulary yet.
+- **Bonsplit's first agent-aware affordance.** `flashTab(_:)` (vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift:301) is, in the abstract, "an external caller can ask a tab strip to draw attention to a non-selected tab without selecting it." That's a generic primitive any consumer wants, but it's especially load-bearing for the operator:agent pair, where agents need to point at things they *aren't* the operator's current focus.
+- **A separation of "where focus is" from "where attention is."** Until now those collapsed: focus changes meant a flash on the now-focused pane. The notification gateway still calls `focusPanel` then flashes. But `triggerFocusFlash` itself is now a *pure attention* event — the v2 socket path uses it without any focus mutation. That separation is small in lines of code and large in implications. (See "Mutations" below — agents calling attention without stealing focus is a design space that just opened.)
+
+The capability statement: **c11 now has a one-call API for "draw the operator's eye to surface X across every layer of the workspace UI, without disturbing what they're doing."** This is the seed of an attention/notification bus.
+
+### Emerging Patterns
+
+**Patterns to formalize:**
+
+1. **Generation-token + `.onChange` + per-row `==` skip.** This pattern appears three times now: pane content (`focusFlashAnimationGeneration` in MarkdownPanelView/BrowserPanelView), Bonsplit tab (`pane.flashTabGeneration` + per-tab gating to 0), sidebar row (`Workspace.sidebarFlashToken` threaded as `let`). The shape is identical: a published Int monotonically increments at fan-out → a precomputed `let` on the view → `.onChange` fires → a `lastObservedX` field guards re-runs and stale segments. This is c11's idiomatic "fire-and-forget transient signal under typing-latency-sensitive equatability." It deserves a name and probably a tiny helper.
+2. **Fan-out at the workspace boundary, not at the call site.** The four trigger paths (keyboard, right-click, v2 socket, notification routing) all converge at `triggerFocusFlash`. The notification routing now also routes *through* `triggerFocusFlash` rather than duplicating the per-channel work. This is good architectural hygiene — the workspace owns the canonical fan-out, callers express intent only.
+3. **Visual-only contracts.** Both new channels make "no selection mutation" an explicit contract documented at the public seam (`flashTab(_:)`'s docstring, `triggerFocusFlash`'s docstring, the `sidebarFlashToken` doc). This is a pattern worth keeping pressure on — every animation channel that "looks like it might select" is a future bug.
+4. **Mirrored-by-construction envelope across module boundaries.** `TabFlashPattern` in Bonsplit reproduces the host's `FocusFlashPattern` shape numerically rather than depending on it. This is the right call for upstream-friendliness, but it means the "match by construction" promise is policed only by code review. A small mismatch (curve, duration) would silently drift the visuals.
+
+**Anti-patterns to catch early:**
+
+1. **Three subtly different segment runners.** `runSidebarFlashAnimation` in ContentView.swift:11604, `runFlashAnimation` in Bonsplit's TabItemView, and the existing focus-flash animation methods in MarkdownPanelView/BrowserPanelView all have the same shape: reset to envelope[0], iterate `segments`, `DispatchQueue.main.asyncAfter` per segment, guard on generation, `withAnimation`. There are now three places where one timing bug needs to be fixed three times. Worth a single helper (Sources/Panels/Panel.swift would host it cleanly next to the patterns).
+2. **`SidebarFlashPattern` and `FocusFlashPattern` share segment-building boilerplate.** Both enums recompute `segments` from `values`/`keyTimes`/`curves`/`duration`. A factory `FlashEnvelope.from(values:keyTimes:duration:curves:)` removes ~12 lines per envelope and centralizes the off-by-one in `min(curves.count, values.count - 1, keyTimes.count - 1)` (which is fine but copied verbatim).
+3. **Fan-out gate at the workspace, not at the channel.** The "Pane Flash" toggle (NotificationPaneFlashSettings.isEnabled) now silences *all three* channels. That's clean today, but as the channels diversify in semantic role (alert / locate / agent-said-something), the operator will eventually want per-channel toggles. The current gate makes that a future schema-breaking change to settings unless the gate moves slightly. Not urgent — but worth noting now while the channel count is small.
+4. **Spelling drift between `lastObservedFlashGeneration` (Bonsplit) and `lastObservedSidebarFlashToken` (c11).** Token vs generation, and the surface-level fact that one calls itself a token and the other a generation. Trivial, but if you formalize this pattern it should pick one word.
+
+### How This Could Evolve
+
+Not polish — directions that change what c11 can be:
+
+1. **Attention bus as an addressable primitive.** Today the only fan-out is "flash everywhere." Tomorrow's API:
+   ```swift
+   workspace.draw(attentionTo: panelId, intensity: .ambient | .normal | .urgent, layers: [.pane, .tab, .sidebar])
+   ```
+   With three intensity tiers and explicit layer choice, you cover: "agent finished a quiet task" (ambient, sidebar only), "build failed" (urgent, all three), "agent has a question" (normal, pane + tab). The infrastructure is already 80% there — three pulse envelopes calibrated for distance, three layers wired up. What's missing is the named API.
+2. **Attention as a first-class agent capability over the v2 socket.** `surface.trigger_flash` becomes one call in a family: `surface.draw_attention {intensity, layers}`. Agents already call this in the existing pane flash. Once the API is named, every Lattice review agent, every long-running build agent, every autonomous loop gets a polite way to say "I changed something here, don't yell, just put a glow on it." This is the operator-loving move.
+3. **Layered telemetry that survives workspace switching.** The sidebar pulse already works on a workspace the operator isn't viewing. The next obvious step: make the sidebar row *carry residue* — a faint gradient or count badge that decays over a few seconds — so the operator who walks back from a coffee break can see *which workspaces flashed while they were away*. This is the Lattice-board-on-the-side-of-the-app-itself move. The `sidebarFlashToken` is already a monotonic counter; it needs a paired "last flashed at" timestamp and a passive decay overlay.
+4. **Mute & route per workspace.** The fan-out is symmetric across workspaces, but workspaces have different urgency profiles (production-monitor workspace versus scratch workspace). A workspace-level "notification policy" that maps incoming flashes to {silenced, ambient-only, full} is a small extension to the gate at line 8812. Now operators can have 30 agents running and only see attention from the four workspaces they care about today.
+5. **Bonsplit upstreams `flashTab` and gets a `flashPane` sibling.** The same primitive at the *pane* level (flash the whole pane container, not the active tab) is the natural complement. With both, `BonsplitController` can express "draw the operator's eye to this surface" generically without needing the host to fan out on its own.
+6. **Attention dispatch from terminal escape sequences.** Terminal apps already write OSC sequences for titles, hyperlinks, etc. A c11-specific OSC for "request attention on this surface" lets *programs running inside terminals* (not just c11 socket clients) point at themselves — `make` finishing, `pytest` printing first failure, `claude --dangerously-skip-permissions` finishing a turn. The handler is one-line: parse sequence → call `triggerFocusFlash`.
+7. **Audit log of attention events.** Sidebar-status/log already exists for workspace telemetry. A debug-mode attention log (timestamps + source-of-flash + which channels fired) would make this whole subsystem observable for free, and is likely 15 lines.
+
+### Mutations and Wild Ideas
+
+- **The "attention storm" mode.** When ten agents all finish in 30 seconds, ten flashes fire across ten sidebar rows. This is information-rich. Lean into it — coalesce into a brief sidebar-wide "shimmer" pattern that signals "lots happened, look at the dashboard." The token machinery is already there; the missing piece is a sidebar-level subscriber that watches every workspace's `sidebarFlashToken` and cross-correlates.
+- **Attention as a recordable channel.** Every `triggerFocusFlash` call is a "the system thinks the operator should look here" event. Persist these (with surface id, timestamp, source) and you have a *gaze record* — a derivable answer to "what was the system trying to tell me in the last hour?" This is highly composable with Lattice, with sidebar status, with retro AARs.
+- **Attention shaping via agent voice.** Different agents could request flash with different *temperaments* — Gregorovitch's flashes might be slow and gold-tinted; a build watcher's might be sharp and red. Replace the single `cmuxAccentColor()` with a `flash.color` parameter at the API level, and now agent identity *visually* registers in the sidebar.
+- **"Attention hover" — the inverse signal.** When the operator's mouse hovers over a sidebar row, briefly pulse the *corresponding tab in that workspace's tab strip* (if mounted). Bidirectional cross-layer pointing. Same primitive (flashTab), opposite direction. Trivial implementation, possibly transformative for navigability.
+- **The "show me what you mean" debug shortcut.** Cmd-Shift-? + click any agent's status line in the sidebar → flashes the surface that wrote it. Re-uses the existing fan-out; closes the loop between sidebar telemetry and the surface that produced it.
+- **Sidebar-only flashes for "remote teammates."** When other operators in the same Lattice plan touch a surface, fire a sidebar-only ambient pulse on workspaces tied to that plan. The fan-out's three-channel structure is *already* shaped for "polite ambient signal" — you just connect the wire from Lattice events into `sidebarFlashToken`.
+
+### Leverage Points
+
+Where small changes create disproportionate value:
+
+1. **Extract a `FlashEnvelope` factory** (Sources/Panels/Panel.swift). Removes duplication, makes adding a fourth or fifth pulse pattern (urgent/agent-voice/storm) a 5-line affair.
+2. **Extract `runFlashAnimation(envelope:generation:onUpdate:)`** as a `@MainActor` free function. Used by sidebar TabItemView, MarkdownPanelView, BrowserPanelView, and Bonsplit's TabItemView (with one-line wrapper for the latter to keep Bonsplit module-local). Single source of truth for the "reset → asyncAfter loop → guard → withAnimation" choreography.
+3. **Name the attention bus.** A `Workspace.drawAttention(panelId:intensity:layers:)` API with `triggerFocusFlash` as the `.normal` / `[.pane, .tab, .sidebar]` case. Costs ~20 lines, opens the per-channel-toggle and per-intensity vocabulary doors immediately.
+4. **Add `lastFlashedAt: Date?` to Workspace alongside `sidebarFlashToken`.** Enables decay overlays, "what flashed while I was away?", attention audit log, and per-workspace mute logic — all for one extra published property.
+5. **Surface-level CLI command `c11 attention <surface>`** (alias of `surface.trigger_flash`, with `--intensity` / `--layers` flags later). Makes the primitive immediately accessible to scripts and the skill, which is where it spreads to every agent in the field.
+
+### The Flywheel
+
+**Existing self-reinforcement (already spinning):**
+
+Single fan-out at `triggerFocusFlash` means every new trigger path (keyboard, right-click, v2 socket, notification, future agents) automatically gets all three channels for free. Each new caller makes the channels more valuable; each new channel makes existing callers more valuable. Today's commit just put the third spoke on this wheel.
+
+**Engineerable next loop:**
+
+Once the attention bus is named (`drawAttention(panelId:intensity:layers:)`), the loop becomes:
+
+1. Skill teaches agents to call `c11 attention <surface> --intensity ambient` when they finish quiet work.
+2. Operators observe ambient flashes are useful → keep them on.
+3. Agents see the operator notice and act → calibrate their attention requests.
+4. New agent classes (build watchers, Lattice review bots, OSC-from-terminal) plug into the same primitive.
+5. The attention log becomes a retro-AAR signal: "where did the system point me, did I respond, was it right?"
+6. Calibration data improves agent attention behavior → more useful flashes → more operator trust → more delegated work.
+
+Each turn of the loop adds calibration data and reduces the cost of the next agent's attention request. This is the real prize — not a prettier flash, but an *attention substrate* for the operator:agent pair.
+
+### Concrete Suggestions
+
+#### High Value
+
+1. **Extract `runFlashAnimation` helper.** Three call sites converge on the same `reset → asyncAfter loop → generation guard → withAnimation` shape. A `@MainActor` helper in `Sources/Panels/Panel.swift` (next to `FocusFlashPattern` / `SidebarFlashPattern`) takes `(envelope: FlashEnvelopeProtocol, generation: Int, isCurrent: () -> Bool, apply: (Double) -> Void)` and centralizes the loop. Bonsplit keeps its own copy (module isolation), but c11's two callers (`MarkdownPanelView.triggerFocusFlashAnimation` plus the new `runSidebarFlashAnimation` at ContentView.swift:11604) collapse to one. ✅ Confirmed — verified the loop shapes are identical and the existing focus-flash animation methods in MarkdownPanelView/BrowserPanelView already use this exact pattern.
+
+2. **Name the attention bus.** Rename / wrap `triggerFocusFlash(panelId:)` as `drawAttention(panelId:intensity:layers:)` with the current call as the default. Why now: the API will accumulate callers and rename cost grows fast. Doing it before agents start scripting against `surface.trigger_flash` (which has only just shipped) is cheap. The v2 socket can keep the `surface.trigger_flash` command name for compat and just route through `drawAttention(.normal, [.pane, .tab, .sidebar])`. ❓ Needs exploration — touches the v2 socket protocol, which may have its own naming policy; worth one round of dialogue with the operator on whether `attention` is the right word vs `flash` / `point`.
+
+3. **Add `lastFlashedAt: Date?` next to `sidebarFlashToken`.** Single field on `Workspace`. Unlocks: (i) sidebar decay overlay, (ii) "what changed while I was away," (iii) per-workspace mute by recency, (iv) attention audit log. The cost is one published property + one assignment in `triggerFocusFlash`. ✅ Confirmed — verified `Workspace.sidebarFlashToken` (Sources/Workspace.swift:5099-5104) is the natural anchor.
+
+4. **Move the typing-latency invariant comment into a doc-comment on `==`.** The warning at Sources/ContentView.swift:10905-10915 is a wall of `//` comments above the struct. With three sites now touching this comparator (the original properties, the new `sidebarFlashToken`, and inevitably more soon), it should be a `///` doc-comment on the `==` function itself so Xcode quick-help surfaces it the moment someone touches the comparator. Same content, different location. ✅ Confirmed — purely a comment relocation, zero behavioral risk.
+
+#### Strategic
+
+5. **Formalize the `FlashEnvelope` shape.** Both `FocusFlashPattern` and `SidebarFlashPattern` have identical structure (values / keyTimes / duration / curves / `var segments`) with the same boilerplate `min(...)` step calculation. A protocol or a single struct factory `FlashEnvelope(values:keyTimes:duration:curves:)` removes the duplication and makes adding a third or fourth envelope (e.g., `UrgentFlashPattern`, `AgentVoiceFlashPattern`) trivial. Sets up the attention-intensity vocabulary cleanly. ✅ Confirmed — the two enums in Sources/Panels/Panel.swift are nearly mechanical duplicates.
+
+6. **OSC sequence handler for "attention from inside the terminal."** Terminal programs already use OSC 7 / OSC 8 / OSC 1337 for various host signals. Define a c11-specific OSC (e.g., OSC 1338 ; type=flash ; intensity=ambient) and route it into `triggerFocusFlash`. Now `make` finishing, `pytest` first-failure, etc. point at themselves without operator scripting. ❓ Needs exploration — requires touching the Ghostty embed's OSC handler; should be checked for collision with upstream Ghostty/cmux conventions before claiming a number.
+
+7. **Bonsplit `flashPane(_ paneId:)` companion.** Same shape as `flashTab`, applied at the pane level (flashes the whole pane container, useful when the relevant signal isn't a tab change but a pane-level event like split focus migrating). Bonsplit-internal patterns are already there; ~30 lines including the public API. Sets up cleaner upstream PR ("Add tab-level and pane-level flash affordances"). ❓ Needs exploration — confirm whether Bonsplit panes have an analog to `PaneState.flashTabId`/`flashTabGeneration` that fits this semantics; likely needs a new pair `flashGeneration` on `PaneState` alone.
+
+8. **Attention debug log behind a `#if DEBUG` flag.** Single `dlog("attention.fan-out panel=… surface=… layers=pane,tab,sidebar")` at `triggerFocusFlash` makes this subsystem observable for free. Pattern matches the existing `dlog("sidebar.close ...")` calls already in the file. ✅ Confirmed — Sources/ContentView.swift:11543 already uses this pattern.
+
+#### Experimental
+
+9. **Per-agent flash temperament.** Plumb a `requestedBy: AgentIdentity?` through `triggerFocusFlash` and let it influence color/curve. Speculative, but cheap to prototype: replace `cmuxAccentColor()` at Sources/ContentView.swift:11517 with a tinted variant if the request includes an agent voice. Worth exploring if/when c11 grows an agent identity registry beyond the manifest.
+
+10. **Sidebar shimmer for attention storms.** When `sidebarFlashToken` increments across N workspaces within T seconds, fire a sidebar-wide low-amplitude pulse. Differentiates "one of my agents finished" from "ten of my agents finished." Adds a coarse-grained meta-signal on top of the per-row signal. Risky in that "coalesce into shimmer" is animation-finicky; payoff is subtle but real for operators running many agents.
+
+11. **Attention bidirectionality.** Hovering a sidebar workspace row briefly flashes the focused tab in *that* workspace (using the existing `flashTab` API, not just selection). Closes the loop the other way: operator pointing at workspace → workspace's current focus surfaces visually. Could be a default-off feature behind an "interactive sidebar pointing" toggle.
+
+12. **"Trace this flash" debug command.** Right-click on a flashing tab → context menu entry "Trace flash source" → opens a debug surface listing the last N attention events with stack source (kbd / right-click / socket / notification / OSC / agent). Pure observability play, but the kind of thing that makes the attention bus reasonable to debug as it grows.
+
+### Closing observation
+
+The most undervalued thing in this PR is the *quietness* of channel (c). At peak opacity 0.18, single pulse, 0.6s — it's almost subliminal. That gentleness is what makes the rest of the system trustworthy. If sidebar flashes shouted, operators would silence the toggle and lose all three channels at once. Because it whispers, the operator can leave it on while running thirty agents, and that's the regime where the attention bus actually pays off. Protect that calibration. Don't let future contributors ratchet up the peak opacity in a "make it more visible" PR. It's already at exactly the right place.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/evolutionary-codex.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/evolutionary-codex.md
@@ -1,0 +1,103 @@
+## Evolutionary Code Review
+- **Date:** 2026-04-28T04:40:21Z
+- **Model:** Codex / GPT-5
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62d4b47e83ec54427d43d95f633deb38ed
+- **Linear Story:** flash-tab
+- **Review Type:** Evolutionary/Exploratory
+---
+
+**Review Scope Note**
+
+Reviewed the single branch commit `9b1e1f62` against `origin/main`; the prompt's context says this repo uses `main`, not `dev`. I did not run `git pull` because the higher-priority instruction for this task is read-only review with only this output file written.
+
+**What's Really Being Built**
+
+This is not just a flash affordance. It is the first version of an **attention routing fabric** for c11: one semantic event, "look here, but do not move me," fans out across multiple spatial representations of the same surface.
+
+The important primitive is "locate without selecting." `Workspace.triggerFocusFlash(panelId:)` now owns that semantic boundary in [Workspace.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Workspace.swift:8811): pane content, Bonsplit tab strip, and sidebar row all react to the same event without changing user focus or selection. That is a strong product primitive for an operator managing many agents, because it preserves the operator's current train of thought while still making another locus visible.
+
+This opens a design space larger than notifications: search hits, completed agent tasks, blocked agents, remote workspace state changes, command palette results, debug probes, and "where did this terminal go?" can all become spatial attention events instead of focus-stealing jumps.
+
+**Emerging Patterns**
+
+The clearest pattern is the **generation-token animation contract**. Markdown and browser panels already use `focusFlashAnimationGeneration` with delayed segment guards in [MarkdownPanelView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Panels/MarkdownPanelView.swift:450) and [BrowserPanelView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Panels/BrowserPanelView.swift:1255). This branch repeats the same shape for the sidebar at [ContentView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/ContentView.swift:11604) and Bonsplit at [TabItemView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:271). That pattern is now real enough to deserve a name and a small helper before the next three channels copy it again.
+
+The second pattern is **semantic fan-out at the workspace boundary**. `triggerFocusFlash` is becoming less like a method on panel chrome and more like a dispatch point for workspace attention. The `NotificationPaneFlashSettings` gate moving to [Workspace.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Workspace.swift:8812) reinforces that this is now a multi-channel policy decision, not a per-view detail.
+
+The third pattern is **Equatable as a subscription firewall**. The sidebar row's `TabItemView` comparator at [ContentView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/ContentView.swift:10917) is effectively a hand-written render subscription list. Adding `sidebarFlashToken` at [ContentView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/ContentView.swift:10934) is the right local move, but the broader pattern should be treated as infrastructure: every new visible sidebar behavior must enter through precomputed scalar state or it risks reintroducing typing latency.
+
+The anti-pattern to watch is **numeric envelope mirroring across modules**. `FocusFlashPattern` in [Panel.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Panels/Panel.swift:41), `SidebarFlashPattern` in [Panel.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Panels/Panel.swift:68), and `TabFlashPattern` in [TabItemView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:23) are intentionally similar but have no contract tying them together. That is okay for upstream friendliness in this branch; it becomes drift-prone if c11 adds more attention channels.
+
+**How This Could Evolve**
+
+The natural next step is to promote flash from a method into an **AttentionSignal**:
+
+```swift
+struct WorkspaceAttentionSignal {
+    enum Kind { case focusFlash, agentDone, agentQuestion, searchHit, warning }
+    enum Intensity { case ambient, normal, urgent }
+    let panelId: UUID
+    let kind: Kind
+    let intensity: Intensity
+    let preservesSelection: Bool
+}
+```
+
+`triggerFocusFlash(panelId:)` can remain as a compatibility shim, but internally it would dispatch a signal with channel policies: pane ring, tab pulse, sidebar pulse, scroll into view, maybe sound, maybe badge, maybe no-op in reduced motion. That makes the next 10 attention features cheaper because they compose through policy instead of adding one-off methods.
+
+Bonsplit could evolve from `flashTab(_:)` into a small **tab attention API** without losing upstream appeal. The current method at [BonsplitController.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift:309) is a good minimal public seam. Later, a generic shape like `requestAttention(for:style:)` could cover flash, badge, mark, and scroll-only behaviors while remaining useful to non-c11 consumers.
+
+The sidebar can evolve from "pulse the row if visible" to **attention navigation**. The plan correctly leaves sidebar scroll-to-row out of scope, but a `ScrollViewReader` around `VerticalTabsSidebar` would let a flash locate a workspace even when the operator has dozens of workspaces. The key is preserving the same contract: scroll is allowed, selection is not.
+
+**Mutations and Wild Ideas**
+
+**Spatial Breadcrumbs.** Instead of a single pulse, an attention event could leave a fading breadcrumb in pane, tab, and sidebar scopes. The operator would see not only where something happened, but where attention has been accumulating over the last few minutes.
+
+**Agent Presence Radar.** Each agent surface could emit attention signals with typed causes: done, blocked, needs review, error, waiting on human. The sidebar row becomes a compact radar for agent state, while the tab strip provides pane-local precision.
+
+**Command Palette Locate Mode.** Searching for a surface, workspace, PR, process, or notification could use the same attention fabric to reveal the thing in place. The command palette would not have to navigate immediately; it could first answer "where is it?"
+
+**Attention Replay.** A debug command could replay the last N attention signals. This would be useful for validating notification routing and for understanding why a workspace keeps asking for attention.
+
+**Leverage Points**
+
+The largest leverage point is a tiny shared animation runner for SwiftUI generation-token pulses. It would remove repeated delayed-segment code from Markdown, Browser, Sidebar, and possibly future sidebar badges. It does not need to be clever; it just needs to encode "increment generation, reset opacity, schedule guarded segments."
+
+The second leverage point is a runtime validation seam for non-pane channels. `tests_v2/test_trigger_flash.py` currently verifies the pane channel via debug flash count, and the terminal flash records that count in [GhosttyTerminalView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/GhosttyTerminalView.swift:7581). Adding debug counters for Bonsplit tab flashes and sidebar row flashes would let CI assert fan-out happened without asserting animation pixels or source text.
+
+The third leverage point is naming. If the codebase starts saying "attention signal" or "visual attention request" now, future features will naturally route through the same primitive instead of scattering more UI-specific verbs.
+
+**The Flywheel**
+
+The flywheel is: more surfaces become addressable, more agent events can point at exact surfaces, and the operator can trust c11 to reveal context without stealing focus. That trust compounds. Once "locate without selecting" is reliable, agents can be more proactive because their signals are less disruptive.
+
+There is a second engineering flywheel: a shared attention primitive makes every new channel cheaper to test and safer for latency. The Bonsplit tab strip, sidebar, and pane content become channel subscribers, not bespoke endpoints. That lets c11 add capability while keeping the hot paths explicit and reviewable.
+
+**Concrete Suggestions**
+
+1. **High Value — Factor the SwiftUI generation-token pulse runner.** ✅ Confirmed — the same guarded delayed-segment structure exists in [MarkdownPanelView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Panels/MarkdownPanelView.swift:450), [BrowserPanelView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Panels/BrowserPanelView.swift:1255), and the new sidebar helper at [ContentView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/ContentView.swift:11604). A small c11-side helper can stay out of Bonsplit and still reduce future c11 duplication. Risk: keep it plain and `@MainActor`; do not introduce observable objects or environment reads into sidebar rows.
+
+2. **High Value — Add artifact-level debug counters for each fan-out channel.** ✅ Confirmed — there is already a debug flash-count seam for pane flashes in [GhosttyTerminalView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/GhosttyTerminalView.swift:7581) and `tests_v2/test_trigger_flash.py` asserts it through the socket. Add counters such as `debug.flash.tab_count` and `debug.flash.sidebar_count` or extend the existing response to include channel counts. This would test observable runtime behavior, not source text. Risk: keep debug-only recording off the typing hot path and avoid making visual opacity itself test state.
+
+3. **Strategic — Introduce `WorkspaceAttentionSignal` behind `triggerFocusFlash`.** ✅ Confirmed — all current paths already converge on [Workspace.triggerFocusFlash(panelId:)](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Workspace.swift:8811), including the v2 socket path at [TerminalController.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/TerminalController.swift:6967) and focused-pane shortcut path at [TabManager.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/TabManager.swift:3857). This can be introduced without changing callers by making `triggerFocusFlash` create a `.focusFlash` signal internally. Risk: do not overgeneralize before a second signal kind exists; start with a private struct or enum.
+
+4. **Strategic — Prepare a small upstream Bonsplit PR.** ✅ Confirmed — the submodule diff is self-contained: `PaneState` fields, `BonsplitController.flashTab(_:)`, `TabBarView` scroll handling, and `TabItemView` overlay. The public method at [BonsplitController.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift:309) is generic and selection-neutral. Risk: upstream may prefer naming like `requestTabAttention`; keep the PR narrow and avoid c11 terminology.
+
+5. **Strategic — Add sidebar scroll-to-attention as a follow-up, still non-selecting.** ❓ Needs exploration — the current sidebar `ForEach` passes `sidebarFlashToken` cleanly at [ContentView.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/ContentView.swift:8489), but the outer sidebar does not currently expose a row scroll proxy in the reviewed lines. A `ScrollViewReader` around the sidebar list could make flashes useful with many workspaces. Risk: scrolling the sidebar on every ambient event could feel noisy; gate it by intensity or source.
+
+6. **Experimental — Add an attention history overlay.** ❓ Needs exploration — the new single fan-out gives a natural place to append a short-lived history event. This could become an operator-facing "what just happened?" surface for agent-heavy sessions. Risk: history can become clutter; start debug-only or command-palette-only.
+
+7. **Experimental — Make flash envelopes theme-aware.** ⬇️ Lower priority than initially thought — the current constants are clear and intentionally calibrated. Theme-aware or reduced-motion variants would fit the attention-signal model later, but this branch should keep the simple numeric envelopes.
+
+**Validation Pass**
+
+High Value suggestion 1 is compatible with the current architecture because the shared c11 types already live in `Panel.swift` and all c11 SwiftUI panel flash callers use `FocusFlashSegment`. The sidebar risk is manageable as long as `TabItemView` continues receiving only scalar inputs and its comparator remains authoritative.
+
+High Value suggestion 2 is compatible with the existing debug socket philosophy: `debug.flash.count` already validates a visual-only pane effect by recording the event, not by inspecting pixels. Extending this to tab/sidebar channels would close the main validation gap called out in the implementation notes.
+
+Strategic suggestion 3 is compatible because the branch has already centralized all reviewed trigger paths at `Workspace.triggerFocusFlash(panelId:)`. The dependency is naming and restraint: keep the initial signal private until more than flash uses it.
+
+Strategic suggestion 4 is compatible because Bonsplit's changes are host-agnostic and do not import c11 concepts. The dependency is submodule hygiene: the commit is present at `vendor/bonsplit` HEAD `78d09a44`, and the parent pointer bump already references that commit.
+
+Strategic suggestion 5 is compatible with the product direction but needs UI tuning. It should be intensity-aware so ambient workspace flashes do not yank the sidebar scroll position during ordinary agent noise.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/evolutionary-gemini.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/evolutionary-gemini.md
@@ -1,0 +1,57 @@
+## Evolutionary Code Review
+- **Date:** 2026-04-28T00:35:00Z
+- **Model:** ugemini
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62
+- **Linear Story:** flash-tab
+- **Review Type:** Evolutionary/Exploratory
+---
+
+### What's Really Being Built
+
+The code ostensibly extends a visual "flash" effect, but what's actually being built is a **Selection-Free Attention Routing Primitive**. 
+
+Before this change, "flashing" a pane was a localized event (a stroke around the content). Now, the system is establishing a pathway to route an attention signal up the hierarchy (Content -> Tab -> Workspace) without ever stealing the user's cursor, altering their current focus, or triggering costly state transitions (like active tab changes). It transforms "look at this" from a disruptive alert into a transient, polite spatial nudge. This is foundational infrastructure for agentic workflows where agents operating in the background need to gently signal state changes or completion without interrupting the operator's flow.
+
+### Emerging Patterns
+
+1. **Selection-Free Attention:** Decoupling visual priority from application focus. This is a powerful UX pattern for multi-agent or heavily asynchronous environments.
+2. **Generation Tokens for Transient Animation State:** The use of `flashTabGeneration` and `sidebarFlashToken` coupled with SwiftUI's `.onChange(of:)` establishes an idiomatic way to handle imperative, non-overlapping trigger-based animations. It cleanly bridges the gap between event-driven signals and declarative UI state.
+3. **Equatability as a Performance Boundary:** The manual `Equatable` implementation in `TabItemView` is doing heavy lifting. While effective, updating `==` alongside struct properties is a fragile pattern that relies entirely on developer discipline.
+
+### How This Could Evolve
+
+- **The Generic Attention Bus:** Currently, `Workspace.triggerFocusFlash` hardcodes the three channels (pane, tab, sidebar). As more UI surfaces require attention routing, this should evolve into a pub/sub `AttentionRouter`. Components would register to handle "attention requests" for specific context IDs, decoupling the trigger source from the visual topology.
+- **Differentiated Attention Semantics:** `SidebarFlashPattern` (polite) and `FocusFlashPattern` (assertive) suggest the beginning of a larger vocabulary. The next step is supporting semantic signals: "Success Pulse" (green tint, fast), "Warning Throttle" (yellow tint, sustained), "Agent Thinking Glow" (slow, breathing pulse).
+- **Spatial Attention without Forced Scrolling:** In `TabBarView`, flashing a non-visible tab forces a scroll `proxy.scrollTo(flashId, anchor: .center)`. If the user is actively reading the current tab, this movement might be disruptive. This could evolve into "off-screen indicators" (e.g., a glow at the scroll view's edge) that hint at the direction of the attention request without moving the viewport.
+
+### Mutations and Wild Ideas
+
+1. **Agentic "Breadcrumbs" and Auras:** Instead of a transient 0.6s pulse, an agent performing work across multiple tabs could leave a persistent, slow-pulsing aura on those tabs. It turns the tab strip into a live map of background activity.
+2. **Audio-Haptic Coupling:** Tie the generation token increment to a subtle spatial audio click or a haptic tap on macOS trackpads. The polite visual nudge becomes a multi-sensory ambient cue.
+3. **Attention Heatmaps:** Log these transient flashes. If a specific tab or workspace is flashing constantly, the system could suggest pulling it into a split or aggregating its notifications.
+
+### Leverage Points
+
+The generation token animation pattern (`lastObserved...` + `DispatchQueue.main.asyncAfter` loop) is robust but highly repetitive. Abstracting this logic into a single, reusable SwiftUI primitive would make adding new transient animations across the app trivial, drastically lowering the cost of implementing future "attention" features.
+
+### The Flywheel
+
+As developers realize they can signal users securely and politely without stealing focus (the "Attention Bus"), they will build more ambiently aware background tools. The less annoying the attention mechanism, the more it gets used, which in turn drives the need for richer, more semantic visual vocabularies (colors, rhythms) to differentiate those signals.
+
+### Concrete Suggestions
+
+1. **High Value:** Formalize the Generation Token Pattern.
+   - *Observation:* The `runSidebarFlashAnimation` and `runFlashAnimation` loops with `DispatchQueue` and `lastObserved` checks are identical boilerplate. 
+   - *Action:* Create a reusable `ViewModifier` (e.g., `.transientFlash(generation:pattern:color:)`) that encapsulates this state machine. This cleans up `TabItemView` in both c11 and Bonsplit.
+   - ✅ *Confirmed:* Verified the implementations are nearly identical and can be cleanly abstracted without breaking the `Equatable` boundary, as the modifier would just sit on top of the view.
+
+2. **Strategic:** Decouple the Fan-out.
+   - *Observation:* `Workspace.triggerFocusFlash` directly mutates `sidebarFlashToken` and calls `bonsplitController.flashTab`. It knows too much about the UI topology.
+   - *Action:* Emit an `AttentionRequested(panelId)` event. Let the Sidebar and Bonsplit controller independently observe and react. This sets up the architecture for the "Generic Attention Bus" mentioned above.
+   - ❓ *Needs exploration:* Depending on the existing eventing infrastructure (Combine vs. raw observers), this might introduce slight latency or complexity over the current direct function calls.
+
+3. **Experimental:** Off-screen Edge Glows.
+   - *Observation:* `proxy.scrollTo(flashId)` might be too aggressive if the user is actively reading.
+   - *Action:* If the flashed tab is out of the `ScrollView`'s visible bounds, apply a transient gradient glow to the leading/trailing edge of the scroll mask instead of forcing a jump.
+   - ❓ *Needs exploration:* Requires geometry readers to determine if the target tab is actually off-screen before deciding between a scroll or an edge glow.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/standard-claude.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/standard-claude.md
@@ -1,0 +1,104 @@
+## Code Review
+- **Date:** 2026-04-28T00:35:00Z
+- **Model:** Claude (claude-opus-4-7)
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62
+- **Linear Story:** flash-tab
+---
+
+## Test status
+
+- `xcodebuild -project GhosttyTabs.xcodeproj -scheme c11 -configuration Debug -derivedDataPath /tmp/c11-flash-review build` → **BUILD SUCCEEDED** (verified locally during this review pass).
+- Unit / E2E / `tests_v2/` not run locally per `CLAUDE.md` "Testing policy". Reviewer assumes CI will exercise `tests_v2/test_trigger_flash.py` for the pane channel; the bonsplit-tab and sidebar-row channels are visual-only and intentionally not asserted, consistent with the "Test quality policy."
+- No new headless tests added; correct call given the policies above and the visual nature of the new channels.
+
+## Architectural assessment
+
+Single fan-out at `Workspace.triggerFocusFlash(panelId:)` is the right shape. Before this change, "flash" already had four entry points (keyboard shortcut, right-click "Trigger Flash", v2 socket `surface.trigger_flash`, `triggerNotificationFocusFlash`) collapsing onto one method that called `panels[panelId]?.triggerFlash()`. Extending that one method to fan out to (b) Bonsplit tab and (c) sidebar row, plus folding `triggerNotificationFocusFlash` to delegate through it, keeps the single-funnel discipline that has kept this corner of the code legible. No new state machines, no new event types, no parallel pipelines.
+
+The seam choice for the Bonsplit channel is well-placed. `BonsplitController.flashTab(_:)` is a clean public method that mirrors `selectTab(_:)` shape; the `flashTabId` + `flashTabGeneration` pair on `PaneState` composes with the existing `ScrollViewReader` machinery in `TabBarView` instead of bolting on a parallel scroll path. The Bonsplit-internal `TabFlashPattern` mirrors the host's `FocusFlashPattern` by numeric construction rather than by import — that's the right call for upstream-friendliness, since `almonk/bonsplit` shouldn't depend on c11 types. ~113 LoC self-contained, plausibly upstreamable to `almonk/bonsplit` as a generic "flash a tab for attention" affordance.
+
+The sidebar channel uses a per-Workspace `@Published Int sidebarFlashToken` threaded as a precomputed `let` parameter into the sidebar `TabItemView`, with the token added to the `Equatable` `==` comparator. This is the single correct pattern for this view, given the typing-latency invariant documented at `Sources/ContentView.swift:10903-10913`. The plan rejected `@ObservedObject` flash store and `@EnvironmentObject` because both would defeat the `==` short-circuit; that reasoning is sound and the implementation matches.
+
+The gating change (moving `NotificationPaneFlashSettings.isEnabled()` from per-panel `triggerFlash` up to fan-out) is a quiet improvement: the bonsplit tab and sidebar channels are now consistently silenced when the operator disables Pane Flash, with one guard rather than three. The per-panel guards remain as defense-in-depth, which is harmless redundancy worth keeping.
+
+The `triggerNotificationFocusFlash` rewrite is the subtle bit. Old behavior was `terminalPanel.triggerFlash()` (terminal panels only, by construction). New behavior keeps the `terminalPanel(for:) != nil` early-return guard but delegates the actual flash through `triggerFocusFlash(panelId:)`. For terminal panels the visible flash chain is identical; for non-terminal panels (markdown, browser) the function still bails before fan-out, so behavior is preserved. This is correct and load-bearing — without that guard, terminal-only notification flashes would suddenly start flashing markdown/browser panels.
+
+## Tactical assessment
+
+### Equatability invariant
+
+The `==` update at `Sources/ContentView.swift:10934` is a single `Int` comparison, consistent with how `unreadCount`, `accessibilityWorkspaceCount`, etc. are handled. The warning comment block at line 10903-10913 was extended to call out the new field's role. Critically, only the workspace whose token bumped sees a `==` mismatch; sibling rows still skip body. The typing-latency invariant is preserved.
+
+One subtlety worth being explicit about: `@Published var sidebarFlashToken: Int = 0` on `Workspace` will publish on every `&+=`. The `VerticalTabsSidebar` body reconstructs every `TabItemView` for every workspace on each publish (because the parent body re-evaluates when any `tab` publishes), but `==` keeps body work to the targeted row only. Reconstruction is cheap; it's body re-evaluation that costs. This matches the existing pattern.
+
+### Generation-token guards
+
+Both new channels use the same `lastObserved...` pattern that already exists in `MarkdownPanelView` / `BrowserPanelView`:
+
+- Bonsplit tab: `lastObservedFlashGeneration` is bumped on the leading edge of `.onChange(of: flashGeneration)` and each scheduled `DispatchQueue.main.asyncAfter` segment bails with `guard generation == lastObservedFlashGeneration else { return }`. Back-to-back flashes restart cleanly. The extra `newValue > 0` guard correctly prevents siblings (which receive `flashGeneration: 0` per the `pane.flashTabId == tab.id` ternary) from animating.
+- Sidebar row: `lastObservedSidebarFlashToken` is bumped on `.onChange(of: sidebarFlashToken)` and segments guard with `token == lastObservedSidebarFlashToken`. Same shape; same correctness.
+
+Both implementations correctly reset `flashOpacity = 0` (or `values.first ?? 0`) at the start of `runFlashAnimation` so a mid-flight prior animation gets clobbered to zero rather than left at peak. Good.
+
+### Bonsplit upstream-friendliness
+
+The `Stage-11-Agentics/bonsplit` commit is genuinely generic. `flashTab(_:)` reads as "any consumer of bonsplit might want this." `TabFlashPattern` is Bonsplit-internal and uses Bonsplit's own `TabBarColors.activeIndicator(for:)` for the tint — no host coupling. The `.onChange(of: pane.flashTabGeneration)` in `TabBarView` does the scroll inside `withTransaction(Transaction(animation: nil))` to avoid an animated scroll fight with the pulse; that's the right choice, and matches how Bonsplit handles other scroll-target changes in the same `ScrollViewReader` block.
+
+One small observation: the per-tab `flashGeneration: (pane.flashTabId == tab.id) ? pane.flashTabGeneration : 0` ternary at `TabBarView.swift:698` runs for every tab on every render. It's fine — `pane.flashTabId` is a single `UUID?` compare — but if Bonsplit ever has panes with hundreds of tabs and a flash happens during high-frequency tab churn, that's worth knowing about. Not a concern here.
+
+### Animation timings
+
+The two channels chose different envelopes by design:
+- Bonsplit tab: two-pulse, 0.9s, peak 0.55. Same shape as pane content but tinted at lower opacity (fill, not stroke).
+- Sidebar row: single-pulse, 0.6s, peak 0.18. Calibrated as "polite ambient nudge" rather than "alert shout."
+
+Visually these complement each other — the pane pulse is the loudest signal (you're being told this surface wants attention), the tab pulse is medium (you're being told which tab in the strip), the sidebar pulse is the softest (you're being told which workspace, and likely you're already looking somewhere else). The intent matches the chosen amplitudes. Operator validation is the last word here, but the numerical relationships are reasonable.
+
+### Color / corner-radius matching
+
+The sidebar overlay at `ContentView.swift:11516` uses `RoundedRectangle(cornerRadius: 6)`, matching the row's `backgroundColor` rect at line 11495 and the border at line 11498. Good — the pulse won't visibly extend beyond the row's chrome.
+
+### Minor nits
+
+- `runSidebarFlashAnimation` and `runFlashAnimation` (Bonsplit) duplicate the segment-iteration boilerplate that already exists in `MarkdownPanelView.triggerFocusFlashAnimation` and `BrowserPanelView.triggerFocusFlashAnimation`. Four near-identical loops now. Not a refactor I'd block on, but a small `runSegmentedAnimation(segments:tokenCheck:)` helper would land if any future flash channel is added.
+- `runSidebarFlashAnimation` reads `SidebarFlashPattern.values.first ?? 0` as the reset opacity. Since `SidebarFlashPattern.values` is a `static let` literal, the `?? 0` is unreachable. Same pattern in `MarkdownPanelView` (also unreachable). Consistent with existing code; not worth changing.
+- The `NotificationPaneFlashSettings.isEnabled()` guard at the top of `triggerFocusFlash` runs on every fan-out call, which means a `UserDefaults.bool(forKey:)` read per flash. `UserDefaults` reads are cheap and these are user-rate (~1-10/sec at most), so this is fine.
+
+## Cross-platform note
+
+Per the review prompt: "iOS and Android equally good." This is a macOS-only codebase (`c11` is a macOS app embedding Ghostty + Bonsplit). The cross-platform check doesn't apply.
+
+## Findings
+
+### Blockers
+
+(none)
+
+### Important
+
+1. ✅ **`tests_v2/test_trigger_flash.py` continues to pass with the gating-relocation.** Confirmed via reading: when `notificationPaneFlashEnabled = true`, the chain `Workspace.triggerFocusFlash` → `panels[panelId]?.triggerFlash()` → `TerminalPanel.triggerFlash()` (still gated, defense-in-depth) → `hostedView.triggerFlash()` → `recordFlash(for:)` is preserved. `flash_count` (debug.flash.count) increments exactly as before for terminal panels. When `notificationPaneFlashEnabled = false`, both old and new code paths skip `recordFlash` (just at different guards). No regression. Worth keeping a CI eye on this assertion if `tests_v2/test_trigger_flash.py` runs with the setting toggled in any case it already exercises.
+
+### Potential
+
+2. ✅ **Behavior asymmetry across trigger paths is preserved, not introduced — but worth documenting.** The four trigger paths now reach `triggerFocusFlash` along different routes:
+   - Keyboard shortcut (`tabManager.triggerFocusFlash` at `ContentView.swift:5937` → `tab.triggerFocusFlash(panelId:)`): flashes any panel type.
+   - Right-click "Trigger Flash" (`triggerDebugFlash` → `triggerNotificationFocusFlash`): bails for non-terminal panels (existing behavior, preserved by the `terminalPanel(for:) != nil` guard).
+   - V2 socket `surface.trigger_flash` (`TerminalController.swift:6967`): flashes any panel type (calls `ws.triggerFocusFlash` directly).
+   - Notification routing (`triggerNotificationFocusFlash` callers in `TabManager.swift`, `AppDelegate.swift`): bails for non-terminal panels.
+   
+   This asymmetry pre-existed; the PR doesn't change it. Worth a one-line code comment near the right-click hookup if a future agent gets confused by why right-click bails on a markdown surface but the keyboard shortcut and socket don't. ⬇️ Lower priority — doesn't gate merge, just an aid for the next reader.
+
+3. ❓ **Two-pulse on bonsplit tab while a workspace is offscreen.** When a flash fires on a workspace that's not currently visible, channel (b) fires on a tab strip that the operator can't see. SwiftUI may throttle offscreen `withAnimation` work but resumes on return. The plan flagged this and decided it's not a correctness issue (the animation simply doesn't "play" while offscreen, and resuming triggers a frame snap). I agree it's not a bug, but the operator UX is "I switched workspaces, now there's a tab quietly pulsing on the workspace I just came back to" which may or may not match intent. No code change suggested — flag for operator eyeballing during validation.
+
+4. ⬇️ **Bonsplit `flashGeneration` ternary recomputes per tab.** `(pane.flashTabId == tab.id) ? pane.flashTabGeneration : 0` at `TabBarView.swift:698` is a per-tab UUID equality compare per render. Negligible at current tab counts but linear in tabs-per-pane. If c11 ever supports panes with very large tab counts, consider hoisting `pane.flashTabId` into a `let` once outside the iteration (SwiftUI may already be doing this; this is a micro-concern).
+
+5. ⬇️ **Four near-identical `runFlashAnimation` loops.** `MarkdownPanelView.triggerFocusFlashAnimation`, `BrowserPanelView.triggerFocusFlashAnimation`, `Bonsplit/TabItemView.runFlashAnimation`, and `ContentView/TabItemView.runSidebarFlashAnimation` all share the same `for segment in pattern.segments { DispatchQueue.main.asyncAfter { guard generation/token; withAnimation { ... } } }` shape. Lifting a shared helper (host-side or duplicating the bonsplit copy as one helper there) would tidy this. Not a refactor I'd block on — the four sites are short, the bonsplit one is intentionally Bonsplit-internal for upstream cleanliness, and the host two predate this PR.
+
+6. ⬇️ **`SidebarFlashPattern.values.first ?? 0` is unreachable defensive code.** `SidebarFlashPattern.values` is a `static let` literal whose first element is `0`. The `?? 0` is dead. Mirrors the existing pattern in `MarkdownPanelView`/`BrowserPanelView`, so consistency wins over deletion; just noting.
+
+## Summary
+
+Solid, well-shaped change. The single-fan-out architecture is preserved and improved (gating now happens once instead of three times). The Bonsplit additions are upstream-friendly. The typing-latency invariant in the sidebar `TabItemView` is correctly preserved by adding the new `Int` field to both the constructor and the `==` comparator and using a precomputed `let` (not a closure or environment object). Generation-token guards mirror the existing pane-content pattern at every layer. Build passes cleanly. No blockers; one preserved behavior asymmetry (right-click bails on non-terminals; keyboard shortcut and socket don't) worth noting in a future code comment if a reader gets confused. The visual envelopes (0.55 / 0.18 / 1.0 peaks across the three channels) look intentionally tiered rather than arbitrary, but final say belongs to the operator's eyes.
+
+Recommend merge after operator visual validation per `notes/flash-extension-plan.md` §7.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/standard-codex.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/standard-codex.md
@@ -1,0 +1,45 @@
+## Code Review
+- **Date:** 2026-04-28T04:40:32Z
+- **Model:** ucodex (Codex, GPT-5)
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62d4b47e83ec54427d43d95f633deb38ed
+- **Linear Story:** flash-tab
+---
+
+General feedback: the branch is small, coherent, and correctly centers the behavior on `Workspace.triggerFocusFlash(panelId:)` as the single fan-out. The Bonsplit addition is appropriately generic: `flashTab(_:)` does not select or focus, and the state lives on `PaneState` rather than transiently polluting `TabItem`. The sidebar equatability invariant was handled carefully by threading a precomputed `Int` and adding it to `==`, which is the right shape for this typing-latency-sensitive view.
+
+Validation note: per the read-only wrapper prompt and c11 local testing policy, I did not fetch/pull, commit, push, or run local tests. I reviewed the local branch state and the diff from `origin/main...HEAD`. Local state shows one commit ahead of `origin/main` at `9b1e1f62`; `notes/.tmp/` is untracked review context.
+
+Changed-flow summary:
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Workspace
+    participant Panel
+    participant Bonsplit
+    participant Sidebar
+    Caller->>Workspace: triggerFocusFlash(panelId)
+    Workspace->>Workspace: NotificationPaneFlashSettings.isEnabled()
+    Workspace->>Panel: panels[panelId]?.triggerFlash()
+    Workspace->>Bonsplit: flashTab(tabId)
+    Workspace->>Sidebar: sidebarFlashToken &+= 1
+```
+
+### Blockers
+
+None found.
+
+### Important
+
+1. ⬇️ Valid, non-blocking: `triggerFocusFlash(panelId:)` now pulses the sidebar even when `panelId` is stale or missing. At [Sources/Workspace.swift:8813](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Workspace.swift:8813), the pane flash is optional (`panels[panelId]?.triggerFlash()`), but [Sources/Workspace.swift:8817](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/Workspace.swift:8817) increments `sidebarFlashToken` unconditionally. Before this branch, a missing panel was effectively a no-op; now it can produce a workspace-row pulse with no corresponding pane or tab flash. Most current callers appear to pass valid IDs, and `triggerNotificationFocusFlash` still guards terminal panels, so I would not block merge on this. A tighter implementation would `guard let panel = panels[panelId] else { return }`, then call `panel.triggerFlash()` before the Bonsplit/sidebar fan-out.
+
+### Potential
+
+2. ✅ Confirmed: local validation relies on the implementer-reported build and smoke test rather than this review run. The repository policy says not to run local tests, and the wrapper prompt restricted this review to one output file. CI should remain the merge gate for compile and behavioral coverage.
+
+3. ✅ Confirmed: Bonsplit upstream-friendliness looks good. The new API in [vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift:309](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/vendor/bonsplit/Sources/Bonsplit/Public/BonsplitController.swift:309) is consumer-neutral, no-op safe, and does not emit delegate selection/focus callbacks. The scroll handler in [vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift:550](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift:550) also preserves selection.
+
+4. ✅ Confirmed: the sidebar equatability change is scoped to one `Int` comparison at [Sources/ContentView.swift:10934](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-flash-tab-and-workspace/Sources/ContentView.swift:10934). The new state and animation helper live inside the row view, and the overlay disables hit testing, so this should not disturb drag/drop or selection.
+
+5. ✅ Confirmed: the generation-token guards cover back-to-back flashes in both new channels. Bonsplit compares `generation == lastObservedFlashGeneration`, and the sidebar compares `token == lastObservedSidebarFlashToken` before applying delayed animation segments.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/standard-gemini.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/standard-gemini.md
@@ -1,0 +1,37 @@
+## Code Review
+- **Date:** 2026-04-28T04:35:00Z
+- **Model:** ugemini
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62d4b47e83ec54427d43d95f633deb38ed
+- **Linear Story:** flash-tab
+---
+
+### Assessment
+
+This branch successfully extends the "flash" affordance from the pane content to both the Bonsplit tab strip and the sidebar workspace row. The implementation is well thought out, adhering strictly to SwiftUI performance requirements and maintaining clear boundaries between the main application and the Bonsplit submodule.
+
+**Architectural:**
+- **Fan-out Design:** Collapsing the various flash triggers (keyboard, context menu, v2 socket, notifications) into a single fan-out point at `Workspace.triggerFocusFlash(panelId:)` is a clean architectural improvement. It ensures all channels (pane, tab, sidebar) stay synchronized without duplicating logic across call sites.
+- **Bonsplit Separation:** The seam added to Bonsplit (`BonsplitController.flashTab`) is well-designed. By mirroring the flash envelope internally (`TabFlashPattern`), the implementation avoids coupling the submodule to the host app's `Panel.swift`, keeping it upstream-friendly.
+- **State Management:** Using generation tokens (`flashTabGeneration` and `sidebarFlashToken`) to drive the animations is the correct pattern here. It handles rapid back-to-back triggers elegantly by cleanly abandoning in-flight animation segments rather than building complex cancellation logic.
+
+**Tactical:**
+- **Equatability Invariant:** Carefully threading `sidebarFlashToken` as a precomputed `let` through the parent `ForEach` and explicitly adding it to the `==` comparator in `TabItemView` correctly preserves the crucial typing-latency invariant without regressions.
+- **Non-blocking UI:** Using `.allowsHitTesting(false)` on both the Bonsplit tab overlay and the sidebar row overlay ensures the new visual affordances don't accidentally intercept user interactions.
+- **Scroll to Tab:** Leveraging the existing `ScrollViewReader` in Bonsplit's `TabBarView` with `.onChange(of: pane.flashTabGeneration)` is an efficient reuse of existing scroll infrastructure.
+- **Guard Preservation:** In `Workspace.swift:8825`, changing `guard let terminalPanel = terminalPanel(for: panelId) else { return }` to `guard terminalPanel(for: panelId) != nil else { return }` correctly preserves the behavior of dropping non-terminal notification flashes while allowing the delegation to `triggerFocusFlash`.
+
+### Issues
+
+- **Blockers** 
+  - None.
+
+- **Important** 
+  - None.
+
+- **Potential** 
+  - None.
+
+### Validation Pass
+
+✅ Confirmed. The code cleanly solves the objectives listed in the plan, introduces no regressions based on manual code inspection, and adheres to the host application's architectural patterns. Ready to merge.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-action.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-action.md
@@ -1,0 +1,110 @@
+# Action-Ready Synthesis: flash-tab
+
+## Verdict
+fix-then-merge
+
+The 9 reviews split into two camps. Standard-claude, standard-codex, standard-gemini, evolutionary-{claude,codex,gemini}, and critical-{claude,codex} all read the change as small, well-shaped, and effectively merge-ready or merge-after-cleanup. Critical-gemini disagrees sharply: it asserts that channel (c) — the sidebar workspace pulse — is functionally **dead**, because the SwiftUI subscription topology cannot deliver `tab.sidebarFlashToken` updates to the threaded `let` parameter the row uses. That claim is the blocker. The critical-gemini reasoning matches a real SwiftUI gotcha (no observer of individual `Workspace`s exists in `VerticalTabsSidebar`; `@ObservedObject var tab` in the child only invalidates the child's body, it does not re-construct the struct, so the captured `let sidebarFlashToken` cannot refresh). The standard reviewers concluded the channel works by code inspection only — none of them ran the binary against this code path, and the smoke test mentioned in the context document only verified that `surface.trigger_flash` returns `OK`, not that the sidebar pulse renders.
+
+Bias toward the more cautious verdict: the sidebar-channel observation question has to be settled by a real visual smoke test (or runtime probe) before merge. If the channel is in fact dead, the fix is small (subscribe to the published value, not the threaded `let`); if it works, the rest of this synthesis still has a real settings-copy contract bug and a small overflow bug that should land in the same PR.
+
+## Apply by default
+
+### Blockers (merge-blocking)
+
+- **B1: Sidebar flash channel may never fire — `.onChange(of: sidebarFlashToken)` watches a stale `let`**
+  - Location: `Sources/ContentView.swift:8489` (parent threading) and `Sources/ContentView.swift:11512-11522` (child `.onChange`)
+  - Problem: `VerticalTabsSidebar` has no `@ObservedObject` / `@EnvironmentObject` on individual `Workspace`s, so `Workspace.sidebarFlashToken` publishing does not re-evaluate the parent body. The child `TabItemView` has `@ObservedObject var tab: Tab`, which invalidates the child's body when `tab` publishes — but the child's `let sidebarFlashToken: Int` is captured at parent-construction time and is not refreshed by child-only re-renders. `.onChange(of:)` on a captured `let` only fires when the parent re-passes a new value; with `Equatable`-gated reconstruction and no parent-side observer of the workspace, it likely never does. Critical-gemini reports verifying this with a SwiftUI test harness mimicking the same topology. The standard reviewers asserted the channel works but did so only by reading code, not by running it.
+  - Fix: First, **verify** by adding a temporary `dlog("sidebar flash onchange fired for ws=…")` inside the `.onChange` and triggering a flash via `c11 trigger-flash`. If the log fires, the implementation is fine and B1 collapses to "no change needed; keep this comment for future maintainers." If it does **not** fire, change the subscription to read the published value directly: replace `.onChange(of: sidebarFlashToken) { _, newValue in … }` with `.onReceive(tab.$sidebarFlashToken) { newValue in … }`, OR change the `.onChange` source to `tab.sidebarFlashToken` so SwiftUI subscribes to the publisher rather than the captured `let`. Both fixes preserve the typing-latency invariant because they don't add a new property to the `==` comparator (the `let sidebarFlashToken` and its inclusion in `==` can stay as defense-in-depth, or be removed once the publisher subscription is the source of truth). After the fix, smoke-test by triggering a flash on a non-active workspace and confirming the row pulses.
+  - Sources: critical-gemini (Blocker 1, with claimed runtime verification). Standard-claude, standard-codex, standard-gemini, critical-claude, critical-codex all asserted the channel works but **none ran the channel**; their confidence is inspection-only, so it does not override critical-gemini's runtime claim.
+
+- **B2: Settings copy lies about what the "Pane Flash" toggle does**
+  - Location: `Sources/c11App.swift:5683-5684`
+  - Problem: The user-facing toggle still describes itself as "Briefly flash a blue outline when c11 highlights a pane." The implementation in `Sources/Workspace.swift:8811-8817` now uses that same setting to gate all three channels (pane ring, Bonsplit tab pulse, sidebar workspace row pulse). A user who reads the description and toggles it expecting only the pane-outline behavior is silently controlling two additional visual channels they have no idea exist.
+  - Fix: Update the English `defaultValue:` in the `String(localized:)` for that setting description to reflect the new scope — something like "Briefly flash the pane, its tab, and its workspace row when c11 highlights a pane." Per `CLAUDE.md` Localization: write English only; spawn a translator sub-agent in a fresh c11 surface to update `Resources/Localizable.xcstrings` for the six other locales. Optionally rename the setting key from "Pane Flash" to "Highlight Flash" or similar; if you do, plumb a settings migration so existing users keep their toggle state.
+  - Sources: critical-codex (Important #1, confirmed with file:line).
+
+### Important (land in same PR)
+
+- **I1: `newValue > 0` guard in Bonsplit `TabItemView` permanently disables tab flash on Int wrap**
+  - Location: `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:236-241`
+  - Problem: `pane.flashTabGeneration &+= 1` wraps `Int.max` to `Int.min` (negative). The guard `guard newValue > 0, newValue != lastObservedFlashGeneration else { return }` fails forever after that wrap, silently bricking channel (b) for the rest of the session. Practically unreachable (9 quintillion flashes), but it's an inconsistency with the c11 sidebar's `!=`-only check and the kind of footgun a future maintainer copy-pastes. The `> 0` is also redundant: the parent's per-tab ternary `(pane.flashTabId == tab.id) ? pane.flashTabGeneration : 0` already guarantees siblings see 0, and `.onChange` doesn't fire on a 0→0 transition anyway.
+  - Fix: Drop the `newValue > 0` half of the guard. Final line: `guard newValue != lastObservedFlashGeneration else { return }`. Commit in the bonsplit submodule first, push to `Stage-11-Agentics/bonsplit` `main`, then bump the parent pointer per `CLAUDE.md` submodule-safety order.
+  - Sources: critical-claude (W3, confirmed), critical-gemini (Important #3, confirmed). Multi-reviewer consensus.
+
+- **I2: Add debug counters for tab/sidebar channels and extend `tests_v2/test_trigger_flash.py`**
+  - Location: new — extend the existing `debug.flash.count` socket command and add to `tests_v2/test_trigger_flash.py`
+  - Problem: Channels (b) and (c) have no observable runtime counter. `tests_v2/test_trigger_flash.py` only asserts `flash_count` for the pane channel via `GhosttyTerminalView`. A future refactor that accidentally drops the bonsplit fan-out or the sidebar token bump would not be caught — and given B1 is a concrete instance of "channel silently doesn't fire," runtime coverage is exactly the missing piece.
+  - Fix: Add two counters analogous to the existing `flash.count`: `debug.flash.tab_count` (incremented inside `BonsplitController.flashTab` or in `Workspace.triggerFocusFlash` after the bonsplit call) and `debug.flash.sidebar_count` (incremented at the `sidebarFlashToken &+= 1` line). Expose via the existing debug socket command pattern. Extend `tests_v2/test_trigger_flash.py` to assert all three counters increment when `surface.trigger_flash` fires, and assert all three stay at 0 when `notificationPaneFlashEnabled = false`. ~30 lines of code; follows `CLAUDE.md` "Test quality policy" because it tests observable runtime behavior, not source text.
+  - Sources: critical-claude (M1, M4, recommended ship-blocker), critical-codex (What's Missing #1), evolutionary-codex (High Value #2), evolutionary-claude (Leverage Point #2). Multi-lens consensus.
+
+### Straightforward mediums
+
+- **M1: `surfaceIdFromPanelId` is O(n) and now on the flash hot path**
+  - Location: `Sources/Workspace.swift:5793-5795`
+  - Problem: The function is a linear scan: `surfaceIdToPanelId.first { $0.value == panelId }?.key`. Every flash now pays this cost (including the v2 socket `surface.trigger_flash` path, which already has the `surfaceId` in scope at `TerminalController.swift:6967`). Negligible for small workspaces, but unnecessary work that compounds with notification volume.
+  - Fix: Either (a) maintain a reverse-lookup dict alongside `surfaceIdToPanelId` and update both on insert/remove, or (b) overload `triggerFocusFlash` to accept an optional `tabId` and have the v2 socket caller pass it directly, falling back to the lookup only for callers that don't have it. Option (b) is smaller and avoids a second source of truth.
+  - Sources: critical-claude (W2, confirmed), standard-claude (#4, lower priority).
+
+- **M2: `static var segments` recomputed on every read**
+  - Location: `Sources/Panels/Panel.swift:74-86` (`SidebarFlashPattern.segments`); `Sources/Panels/Panel.swift:55-67` (existing `FocusFlashPattern.segments`); `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:42-55` (`TabFlashPattern.segments`)
+  - Problem: `static var segments: [FocusFlashSegment] { … }` is a computed property — each access re-runs `min(...)` and `(0..<stepCount).map { … }`, allocating a fresh array. The arrays are constants and never depend on input, so each access on the animation hot path allocates and maps unnecessarily.
+  - Fix: Change `static var segments: [Type] { … }` to `static let segments: [Type] = { … }()` (immediately-invoked closure assigned to a `static let`) in all three pattern enums. The arrays are computed once at first access and cached. No behavior change. Apply consistently across `FocusFlashPattern`, `SidebarFlashPattern`, and `TabFlashPattern`.
+  - Sources: critical-gemini (Potential #4, confirmed). Single reviewer but the citation is concrete and the fix is mechanical — `static var` of a pure expression is a verifiable Swift wart, not a subjective preference.
+
+### Evolutionary clear wins
+
+(none — every evolutionary item involves either a rename of a public API surface, a new abstraction, or a scope expansion that the user should weigh; nothing here is small-and-obvious enough to apply silently)
+
+## Surface to user (do not apply silently)
+
+- **S1: Notification fan-out scope is a unilateral product expansion**
+  - Why deferred: design-needed
+  - Summary: `triggerNotificationFocusFlash` (called from terminal notification routing in `TabManager.swift:2982,2995,3175` and `AppDelegate.swift:2760` — i.e., agent-finish notifications, Zulip-style pings) previously fired only the pane ring. After this PR it fans out through `triggerFocusFlash` to all three channels including the sidebar workspace row. Critical-claude flags this as a real product question: "polite peak 0.18 opacity" is calibrated for ambient signal, but with 8-12 active workspaces and many agents firing notifications, the operator may experience a sidebar that twitches several times per minute. The implementer made the call unilaterally without flagging the tradeoff. Possible answers: (a) accept the expansion as intended (and validate under realistic notification load), (b) bypass channel (c) for `triggerNotificationFocusFlash` callers — keep notification flashes pane-only, reserve the three-channel fan-out for explicit user-action paths (keyboard shortcut, right-click, v2 socket).
+  - Sources: critical-claude (W1, the headline concern of that review), standard-claude (#3, related but framed only as "operator should eyeball during validation"), evolutionary-{claude,codex} both lean into the multi-channel future without flagging the calibration question.
+
+- **S2: `NotificationPaneFlashSettings` toggle silences flashes but still allows focus-stealing**
+  - Why deferred: pre-existing behavior, scope question
+  - Summary: `triggerNotificationFocusFlash` calls `focusPanel(panelId)` before the gate check; an operator who toggles "Pane Flash" off expecting "stop yanking my focus on notifications" will be surprised. Pre-existing, not introduced by this PR. The new fan-out makes the setting more visible and more likely to get revisited, which is why critical-claude flagged it now. Either document the actual scope of the toggle in the description (paired naturally with B2's copy update), or split into two toggles ("flash" and "focus-on-notification"). The latter is design-needed.
+  - Sources: critical-claude (W7, confirmed pre-existing).
+
+- **S3: Sidebar overlay sits on top of the active-row leading rail**
+  - Why deferred: visual subjective
+  - Summary: At `Sources/ContentView.swift:11494-11520`, the flash overlay is appended after the leading-rail overlay. When the active workspace's row receives a flash, the accent fill briefly tints the rail. Peak 0.18 opacity makes this minor; whether it muddles the active-state signal or reads as a coherent unified pulse is an operator visual call. Easy to fix (reorder overlays so the rail sits on top of the flash) but requires the operator to actually look and decide.
+  - Sources: critical-claude (W4, marked as visual nit).
+
+- **S4: Stale `panelId` produces a sidebar pulse with no pane/tab flash**
+  - Why deferred: defensive-vs-strict design choice
+  - Summary: `triggerFocusFlash` currently does `panels[panelId]?.triggerFlash()` (optional), then `bonsplitController.flashTab(tabId)` if `surfaceIdFromPanelId(panelId)` returns non-nil, then unconditionally `sidebarFlashToken &+= 1`. If a stale or invalid `panelId` is passed, only the sidebar pulses. Today's callers all pass valid IDs, so this is not a present bug. Two reasonable fixes diverge: (a) `guard let panel = panels[panelId] else { return }` and bail entirely — strict, breaks future "draw attention to a workspace" use cases; (b) keep current behavior, document that workspace-level flash without a panel is allowed. Critical-codex prefers (a); evolutionary-{claude,codex} are pulling toward an "attention bus" that benefits from (b). User should decide direction.
+  - Sources: standard-codex (Important #1), critical-codex (Potential #1).
+
+- **S5: Bonsplit `TabItemView` is not `Equatable` — siblings re-evaluate body on every flash**
+  - Why deferred: scope, upstream-friendliness tradeoff
+  - Summary: c11's sidebar `TabItemView` is meticulously `Equatable` for typing-latency; Bonsplit's per-pane `TabItemView` is not. Every flash invalidates the parent and re-evaluates all sibling tabs' bodies, even though siblings receive `flashGeneration: 0` and don't animate. Negligible at current per-pane tab counts (1-15). Adding `Equatable` to Bonsplit's `TabItemView` would be a real architectural improvement, but it's also a bigger change to a vendored fork that may be PR'd upstream — worth a separate decision rather than rolled in here.
+  - Sources: critical-claude (W5, confirmed).
+
+- **S6: Lazy-mounted sidebar rows lose flashes that fire while scrolled out of view**
+  - Why deferred: design-needed, follow-up
+  - Summary: `LazyVStack` defers row creation; if a flash fires for a workspace whose row hasn't been materialized, the token bumps but no `.onChange` observer exists. When the operator scrolls the row in, `lastObservedSidebarFlashToken` initializes to 0 and the flash never replays. This is probably the right behavior (no point replaying a 5-second-old pulse on scroll-in), but it means the sidebar pulse is "best-effort, observable-while-mounted," not a reliable "this workspace had something happen" indicator. The proper mitigation is a separate "has unseen flash" sticky badge that decays, which is out of scope here. File as a follow-up.
+  - Sources: critical-claude (W6, confirmed).
+
+- **S7: Plan §9 verification checklist boxes left unchecked**
+  - Why deferred: doc hygiene only
+  - Summary: `notes/flash-extension-plan.md` §9 has three unchecked boxes (`NotificationPaneFlashSettings.isEnabled()` confirmed, `appearance.activeIndicatorColor` confirmed, sidebar row corner-radius confirmed). Critical-claude verified that all three were resolved correctly in the implementation, so the checklist is misleading documentation. Either tick the boxes or strike the section before merging. User should decide whether to keep `flash-extension-plan.md` as a checked-off historical artifact or trim it.
+  - Sources: critical-claude (M6, confirmed).
+
+## Evolutionary worth considering (do not apply silently)
+
+- **E1: Name the attention bus before more callers script against `surface.trigger_flash`**
+  - Summary: All three evolutionary reviewers independently arrived at the same observation — `Workspace.triggerFocusFlash(panelId:)` has stopped being a "pane flash" method and started being a workspace-scope attention dispatch. Naming it now (`drawAttention(panelId:intensity:layers:)` or similar) before agents start scripting against the v2 socket name `surface.trigger_flash` is cheaper than later. The current call becomes the `.normal` / `[.pane, .tab, .sidebar]` case; future calls (`agent_finished` ambient, `build_failed` urgent) compose through layer/intensity policy instead of adding bespoke methods.
+  - Why worth a look: the rename cost is small now and grows fast; the underlying primitive opens per-channel toggles, agent-emitted attention requests over the socket, and a future per-workspace mute/route policy.
+  - Sources: evolutionary-claude (#2 + Concrete #2), evolutionary-codex (Strategic #3), evolutionary-gemini (How This Could Evolve #1).
+
+- **E2: Extract a shared SwiftUI generation-token pulse runner**
+  - Summary: The same `reset opacity → for-segment-in-pattern asyncAfter → guard generation/token → withAnimation` shape now exists in four places: `MarkdownPanelView.triggerFocusFlashAnimation`, `BrowserPanelView.triggerFocusFlashAnimation`, the new `runSidebarFlashAnimation` in `ContentView.swift`, and Bonsplit's `runFlashAnimation` in `TabItemView.swift`. A small `@MainActor` helper in `Sources/Panels/Panel.swift` would collapse the c11-side three to one (Bonsplit keeps its own copy for module isolation). Future flash channels add in 5 lines instead of 30.
+  - Why worth a look: removes duplication, lowers the cost of the next attention channel, and centralizes the timing-bug surface; downside is it's a refactor of working code with no behavior change, so the timing for "now" vs "after the next channel forces it" is a judgment call.
+  - Sources: evolutionary-claude (Concrete #1), evolutionary-codex (Concrete #1), evolutionary-gemini (Concrete #1), standard-claude (#5). Multi-lens consensus on the observation; user should decide on the timing.
+
+- **E3: Add `lastFlashedAt: Date?` next to `sidebarFlashToken`**
+  - Summary: One extra `@Published` property on `Workspace`. Unlocks several future capabilities cheaply: a sidebar decay overlay (faint residue showing "this workspace flashed recently"), a "what flashed while I was at lunch" recap, per-workspace mute by recency, and a debug attention audit log. All optional; the field itself costs essentially nothing and doesn't change current behavior.
+  - Why worth a look: it's a one-line change with disproportionate optionality for the attention-bus direction (E1) without committing to that direction yet.
+  - Sources: evolutionary-claude (Concrete #3, How This Could Evolve #3).

--- a/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-critical.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-critical.md
@@ -1,0 +1,187 @@
+# Trident Critical Review Synthesis: flash-tab
+
+- **Date:** 2026-04-28
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62
+- **Reviewers:** Claude Opus 4.7, GPT-5 Codex, Gemini
+- **Source Files:**
+  - `critical-claude.md`
+  - `critical-codex.md`
+  - `critical-gemini.md`
+
+---
+
+## Executive Summary
+
+The flash-tab change is small and well-shaped: a single fan-out point (`triggerFocusFlash`) drives three visual channels (pane ring, Bonsplit tab pulse, sidebar workspace pulse). All three reviewers agree the structural design is sound, the submodule push order is correct, and the typing-latency invariant on `TabItemView` was preserved.
+
+However, the reviewers diverge sharply on production readiness. **Claude and Codex say "ship after small fixes"; Gemini says "absolutely NOT ready" because channel (c) — the sidebar pulse — is allegedly completely broken** due to a SwiftUI state-observation defect. This contradiction is the single most important thing to resolve before merging.
+
+Two issues are unanimously confirmed:
+
+1. The Bonsplit `flashGeneration > 0` guard combined with `&+= 1` overflow can silently brick tab flashing forever.
+2. The settings copy ("flash a blue outline") is now stale because the toggle silences three channels, not one.
+
+Beyond that, each reviewer surfaced unique concerns worth investigating independently.
+
+### Production Readiness Verdict
+
+**NOT READY TO SHIP** until one specific contradiction is resolved: Gemini's claim that channel (c) is dead due to `let`-parameter staleness in `TabItemView`. If Gemini is right, this is a hard blocker. If Claude/Codex are right, the change is shippable after settings copy + the minor cleanups.
+
+Recommended path:
+1. Empirically verify channel (c) actually flashes in a tagged build (1-minute eyeball under the operator's dev setup). This resolves the Gemini blocker decisively.
+2. If channel (c) works: fix the `> 0` overflow guard, update the settings copy + run localization, and ship.
+3. If channel (c) does NOT work: stop and rewire observation per Gemini's analysis before doing anything else.
+
+---
+
+## 1. Consensus Risks (Multiple Models Agree)
+
+1. **`flashGeneration > 0` guard + `&+= 1` overflow silently bricks tab flashing.** (Claude W3, Gemini Important #3)
+   - Both reviewers independently identified this at `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:236-241`.
+   - After `Int.max` flashes, `&+= 1` wraps to `Int.min`, the `newValue > 0` guard fails forever, and tab flashes silently stop.
+   - Practically unreachable (9 quintillion flashes), but the inconsistency with c11 sidebar's `!=` guard is the real smell — a future maintainer copy-pasting either pattern gets a subtly different contract.
+   - **Fix:** Drop the `> 0` predicate; keep only `newValue != lastObservedFlashGeneration`. The parent's `(pane.flashTabId == tab.id) ? gen : 0` already guarantees targeted-tab semantics.
+
+2. **No automated coverage for two of three channels.** (Claude M1, Codex "What's Missing", Gemini "What's Missing")
+   - All three reviewers note that `tests_v2/test_trigger_flash.py` only verifies the pane channel. Sidebar pulse and tab pulse have no observable counter and can silently regress.
+   - The CLAUDE.md test policy permits the gap, but a small extension (debug socket counters for `sidebarFlashToken` and `flashTabGeneration`, ~30 lines) would close it cheaply.
+   - **Fix:** Add debug socket counters, extend `tests_v2/test_trigger_flash.py` to assert all three increment.
+
+3. **Sidebar/tab visual channels rely on manual/CI confidence only.** (Claude M1, Codex Potential #2, Gemini "Important")
+   - Codex and Claude both note CI catches compilation but not "did the pulse actually appear." Gemini's bug claim (if real) is the exact regression mode this gap permits.
+
+---
+
+## 2. Unique Concerns (Single-Model Risks Worth Investigating)
+
+### From Gemini (most consequential)
+
+1. **CLAIMED BLOCKER: Channel (c) is completely dead.** (Gemini Blocker #1, `Sources/ContentView.swift:10906`)
+   - Gemini argues the `let sidebarFlashToken` parameter on c11's `TabItemView` never updates because the parent `VerticalTabsSidebar` does not observe `Workspace`. The child re-evaluates from `objectWillChange` but with a stale `let` value, so `.onChange` never fires.
+   - Gemini reports running an explicit SwiftUI test script mimicking the structure to confirm.
+   - **CRITICAL CONTRADICTION:** Claude's validation pass confirms W6 (LazyVStack lazy-mount loses flashes for off-screen rows) but does not flag this broader observation defect. Claude assumes the sidebar pulse works while mounted. Codex does not test this path at all.
+   - **Action:** This is the single highest-priority unknown. Empirically confirm or refute in a tagged build before any other work. If Gemini is right, the fix is structural (use `.onReceive(tab.$sidebarFlashToken)` or ensure parent observes `Workspace`).
+
+2. **Square `Rectangle` overlay on rounded Bonsplit tab.** (Gemini Important #2, `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:229`)
+   - Gemini claims the flash overlay uses `Rectangle()` while the tab background is rounded, producing visible sharp-edge bleed.
+   - Neither Claude nor Codex flagged this. Worth a 5-second visual eyeball.
+   - **Fix (if confirmed):** Use `RoundedRectangle(cornerRadius: tabCornerRadius)`.
+
+3. **`SidebarFlashPattern.segments` / `TabFlashPattern.segments` are `static var` computed properties.** (Gemini Potential #4, `Sources/Panels/Panel.swift:75`)
+   - Re-evaluated and re-mapped on every access. On the animation hot path on the main thread.
+   - Neither Claude nor Codex caught this. Trivial fix: change `static var` to `static let`.
+
+### From Claude (most thorough enumeration)
+
+1. **W1: Notification fan-out scope is a unilateral product decision.** (`Sources/Workspace.swift:8820-8834`)
+   - Terminal-notification-routed flashes (Zulip pings, agent-completion, remote daemon events) now drive sidebar pulses on every notification, where previously only the pane ring pulsed. With 8-12 active workspaces, 5 simultaneous pulses across the sidebar reads differently than one pane flash.
+   - The implementer did not flag this as a tradeoff. Whether this is "polite ambient nudge" or "twitchy" needs operator calibration under realistic notification volume.
+   - **Action:** Five-second eyeball under realistic load OR bypass channel (c) for `triggerNotificationFocusFlash` callsites (only fire on explicit user actions).
+
+2. **W2: `surfaceIdFromPanelId` is O(n) per flash.** (`Sources/Workspace.swift:5793`)
+   - Linear scan through `surfaceIdToPanelId.values` now on the v2 socket flash hot path. Trivially avoided by passing `tabId` directly from callsites that have it.
+
+3. **W4: Sidebar flash overlay sits on top of the active-row leading rail.** (`Sources/ContentView.swift:11494-11520`)
+   - The accent fill briefly tints the active-state rail at peak 0.18 opacity. Visual nit, not a blocker. Reorder overlays.
+
+4. **W5: Bonsplit `TabItemView` is not Equatable; siblings re-evaluate on every flash.** (`vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift`)
+   - c11's sidebar version was carefully designed with `Equatable` to skip sibling re-eval. Bonsplit dropped that discipline. Acceptable for current pane tab counts but a regression in pattern.
+
+5. **W6: LazyVStack defers row creation; flashes for off-screen rows are lost.** (`Sources/ContentView.swift:8424`)
+   - Probably correct behavior, but means the sidebar pulse is "best-effort while mounted," not a reliable signal. Worth filing a follow-up for a "has unseen flash" sticky indicator.
+
+6. **W7: `NotificationPaneFlashSettings` toggle disables flash but not focus-stealing.** (`Sources/Workspace.swift:8820-8828`)
+   - Pre-existing, but the new fan-out makes the setting more visible. An operator who turns the flash OFF expecting "stop yanking focus" will be surprised. Worth a docstring update.
+
+7. **M5: Synchronous-on-main fan-out under burst load.** (`Sources/Workspace.swift:8811-8818`)
+   - Three UI mutations sync on `@MainActor` per notification. Pre-existing pattern but worth a comment acknowledging that 20 notifications in 100ms could stall typing.
+
+8. **M6: Plan §9 verification checklist has unchecked boxes despite resolution in code.**
+   - Tick the boxes or remove the section to avoid misleading documentation.
+
+### From Codex (sharpest product framing)
+
+1. **Settings copy is stale and misleading.** (Codex Important #1, `Sources/c11App.swift:5683-5684`)
+   - "Pane Flash" still describes "Briefly flash a blue outline when c11 highlights a pane." The toggle now silences three channels including sidebar workspace pulse and Bonsplit tab strip pulse.
+   - This is a real settings-contract bug — exactly how confusing settings regressions ship.
+   - **Fix:** Update English default copy; run the localization sync (Japanese, Ukrainian, Korean, Simplified Chinese, Traditional Chinese, Russian) per CLAUDE.md.
+
+2. **`triggerFocusFlash(panelId:)` is not defensive against invalid panel ids.** (Codex Potential #1, `Sources/Workspace.swift:8811-8817`)
+   - `sidebarFlashToken &+= 1` runs unconditionally even if `panels[panelId] == nil`. Current callers all validate, but the API itself is undefensive.
+   - **Fix:** Either early-return when `panels[panelId] == nil` or document that workspace-level-only flashes are intentional.
+
+---
+
+## 3. The Ugly Truths (Recurring Hard Messages)
+
+1. **The implementer made unilateral product decisions and did not flag them as tradeoffs.**
+   - Claude (W1): Notification fan-out scope unilateral.
+   - Codex (Important #1): Settings copy diverged from new behavior.
+   - The pattern: behavior was expanded silently. Design intent is documented in the plan; product impact under realistic load was not surfaced for review.
+
+2. **The change preserves the typing-latency contract on the sidebar but drops it in Bonsplit.**
+   - Claude (W5): Bonsplit `TabItemView` is not Equatable.
+   - The c11 sidebar `TabItemView` was carefully kept Equatable + `.equatable()` per CLAUDE.md typing-latency-sensitive paths. The Bonsplit-side equivalent dropped that discipline. Same surface, two standards.
+
+3. **Visual-channel coverage is missing from the test pyramid, and the reviewers disagree on whether channel (c) even works.**
+   - Three reviewers, three different confidence levels in the sidebar pulse. Claude says "works while mounted." Codex says "untested but plausible." Gemini says "completely broken." That spread is itself the truth: nobody actually proved the pulse fires on a real tagged build, because the test surface doesn't exist.
+
+4. **The Bonsplit + c11 sidebar implementations of the same idea drifted.**
+   - Different overflow guards (`> 0` vs `!=`).
+   - Different equatability disciplines.
+   - Different overlay shapes (Rectangle vs RoundedRectangle, per Gemini).
+   - Different segment-table types (`[FocusFlashCurve]` vs Bonsplit's internal `Curve`).
+   - The decoupling was deliberate and upstream-friendly, but the duplication needs explicit "intentionally divergent" comments or it will rot.
+
+---
+
+## 4. Consolidated Blockers and Production Risk Assessment
+
+### Consolidated Blockers (must fix before merge)
+
+1. **Empirically confirm channel (c) actually fires in a tagged build.** Gemini's blocker claim is incompatible with Claude's "ship-ready" verdict. Resolve the contradiction with a 1-minute visual test before any other work. If Gemini is right, the rewiring is structural and gates everything else.
+
+2. **Drop the `> 0` overflow guard in Bonsplit `TabItemView.onChange`.** Confirmed by both Claude and Gemini. ~1-line fix at `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabItemView.swift:237`.
+
+3. **Update the "Pane Flash" settings copy to reflect three-channel behavior, then run the localization pass.** Per Codex, this is a real settings-contract bug. Per CLAUDE.md, English-only edits at the call site, then delegate the six locales to a sub-agent in a fresh c11 pane.
+
+4. **Verify the Bonsplit overlay shape is `RoundedRectangle`, not `Rectangle`.** Per Gemini. If `Rectangle`, fix immediately.
+
+### Important (fix in this PR or file follow-up before broad release)
+
+1. **Add debug socket counters for sidebar and tab channels; extend `tests_v2/test_trigger_flash.py` to assert all three increment.** (~30 LoC.) Closes the regression-coverage gap unanimously identified.
+
+2. **Resolve W1 notification fan-out scope.** Either accept the expansion explicitly with a calibration note after a five-second eyeball under realistic notification load, or bypass channel (c) for `triggerNotificationFocusFlash` callsites.
+
+3. **Change `SidebarFlashPattern.segments` and `TabFlashPattern.segments` from `static var` to `static let`.** Per Gemini. Trivial.
+
+4. **Fix `surfaceIdFromPanelId` O(n) lookup or pass `tabId` from callsites that have it.** Per Claude W2.
+
+5. **Add `Equatable` conformance to Bonsplit `TabItemView`** to mirror c11 sidebar discipline, OR document the divergence explicitly. Per Claude W5.
+
+6. **Reorder overlays so the active-row leading rail sits above the flash fill.** Per Claude W4.
+
+7. **Add early-return / docstring to `triggerFocusFlash` for invalid panel ids.** Per Codex Potential #1.
+
+### Potential (follow-up filings)
+
+1. **"Has unseen flash" sticky indicator for off-screen sidebar rows.** Per Claude W6.
+
+2. **Docstring update on `NotificationPaneFlashSettings`** clarifying the toggle does NOT silence focus-stealing. Per Claude W7.
+
+3. **Comment block on synchronous-on-main fan-out** noting that burst load (~20 notifications in 100ms) could stall typing. Per Claude M5.
+
+4. **Plan §9 verification checklist cleanup.** Tick the boxes or remove the section. Per Claude M6.
+
+5. **Add `flashGeneration: Int = 0` default arg to Bonsplit `TabItemView`** for defensive call-site ergonomics. Per Claude N4.
+
+6. **Drop the `?? 0` fallback on known-non-empty constant arrays** in both `runSidebarFlashAnimation` and `runFlashAnimation`. Per Claude N1.
+
+### Production Risk Assessment
+
+- **If Gemini's blocker is real:** HIGH RISK. Channel (c) does not flash; the change ships a feature that is silently broken on the most operator-visible channel. Do not merge. Rewire observation per Gemini's analysis (likely `.onReceive(tab.$sidebarFlashToken)` or ensure parent view observes `Workspace`).
+- **If Gemini's blocker is wrong:** LOW-TO-MEDIUM RISK. The change is small and well-scoped. The settings-copy bug (Codex) and overflow guard (Claude+Gemini) are both real but trivial. The notification fan-out (Claude W1) is a calibration question, not a bug. The remaining items are cleanup quality.
+- **Either way:** the visual-channel test gap is a coverage debt that will pay back the first time someone refactors the fan-out.
+
+**Final Recommendation:** Do not merge until step 1 of the recommended path (verify channel (c) in a tagged build) is performed. The cost of that verification is one minute; the cost of being wrong is shipping a feature that doesn't work on the channel users will most notice.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-evolutionary.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-evolutionary.md
@@ -1,0 +1,85 @@
+## Evolutionary Synthesis — flash-tab
+
+- **Date:** 2026-04-28
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62
+- **Inputs:** evolutionary-claude.md, evolutionary-codex.md, evolutionary-gemini.md
+- **Type:** Synthesis (read-only)
+
+---
+
+### Executive Summary — Biggest Opportunities
+
+All three models converged with unusual force on a single reframing: this PR is not a flash feature, it is the seed of an **attention routing primitive** for c11 — a one-call API for "draw the operator's eye to surface X across every layer of the workspace UI without disturbing what they are doing." The unique product value is *"locate without selecting"* — separating "where attention is" from "where focus is." The three biggest opportunities, in priority order:
+
+1. **Name and formalize the attention bus.** `Workspace.triggerFocusFlash(panelId:)` is already the de-facto fan-out point (keyboard, right-click, v2 socket, notification routing all converge there). Rename or wrap it as an explicit attention API (intensity tiers, layer choices, optional cause/source). This is the highest-leverage move because the API will accumulate callers fast and rename cost grows with each one.
+2. **Extract a single shared generation-token animation runner.** The "reset → asyncAfter loop → generation guard → withAnimation" choreography now appears in MarkdownPanelView, BrowserPanelView, sidebar TabItemView, and Bonsplit's TabItemView. One timing bug currently needs three or four fixes. A single `@MainActor` helper (or SwiftUI ViewModifier) is the canonical "fire-and-forget transient signal under typing-latency-sensitive equatability" pattern and unlocks cheap addition of future channels.
+3. **Open the agent-facing flywheel.** Once the attention bus is named and exposed via the v2 socket and CLI (e.g., `c11 attention <surface> --intensity ambient`), every Lattice review agent, build watcher, and autonomous loop gets a polite way to say "look here, don't yell." Calibrated low-intensity signals (the 0.18 / single-pulse sidebar channel especially) are the regime where 30-agent operation becomes legible — and the operator's trust in those signals compounds.
+
+The undercurrent across all three reviews: **protect the calibration of the quietest channel.** The sidebar pulse at peak opacity 0.18 / single pulse / 0.6s is what makes the whole system trustworthy. Lose that gentleness and operators silence the toggle, taking the other two channels with it.
+
+---
+
+### 1. Consensus Direction — Evolution Paths Multiple Models Identified
+
+1. **"Locate without selecting" is the core primitive.** All three reviews independently flagged that the deepest thing in the PR is the separation of attention from focus/selection. Claude calls it "a separation of where focus is from where attention is." Codex calls it "an attention routing fabric" whose semantic boundary is "look here, but do not move me." Gemini calls it a "Selection-Free Attention Routing Primitive." Same insight, three voices.
+2. **Promote `triggerFocusFlash` from a method to an attention dispatch.** Claude proposes `drawAttention(panelId:intensity:layers:)`. Codex proposes a `WorkspaceAttentionSignal { kind, intensity, panelId, preservesSelection }` struct dispatched behind the existing call. Gemini proposes a generic pub/sub `AttentionRouter`. Different shapes, identical direction: one semantic event, multiple channel subscribers, policy at the workspace boundary.
+3. **Generation-token + `.onChange` + per-row `==` skip is now an idiomatic pattern that needs a name.** The shape repeats four times in this branch alone (pane content, sidebar row, Bonsplit tab, plus the original BrowserPanelView). All three reviews call out the duplication as the single highest-leverage refactor. Codex and Gemini specifically flag it as the cheapest path to the next N attention channels.
+4. **An intensity vocabulary is already implicit.** Peak opacities of 1.0 / 0.55 / 0.18 and pulse counts of 2 / 2 / 1 across pane / tab / sidebar are not animation aesthetics — they are an emerging "spatial distance from gaze" gradient. Claude, Codex, and Gemini all suggest formalizing this into named tiers (ambient / normal / urgent or polite / assertive / breathing).
+5. **Bonsplit's `flashTab(_:)` is genuinely upstreamable.** All three reviews note the public API is selection-neutral and host-agnostic. Codex explicitly recommends preparing a narrow upstream PR (avoiding c11 terminology — "requestTabAttention" or similar). Claude proposes a `flashPane` companion to round out the primitive at the pane level.
+6. **Numeric envelope mirroring across module boundaries is the main drift risk.** `FocusFlashPattern`, `SidebarFlashPattern`, and `TabFlashPattern` are intentionally similar but uncoupled. Claude and Codex both flag this — Codex calling it "drift-prone if c11 adds more attention channels," Claude proposing a `FlashEnvelope.from(values:keyTimes:duration:curves:)` factory. The fix is small now and expensive later.
+7. **Debug-counter validation seam should extend to the new channels.** The pane channel already exposes a debug flash count consumed by `tests_v2/test_trigger_flash.py`. Codex (most specifically) and Claude both propose adding `debug.flash.tab_count` and `debug.flash.sidebar_count` so CI can assert fan-out happened without inspecting pixels or source text — the c11 test-quality policy explicitly forbids the latter.
+
+---
+
+### 2. Best Concrete Suggestions — Most Actionable Across All Three
+
+1. **Extract `runFlashAnimation(envelope:generation:isCurrent:apply:)` as a `@MainActor` helper.** All three models converged on this as the highest-value low-risk refactor. Lives near `FocusFlashPattern` / `SidebarFlashPattern` in `Sources/Panels/Panel.swift`. c11's two callers (sidebar `runSidebarFlashAnimation` at `ContentView.swift:11604` and the existing panel methods) collapse to one. Bonsplit keeps its own copy for module isolation. Gemini's variant — wrap it as a `.transientFlash(generation:pattern:color:)` ViewModifier — is worth considering but must not introduce `@EnvironmentObject` / `@ObservedObject` reads in `TabItemView` (typing-latency invariant).
+2. **Add per-channel debug counters and extend `tests_v2/test_trigger_flash.py`.** Mirror the existing `debug.flash.count` pattern in `GhosttyTerminalView.swift:7581`. Add counters for tab and sidebar fan-out. Closes the validation gap without violating the "no source-text tests" policy. Off the typing hot path, debug-only recording.
+3. **Formalize `FlashEnvelope` as a single struct or factory.** `FocusFlashPattern` and `SidebarFlashPattern` share the values / keyTimes / duration / curves / `var segments` shape with the same `min(curves.count, values.count - 1, keyTimes.count - 1)` boilerplate. One factory removes ~12 lines per envelope and makes adding urgent / agent-voice / storm tiers a 5-line affair.
+4. **Introduce `WorkspaceAttentionSignal` privately behind `triggerFocusFlash`.** Codex's framing is the cleanest: keep the existing public method as a compat shim, route internally through a `.focusFlash` signal. Do not over-generalize until a second signal kind exists. This is the one-step preparation for the named attention bus without requiring naming dialogue first.
+5. **Add `lastFlashedAt: Date?` next to `Workspace.sidebarFlashToken`.** One published property, one assignment in `triggerFocusFlash`. Unlocks: sidebar decay overlay, "what flashed while I was away?", per-workspace mute by recency, attention audit log.
+6. **Move the typing-latency invariant comment onto `==`.** The wall-of-`//` warning at `ContentView.swift:10905-10915` should be a `///` doc-comment on the `==` function so Xcode quick-help surfaces it the moment someone touches the comparator. Pure relocation, zero risk.
+7. **Prepare a narrow upstream Bonsplit PR for `flashTab`.** Self-contained submodule diff, host-agnostic public API. Use upstream-friendly naming (e.g., `requestTabAttention` rather than c11's "flash"). Codex confirms parent pointer already references `78d09a44`.
+8. **Add a `#if DEBUG` attention log.** A single `dlog("attention.fan-out panel=… layers=pane,tab,sidebar")` at `triggerFocusFlash` matches the existing `dlog("sidebar.close ...")` pattern. Subsystem becomes observable for free.
+
+---
+
+### 3. Wildest Mutations — Creative / Ambitious Ideas Worth Exploring
+
+1. **OSC sequence handler for "attention from inside the terminal."** (Claude.) A c11-specific OSC (e.g., 1338) so `make` finishing, `pytest` first-failure, or `claude --dangerously-skip-permissions` finishing a turn can flash their own surface without the operator scripting anything. Routes through `triggerFocusFlash`. Requires checking collision with upstream Ghostty/cmux conventions before claiming a number.
+2. **Per-agent flash temperament.** (Claude.) Plumb `requestedBy: AgentIdentity?` through the attention dispatch and let it influence color/curve. Gregorovitch's flashes slow and gold-tinted; a build watcher's sharp and red. Agent identity registers visually in the sidebar.
+3. **Sidebar shimmer for attention storms.** (Claude, Gemini "Heatmaps".) When N workspaces flash within T seconds, fire a coalesced sidebar-wide low-amplitude pulse — the meta-signal "lots happened, look at the dashboard." A coarse-grained signal layered on top of the per-row signal.
+4. **Attention as a recordable / replayable channel.** (Claude, Codex, Gemini all touched this.) Persist every fan-out event with surface id, timestamp, source. Becomes a *gaze record* — "what was the system trying to tell me in the last hour?" Composable with Lattice retro-AARs. Codex's "Attention Replay" debug command falls here.
+5. **Agent Presence Radar / Spatial Breadcrumbs.** (Codex, Gemini.) Each agent surface emits typed-cause signals (done / blocked / needs review / error / waiting on human). Sidebar row becomes a compact radar; tab strip becomes a live map of background activity via persistent slow-pulsing auras instead of single transient pulses.
+6. **Audio-haptic coupling.** (Gemini.) Tie the generation-token increment to a subtle spatial audio click or a macOS trackpad haptic tap. The polite visual nudge becomes a multi-sensory ambient cue. Most useful for accessibility and ambient awareness when the operator is not looking at the screen.
+7. **Attention bidirectionality / "hover to point back."** (Claude.) Hovering a sidebar workspace row briefly flashes the focused tab in *that* workspace. Closes the loop the other way: operator pointing at workspace → workspace's current focus surfaces visually. Same primitive, opposite direction.
+8. **Off-screen edge glows instead of forced scroll.** (Gemini.) When the flashed tab is outside `TabBarView`'s visible bounds, apply a transient gradient glow on the leading/trailing edge of the scroll mask rather than yanking the viewport with `proxy.scrollTo`. Less disruptive when the operator is actively reading. Codex's "scroll only on intensity tier" is the more conservative variant of the same insight.
+9. **Command Palette Locate Mode.** (Codex.) Searching for a surface, workspace, PR, or process uses the attention fabric to *reveal in place* before navigating. The palette first answers "where is it?" — selection becomes a follow-up.
+10. **Sidebar-only flashes for remote teammates.** (Claude.) When other operators in the same Lattice plan touch a surface, fire a sidebar-only ambient pulse on workspaces tied to that plan. The three-channel structure is already shaped for "polite ambient signal" — just connect the wire from Lattice events into `sidebarFlashToken`.
+11. **"Trace this flash" debug command.** (Claude.) Right-click a flashing tab → "Trace flash source" → opens a debug surface listing the last N attention events with stack source (kbd / right-click / socket / notification / OSC / agent). Pure observability, pays off as the bus grows.
+12. **Differentiated attention semantics as a vocabulary.** (Gemini.) Beyond intensity tiers: "Success Pulse" (green, fast), "Warning Throttle" (yellow, sustained), "Agent Thinking Glow" (slow, breathing). Couples color + rhythm + intensity into a small named lexicon agents can target.
+
+---
+
+### 4. Leverage Points and Flywheel Opportunities
+
+#### Leverage Points (small change, disproportionate value)
+
+1. **The shared `runFlashAnimation` helper** — one helper, four current callers, every future channel for free. Claude, Codex, and Gemini all rank this #1.
+2. **Naming the attention bus now (privately or publicly)** — Codex's framing of "introduce the language now, restrain the API surface" is the cheapest path. Once codebase prose says "attention signal," future features route through the same primitive instead of scattering UI-specific verbs.
+3. **A single `lastFlashedAt: Date?` field on Workspace** — unlocks four downstream features (decay overlay, away-summary, per-workspace mute, audit log) for one published property.
+4. **Per-channel debug counters** — closes the validation gap, satisfies the c11 test-quality policy, and makes future channels CI-assertable for free.
+5. **CLI surface (`c11 attention <surface>`)** — once exposed, the skill spreads it to every agent in the field. Lowest-friction path from primitive to ecosystem.
+
+#### Flywheels (already spinning + engineerable next loops)
+
+1. **Already spinning: every new trigger path gets all three channels for free.** Single fan-out at `triggerFocusFlash` means keyboard, right-click, v2 socket, notification routing — and any future agent-driven path — automatically light up pane + tab + sidebar. Each new caller increases channel value; each new channel increases caller value. This PR added the third spoke.
+2. **Engineerable: agent calibration loop.** Skill teaches agents to call attention with intensity → operators leave low-intensity signals on because they whisper → agents see the operator notice and act → calibration data refines agent attention behavior → trust compounds → operators delegate more work → more attention requests, lower disruption per request. The flywheel is *trust as compound interest*, mediated by the gentleness of the lowest-intensity channel.
+3. **Engineerable: shared primitive lowers the cost of every new channel.** Bonsplit tab strip, sidebar row, pane content become channel subscribers, not bespoke endpoints. The fifth and tenth attention surface (badge counts, scroll-to-row, edge glow, audio cue) cost a fraction of the first three because the substrate is in place. Codex's framing.
+4. **Engineerable: "locate without selecting" reframes adjacent problems.** Search hits, command palette results, blocked-agent indicators, debug probes, "where did this terminal go?" — all currently solved (or not solved) via focus-stealing jumps — become spatial attention events using the same primitive. Codex calls this out explicitly; the design space "larger than notifications" is the prize.
+5. **Engineerable: attention log → retro-AAR signal.** Persisted attention events become "where did the system point me, did I respond, was it right?" — a derivable answer composable with Lattice. Closes the operator-feedback loop on the calibration cycle in #2.
+
+#### Final calibration warning (consensus across all three reviews)
+
+The 0.18 / single-pulse / 0.6s sidebar channel is the load-bearing whisper. It is what makes leaving the toggle on tolerable in a 30-agent regime. **Future PRs that ratchet up peak opacity, pulse count, or duration in the name of "make it more visible" should be scrutinized hard.** The whole flywheel above depends on the gentlest channel staying gentle.

--- a/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-standard.md
+++ b/notes/trident-review-flash-tab-pack-20260428-0035/synthesis-standard.md
@@ -1,0 +1,116 @@
+## Synthesis: Standard Code Review (flash-tab)
+
+- **Date:** 2026-04-28
+- **Branch:** c11-flash-tab-and-workspace
+- **Latest Commit:** 9b1e1f62
+- **Reviewers:** Claude (claude-opus-4-7), Codex (GPT-5), Gemini
+- **Tier:** Standard
+
+---
+
+## Executive Summary
+
+All three reviewers independently arrive at the same verdict: the flash-tab pack is a small, coherent, well-shaped change with no blockers and no important issues that gate merge. The single fan-out at `Workspace.triggerFocusFlash(panelId:)` is unanimously praised as the right architectural shape. The Bonsplit seam is judged upstream-friendly. The sidebar typing-latency invariant is preserved correctly via precomputed `let` + `==` update. Generation-token guards are confirmed correct in both new channels.
+
+Codex raised a single non-blocking tactical observation about unconditional sidebar pulse on stale/missing `panelId`. Claude raised five lower-priority potentials (documentation, micro-perf, dead defensive code, refactor opportunity, offscreen UX). Gemini reported zero issues at any tier.
+
+## Merge Verdict
+
+**Approve / merge after operator visual validation.** No blockers from any model. No "Important" items from any model that gate merge (Codex's lone Important is explicitly self-marked as non-blocking). All three converge on "ready to merge."
+
+Operator validation per `notes/flash-extension-plan.md` §7 remains the last word on the visual envelopes (0.55 / 0.18 / 1.0 peak amplitudes across the three channels).
+
+---
+
+## 1. Consensus (2+ models agree)
+
+1. **No blockers.** Claude, Codex, and Gemini all explicitly report zero blocking issues.
+2. **Single fan-out at `Workspace.triggerFocusFlash(panelId:)` is the correct architectural shape.** All three reviewers independently identify this as the load-bearing design choice and praise the consolidation of keyboard / right-click / v2 socket / notification routes through one method.
+3. **Bonsplit seam is upstream-friendly.** All three confirm `BonsplitController.flashTab(_:)` is consumer-neutral, makes no host-coupling assumptions, mirrors `selectTab(_:)` shape, and uses Bonsplit-internal `TabFlashPattern` rather than importing host types. Plausibly upstreamable to `almonk/bonsplit`.
+4. **Sidebar typing-latency invariant correctly preserved.** Claude, Codex, and Gemini all confirm threading `sidebarFlashToken` as a precomputed `let` parameter and adding it to the `==` comparator at `Sources/ContentView.swift:10934` is the single correct pattern given the documented invariant at lines 10903-10913. The plan's rejection of `@ObservedObject` / `@EnvironmentObject` (which would defeat `==` short-circuit) is validated.
+5. **Generation-token guards correctly handle back-to-back flashes.** All three confirm `lastObservedFlashGeneration` (Bonsplit) and `lastObservedSidebarFlashToken` (sidebar) bail out cleanly on stale segments, mirroring the existing pane-content pattern in `MarkdownPanelView` / `BrowserPanelView`.
+6. **`triggerNotificationFocusFlash` rewrite preserves terminal-only-bail behavior.** Claude and Gemini both call out that switching from `guard let terminalPanel = terminalPanel(for: panelId) else { return }` to `guard terminalPanel(for: panelId) != nil else { return }` correctly preserves the "non-terminal panels don't get notification flashes" semantics while delegating through the new fan-out.
+7. **No new headless tests needed; CI is the merge gate.** Claude and Codex both confirm local testing was not run (per c11 testing policy), and that CI exercising `tests_v2/test_trigger_flash.py` is sufficient. The two new channels are visual-only and intentionally not asserted, consistent with the test-quality policy.
+
+## 2. Divergent Views
+
+1. **Severity of unconditional sidebar pulse on stale/missing panelId.**
+   - **Codex:** Raised as Important (1) but self-marked "non-blocking." Suggests tightening to `guard let panel = panels[panelId] else { return }` before fan-out, otherwise a stale `panelId` produces a workspace-row pulse with no corresponding pane or tab flash.
+   - **Claude:** Did not flag this directly. Claude's analysis focused on the `triggerNotificationFocusFlash` guard path (which still bails for non-terminal panels) and treated the fan-out as correct.
+   - **Gemini:** Did not flag this; reported no issues at any tier.
+   - **Resolution:** Codex's observation is real but low-impact: most current callers pass valid IDs, and `triggerNotificationFocusFlash` retains its terminal-panel guard. Worth a small follow-up tightening but not a merge blocker.
+
+2. **Documentation of trigger-path asymmetry (right-click bails on non-terminals; keyboard / socket do not).**
+   - **Claude:** Raised as Potential #2 (preserved, not introduced; suggests a one-line code comment).
+   - **Codex / Gemini:** Did not flag.
+   - **Resolution:** Documentation aid only; doesn't gate merge.
+
+3. **Offscreen-workspace pulse UX.**
+   - **Claude:** Raised as Potential #3 — flash fires on a workspace the operator can't see, animation may resume on return ("I switched workspaces, now there's a tab quietly pulsing").
+   - **Codex / Gemini:** Did not flag.
+   - **Resolution:** Operator-eyeballing item during validation; not a code change.
+
+## 3. Unique Findings (single-model observations)
+
+### Codex only
+
+1. **Sidebar pulse fires unconditionally on stale/missing panelId** (Codex Important #1). At `Sources/Workspace.swift:8813`, pane flash is optional via `panels[panelId]?.triggerFlash()`, but line 8817 increments `sidebarFlashToken` regardless. Pre-branch behavior was a no-op for missing panels; new behavior produces a workspace-row pulse with no pane/tab counterpart. Suggested fix: `guard let panel = panels[panelId] else { return }` ahead of fan-out. Self-marked non-blocking.
+
+### Claude only
+
+2. **`tests_v2/test_trigger_flash.py` regression-traced through gating relocation** (Claude Important #1). Confirmed via reading that with the gating moved up to fan-out, the chain `Workspace.triggerFocusFlash` → `panels[panelId]?.triggerFlash()` → `TerminalPanel.triggerFlash()` → `hostedView.triggerFlash()` → `recordFlash(for:)` is preserved when `notificationPaneFlashEnabled = true`, and both old and new paths skip `recordFlash` when disabled (just at different guards). No regression. Worth a CI eye if the test exercises the toggle.
+
+3. **Right-click vs. keyboard / socket asymmetry on non-terminal panels** (Claude Potential #2). Asymmetry pre-existed; PR doesn't change it. One-line code comment near right-click hookup would help the next reader.
+
+4. **Offscreen workspace pulse UX** (Claude Potential #3). Tab on an offscreen workspace pulses; SwiftUI throttles offscreen animation but resumes on return. Not a bug, but operator UX worth eyeballing during validation.
+
+5. **Bonsplit `flashGeneration` ternary recomputes per tab per render** (Claude Potential #4). `(pane.flashTabId == tab.id) ? pane.flashTabGeneration : 0` at `TabBarView.swift:698` is per-tab UUID-equality compare per render. Negligible at current tab counts, linear in tabs-per-pane. Micro-concern only.
+
+6. **Four near-identical `runFlashAnimation` loops** (Claude Potential #5). `MarkdownPanelView.triggerFocusFlashAnimation`, `BrowserPanelView.triggerFocusFlashAnimation`, `Bonsplit/TabItemView.runFlashAnimation`, `ContentView/TabItemView.runSidebarFlashAnimation` share the same segment-iteration shape. Refactor into a shared helper would tidy this; not block-worthy because the bonsplit copy is intentionally Bonsplit-internal for upstream cleanliness.
+
+7. **`SidebarFlashPattern.values.first ?? 0` is unreachable defensive code** (Claude Potential #6). `values` is a `static let` literal whose first element is `0`; `?? 0` is dead. Mirrors existing pattern in `MarkdownPanelView`/`BrowserPanelView`; consistency wins over deletion.
+
+8. **Animation envelope intentional tiering** (Claude tactical commentary). 0.55 (tab) / 0.18 (sidebar) / 1.0 (pane) peak amplitudes are intentionally tiered (loudest signal: pane = "this surface wants attention", medium: tab = "which tab in the strip", softest: sidebar = "which workspace"). Numerical relationships reasonable; operator visual validation has the last word.
+
+9. **`UserDefaults.bool(forKey:)` per-flash gating cost** (Claude tactical nit). Cheap reads at user-rate (~1-10/sec); fine.
+
+### Gemini only
+
+10. **Validation pass: cleanly solves plan objectives, no regressions on inspection, ready to merge.** No additional tactical findings beyond the consensus items.
+
+## 4. Consolidated Findings
+
+### Blockers (deduplicated)
+
+(none)
+
+### Important (deduplicated, non-blocking-but-worth-considering)
+
+1. **Tighten `Workspace.triggerFocusFlash(panelId:)` to bail on missing panel before fan-out** (Codex). Add `guard let panel = panels[panelId] else { return }` ahead of the `triggerFlash()` / `flashTab` / `sidebarFlashToken &+=` sequence so a stale `panelId` doesn't produce an orphaned workspace-row pulse. Low risk, small diff, can be a follow-up. Not a merge blocker.
+
+### Potential / Suggestions (deduplicated, low-priority)
+
+2. **Add a one-line code comment near the right-click "Trigger Flash" hookup** documenting the preserved asymmetry: right-click bails on non-terminal panels (via `triggerNotificationFocusFlash`), while keyboard shortcut and v2 socket flash any panel type (Claude Potential #2). Pure aid for next reader.
+
+3. **Operator-eyeball offscreen workspace UX during visual validation** (Claude Potential #3). Confirm that a flash on a non-visible workspace producing a quiet tab pulse on return matches operator intent.
+
+4. **Hoist `pane.flashTabId` outside the per-tab `ForEach` ternary** at `vendor/bonsplit/Sources/Bonsplit/Internal/Views/TabBarView.swift:698` (Claude Potential #4). Negligible at current tab counts; relevant only if c11 ever supports panes with very large tab counts. Micro-perf.
+
+5. **Lift a shared `runSegmentedAnimation(segments:tokenCheck:)` helper** to dedupe the four near-identical segment-iteration loops across `MarkdownPanelView`, `BrowserPanelView`, Bonsplit `TabItemView`, and sidebar `TabItemView` (Claude Potential #5). Bonsplit copy stays internal for upstream cleanliness; host two could merge. Not block-worthy.
+
+6. **Leave `SidebarFlashPattern.values.first ?? 0` as-is** (Claude Potential #6). Dead defensive code, but mirrors existing pattern; consistency wins.
+
+### Confirmations (cross-model validations recorded as positive findings)
+
+7. Build passes locally on Claude's machine (`xcodebuild ... build` → BUILD SUCCEEDED).
+8. Branch state: 1 commit ahead of `origin/main` at `9b1e1f62`; `notes/.tmp/` untracked review context only (Codex).
+9. `.allowsHitTesting(false)` on both Bonsplit tab overlay and sidebar row overlay correctly prevents interaction interception (Gemini).
+10. Sidebar overlay corner-radius (6) matches the row's background and border rects; pulse stays within row chrome (Claude).
+11. Bonsplit `TabBarView` `.onChange(of: pane.flashTabGeneration)` correctly wraps scroll in `withTransaction(Transaction(animation: nil))` to avoid scroll/pulse animation conflict (Claude, Codex).
+12. Gating relocation from per-panel `triggerFlash` up to fan-out is a quiet consistency improvement: Bonsplit tab and sidebar channels now silenced uniformly when Pane Flash is disabled. Per-panel guards remain as harmless defense-in-depth (Claude).
+
+---
+
+## Recommendation
+
+Merge after operator visual validation per `notes/flash-extension-plan.md` §7. Optionally, in a follow-up commit, address Codex's stale-panelId tightening (Important #1) — it's a one-line `guard let` and would close the only real semantic gap any reviewer identified. Everything else is documentation, micro-perf, or stylistic and explicitly non-blocking.


### PR DESCRIPTION
## Summary
- Single fan-out at `Workspace.triggerFocusFlash(panelId:)` now drives three visual channels in lockstep: (a) terminal/markdown/browser pane ring, (b) Bonsplit tab strip (scroll-into-view + two-pulse accent fill, selection unchanged), (c) sidebar workspace row (single gentle accent pulse, visual-only).
- All three channels share the yellow `cmuxAccentColor` (terminal pane was the lone holdout still on `systemBlue`); tab flash envelope reshaped to fade-in 0.5s → hold 1.0s → fade-out 0.5s (~2s total) so the operator has time to glance and locate.
- Right-click "Trigger Flash", keyboard shortcut, v2 socket command, and notification routing all funnel through the same fan-out, and the existing Pane Flash settings toggle gates all three channels consistently.

## Architecture notes
- `Workspace.sidebarFlashToken` (`@Published Int`) is the seam to the sidebar `TabItemView`. The token is threaded as a precomputed `let` and added to `==` so only the targeted row re-renders — sibling rows skip body and the typing-latency `Equatable` contract holds.
- New `SidebarFlashPattern` in `Panels/Panel.swift` defines the gentler single-pulse envelope used only by the sidebar.
- Bonsplit submodule bumped to pick up the new `TabFlashPattern` shape.

## Review
A full Trident review pack (9 reviews x 3 lenses + 4 syntheses) is committed under `notes/` for traceability. Action items from `synthesis-action.md` (B1 sidebar-channel SwiftUI subscription verification, B2 settings copy, I1 Bonsplit overflow guard, etc.) are tracked separately and not blocking this PR.

## Test plan
- [x] Right-click "Trigger Flash" on a workspace fires all three channels with shared accent color
- [x] `c11 trigger-flash` CLI produces the same fan-out
- [x] Tab flash fade-in/hold/fade-out reads as steady highlight, not strobe
- [x] Sidebar Pane Flash toggle silences all three channels when off
- [ ] Verify B1 (sidebar channel SwiftUI subscription) with a dlog probe — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)