### PR TITLE
ci: bundle Dependabot GitHub Actions bumps (closes #90, #91, #92, #93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: daemon/remote/go.mod
 

--- a/.github/workflows/mailbox-parity.yml
+++ b/.github/workflows/mailbox-parity.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -189,7 +189,7 @@ jobs:
           restore-keys: spm-
 
       - name: Setup Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: daemon/remote/go.mod
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -489,7 +489,7 @@ jobs:
 
       - name: Upload branch nightly artifacts
         if: needs.decide.outputs.should_publish != 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: c11-nightly-${{ needs.decide.outputs.short_sha }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
 
       - name: Setup Go
         if: steps.guard_release_assets.outputs.skip_all != 'true'
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: daemon/remote/go.mod
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -341,7 +341,7 @@ jobs:
 
       - name: Upload recording artifact
         if: ${{ always() && inputs.record_video }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-recording
           path: /tmp/test-recording.mp4


### PR DESCRIPTION
## Summary

Bundles four open Dependabot GitHub Actions version bumps into a single PR for review and merge:

- #90 — `actions/setup-go` 5.5.0 → 6.4.0 (ci.yml, nightly.yml, release.yml)
- #91 — `actions/upload-artifact` v4 → v7.0.1 (nightly.yml, test-e2e.yml)
- #92 — `oven-sh/setup-bun` 2.1.2 → 2.2.0 SHA bump (ci.yml)
- #93 — `actions/setup-python` 5.6.0 → 6.2.0 (mailbox-parity.yml)

All four merged cleanly with no conflicts. Net diff is 7 lines across 5 workflow files.

## Notes

- `actions/upload-artifact` v5+ removed in-run append/overwrite of artifacts with the same name. Both call sites here already use unique artifact names (`c11-nightly-${short_sha}`, `test-recording`) and don't append in-run, so the breaking change doesn't bite us.
- The `build` / `mailbox-unit` jobs are red on each of the four source PRs because of a GitHub Actions billing failure on the macOS runners (`recent account payments have failed`), not a code issue. Same red is expected here until billing is sorted. All other checks pass on each source PR.

Closes #90
Closes #91
Closes #92
Closes #93

## Test plan

- [ ] Verify CI checks (excluding the billing-blocked `build` / `mailbox-unit` jobs) come back green on the bundle branch.
- [ ] Once billing is restored, confirm the four bumped actions resolve and run on a fresh CI pass.