### PR TITLE
Add OpenAI computer-use runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+artifacts/openai-cua-runs/
 
 # Claude Code per-session state and agent scratch worktrees
 .claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ The distinction matters. Socket/CLI commands are excellent for setup, orchestrat
 When validating c11 with computer use:
 
 - Launch only tagged builds (`./scripts/reload.sh --tag <tag>` and `./scripts/launch-tagged-automation.sh <tag>`). Never launch an untagged `c11 DEV.app`.
+- Default handoff is a fresh c11 surface running interactive Codex: create a new terminal pane/surface, run `codex --yolo`, then send a file-backed expert prompt. Do not use `codex exec` for watched validation panes.
+- The expert prompt should name the target tagged app/window, the scenario, success criteria, safety boundaries, artifact expectations, and the caller's workspace/surface refs so Codex can report back with `c11 send` or leave a readable result for `read-screen`.
+- This pattern is cross-agent: Claude Code can delegate visual validation to Codex, and Codex can delegate a clean computer-use pass to another Codex surface. Keep the handoff explicit so the validation context is fresh and inspectable.
 - Use the socket as setup/oracle infrastructure, not as a substitute for the UI path being tested.
 - Capture screenshots and scenario artifacts for claims about visible behavior.
 - Inspect `c11 tree --no-layout` before calling a run successful. If important panes are too small for a human to read, rebalance them and treat that as part of the validation, not cleanup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,25 @@ c11's value to an agent is **the skill** — `skills/c11/SKILL.md` plus the peer
 
 **Therefore:** every change to the CLI, socket protocol, metadata schema, or surface model is incomplete until the skill is updated to match. If you add a command, add it to the skill. If you rename a command, rename it in the skill. If you change defaults, update the examples. The skill is the contract; let it rot and agents get worse at using c11. Invest there first, not last.
 
+## Computer use is a maintainer validation skill, not the c11 operating skill
+
+There are two different genres here; do not blur them:
+
+- **Agent operating skill (`c11`).** Teaches an agent inside c11 how to use the room: split panes, open surfaces, target handles, report status, drive browser/markdown surfaces, and compose its own working environment.
+- **Maintainer validation skill (`c11-computer-use`, planned).** Teaches a maintainer/developer agent how to test c11 as a product through the real macOS UI: screenshots, clicks, keyboard focus, pane readability, visual recovery, and user-path validation.
+
+The distinction matters. Socket/CLI commands are excellent for setup, orchestration, recovery, and deterministic oracle checks, but they do not prove that a human-visible workflow works. Computer use should validate behaviors that are visual, spatial, focus-sensitive, pointer-driven, or human-ergonomic.
+
+When validating c11 with computer use:
+
+- Launch only tagged builds (`./scripts/reload.sh --tag <tag>` and `./scripts/launch-tagged-automation.sh <tag>`). Never launch an untagged `c11 DEV.app`.
+- Use the socket as setup/oracle infrastructure, not as a substitute for the UI path being tested.
+- Capture screenshots and scenario artifacts for claims about visible behavior.
+- Inspect `c11 tree --no-layout` before calling a run successful. If important panes are too small for a human to read, rebalance them and treat that as part of the validation, not cleanup.
+- Prefer repeatable harness scenarios for comparisons across providers. Manual computer-use runs are useful, but they should feed back into reusable scenarios and skill guidance.
+
+The lesson from the OpenAI CUA runner work: "it executed" is not enough. If the resulting workspace is hard for the operator to read, the validation found a product/workflow issue worth preserving.
+
 ## Principle: unopinionated about the terminal
 
 c11 is **host and primitive, not configurator.** It provides surfaces, panes, a socket, a CLI, and a metadata seam — all scoped to c11's own runtime. The operator's tenant config files (`~/.claude/settings.json`, `~/.codex/*`, `~/.kimi/*`, shell rc files, etc.) are off-limits: c11 never reaches in to install hooks, persist configuration, or inject behavior into any TUI's on-disk state.

--- a/docs/openai-codex-computer-use-plan.md
+++ b/docs/openai-codex-computer-use-plan.md
@@ -1,6 +1,6 @@
 # OpenAI Codex Computer Use Plan
 
-Status: planning artifact only. No runner implementation has started in this branch.
+Status: implementation started. The initial provider-neutral Swift macOS adapter and OpenAI-specific Python runner live under `tools/computer-use/`.
 
 Branch/worktree:
 
@@ -36,6 +36,8 @@ Official references:
 - Codex app Computer Use: `https://developers.openai.com/codex/app/computer-use`
 - API Computer Use guide: `https://developers.openai.com/api/docs/guides/tools-computer-use`
 - CUA sample app: `https://github.com/openai/openai-cua-sample-app`
+
+Implementation note: the runner targets the current GA Responses API `computer` tool shape: `tools=[{"type": "computer"}]`, `computer_call` outputs, and follow-up `computer_call_output` items sent with `previous_response_id`.
 
 ## Non-goals
 
@@ -418,6 +420,8 @@ Deliverables:
 - JSON action/result schema.
 - Local artifact screenshots.
 
+Implementation status: initial adapter added at `tools/computer-use/mac-adapter`. It also includes `launch`, frontmost bundle guardrails for input, `double_click`, `move`, `drag`, and `scroll`.
+
 Validation:
 
 - Run `doctor`.
@@ -439,6 +443,8 @@ Deliverables:
 - Run artifacts.
 - `launch-window` scenario.
 
+Implementation status: initial runner added at `tools/computer-use/openai-runner`. It discovers `OPENAI_API_KEY` from the environment only, writes ignored artifact bundles, and handles current Responses API computer calls.
+
 Validation:
 
 - Complete Scenario 1 against tagged c11.
@@ -452,6 +458,8 @@ Deliverables:
 - Socket oracle integration with `C11_SOCKET`/`CMUX_SOCKET`.
 - Scenario definitions for launch, split, focus/type.
 - Failure bundles with screenshots, logs, socket snapshots, and model trace.
+
+Implementation status: `doctor`, `smoke`, `launch-window`, `create-split`, and `focus-and-type` CLI paths are implemented. Socket usage is limited to launch/oracle/artifact capture.
 
 Validation:
 
@@ -575,4 +583,3 @@ Start Phase 1 and Phase 2:
 2. Implement the provider-neutral Swift mac adapter `doctor` and `observe` commands.
 3. Launch tagged c11 with `openai-cua` and capture the first window screenshot.
 4. Add the OpenAI runner only after the local screenshot/action loop is reliable.
-

--- a/docs/openai-codex-computer-use-plan.md
+++ b/docs/openai-codex-computer-use-plan.md
@@ -1,0 +1,578 @@
+# OpenAI Codex Computer Use Plan
+
+Status: planning artifact only. No runner implementation has started in this branch.
+
+Branch/worktree:
+
+- Branch: `feat/openai-cua-runner`
+- Worktree: `/Users/atin/Projects/Stage11/code/c11-worktrees/openai-cua-runner`
+
+Date: 2026-04-30
+
+## Goal
+
+Build an OpenAI-backed computer-use path for testing c11 the way an operator uses it: through the real macOS app UI, with screenshots, clicks, keyboard input, focus changes, menus, panels, drag gestures, and visual recovery when the app is not in the expected state.
+
+This branch is the OpenAI side of an apples-to-apples comparison with the Anthropic computer-use effort running separately. The comparison should measure the agent's ability to operate c11 visually, not just mutate files or query the socket.
+
+## Current OpenAI Landscape
+
+There are two relevant OpenAI routes.
+
+1. Codex app Computer Use plugin
+
+   OpenAI's Codex app now has a macOS Computer Use plugin. The docs say to install it from Codex settings, then grant Screen Recording and Accessibility permissions. It lets Codex see and operate graphical macOS apps, including desktop apps and browser flows. It is currently documented as macOS-only at launch and unavailable in the EEA, UK, and Switzerland.
+
+   This is the fastest path to let Codex itself operate c11 visually in an interactive session.
+
+2. Responses API `computer` tool
+
+   The developer API exposes a `computer` tool. The model inspects screenshots and returns actions such as `click`, `double_click`, `scroll`, `type`, `wait`, `keypress`, `drag`, `move`, and `screenshot`. Our code executes those actions in a harness, captures the next screenshot, and sends it back as `computer_call_output`.
+
+   This is the right path for a reproducible comparison harness because we control the environment, artifacts, prompts, scenarios, scoring, retries, and state reset.
+
+Official references:
+
+- Codex app Computer Use: `https://developers.openai.com/codex/app/computer-use`
+- API Computer Use guide: `https://developers.openai.com/api/docs/guides/tools-computer-use`
+- CUA sample app: `https://github.com/openai/openai-cua-sample-app`
+
+## Non-goals
+
+- Do not replace c11 socket or CLI tests. Those remain the deterministic oracle and setup/reset layer.
+- Do not make the c11 app depend on OpenAI, Anthropic, or any computer-use SDK.
+- Do not add persistent writes to tenant configs such as `~/.codex`, `~/.claude`, shell rc files, or app-specific agent config.
+- Do not automate Codex itself or terminal security prompts through the Codex app Computer Use plugin. OpenAI's Codex Computer Use docs explicitly call out restrictions around automating terminal apps, Codex itself, admin authentication, and security/privacy permission prompts.
+- Do not treat screenshot-only success as enough when a deterministic state check exists.
+
+## Principle
+
+Computer use is the primary exercise path. The agent should complete workflows through the visible app UI whenever possible.
+
+Socket and CLI access are support infrastructure:
+
+- setup: launch tagged build, clean previous state, create deterministic initial conditions
+- oracle: assert workspace/pane/surface state after the visual action
+- artifact capture: collect logs, tree output, socket snapshots, and screenshots
+- recovery: help diagnose failures without pretending a socket-only operation proved user behavior
+
+The gold standard is: "Could a real operator have done this through the UI, and did the app visibly respond correctly?"
+
+## Recommended Shape
+
+Build a provider-neutral local macOS adapter and an OpenAI-specific orchestrator.
+
+```text
+tools/computer-use/
+  mac-adapter/
+    Package.swift
+    Sources/CUAMacAdapter/
+      main.swift
+      WindowTarget.swift
+      ScreenshotCapture.swift
+      InputEvents.swift
+      Accessibility.swift
+      Permissions.swift
+  openai-runner/
+    pyproject.toml
+    README.md
+    openai_cua_runner/
+      __main__.py
+      responses_loop.py
+      adapter_client.py
+      scenarios.py
+      artifacts.py
+      c11_oracle.py
+      safety.py
+```
+
+Rationale:
+
+- Swift is the cleanest local choice for native macOS APIs: AppKit, CoreGraphics, ApplicationServices, AXUIElement, and TCC permission checks.
+- Python is the fastest choice for the Responses API loop, JSON traces, scenario orchestration, and artifact handling.
+- Keeping `mac-adapter` provider-neutral lets the Anthropic branch reuse or mirror the same OS bridge later, which makes the OpenAI-vs-Anthropic comparison fairer.
+
+If the Anthropic branch independently creates a different adapter first, reconcile around a shared minimal JSON contract instead of rewriting both sides.
+
+## Adapter Contract
+
+The mac adapter should expose a small JSON-over-stdio CLI. Keep it boring and auditable.
+
+Commands:
+
+- `doctor`: report macOS version, TCC permissions, target app availability, screen scale, and whether the bundle id can be found.
+- `launch`: optionally launch or activate a target app by bundle id or path.
+- `observe`: capture a screenshot and return metadata.
+- `act`: execute one computer-use action.
+- `window-list`: list candidate windows for debugging target selection.
+- `quit`: shut down any adapter session state.
+
+Target selection:
+
+- Prefer bundle id. For tagged c11 builds this should be `com.stage11.c11.debug.<tag-id>`.
+- Fall back to app path only for launch.
+- Require a matching visible window before executing input.
+- Fail closed if the focused or frontmost app is not the allowed bundle id, unless the scenario explicitly permits a system dialog or permission prompt.
+
+Coordinate model:
+
+- The screenshot returned to the model defines the action coordinate space.
+- The adapter maps screenshot pixels to global display points using the captured window bounds and backing scale factor.
+- Store scale factor, window bounds, screenshot size, and display id with every observation artifact.
+
+Supported actions:
+
+- `click`
+- `double_click`
+- `move`
+- `drag`
+- `scroll`
+- `type`
+- `keypress`
+- `wait`
+- `screenshot`
+
+Action execution:
+
+- Mouse and keyboard events should use CoreGraphics events where practical.
+- Accessibility actions are allowed for window targeting, raising, permission diagnosis, and controls where CGEvent is insufficient.
+- Do not bypass the UI path for product behavior. For example, `AXPress` is acceptable for a known macOS permission prompt, but not as the default way to "test" c11 buttons if the user path is pointer hit-testing.
+
+## OpenAI Runner Contract
+
+The OpenAI runner should own:
+
+- `OPENAI_API_KEY` discovery from environment only.
+- Model/tool configuration for the Responses API `computer` tool.
+- Prompt construction for each scenario.
+- The computer-use loop: send task, receive `computer_call`, execute actions through the mac adapter, capture screenshot, send `computer_call_output`, repeat until final answer or failure.
+- Safety policy: max actions, max wall time, app allowlist, sensitive-action prompts, and fail-closed target checks.
+- Artifact writing.
+
+Initial CLI:
+
+```bash
+python -m openai_cua_runner doctor
+python -m openai_cua_runner smoke --tag openai-cua
+python -m openai_cua_runner scenario launch-window --tag openai-cua
+python -m openai_cua_runner scenario split-pane --tag openai-cua
+```
+
+Artifacts:
+
+```text
+artifacts/openai-cua-runs/<timestamp>-<scenario>/
+  run.json
+  prompt.md
+  final.md
+  actions.jsonl
+  observations.jsonl
+  screenshots/
+    000-initial.png
+    001-after-click.png
+  c11/
+    tree-before.json
+    tree-after.json
+    identify.json
+  logs/
+    c11-debug.log
+```
+
+Do not commit run artifacts. Add ignore rules when implementation begins.
+
+## c11 Launch and Runtime Discipline
+
+Use tagged builds only.
+
+Build:
+
+```bash
+./scripts/reload.sh --tag openai-cua
+```
+
+Launch existing tagged build for automation:
+
+```bash
+./scripts/launch-tagged-automation.sh openai-cua --wait-socket 10
+```
+
+Expected derived values:
+
+- App: `~/Library/Developer/Xcode/DerivedData/c11-openai-cua/Build/Products/Debug/c11 DEV openai-cua.app`
+- Bundle id: `com.stage11.c11.debug.openai.cua`
+- Socket: `/tmp/c11-debug-openai-cua.sock`
+- Log: `/tmp/c11-debug-openai-cua.log`
+
+The runner should not launch an untagged `c11 DEV.app`.
+
+## Permission Plan
+
+The first run will likely require human approval.
+
+Required macOS permissions:
+
+- Screen Recording, so screenshots include the target app.
+- Accessibility, so the adapter can click, type, scroll, and inspect windows.
+
+The runner must have a `doctor` command that detects missing permissions before attempting a scenario and prints exact remediation:
+
+```text
+System Settings > Privacy & Security > Screen Recording
+System Settings > Privacy & Security > Accessibility
+```
+
+The runner should stop at missing TCC permissions, not spin or guess. Security and privacy prompts are a legitimate human-in-the-loop boundary.
+
+## Safety Policy
+
+Default safety rules:
+
+- One target app per scenario.
+- Bundle-id allowlist is required.
+- Refuse to type into or click outside the allowed app window unless the step is explicitly marked as a system permission prompt.
+- Refuse scenarios involving credentials, payments, account settings, admin prompts, or destructive file operations.
+- Cap each run by action count and wall time.
+- Save every model action and screenshot for review.
+- Keep sensitive apps closed during runs.
+- Require explicit operator approval before enabling browser scenarios against signed-in sessions.
+
+The implementation should bias toward stopping with a high-quality artifact bundle rather than trying increasingly broad desktop interactions.
+
+## Scenario Design
+
+Scenarios should be small, observable, and repeatable. The initial suite should avoid fragile pixel-perfect coordinates and ask the model to inspect the screenshot before acting.
+
+### Scenario 0: Doctor
+
+Purpose: prove the environment is eligible.
+
+Steps:
+
+- Check `OPENAI_API_KEY`.
+- Check adapter executable availability.
+- Check Screen Recording and Accessibility.
+- Check tagged c11 app exists or explain build command.
+- Check target app window can be found after launch.
+- Check socket path exists after launch.
+
+Pass criteria:
+
+- Clear pass/fail report with no model call required.
+
+### Scenario 1: Launch Window
+
+Purpose: first full visual loop.
+
+Steps:
+
+- Launch tagged c11.
+- Use computer use to inspect the window.
+- Ask the model to report whether the app appears ready.
+
+Pass criteria:
+
+- Screenshot captured.
+- Model completes without needing actions or after a `wait`.
+- Socket tree confirms at least one workspace, pane, and terminal surface.
+
+### Scenario 2: Create Split
+
+Purpose: first real user-like app interaction.
+
+Preferred user path:
+
+- Use visible UI or menu/keyboard shortcut to create a split, depending on the current c11 UX.
+
+Pass criteria:
+
+- Computer use performs the action visually.
+- `c11 tree --json` against `/tmp/c11-debug-openai-cua.sock` shows pane count increased.
+- Artifact includes before/after screenshot and before/after tree.
+
+### Scenario 3: Focus and Type
+
+Purpose: verify real terminal focus, keyboard event routing, and rendering.
+
+Steps:
+
+- Use computer use to click a visible terminal pane.
+- Type a harmless command such as `printf 'openai-cua-ok\n'`.
+- Press Enter.
+
+Pass criteria:
+
+- The visible terminal renders the expected output.
+- `read-screen` or equivalent socket read confirms the output.
+- This scenario must not use `c11 send` for the typing step.
+
+### Scenario 4: Browser Surface
+
+Purpose: verify a non-terminal surface through user-facing UI.
+
+Steps:
+
+- Create or select a browser surface through the UI path available in c11.
+- Navigate to a deterministic local or data URL.
+
+Pass criteria:
+
+- Visual screenshot shows browser content.
+- Socket/browser API confirms URL or title where available.
+
+### Scenario 5: Markdown Surface
+
+Purpose: verify surface creation and non-terminal rendering.
+
+Steps:
+
+- Open a known local markdown file in a markdown surface through the user-facing path.
+
+Pass criteria:
+
+- Visual screenshot shows rendered markdown.
+- Socket tree confirms markdown surface type.
+
+### Scenario 6: Sidebar Metadata
+
+Purpose: compare model ability to inspect c11's agent-centric UI.
+
+Steps:
+
+- Use socket only to set up a deterministic metadata state.
+- Ask computer use to inspect the sidebar and summarize visible status/title/description.
+
+Pass criteria:
+
+- Model identifies the correct visible state from screenshot.
+- Socket remains the oracle for exact metadata.
+
+### Scenario 7: Drag/Resize
+
+Purpose: exercise pointer-drag behavior that socket tests cannot fully stand in for.
+
+Steps:
+
+- Ask computer use to drag a divider or resize affordance.
+
+Pass criteria:
+
+- Visual layout changes.
+- Socket tree reports changed pane geometry.
+
+This should come after launch/split/focus are stable because drag is the highest-fragility action class.
+
+## Comparison Metrics
+
+Capture the same metrics for OpenAI and Anthropic runs.
+
+- Scenario result: pass, fail, blocked, inconclusive.
+- Number of model turns.
+- Number of UI actions.
+- Wall-clock time.
+- Recovery quality when initial UI state differs.
+- Whether the model used visual evidence correctly.
+- Whether it clicked/typed outside the target app.
+- Whether it asked for clarification or stopped appropriately.
+- Artifact completeness.
+- Deterministic oracle result.
+
+Use identical scenario prompts where provider APIs allow it.
+
+## Implementation Phases
+
+### Phase 0: Plan and Branch
+
+Status: current phase.
+
+Deliverables:
+
+- Dedicated worktree and branch.
+- This plan committed as a markdown artifact.
+- No runner code yet.
+
+### Phase 1: Operator Enablement for Codex App Plugin
+
+Purpose: let the operator quickly try OpenAI's built-in Codex app computer use while the reproducible harness is being built.
+
+Steps:
+
+- In Codex app settings, open Computer Use and install the plugin.
+- Grant Screen Recording and Accessibility when macOS prompts.
+- Try one manual scoped task against the tagged c11 app:
+
+```text
+Use computer use to inspect the c11 DEV openai-cua app window and tell me whether the initial terminal surface is visible. Do not edit files.
+```
+
+Deliverables:
+
+- Short note in the plan or follow-up docs with observed behavior, permission prompts, and limitations.
+
+### Phase 2: Native Mac Adapter
+
+Deliverables:
+
+- Swift CLI with `doctor`, `window-list`, `observe`, and minimal `act`.
+- Window-targeted screenshot capture.
+- Click, keypress, type, wait.
+- JSON action/result schema.
+- Local artifact screenshots.
+
+Validation:
+
+- Run `doctor`.
+- Launch tagged c11.
+- Capture one screenshot.
+- Execute one harmless focus/click action.
+
+Expected human blocker:
+
+- macOS TCC permissions may require operator approval.
+
+### Phase 3: OpenAI Responses Loop
+
+Deliverables:
+
+- Python runner that calls the Responses API with `tools=[{"type": "computer"}]`.
+- Loop handling `computer_call` and `computer_call_output`.
+- Adapter subprocess client.
+- Run artifacts.
+- `launch-window` scenario.
+
+Validation:
+
+- Complete Scenario 1 against tagged c11.
+- Review trace for action correctness and screenshot fidelity.
+
+### Phase 4: c11 Scenario Harness
+
+Deliverables:
+
+- Tagged build launcher integration.
+- Socket oracle integration with `C11_SOCKET`/`CMUX_SOCKET`.
+- Scenario definitions for launch, split, focus/type.
+- Failure bundles with screenshots, logs, socket snapshots, and model trace.
+
+Validation:
+
+- Complete Scenarios 1-3.
+- Confirm typing scenario uses real keyboard events, not socket send.
+
+### Phase 5: Broaden UI Coverage
+
+Deliverables:
+
+- Browser surface scenario.
+- Markdown surface scenario.
+- Sidebar metadata inspection scenario.
+- Drag/resize scenario if stable.
+
+Validation:
+
+- Each scenario has both visual evidence and deterministic oracle where possible.
+
+### Phase 6: Apples-to-Apples Comparison
+
+Deliverables:
+
+- Shared scenario prompt set.
+- Shared scoring schema.
+- OpenAI run summary.
+- Comparison-ready artifact format for Anthropic branch.
+
+Validation:
+
+- At least three scenarios run through OpenAI with reusable artifacts.
+- Anthropic branch can consume or mirror the same scenario definitions.
+
+## Expected Files During Implementation
+
+Likely new files:
+
+- `docs/openai-codex-computer-use-plan.md`
+- `tools/computer-use/mac-adapter/Package.swift`
+- `tools/computer-use/mac-adapter/Sources/CUAMacAdapter/*.swift`
+- `tools/computer-use/openai-runner/pyproject.toml`
+- `tools/computer-use/openai-runner/README.md`
+- `tools/computer-use/openai-runner/openai_cua_runner/*.py`
+- `.gitignore` entries for `artifacts/openai-cua-runs/` if not already covered
+
+Likely untouched files:
+
+- c11 product source under `Sources/`
+- localization catalogs
+- build workflows
+- tenant config files
+
+## Testing and Validation Policy
+
+Respect this repo's testing policy.
+
+- Do not run the local test suite.
+- Use tagged app builds for local visual validation.
+- Use the runner's `doctor` and smoke scenarios for harness validation.
+- Use GitHub Actions or the VM for broader tests if code outside `tools/` changes.
+- Do not launch untagged DerivedData apps.
+
+For this feature, the main validation is an end-to-end tagged-build visual run plus artifact review.
+
+## Known Risks
+
+### TCC Permissions
+
+Screen Recording and Accessibility cannot be granted by the agent. The implementation must detect missing permissions and stop with clear instructions.
+
+### Coordinate Drift
+
+Screenshots are pixels; CGEvent coordinates are display points. Retina scaling and window title bars can cause off-by-scale or off-by-origin errors. Every observation must record scale and bounds.
+
+### Wrong-window Actions
+
+Computer use can interact with whatever is visible if guardrails are weak. The adapter must fail closed when the target bundle/window is not active or visible.
+
+### Visual Nondeterminism
+
+Animations, first-launch state, stale windows, and overlapping apps can confuse the model. Scenarios should start from a tagged launch, capture initial state, and keep instructions narrow.
+
+### Socket Oracle Overreach
+
+It is tempting to use socket commands for everything. The scenario definition must mark which steps are setup/oracle and which steps must be performed visually.
+
+### Provider Comparison Bias
+
+If OpenAI and Anthropic use different adapters, prompts, reset logic, or oracle checks, the comparison will be noisy. Keep scenario specs provider-neutral.
+
+### Cost and Latency
+
+Computer-use loops can be expensive because each step sends screenshots. Cap action count, screenshot detail, and wall time per scenario.
+
+## Definition of Done for Implementation
+
+The OpenAI implementation is done when:
+
+- A clean tagged c11 build can be launched from the runner.
+- `doctor` accurately reports API key, app, socket, and macOS permissions.
+- The runner completes at least:
+  - launch-window
+  - create-split
+  - focus-and-type
+- Each completed scenario has:
+  - prompt
+  - action trace
+  - screenshots
+  - c11 socket oracle before/after
+  - final result summary
+- The focus-and-type scenario uses real macOS input events.
+- Failures produce a useful artifact bundle instead of silent retries.
+- No run artifacts, API keys, or tenant config changes are committed.
+- The implementation is committed on `feat/openai-cua-runner`.
+
+## Immediate Next Step After Plan Approval
+
+Start Phase 1 and Phase 2:
+
+1. Have the operator install/enable Codex app Computer Use if they want the immediate Codex-app path.
+2. Implement the provider-neutral Swift mac adapter `doctor` and `observe` commands.
+3. Launch tagged c11 with `openai-cua` and capture the first window screenshot.
+4. Add the OpenAI runner only after the local screenshot/action loop is reliable.
+

--- a/scripts/launch-tagged-automation.sh
+++ b/scripts/launch-tagged-automation.sh
@@ -44,6 +44,7 @@ MODE="automation"
 SHELL_LOG=""
 WAIT_SOCKET="10"
 EXTRA_ENV=()
+EXTRA_ENV_COUNT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +62,7 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       EXTRA_ENV+=("${2}")
+      EXTRA_ENV_COUNT=$((EXTRA_ENV_COUNT + 1))
       shift 2
       ;;
     --shell-log)
@@ -152,9 +154,11 @@ OPEN_ENV=(
   "CMUX_DEBUG_LOG=${LOG}"
 )
 
-for kv in "${EXTRA_ENV[@]}"; do
-  OPEN_ENV+=("${kv}")
-done
+if [[ "$EXTRA_ENV_COUNT" -gt 0 ]]; then
+  for kv in "${EXTRA_ENV[@]}"; do
+    OPEN_ENV+=("${kv}")
+  done
+fi
 if [[ -n "$SHELL_LOG" ]]; then
   OPEN_ENV+=("GHOSTTY_ZSH_INTEGRATION_LOG=${SHELL_LOG}")
 fi
@@ -181,7 +185,7 @@ echo "socket_ready: $(if [[ -S "$SOCK" ]]; then echo yes; else echo no; fi)"
 if [[ -n "$SHELL_LOG" ]]; then
   echo "shell_log: $SHELL_LOG"
 fi
-if [[ "${#EXTRA_ENV[@]}" -gt 0 ]]; then
+if [[ "$EXTRA_ENV_COUNT" -gt 0 ]]; then
   echo "extra_env:"
   for kv in "${EXTRA_ENV[@]}"; do
     echo "  $kv"

--- a/tools/computer-use/mac-adapter/Package.swift
+++ b/tools/computer-use/mac-adapter/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "CUAMacAdapter",
+    platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "cua-mac-adapter", targets: ["CUAMacAdapter"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CUAMacAdapter"
+        ),
+    ]
+)

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Accessibility.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Accessibility.swift
@@ -1,0 +1,24 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum AccessibilitySupport {
+    static func raise(pid: pid_t) -> Bool {
+        let app = AXUIElementCreateApplication(pid)
+        return AXUIElementPerformAction(app, kAXRaiseAction as CFString) == .success
+    }
+
+    static func windowTitle(pid: pid_t) -> String? {
+        let app = AXUIElementCreateApplication(pid)
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &focused) == .success,
+              let window = focused else {
+            return nil
+        }
+        var title: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window as! AXUIElement, kAXTitleAttribute as CFString, &title) == .success else {
+            return nil
+        }
+        return title as? String
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/InputEvents.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/InputEvents.swift
@@ -1,0 +1,241 @@
+import CoreGraphics
+import Foundation
+
+struct ComputerAction: Codable {
+    let type: String
+    let x: Double?
+    let y: Double?
+    let button: String?
+    let dx: Double?
+    let dy: Double?
+    let text: String?
+    let keys: [String]?
+    let durationMs: Int?
+    let path: [ActionPoint]?
+}
+
+struct ActionPoint: Codable {
+    let x: Double
+    let y: Double
+}
+
+struct ActionResult: Codable {
+    let ok: Bool
+    let action: String
+    let message: String
+}
+
+enum InputEventError: Error, CustomStringConvertible {
+    case missingCoordinate(String)
+    case missingText
+    case unsupportedAction(String)
+    case unsupportedKey(String)
+
+    var description: String {
+        switch self {
+        case .missingCoordinate(let action):
+            return "\(action) requires x and y"
+        case .missingText:
+            return "type requires text"
+        case .unsupportedAction(let action):
+            return "unsupported action: \(action)"
+        case .unsupportedKey(let key):
+            return "unsupported key: \(key)"
+        }
+    }
+}
+
+enum InputEvents {
+    static func perform(_ action: ComputerAction, observation: Observation) throws -> ActionResult {
+        switch action.type {
+        case "click":
+            try click(action, observation: observation, clickCount: 1)
+        case "double_click", "doubleClick":
+            try click(action, observation: observation, clickCount: 2)
+        case "move":
+            try move(action, observation: observation)
+        case "drag":
+            try drag(action, observation: observation)
+        case "scroll":
+            try scroll(action)
+        case "type":
+            try typeText(action.text)
+        case "keypress", "key":
+            try keypress(action.keys)
+        case "wait":
+            Thread.sleep(forTimeInterval: Double(action.durationMs ?? 1000) / 1000.0)
+        case "screenshot":
+            break
+        default:
+            throw InputEventError.unsupportedAction(action.type)
+        }
+        return ActionResult(ok: true, action: action.type, message: "executed")
+    }
+
+    private static func click(_ action: ComputerAction, observation: Observation, clickCount: Int) throws {
+        guard let x = action.x, let y = action.y else {
+            throw InputEventError.missingCoordinate(action.type)
+        }
+        let point = ScreenshotCapture.pointInWindow(x: x, y: y, observation: observation)
+        let button = mouseButton(action.button)
+        let down = mouseType(button: button, down: true)
+        let up = mouseType(button: button, down: false)
+        for index in 1...clickCount {
+            let clickState = Int64(index)
+            postMouse(type: .mouseMoved, point: point, button: button, clickState: clickState)
+            postMouse(type: down, point: point, button: button, clickState: clickState)
+            usleep(45_000)
+            postMouse(type: up, point: point, button: button, clickState: clickState)
+            usleep(80_000)
+        }
+    }
+
+    private static func move(_ action: ComputerAction, observation: Observation) throws {
+        guard let x = action.x, let y = action.y else {
+            throw InputEventError.missingCoordinate(action.type)
+        }
+        let point = ScreenshotCapture.pointInWindow(x: x, y: y, observation: observation)
+        postMouse(type: .mouseMoved, point: point, button: .left, clickState: 0)
+    }
+
+    private static func drag(_ action: ComputerAction, observation: Observation) throws {
+        let points: [ActionPoint]
+        if let path = action.path, path.count >= 2 {
+            points = path
+        } else if let x = action.x, let y = action.y, let dx = action.dx, let dy = action.dy {
+            points = [ActionPoint(x: x, y: y), ActionPoint(x: x + dx, y: y + dy)]
+        } else {
+            throw InputEventError.missingCoordinate(action.type)
+        }
+        let mapped = points.map { ScreenshotCapture.pointInWindow(x: $0.x, y: $0.y, observation: observation) }
+        guard let first = mapped.first, let last = mapped.last else { return }
+        postMouse(type: .mouseMoved, point: first, button: .left, clickState: 0)
+        postMouse(type: .leftMouseDown, point: first, button: .left, clickState: 1)
+        usleep(80_000)
+        for point in mapped.dropFirst().dropLast() {
+            postMouse(type: .leftMouseDragged, point: point, button: .left, clickState: 1)
+            usleep(35_000)
+        }
+        postMouse(type: .leftMouseDragged, point: last, button: .left, clickState: 1)
+        usleep(50_000)
+        postMouse(type: .leftMouseUp, point: last, button: .left, clickState: 1)
+    }
+
+    private static func scroll(_ action: ComputerAction) throws {
+        let dx = Int32(action.dx ?? 0)
+        let dy = Int32(action.dy ?? 0)
+        guard let event = CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 2, wheel1: dy, wheel2: dx, wheel3: 0) else {
+            return
+        }
+        event.post(tap: .cghidEventTap)
+    }
+
+    private static func typeText(_ text: String?) throws {
+        guard let text else { throw InputEventError.missingText }
+        for scalar in text.unicodeScalars {
+            var value = UniChar(scalar.value)
+            guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else {
+                continue
+            }
+            down.keyboardSetUnicodeString(stringLength: 1, unicodeString: &value)
+            up.keyboardSetUnicodeString(stringLength: 1, unicodeString: &value)
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+            usleep(8_000)
+        }
+    }
+
+    private static func keypress(_ keys: [String]?) throws {
+        let rawKeys = keys ?? []
+        let events: [[String]]
+        if rawKeys.count > 1 && rawKeys.dropLast().allSatisfy({ isModifier($0) }) {
+            events = [rawKeys.map { $0.lowercased() }]
+        } else {
+            events = rawKeys.map { $0.split(separator: "+").map { String($0).lowercased() } }
+        }
+        for combo in events {
+            let modifiers = modifierFlags(combo)
+            guard let keyName = combo.last else { continue }
+            guard let keyCode = keyCode(for: keyName) else {
+                throw InputEventError.unsupportedKey(combo.joined(separator: "+"))
+            }
+            guard let down = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
+                continue
+            }
+            down.flags = modifiers
+            up.flags = modifiers
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+            usleep(20_000)
+        }
+    }
+
+    private static func isModifier(_ raw: String) -> Bool {
+        ["cmd", "command", "meta", "shift", "option", "alt", "ctrl", "control"].contains(raw.lowercased())
+    }
+
+    private static func postMouse(type: CGEventType, point: CGPoint, button: CGMouseButton, clickState: Int64) {
+        guard let event = CGEvent(mouseEventSource: nil, mouseType: type, mouseCursorPosition: point, mouseButton: button) else {
+            return
+        }
+        event.setIntegerValueField(.mouseEventClickState, value: clickState)
+        event.post(tap: .cghidEventTap)
+    }
+
+    private static func mouseButton(_ value: String?) -> CGMouseButton {
+        switch value?.lowercased() {
+        case "right":
+            return .right
+        case "middle":
+            return .center
+        default:
+            return .left
+        }
+    }
+
+    private static func mouseType(button: CGMouseButton, down: Bool) -> CGEventType {
+        switch (button, down) {
+        case (.right, true): return .rightMouseDown
+        case (.right, false): return .rightMouseUp
+        case (.center, true): return .otherMouseDown
+        case (.center, false): return .otherMouseUp
+        case (_, true): return .leftMouseDown
+        case (_, false): return .leftMouseUp
+        }
+    }
+
+    private static func modifierFlags(_ parts: [String]) -> CGEventFlags {
+        var flags: CGEventFlags = []
+        if parts.contains("cmd") || parts.contains("command") || parts.contains("meta") { flags.insert(.maskCommand) }
+        if parts.contains("shift") { flags.insert(.maskShift) }
+        if parts.contains("option") || parts.contains("alt") { flags.insert(.maskAlternate) }
+        if parts.contains("ctrl") || parts.contains("control") { flags.insert(.maskControl) }
+        return flags
+    }
+
+    private static func keyCode(for key: String) -> CGKeyCode? {
+        let normalized = key.lowercased()
+        if normalized.count == 1, let scalar = normalized.unicodeScalars.first {
+            return letterAndDigitKeyCodes[CharacterSet(charactersIn: String(scalar)).description] ?? letterAndDigitKeyCodes[String(scalar)]
+        }
+        return specialKeyCodes[normalized]
+    }
+
+    private static let specialKeyCodes: [String: CGKeyCode] = [
+        "return": 36, "enter": 36, "tab": 48, "space": 49, "escape": 53, "esc": 53,
+        "delete": 51, "backspace": 51, "forwarddelete": 117,
+        "left": 123, "right": 124, "down": 125, "up": 126,
+        "home": 115, "end": 119, "pageup": 116, "pagedown": 121
+    ]
+
+    private static let letterAndDigitKeyCodes: [String: CGKeyCode] = [
+        "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7, "c": 8, "v": 9,
+        "b": 11, "q": 12, "w": 13, "e": 14, "r": 15, "y": 16, "t": 17,
+        "1": 18, "2": 19, "3": 20, "4": 21, "6": 22, "5": 23, "=": 24, "9": 25, "7": 26, "-": 27,
+        "8": 28, "0": 29, "]": 30, "o": 31, "u": 32, "[": 33, "i": 34, "p": 35,
+        "l": 37, "j": 38, "'": 39, "k": 40, ";": 41, "\\": 42, ",": 43, "/": 44, "n": 45, "m": 46,
+        ".": 47, "`": 50
+    ]
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Permissions.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Permissions.swift
@@ -1,0 +1,22 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+struct PermissionStatus: Codable {
+    let screenRecording: Bool
+    let accessibility: Bool
+    let remediation: [String]
+
+    static func current() -> PermissionStatus {
+        let screen = CGPreflightScreenCaptureAccess()
+        let ax = AXIsProcessTrusted()
+        var remediation: [String] = []
+        if !screen {
+            remediation.append("Grant Screen Recording to the terminal or adapter host in System Settings > Privacy & Security > Screen Recording.")
+        }
+        if !ax {
+            remediation.append("Grant Accessibility to the terminal or adapter host in System Settings > Privacy & Security > Accessibility.")
+        }
+        return PermissionStatus(screenRecording: screen, accessibility: ax, remediation: remediation)
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/ScreenshotCapture.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/ScreenshotCapture.swift
@@ -1,0 +1,103 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+struct Observation: Codable {
+    let ok: Bool
+    let window: WindowInfo
+    let screenshotPath: String?
+    let screenshotBase64: String?
+    let screenshotWidth: Int
+    let screenshotHeight: Int
+    let scale: Double
+    let displayID: UInt32?
+    let capturedAt: String
+}
+
+enum ScreenshotError: Error, CustomStringConvertible {
+    case captureFailed(UInt32)
+    case writeFailed(String)
+
+    var description: String {
+        switch self {
+        case .captureFailed(let id):
+            return "failed to capture window \(id)"
+        case .writeFailed(let path):
+            return "failed to write screenshot to \(path)"
+        }
+    }
+}
+
+enum ScreenshotCapture {
+    static func observe(window: WindowInfo, outPath: String?, includeBase64: Bool) throws -> Observation {
+        guard let image = CGWindowListCreateImage(
+            .null,
+            .optionIncludingWindow,
+            CGWindowID(window.windowID),
+            [.boundsIgnoreFraming, .bestResolution]
+        ) else {
+            throw ScreenshotError.captureFailed(window.windowID)
+        }
+
+        let width = image.width
+        let height = image.height
+        let scale = window.bounds.width > 0 ? Double(width) / window.bounds.width : 1.0
+        var normalizedOut: String?
+        var base64: String?
+
+        if let outPath {
+            let expanded = NSString(string: outPath).expandingTildeInPath
+            let url = URL(fileURLWithPath: expanded)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            guard let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+                throw ScreenshotError.writeFailed(expanded)
+            }
+            CGImageDestinationAddImage(destination, image, nil)
+            guard CGImageDestinationFinalize(destination) else {
+                throw ScreenshotError.writeFailed(expanded)
+            }
+            normalizedOut = expanded
+            if includeBase64 {
+                base64 = try Data(contentsOf: url).base64EncodedString()
+            }
+        } else if includeBase64 {
+            let data = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(data, UTType.png.identifier as CFString, 1, nil) else {
+                throw ScreenshotError.writeFailed("<memory>")
+            }
+            CGImageDestinationAddImage(destination, image, nil)
+            guard CGImageDestinationFinalize(destination) else {
+                throw ScreenshotError.writeFailed("<memory>")
+            }
+            base64 = (data as Data).base64EncodedString()
+        }
+
+        return Observation(
+            ok: true,
+            window: window,
+            screenshotPath: normalizedOut,
+            screenshotBase64: base64,
+            screenshotWidth: width,
+            screenshotHeight: height,
+            scale: scale,
+            displayID: displayID(for: window.bounds.cgRect),
+            capturedAt: ISO8601DateFormatter().string(from: Date())
+        )
+    }
+
+    static func pointInWindow(x: Double, y: Double, observation: Observation) -> CGPoint {
+        let scale = observation.scale == 0 ? 1 : observation.scale
+        let bounds = observation.window.bounds
+        return CGPoint(x: bounds.x + x / scale, y: bounds.y + y / scale)
+    }
+
+    private static func displayID(for rect: CGRect) -> UInt32? {
+        var count: UInt32 = 0
+        var displays = [CGDirectDisplayID](repeating: 0, count: 16)
+        let err = CGGetDisplaysWithRect(rect, UInt32(displays.count), &displays, &count)
+        guard err == .success, count > 0 else { return nil }
+        return displays[0]
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/WindowTarget.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/WindowTarget.swift
@@ -1,0 +1,202 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+struct RectInfo: Codable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(_ rect: CGRect) {
+        x = rect.origin.x
+        y = rect.origin.y
+        width = rect.size.width
+        height = rect.size.height
+    }
+
+    var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+}
+
+struct WindowInfo: Codable {
+    let windowID: UInt32
+    let pid: Int32
+    let ownerName: String
+    let bundleID: String?
+    let title: String?
+    let bounds: RectInfo
+    let layer: Int
+    let alpha: Double
+    let isOnscreen: Bool
+    let isFrontmostApp: Bool
+}
+
+struct TargetOptions {
+    let bundleID: String
+    let appPath: String?
+}
+
+enum WindowTargetError: Error, CustomStringConvertible {
+    case bundleNotRunning(String)
+    case noVisibleWindow(String)
+    case frontmostMismatch(expected: String, actual: String?)
+    case launchFailed(String)
+
+    var description: String {
+        switch self {
+        case .bundleNotRunning(let bundle):
+            return "target bundle is not running: \(bundle)"
+        case .noVisibleWindow(let bundle):
+            return "no visible window found for target bundle: \(bundle)"
+        case .frontmostMismatch(let expected, let actual):
+            return "frontmost app mismatch; expected \(expected), actual \(actual ?? "none")"
+        case .launchFailed(let reason):
+            return "launch failed: \(reason)"
+        }
+    }
+}
+
+final class WindowTarget {
+    let options: TargetOptions
+
+    init(options: TargetOptions) {
+        self.options = options
+    }
+
+    func launchOrActivate(waitSeconds: Double) throws -> WindowInfo {
+        if let app = runningApplications().first {
+            app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        } else if let path = options.appPath {
+            let url = URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            var launched: NSRunningApplication?
+            var launchError: Error?
+            let sema = DispatchSemaphore(value: 0)
+            NSWorkspace.shared.openApplication(at: url, configuration: config) { app, error in
+                launched = app
+                launchError = error
+                sema.signal()
+            }
+            _ = sema.wait(timeout: .now() + max(waitSeconds, 1))
+            if let launchError {
+                throw WindowTargetError.launchFailed(launchError.localizedDescription)
+            }
+            guard let launched else {
+                throw WindowTargetError.launchFailed("no NSRunningApplication returned for \(url.path)")
+            }
+            launched.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        } else {
+            guard let app = NSWorkspace.shared.urlForApplication(withBundleIdentifier: options.bundleID) else {
+                throw WindowTargetError.launchFailed("bundle id not found by LaunchServices and no --app-path supplied")
+            }
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            var launchError: Error?
+            let sema = DispatchSemaphore(value: 0)
+            NSWorkspace.shared.openApplication(at: app, configuration: config) { _, error in
+                launchError = error
+                sema.signal()
+            }
+            _ = sema.wait(timeout: .now() + max(waitSeconds, 1))
+            if let launchError {
+                throw WindowTargetError.launchFailed(launchError.localizedDescription)
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(waitSeconds)
+        var lastError: Error?
+        repeat {
+            do {
+                let window = try bestVisibleWindow()
+                if let app = NSRunningApplication(processIdentifier: window.pid) {
+                    app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+                }
+                _ = AccessibilitySupport.raise(pid: window.pid)
+                if waitUntilFrontmost(deadline: deadline) {
+                    return try bestVisibleWindow()
+                }
+                return window
+            } catch {
+                lastError = error
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+        } while Date() < deadline
+        throw lastError ?? WindowTargetError.noVisibleWindow(options.bundleID)
+    }
+
+    func requireFrontmostTarget() throws -> WindowInfo {
+        guard let front = NSWorkspace.shared.frontmostApplication else {
+            throw WindowTargetError.frontmostMismatch(expected: options.bundleID, actual: nil)
+        }
+        guard front.bundleIdentifier == options.bundleID else {
+            throw WindowTargetError.frontmostMismatch(expected: options.bundleID, actual: front.bundleIdentifier)
+        }
+        return try bestVisibleWindow()
+    }
+
+    func bestVisibleWindow() throws -> WindowInfo {
+        let matches = windows().filter { $0.bundleID == options.bundleID && $0.isOnscreen && $0.layer == 0 && $0.alpha > 0 && $0.bounds.width > 80 && $0.bounds.height > 80 }
+        if matches.isEmpty {
+            if runningApplications().isEmpty {
+                throw WindowTargetError.bundleNotRunning(options.bundleID)
+            }
+            throw WindowTargetError.noVisibleWindow(options.bundleID)
+        }
+        if let front = NSWorkspace.shared.frontmostApplication?.processIdentifier,
+           let frontWindow = matches.first(where: { $0.pid == front }) {
+            return frontWindow
+        }
+        return matches[0]
+    }
+
+    func windows() -> [WindowInfo] {
+        guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+        let frontPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        return raw.compactMap { item in
+            guard let windowID = item[kCGWindowNumber as String] as? UInt32,
+                  let pidNumber = item[kCGWindowOwnerPID as String] as? NSNumber,
+                  let owner = item[kCGWindowOwnerName as String] as? String,
+                  let boundsDict = item[kCGWindowBounds as String] as? [String: Any],
+                  let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else {
+                return nil
+            }
+            let pid = pidNumber.int32Value
+            let app = NSRunningApplication(processIdentifier: pid)
+            let layer = (item[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+            let alpha = (item[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1
+            let title = item[kCGWindowName as String] as? String
+            let onscreen = (item[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? false
+            return WindowInfo(
+                windowID: windowID,
+                pid: pid,
+                ownerName: owner,
+                bundleID: app?.bundleIdentifier,
+                title: title,
+                bounds: RectInfo(bounds),
+                layer: layer,
+                alpha: alpha,
+                isOnscreen: onscreen,
+                isFrontmostApp: frontPid == pid
+            )
+        }
+    }
+
+    private func runningApplications() -> [NSRunningApplication] {
+        NSRunningApplication.runningApplications(withBundleIdentifier: options.bundleID)
+    }
+
+    private func waitUntilFrontmost(deadline: Date) -> Bool {
+        repeat {
+            if NSWorkspace.shared.frontmostApplication?.bundleIdentifier == options.bundleID {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+        return false
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/main.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/main.swift
@@ -1,0 +1,149 @@
+import AppKit
+import Foundation
+
+struct Envelope<T: Codable>: Codable {
+    let ok: Bool
+    let value: T?
+    let error: String?
+}
+
+struct DoctorReport: Codable {
+    let ok: Bool
+    let macOSVersion: String
+    let permissions: PermissionStatus
+    let targetBundleID: String
+    let targetAppPath: String?
+    let targetAppExists: Bool?
+    let running: Bool
+    let frontmostBundleID: String?
+    let visibleWindow: WindowInfo?
+    let windows: [WindowInfo]
+}
+
+struct LaunchReport: Codable {
+    let ok: Bool
+    let window: WindowInfo
+}
+
+let encoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return encoder
+}()
+
+func printJSON<T: Encodable>(_ value: T) {
+    do {
+        let data = try encoder.encode(value)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    } catch {
+        fputs("{\"ok\":false,\"error\":\"failed to encode JSON\"}\n", stderr)
+        exit(2)
+    }
+}
+
+func fail(_ error: Error, code: Int32 = 1) -> Never {
+    printJSON(Envelope<String>(ok: false, value: nil, error: String(describing: error)))
+    exit(code)
+}
+
+func value(after flag: String, in args: [String]) -> String? {
+    guard let index = args.firstIndex(of: flag), index + 1 < args.count else { return nil }
+    return args[index + 1]
+}
+
+func has(_ flag: String, in args: [String]) -> Bool {
+    args.contains(flag)
+}
+
+func targetOptions(args: [String]) -> TargetOptions {
+    let bundle = value(after: "--bundle-id", in: args) ?? "com.stage11.c11.debug.openai.cua"
+    let appPath = value(after: "--app-path", in: args)
+    return TargetOptions(bundleID: bundle, appPath: appPath)
+}
+
+func readAction(args: [String]) throws -> ComputerAction {
+    let data: Data
+    if let raw = value(after: "--json", in: args) {
+        data = Data(raw.utf8)
+    } else if let file = value(after: "--json-file", in: args) {
+        data = try Data(contentsOf: URL(fileURLWithPath: NSString(string: file).expandingTildeInPath))
+    } else {
+        data = FileHandle.standardInput.readDataToEndOfFile()
+    }
+    return try JSONDecoder().decode(ComputerAction.self, from: data)
+}
+
+let args = Array(CommandLine.arguments.dropFirst())
+guard let command = args.first, ["doctor", "window-list", "launch", "observe", "act", "quit", "help", "--help", "-h"].contains(command) else {
+    print("""
+    Usage: cua-mac-adapter <command> [options]
+
+    Commands:
+      doctor       Report permissions, target app/window, and display state as JSON.
+      window-list  List visible windows as JSON.
+      launch       Launch or activate the target app.
+      observe      Capture the target window screenshot.
+      act          Execute one computer action from --json, --json-file, or stdin.
+      quit         No-op placeholder for JSON command parity.
+
+    Options:
+      --bundle-id <id>       Target bundle id. Default: com.stage11.c11.debug.openai.cua
+      --app-path <path>      Tagged app path for launch fallback.
+      --out <path>           Screenshot PNG output path for observe/act.
+      --include-base64       Include screenshot base64 in observe output.
+      --wait <seconds>       Launch wait. Default: 10.
+    """)
+    exit(args.first == nil ? 1 : 0)
+}
+
+let target = WindowTarget(options: targetOptions(args: args))
+
+do {
+    switch command {
+    case "doctor":
+        let path = target.options.appPath.map { NSString(string: $0).expandingTildeInPath }
+        let appExists = path.map { FileManager.default.fileExists(atPath: $0) }
+        let visibleWindow = try? target.bestVisibleWindow()
+        let windows = target.windows()
+        let report = DoctorReport(
+            ok: PermissionStatus.current().screenRecording && PermissionStatus.current().accessibility,
+            macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            permissions: PermissionStatus.current(),
+            targetBundleID: target.options.bundleID,
+            targetAppPath: path,
+            targetAppExists: appExists,
+            running: NSRunningApplication.runningApplications(withBundleIdentifier: target.options.bundleID).isEmpty == false,
+            frontmostBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
+            visibleWindow: visibleWindow,
+            windows: windows.filter { $0.bundleID == target.options.bundleID }
+        )
+        printJSON(report)
+    case "window-list":
+        printJSON(Envelope(ok: true, value: target.windows(), error: nil))
+    case "launch":
+        let wait = Double(value(after: "--wait", in: args) ?? "10") ?? 10
+        let window = try target.launchOrActivate(waitSeconds: wait)
+        printJSON(LaunchReport(ok: true, window: window))
+    case "observe":
+        let window = has("--no-frontmost-required", in: args) ? try target.bestVisibleWindow() : try target.requireFrontmostTarget()
+        let observation = try ScreenshotCapture.observe(window: window, outPath: value(after: "--out", in: args), includeBase64: has("--include-base64", in: args))
+        printJSON(observation)
+    case "act":
+        guard PermissionStatus.current().accessibility else {
+            throw InputEventError.unsupportedAction("missing Accessibility permission; grant it in System Settings > Privacy & Security > Accessibility")
+        }
+        let action = try readAction(args: args)
+        let window = try target.requireFrontmostTarget()
+        let observation = try ScreenshotCapture.observe(window: window, outPath: nil, includeBase64: false)
+        let result = try InputEvents.perform(action, observation: observation)
+        printJSON(result)
+    case "quit":
+        printJSON(Envelope(ok: true, value: "quit", error: nil))
+    default:
+        print("unknown command \(command)")
+        exit(1)
+    }
+} catch {
+    fail(error)
+}

--- a/tools/computer-use/openai-runner/README.md
+++ b/tools/computer-use/openai-runner/README.md
@@ -1,0 +1,65 @@
+# OpenAI CUA Runner
+
+This harness drives tagged c11 debug builds through the OpenAI Responses API `computer` tool and a provider-neutral native macOS adapter. It keeps the UI action path visual: screenshots and CoreGraphics input events go through the target app window, while the c11 socket is used for setup, oracle checks, and artifact capture.
+
+Official API reference: <https://developers.openai.com/api/docs/guides/tools-computer-use>
+
+## Layout
+
+- `../mac-adapter`: Swift CLI for macOS window discovery, permission checks, screenshot capture, and input events.
+- `openai_cua_runner`: Python scenario runner, artifact writer, Responses API loop, and c11 socket oracle.
+- `artifacts/openai-cua-runs/`: ignored runtime output written from the repo root.
+
+## Build
+
+From the repo root:
+
+```bash
+swift build --package-path tools/computer-use/mac-adapter
+```
+
+Build the tagged c11 app only with a tag:
+
+```bash
+./scripts/reload.sh --tag openai-cua
+```
+
+The default target values are:
+
+- Bundle id: `com.stage11.c11.debug.openai.cua`
+- App: `~/Library/Developer/Xcode/DerivedData/c11-openai-cua/Build/Products/Debug/c11 DEV openai-cua.app`
+- Socket: `/tmp/c11-debug-openai-cua.sock`
+
+## Commands
+
+Run from the repo root with `PYTHONPATH` unless installed in a virtualenv:
+
+```bash
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner doctor --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner smoke --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner scenario launch-window --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner scenario create-split --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner scenario focus-and-type --tag openai-cua
+```
+
+Use `--build` on `smoke` or `scenario` to run `./scripts/reload.sh --tag <tag>` before launch. The runner reads `OPENAI_API_KEY` from the environment only. Override the model with `--model` or `OPENAI_CUA_MODEL`; override the per-request API timeout with `OPENAI_CUA_REQUEST_TIMEOUT`.
+
+## Permissions
+
+The adapter requires macOS Screen Recording and Accessibility permissions for the terminal or host process running it:
+
+- System Settings > Privacy & Security > Screen Recording
+- System Settings > Privacy & Security > Accessibility
+
+If either permission is missing, `doctor`, `smoke`, and scenarios stop with a remediation message instead of attempting broad desktop interaction.
+
+## Adapter CLI
+
+```bash
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter doctor --bundle-id com.stage11.c11.debug.openai.cua
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter window-list
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter launch --bundle-id com.stage11.c11.debug.openai.cua --app-path "$HOME/Library/Developer/Xcode/DerivedData/c11-openai-cua/Build/Products/Debug/c11 DEV openai-cua.app"
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter observe --bundle-id com.stage11.c11.debug.openai.cua --out /tmp/c11-openai-cua.png
+```
+
+`act` accepts one JSON action from `--json`, `--json-file`, or stdin. Supported actions are `click`, `double_click`, `move`, `drag`, `scroll`, `type`, `keypress`, `wait`, and `screenshot`.

--- a/tools/computer-use/openai-runner/openai_cua_runner/__init__.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/__init__.py
@@ -1,0 +1,4 @@
+"""OpenAI computer-use runner for c11."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/tools/computer-use/openai-runner/openai_cua_runner/__main__.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/__main__.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+from .scenarios import ScenarioConfig, dependency_report, run_doctor, run_scenario, run_smoke
+
+
+DEFAULT_TAG = "openai-cua"
+DEFAULT_MODEL = os.environ.get("OPENAI_CUA_MODEL", "gpt-5.5")
+
+
+def repo_root_from_here() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def config_from_args(args: argparse.Namespace) -> ScenarioConfig:
+    return ScenarioConfig(
+        repo_root=Path(args.repo_root).resolve(),
+        tag=args.tag,
+        model=args.model,
+        build=args.build,
+        max_actions=args.max_actions,
+        max_seconds=args.max_seconds,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--repo-root", default=str(repo_root_from_here()))
+    common.add_argument("--tag", default=DEFAULT_TAG)
+    common.add_argument("--model", default=DEFAULT_MODEL)
+    common.add_argument("--build", action="store_true", help="Run ./scripts/reload.sh --tag before launch/smoke/scenario.")
+    common.add_argument("--max-actions", type=int, default=25)
+    common.add_argument("--max-seconds", type=int, default=180)
+
+    parser = argparse.ArgumentParser(prog="python -m openai_cua_runner")
+    sub = parser.add_subparsers(dest="command", required=True)
+    doctor = sub.add_parser("doctor", parents=[common], help="Check environment, adapter, target app, permissions, and API key.")
+    doctor.add_argument("--launch", action="store_true", help="Launch tagged c11 before adapter doctor checks.")
+    sub.add_parser("smoke", parents=[common], help="Launch tagged c11 and capture one screenshot without a model call.")
+    scenario = sub.add_parser("scenario", parents=[common], help="Run one OpenAI computer-use scenario.")
+    scenario.add_argument("name", choices=["launch-window", "create-split", "focus-and-type"])
+    sub.add_parser("deps", help="Show local dependency paths.")
+
+    args = parser.parse_args(argv)
+    if args.command == "deps":
+        print(json.dumps(dependency_report(), indent=2, sort_keys=True))
+        return 0
+
+    config = config_from_args(args)
+    try:
+        if args.command == "doctor":
+            result = run_doctor(config, launch=args.launch)
+        elif args.command == "smoke":
+            result = run_smoke(config)
+        elif args.command == "scenario":
+            result = run_scenario(args.name, config)
+        else:
+            raise AssertionError(args.command)
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if result.get("ok") is False and not result.get("blocked"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/computer-use/openai-runner/openai_cua_runner/adapter_client.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/adapter_client.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+class AdapterError(RuntimeError):
+    pass
+
+
+class AdapterClient:
+    def __init__(
+        self,
+        *,
+        bundle_id: str,
+        app_path: Path | None = None,
+        executable: Path | None = None,
+        repo_root: Path | None = None,
+    ) -> None:
+        self.bundle_id = bundle_id
+        self.app_path = app_path
+        self.repo_root = repo_root or Path.cwd()
+        self.package_dir = self.repo_root / "tools/computer-use/mac-adapter"
+        env_executable = os.environ.get("CUA_MAC_ADAPTER")
+        self.executable = executable or (Path(env_executable) if env_executable else self.package_dir / ".build/debug/cua-mac-adapter")
+
+    def available(self) -> bool:
+        return self.executable.exists() and os.access(self.executable, os.X_OK)
+
+    def build(self) -> None:
+        proc = subprocess.run(
+            ["swift", "build", "--package-path", str(self.package_dir)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise AdapterError(proc.stderr.strip() or proc.stdout.strip() or "swift build failed")
+
+    def doctor(self) -> dict[str, Any]:
+        return self._run("doctor")
+
+    def window_list(self) -> dict[str, Any]:
+        return self._run("window-list")
+
+    def launch(self, wait: int = 10) -> dict[str, Any]:
+        return self._run("launch", "--wait", str(wait))
+
+    def observe(self, *, out: Path | None = None, include_base64: bool = False, frontmost_required: bool = True) -> dict[str, Any]:
+        args: list[str] = []
+        if out is not None:
+            args += ["--out", str(out)]
+        if include_base64:
+            args.append("--include-base64")
+        if not frontmost_required:
+            args.append("--no-frontmost-required")
+        return self._run("observe", *args)
+
+    def act(self, action: dict[str, Any]) -> dict[str, Any]:
+        return self._run("act", "--json", json.dumps(action))
+
+    def _run(self, command: str, *args: str) -> dict[str, Any]:
+        if not self.available():
+            raise AdapterError(f"adapter executable is missing; run: swift build --package-path {self.package_dir}")
+        full = [str(self.executable), command, "--bundle-id", self.bundle_id]
+        if self.app_path is not None:
+            full += ["--app-path", str(self.app_path)]
+        full += list(args)
+        proc = subprocess.run(full, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        if proc.returncode != 0:
+            try:
+                payload = json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                payload = {"ok": False, "error": proc.stderr.strip() or proc.stdout.strip()}
+            raise AdapterError(payload.get("error") or json.dumps(payload))
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise AdapterError(f"adapter returned non-JSON output: {proc.stdout[:500]}") from exc

--- a/tools/computer-use/openai-runner/openai_cua_runner/artifacts.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/artifacts.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+@dataclass
+class RunArtifacts:
+    root: Path
+
+    @classmethod
+    def create(cls, scenario: str, base_dir: Path | None = None) -> "RunArtifacts":
+        base = base_dir or Path("artifacts/openai-cua-runs")
+        root = base / f"{_timestamp()}-{scenario}"
+        for child in ["screenshots", "c11", "logs"]:
+            (root / child).mkdir(parents=True, exist_ok=True)
+        return cls(root=root)
+
+    def write_json(self, relative: str, value: Any) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    def append_jsonl(self, relative: str, value: Any) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(value, sort_keys=True) + "\n")
+        return path
+
+    def write_text(self, relative: str, value: str) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value, encoding="utf-8")
+        return path
+
+    def screenshot_path(self, index: int, label: str) -> Path:
+        safe = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in label).strip("-") or "shot"
+        return self.root / "screenshots" / f"{index:03d}-{safe}.png"

--- a/tools/computer-use/openai-runner/openai_cua_runner/c11_oracle.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/c11_oracle.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+
+
+def sanitize_bundle(raw: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", ".", raw.lower()).strip(".")
+    cleaned = re.sub(r"\.+", ".", cleaned)
+    return cleaned or "agent"
+
+
+def sanitize_path(raw: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    cleaned = re.sub(r"-+", "-", cleaned)
+    return cleaned or "agent"
+
+
+@dataclass(frozen=True)
+class TaggedC11:
+    tag: str
+    repo_root: Path
+
+    @property
+    def tag_id(self) -> str:
+        return sanitize_bundle(self.tag)
+
+    @property
+    def slug(self) -> str:
+        return sanitize_path(self.tag)
+
+    @property
+    def bundle_id(self) -> str:
+        return f"com.stage11.c11.debug.{self.tag_id}"
+
+    @property
+    def app_path(self) -> Path:
+        return Path.home() / "Library/Developer/Xcode/DerivedData" / f"c11-{self.slug}" / "Build/Products/Debug" / f"c11 DEV {self.tag}.app"
+
+    @property
+    def socket_path(self) -> Path:
+        return Path(f"/tmp/c11-debug-{self.slug}.sock")
+
+    @property
+    def log_path(self) -> Path:
+        return Path(f"/tmp/c11-debug-{self.slug}.log")
+
+    def build(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["./scripts/reload.sh", "--tag", self.tag],
+            cwd=self.repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+    def launch(self, wait_socket: int = 10) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["./scripts/launch-tagged-automation.sh", self.tag, "--wait-socket", str(wait_socket)],
+            cwd=self.repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+
+class C11Oracle:
+    def __init__(self, tagged: TaggedC11) -> None:
+        self.tagged = tagged
+
+    def command(self, *args: str, expect_json: bool = True) -> Any:
+        env = os.environ.copy()
+        for key in [
+            "CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_TAB_ID", "CMUX_PANE_ID",
+            "C11_WORKSPACE_ID", "C11_SURFACE_ID", "C11_TAB_ID", "C11_PANE_ID",
+        ]:
+            env.pop(key, None)
+        env["CMUX_SOCKET_PATH"] = str(self.tagged.socket_path)
+        env["CMUX_SOCKET"] = str(self.tagged.socket_path)
+        proc = subprocess.run(
+            ["c11", "--socket", str(self.tagged.socket_path), *args],
+            cwd=self.tagged.repo_root,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return {"ok": False, "command": ["c11", *args], "stdout": proc.stdout, "stderr": proc.stderr, "returncode": proc.returncode}
+        if not expect_json:
+            return {"ok": True, "stdout": proc.stdout}
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return {"ok": True, "stdout": proc.stdout}
+
+    def tree(self) -> Any:
+        return self.command("tree", "--json")
+
+    def identify(self) -> Any:
+        return self.command("identify")
+
+    def read_screen(self, lines: int = 80) -> Any:
+        return self.command("read-screen", "--lines", str(lines), expect_json=False)
+
+
+def count_panes(tree: Any) -> int:
+    count = 0
+    if isinstance(tree, dict):
+        if "panes" in tree and isinstance(tree["panes"], list):
+            count += len(tree["panes"])
+        for value in tree.values():
+            count += count_panes(value)
+    elif isinstance(tree, list):
+        for item in tree:
+            count += count_panes(item)
+    return count

--- a/tools/computer-use/openai-runner/openai_cua_runner/responses_loop.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/responses_loop.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from typing import Any
+
+from .adapter_client import AdapterClient
+from .artifacts import RunArtifacts
+from .safety import SafetyBudget, SafetyLimits
+
+
+def _dump(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, list):
+        return [_dump(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _dump(item) for key, item in value.items()}
+    return value
+
+
+def _get(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _response_output(response: Any) -> list[Any]:
+    return list(_get(response, "output", []) or [])
+
+
+def _output_text(response: Any) -> str:
+    direct = _get(response, "output_text")
+    if isinstance(direct, str) and direct:
+        return direct
+    chunks: list[str] = []
+    for item in _response_output(response):
+        if _get(item, "type") == "message":
+            for content in _get(item, "content", []) or []:
+                text = _get(content, "text")
+                if text:
+                    chunks.append(text)
+    return "\n".join(chunks)
+
+
+def _computer_calls(response: Any) -> list[Any]:
+    return [item for item in _response_output(response) if _get(item, "type") == "computer_call"]
+
+
+def _normalize_action(action: dict[str, Any]) -> dict[str, Any]:
+    action_type = action.get("type") or action.get("action")
+    normalized: dict[str, Any] = {"type": action_type}
+    for src, dst in [
+        ("x", "x"), ("y", "y"), ("button", "button"), ("text", "text"),
+        ("dx", "dx"), ("dy", "dy"), ("scroll_x", "dx"), ("scroll_y", "dy"),
+        ("scrollX", "dx"), ("scrollY", "dy"), ("duration_ms", "durationMs"),
+        ("durationMs", "durationMs"), ("path", "path")
+    ]:
+        if src in action:
+            normalized[dst] = action[src]
+    if "keys" in action:
+        normalized["keys"] = action["keys"]
+    elif "key" in action:
+        normalized["keys"] = [action["key"]]
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _call_actions(call: Any) -> list[dict[str, Any]]:
+    actions = _get(call, "actions")
+    if actions:
+        return [_normalize_action(_dump(action)) for action in actions]
+    action = _get(call, "action")
+    if action:
+        return [_normalize_action(_dump(action))]
+    return []
+
+
+class ResponsesComputerLoop:
+    def __init__(
+        self,
+        *,
+        adapter: AdapterClient,
+        artifacts: RunArtifacts,
+        model: str,
+        limits: SafetyLimits | None = None,
+    ) -> None:
+        self.adapter = adapter
+        self.artifacts = artifacts
+        self.model = model
+        self.budget = SafetyBudget(limits or SafetyLimits())
+
+    def run(self, prompt: str) -> dict[str, Any]:
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise RuntimeError("openai package is not installed; run from tools/computer-use/openai-runner with your Python env installed") from exc
+
+        request_timeout = float(os.environ.get("OPENAI_CUA_REQUEST_TIMEOUT", "120"))
+        client = OpenAI(timeout=request_timeout)
+        self.artifacts.write_text("prompt.md", prompt)
+        response = client.responses.create(
+            model=self.model,
+            tools=[{"type": "computer"}],
+            input=prompt,
+        )
+        self.artifacts.write_json("response-000.json", _dump(response))
+
+        turn = 0
+        while True:
+            calls = _computer_calls(response)
+            if not calls:
+                final = _output_text(response)
+                self.artifacts.write_text("final.md", final)
+                return {"ok": True, "final": final, "actions": self.budget.actions, "response_id": _get(response, "id")}
+
+            outputs: list[dict[str, Any]] = []
+            for call in calls:
+                call_id = _get(call, "call_id") or _get(call, "id")
+                pending_safety = _get(call, "pending_safety_checks") or []
+                if pending_safety:
+                    raise RuntimeError(f"computer call returned pending safety checks; stopping fail-closed: {pending_safety}")
+                actions = _call_actions(call)
+                if not actions:
+                    actions = [{"type": "screenshot"}]
+                for action in actions:
+                    self.budget.record_action()
+                    self.artifacts.append_jsonl("actions.jsonl", {"turn": turn, "call_id": call_id, "action": action})
+                    if action["type"] != "screenshot":
+                        self.adapter.launch(wait=2)
+                        result = self.adapter.act(action)
+                        self.artifacts.append_jsonl("actions.jsonl", {"turn": turn, "call_id": call_id, "result": result})
+                    self.adapter.launch(wait=2)
+                    shot = self.artifacts.screenshot_path(self.budget.actions, f"after-{action['type']}")
+                    obs = self.adapter.observe(out=shot, include_base64=False)
+                    self.artifacts.append_jsonl("observations.jsonl", {"turn": turn, "call_id": call_id, "observation": obs})
+                    image_url = self._image_data_url(shot)
+                    outputs.append({
+                        "type": "computer_call_output",
+                        "call_id": call_id,
+                        "output": {
+                            "type": "input_image",
+                            "image_url": image_url,
+                        },
+                    })
+
+            turn += 1
+            response = client.responses.create(
+                model=self.model,
+                tools=[{"type": "computer"}],
+                previous_response_id=_get(response, "id"),
+                input=outputs,
+            )
+            self.artifacts.write_json(f"response-{turn:03d}.json", _dump(response))
+
+    @staticmethod
+    def _image_data_url(path: Path) -> str:
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        return f"data:image/png;base64,{encoded}"

--- a/tools/computer-use/openai-runner/openai_cua_runner/safety.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/safety.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+
+
+class SafetyBlocked(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SafetyLimits:
+    max_actions: int = 25
+    max_seconds: int = 180
+    allow_system_prompts: bool = False
+
+
+class SafetyBudget:
+    def __init__(self, limits: SafetyLimits) -> None:
+        self.limits = limits
+        self.started = time.monotonic()
+        self.actions = 0
+
+    def record_action(self) -> None:
+        self.actions += 1
+        if self.actions > self.limits.max_actions:
+            raise SafetyBlocked(f"max action count exceeded: {self.limits.max_actions}")
+        elapsed = time.monotonic() - self.started
+        if elapsed > self.limits.max_seconds:
+            raise SafetyBlocked(f"max wall time exceeded: {self.limits.max_seconds}s")

--- a/tools/computer-use/openai-runner/openai_cua_runner/scenarios.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/scenarios.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import shutil
+from typing import Any
+
+from .adapter_client import AdapterClient
+from .artifacts import RunArtifacts
+from .c11_oracle import C11Oracle, TaggedC11, count_panes
+from .responses_loop import ResponsesComputerLoop
+from .safety import SafetyLimits
+
+
+@dataclass(frozen=True)
+class ScenarioConfig:
+    repo_root: Path
+    tag: str
+    model: str
+    build: bool = False
+    max_actions: int = 25
+    max_seconds: int = 180
+
+    @property
+    def tagged(self) -> TaggedC11:
+        return TaggedC11(tag=self.tag, repo_root=self.repo_root)
+
+
+SCENARIO_PROMPTS: dict[str, str] = {
+    "launch-window": """You are testing the c11 macOS app through a computer-use screenshot.
+
+Inspect the visible c11 window and report whether the app appears ready for operator use. Do not edit files. If the app is still launching, wait once and inspect again.
+""",
+    "create-split": """You are testing c11 through its visible macOS UI.
+
+Create one new terminal split using the visible UI or a normal user keyboard shortcut. Inspect the screen first. Do not use terminal commands, socket commands, or shell shortcuts as the action path. Stop and explain if no user-facing split affordance or shortcut is reasonably available from the visible state.
+""",
+    "focus-and-type": """You are testing c11 terminal focus and keyboard event routing through the visible macOS UI.
+
+Click inside the visible terminal surface, type exactly:
+printf 'openai-cua-ok\\n'
+
+Then press Enter. Do not use socket commands or paste through any out-of-band mechanism.
+""",
+}
+
+
+def make_adapter(config: ScenarioConfig) -> AdapterClient:
+    return AdapterClient(bundle_id=config.tagged.bundle_id, app_path=config.tagged.app_path, repo_root=config.repo_root)
+
+
+def run_doctor(config: ScenarioConfig, *, launch: bool = False) -> dict[str, Any]:
+    adapter = make_adapter(config)
+    result: dict[str, Any] = {
+        "openai_api_key_present": bool(os.environ.get("OPENAI_API_KEY")),
+        "openai_model": config.model,
+        "adapter_executable": str(adapter.executable),
+        "adapter_available": adapter.available(),
+        "tag": config.tag,
+        "bundle_id": config.tagged.bundle_id,
+        "app_path": str(config.tagged.app_path),
+        "app_exists": config.tagged.app_path.exists(),
+        "socket_path": str(config.tagged.socket_path),
+        "socket_exists": config.tagged.socket_path.exists(),
+        "build_command": f"./scripts/reload.sh --tag {config.tag}",
+        "launch_command": f"./scripts/launch-tagged-automation.sh {config.tag} --wait-socket 10",
+    }
+    if not adapter.available():
+        result["adapter_build_command"] = f"swift build --package-path {adapter.package_dir}"
+        return result
+    if launch:
+        result["launch_output"] = _launch_tagged(config)
+    try:
+        result["adapter_doctor"] = adapter.doctor()
+    except Exception as exc:
+        result["adapter_doctor_error"] = str(exc)
+    return result
+
+
+def run_smoke(config: ScenarioConfig) -> dict[str, Any]:
+    adapter = make_adapter(config)
+    if not adapter.available():
+        adapter.build()
+    artifacts = RunArtifacts.create("smoke", config.repo_root / "artifacts/openai-cua-runs")
+    doctor = adapter.doctor()
+    blocked = _permission_block(doctor)
+    if blocked:
+        run = {"ok": False, "blocked": True, "reason": blocked, "adapter_doctor": doctor, "artifacts": str(artifacts.root)}
+        artifacts.write_json("run.json", run)
+        return run
+    launch_result = _launch_tagged(config)
+    artifacts.write_text("logs/launch.txt", launch_result.get("stdout", ""))
+    adapter_launch = adapter.launch(wait=10)
+    shot = artifacts.screenshot_path(0, "initial")
+    observation = adapter.observe(out=shot, frontmost_required=False)
+    oracle = C11Oracle(config.tagged)
+    tree = oracle.tree()
+    identify = oracle.identify()
+    artifacts.write_json("c11/tree-before.json", tree)
+    artifacts.write_json("c11/identify.json", identify)
+    run = {
+        "ok": launch_result["returncode"] == 0 and bool(observation.get("ok")),
+        "artifacts": str(artifacts.root),
+        "launch": launch_result,
+        "adapter_launch": adapter_launch,
+        "observation": observation,
+        "tree_panes": count_panes(tree),
+    }
+    artifacts.write_json("run.json", run)
+    return run
+
+
+def run_scenario(name: str, config: ScenarioConfig) -> dict[str, Any]:
+    if name not in SCENARIO_PROMPTS:
+        raise ValueError(f"unknown scenario: {name}")
+    if not os.environ.get("OPENAI_API_KEY"):
+        return {"ok": False, "blocked": True, "reason": "OPENAI_API_KEY is not present in the environment"}
+
+    adapter = make_adapter(config)
+    if not adapter.available():
+        adapter.build()
+    artifacts = RunArtifacts.create(name, config.repo_root / "artifacts/openai-cua-runs")
+    doctor = adapter.doctor()
+    blocked = _permission_block(doctor)
+    if blocked:
+        run = {"ok": False, "blocked": True, "reason": blocked, "adapter_doctor": doctor, "artifacts": str(artifacts.root)}
+        artifacts.write_json("run.json", run)
+        return run
+    launch_result = _launch_tagged(config)
+    artifacts.write_text("logs/launch.txt", launch_result.get("stdout", ""))
+    if launch_result["returncode"] != 0:
+        run = {"ok": False, "blocked": True, "reason": "tagged c11 launch failed", "launch": launch_result, "artifacts": str(artifacts.root)}
+        artifacts.write_json("run.json", run)
+        return run
+
+    adapter.launch(wait=10)
+    initial_shot = artifacts.screenshot_path(0, "initial")
+    adapter.observe(out=initial_shot, frontmost_required=False)
+    oracle = C11Oracle(config.tagged)
+    before = oracle.tree()
+    artifacts.write_json("c11/tree-before.json", before)
+
+    loop = ResponsesComputerLoop(
+        adapter=adapter,
+        artifacts=artifacts,
+        model=config.model,
+        limits=SafetyLimits(max_actions=config.max_actions, max_seconds=config.max_seconds),
+    )
+    prompt = SCENARIO_PROMPTS[name]
+    try:
+        loop_result = loop.run(prompt)
+    except Exception as exc:
+        after_error = oracle.tree()
+        artifacts.write_json("c11/tree-after-error.json", after_error)
+        run = {
+            "ok": False,
+            "scenario": name,
+            "model": config.model,
+            "artifacts": str(artifacts.root),
+            "error": str(exc),
+        }
+        artifacts.write_json("run.json", run)
+        return run
+    after = oracle.tree()
+    artifacts.write_json("c11/tree-after.json", after)
+
+    oracle_result = _oracle_result(name, oracle, before, after)
+    run = {
+        "ok": bool(loop_result.get("ok")) and oracle_result.get("ok", True),
+        "scenario": name,
+        "model": config.model,
+        "artifacts": str(artifacts.root),
+        "loop": loop_result,
+        "oracle": oracle_result,
+    }
+    artifacts.write_json("run.json", run)
+    return run
+
+
+def _launch_tagged(config: ScenarioConfig) -> dict[str, Any]:
+    if config.build:
+        build = config.tagged.build()
+        if build.returncode != 0:
+            return {"returncode": build.returncode, "stdout": build.stdout, "phase": "build"}
+    if not config.tagged.app_path.exists():
+        return {
+            "returncode": 2,
+            "stdout": f"tagged app not found at {config.tagged.app_path}\nrun: ./scripts/reload.sh --tag {config.tag}\n",
+            "phase": "preflight",
+        }
+    launch = config.tagged.launch(wait_socket=10)
+    return {"returncode": launch.returncode, "stdout": launch.stdout, "phase": "launch"}
+
+
+def _oracle_result(name: str, oracle: C11Oracle, before: Any, after: Any) -> dict[str, Any]:
+    if name == "create-split":
+        before_count = count_panes(before)
+        after_count = count_panes(after)
+        return {"ok": after_count > before_count, "before_panes": before_count, "after_panes": after_count}
+    if name == "focus-and-type":
+        screen = oracle.read_screen(lines=120)
+        stdout = screen.get("stdout", "") if isinstance(screen, dict) else ""
+        return {"ok": "openai-cua-ok" in stdout, "read_screen_contains_expected": "openai-cua-ok" in stdout}
+    if name == "launch-window":
+        after_count = count_panes(after)
+        return {"ok": after_count >= 1, "after_panes": after_count}
+    return {"ok": True}
+
+
+def _permission_block(doctor: dict[str, Any]) -> str | None:
+    permissions = doctor.get("permissions", {})
+    missing: list[str] = []
+    if not permissions.get("screenRecording"):
+        missing.append("Screen Recording")
+    if not permissions.get("accessibility"):
+        missing.append("Accessibility")
+    if not missing:
+        return None
+    remediation = " ".join(permissions.get("remediation", []))
+    return f"missing macOS permission(s): {', '.join(missing)}. {remediation}".strip()
+
+
+def dependency_report() -> dict[str, Any]:
+    return {
+        "python": shutil.which("python3"),
+        "swift": shutil.which("swift"),
+        "c11": shutil.which("c11"),
+    }

--- a/tools/computer-use/openai-runner/pyproject.toml
+++ b/tools/computer-use/openai-runner/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "openai-cua-runner"
+version = "0.1.0"
+description = "OpenAI Responses API computer-use runner for c11 tagged macOS builds"
+requires-python = ">=3.11"
+dependencies = [
+  "openai>=1.109.0",
+]
+
+[project.scripts]
+openai-cua-runner = "openai_cua_runner.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["openai_cua_runner"]


### PR DESCRIPTION
## Summary

Adds the OpenAI side of the c11 computer-use comparison harness:

- provider-neutral Swift macOS adapter for window targeting, permission checks, screenshots, and CoreGraphics input
- OpenAI Responses API runner for the `computer` tool loop
- tagged c11 launch/socket oracle integration
- scenario/artifact support for `doctor`, `smoke`, `launch-window`, `create-split`, and `focus-and-type`
- docs and ignored runtime artifact output
- a small `launch-tagged-automation.sh` fix for empty `--env` handling under `set -u`

## Validation

- `swift build --package-path tools/computer-use/mac-adapter`
- `python3 -m compileall tools/computer-use/openai-runner/openai_cua_runner`
- `./scripts/reload.sh --tag openai-cua`
- `PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner smoke --tag openai-cua`
- OpenAI model-backed scenarios passed:
  - `launch-window`
  - `create-split`
  - `focus-and-type`

Additional realistic c11 user test:

- launched tagged `c11 DEV openai-cua.app`
- started `codex --yolo` inside a c11 pane
- created two additional panes with independent Codex instances
- prompted each Codex instance to emit its own poem in its pane
- rebalanced panes after observing that the rightmost Codex pane was too narrow for human readability

Proof screenshots were written under `/tmp/` and are intentionally not committed.
