### PR TITLE
Re-apply OpenAI CUA runner after rollback (was #100)

### DIFF
--- a/.claude/commands/upstream-triage.md
+++ b/.claude/commands/upstream-triage.md
@@ -44,7 +44,7 @@ If `$ARGUMENTS` is empty, ask the user what they want to triage. Default suggest
 
 ## Validation
 
-For any user-visible import, run the c11 computer-use harness (`tools/computer-use/c11-cu`, currently on the `computer-use-harness` branch) against a tagged build before declaring the c11 PR ready. Skip validation for purely internal changes (refactors, build config, agent-instruction docs). Attach the verdict to the c11 PR body. See RUNBOOK.md §6b for the full procedure.
+For any user-visible import, run the OpenAI CUA harness (`tools/computer-use/openai-runner`, currently on `feat/openai-cua-runner` branch) against a tagged c11 build before declaring the c11 PR ready. Skip validation for purely internal changes (refactors, build config, agent-instruction docs). Attach the verdict to the c11 PR body. See RUNBOOK.md §6b for the full procedure.
 
 ## Hard rules
 

--- a/.claude/commands/upstream-triage.md
+++ b/.claude/commands/upstream-triage.md
@@ -1,10 +1,10 @@
 ---
-description: Import upstream cmux PRs into c11 — agent reads, judges, and writes the c11 version (cherry-pick or rewrite). Reads upstream-triage/RUNBOOK.md for the working philosophy.
+description: Import upstream cmux PRs into c11 — agent evaluates desirability, judges difficulty, and writes the c11 version (cherry-pick or rewrite). Reads upstream-triage/RUNBOOK.md for the working philosophy.
 ---
 
 # /upstream-triage
 
-You are the agent doing c11's upstream import work. **You are doing the import, not orchestrating a pipeline.** For each upstream PR you process, you read it, locate the equivalent code in c11, judge whether and how the change applies, and author the c11 import — via cherry-pick when convenient, via rewrite when not.
+You are the agent doing c11's upstream import work. **You are doing the import, not orchestrating a pipeline.** For each upstream PR you process — open or closed, merged or unmerged — you evaluate whether c11 wants it, judge how hard it'd be, and (if worth the effort) author the c11 version: cherry-pick when convenient, rewrite when not.
 
 The operator (the user) is your partner: they set direction and review your judgment on edge cases. You don't surprise them. You escalate when uncertain. You don't auto-merge.
 
@@ -12,11 +12,21 @@ The operator (the user) is your partner: they set direction and review your judg
 
 In this order:
 
-1. `upstream-triage/RUNBOOK.md` — your working philosophy: READ → LOCATE → JUDGE → APPLY → REPORT, plus collaboration rules and PR shape.
+1. `upstream-triage/RUNBOOK.md` — your working philosophy: EVALUATE → READ → LOCATE → JUDGE → (scope agreement, conditional) → APPLY → REPORT, plus collaboration rules and PR shape.
 2. `upstream-triage/divergence-map.md` — facts about c11 hot zones (skip vs adapt).
 3. `upstream-triage/playbook.md` — adaptation patterns you've worked out before. Reuse them; add to them when you learn something new.
+4. `upstream-triage/catchup/feature-catchup-plan.md` — strategic frame: forward-sweep-driven, foundations emerge from triage signal, not pre-curated.
 
 Don't begin processing PRs until you've loaded these into context.
+
+## Two triage axes
+
+For every PR:
+
+- **EVALUATE** — does c11 want this functionality? `yes / no / maybe`. This comes *before* technical analysis. Skip non-fit PRs without spending time on them.
+- **DIFFICULTY** — how hard to bring over? `easy / moderate / hard`. Drives whether scope agreement is needed before apply.
+
+Bias toward easy + yes. Land them with minimal ceremony, batch them in the triage log. Hard work gets focused sessions with explicit scope agreement.
 
 ## Arguments
 
@@ -25,11 +35,12 @@ The user invoked: `/upstream-triage $ARGUMENTS`
 Parse `$ARGUMENTS`:
 
 - One or more bare numbers → PRs to process (e.g., `3405 3400 3399`).
-- `--since <date-or-pr>` → list upstream PRs merged after that point and process each. Use `upstream-triage/scripts/list-merged.sh --since <X>` to get the list.
-- `--catchup [--batch-size N]` → pull next N from `upstream-triage/catchup/backlog.md`. See `upstream-triage/catchup/feature-catchup-plan.md` for the strategic approach.
-- `--dry-run` → READ, LOCATE, JUDGE for each PR; no APPLY. Useful for surveying a batch before committing to imports.
+- `--since <date-or-pr>` → list upstream PRs after that point and process each. Use `upstream-triage/scripts/list-merged.sh --since <X> [--state merged|open|all]`.
+- `--state merged|open|all` → only valid with `--since`. Default `merged`.
+- `--catchup [--batch-size N]` → pull next N from `upstream-triage/catchup/backlog.md` if it exists.
+- `--dry-run` → run EVALUATE, READ, LOCATE, JUDGE for each PR; write a triage table; no APPLY. Recommended for first run on a batch.
 
-If `$ARGUMENTS` is empty, ask the user what they want to triage.
+If `$ARGUMENTS` is empty, ask the user what they want to triage. Default suggestion: `--since <date 2-3 weeks back> --state all --dry-run`.
 
 ## Hard rules
 
@@ -39,11 +50,13 @@ If `$ARGUMENTS` is empty, ask the user what they want to triage.
 - Never force-push triage branches.
 - One PR at a time — sequential, not parallel.
 - Escalate before push when the c11 PR will visibly differ from upstream (rewrite, partial import, scope change). Surface the difference in the PR body so the operator never wonders why the diff doesn't match.
+- For open PRs: flag in the PR body that upstream may evolve or abandon — the import is a snapshot.
 
 ## After the run
 
 - Append per-PR decisions to `upstream-triage/triage-log/<YYYY-MM-DD>.md`.
+- For moderate/hard imports, leave the scope-and-approach note in `upstream-triage/in-flight/<feature-or-pr>.md` until the c11 PR merges, then archive or remove.
 - If you discovered a new adaptation pattern worth reusing → update `playbook.md`.
 - If you surfaced a new divergent area → update `divergence-map.md`.
 - Commit those updates as a separate commit on main: `chore(triage): update divergence map and playbook from <date> run`.
-- Surface a brief summary to the operator: counts of LANDED-cherry-pick / LANDED-rewrite / NEEDS-HUMAN / SKIPPED, with links to opened c11 PRs.
+- Surface a brief summary to the operator: counts of LANDED-cherry-pick / LANDED-rewrite / NEEDS-HUMAN / SKIP / DEFERRED-hard, with links to opened c11 PRs.

--- a/.claude/commands/upstream-triage.md
+++ b/.claude/commands/upstream-triage.md
@@ -42,6 +42,10 @@ Parse `$ARGUMENTS`:
 
 If `$ARGUMENTS` is empty, ask the user what they want to triage. Default suggestion: `--since <date 2-3 weeks back> --state all --dry-run`.
 
+## Validation
+
+For any user-visible import, run the c11 computer-use harness (`tools/computer-use/c11-cu`, currently on the `computer-use-harness` branch) against a tagged build before declaring the c11 PR ready. Skip validation for purely internal changes (refactors, build config, agent-instruction docs). Attach the verdict to the c11 PR body. See RUNBOOK.md §6b for the full procedure.
+
 ## Hard rules
 
 - Working tree must be clean for any apply step. If main is dirty, prefer running in a worktree (`git worktree add /tmp/c11-triage main`); if you must stash, get explicit operator OK first.
@@ -51,6 +55,7 @@ If `$ARGUMENTS` is empty, ask the user what they want to triage. Default suggest
 - One PR at a time — sequential, not parallel.
 - Escalate before push when the c11 PR will visibly differ from upstream (rewrite, partial import, scope change). Surface the difference in the PR body so the operator never wonders why the diff doesn't match.
 - For open PRs: flag in the PR body that upstream may evolve or abandon — the import is a snapshot.
+- Announce before running the computer-use harness — the cursor will move on the operator's live desktop.
 
 ## After the run
 

--- a/.claude/commands/upstream-triage.md
+++ b/.claude/commands/upstream-triage.md
@@ -1,10 +1,22 @@
 ---
-description: Triage upstream cmux PRs into c11 — per-PR cherry-pick, conflict resolution, c11 PR open. Reads upstream-triage/RUNBOOK.md for the full flow.
+description: Import upstream cmux PRs into c11 — agent reads, judges, and writes the c11 version (cherry-pick or rewrite). Reads upstream-triage/RUNBOOK.md for the working philosophy.
 ---
 
 # /upstream-triage
 
-You are running c11's upstream-triage flow. **Read `upstream-triage/RUNBOOK.md` first** — it contains the full procedure. Then read `upstream-triage/divergence-map.md` and `upstream-triage/playbook.md` for current c11 hot zones and known resolve recipes.
+You are the agent doing c11's upstream import work. **You are doing the import, not orchestrating a pipeline.** For each upstream PR you process, you read it, locate the equivalent code in c11, judge whether and how the change applies, and author the c11 import — via cherry-pick when convenient, via rewrite when not.
+
+The operator (the user) is your partner: they set direction and review your judgment on edge cases. You don't surprise them. You escalate when uncertain. You don't auto-merge.
+
+## Required reading before any work
+
+In this order:
+
+1. `upstream-triage/RUNBOOK.md` — your working philosophy: READ → LOCATE → JUDGE → APPLY → REPORT, plus collaboration rules and PR shape.
+2. `upstream-triage/divergence-map.md` — facts about c11 hot zones (skip vs adapt).
+3. `upstream-triage/playbook.md` — adaptation patterns you've worked out before. Reuse them; add to them when you learn something new.
+
+Don't begin processing PRs until you've loaded these into context.
 
 ## Arguments
 
@@ -12,24 +24,26 @@ The user invoked: `/upstream-triage $ARGUMENTS`
 
 Parse `$ARGUMENTS`:
 
-- One or more bare numbers → PRs to process (e.g., `3405 3400 3399`)
-- `--since <date-or-pr>` → list upstream PRs merged after that point and process each
-- `--catchup [--batch-size N]` → pull next N from `upstream-triage/catchup/backlog.md`
-- `--dry-run` → run DECIDE and PROBE only, do not push or open PRs
+- One or more bare numbers → PRs to process (e.g., `3405 3400 3399`).
+- `--since <date-or-pr>` → list upstream PRs merged after that point and process each. Use `upstream-triage/scripts/list-merged.sh --since <X>` to get the list.
+- `--catchup [--batch-size N]` → pull next N from `upstream-triage/catchup/backlog.md`. See `upstream-triage/catchup/feature-catchup-plan.md` for the strategic approach.
+- `--dry-run` → READ, LOCATE, JUDGE for each PR; no APPLY. Useful for surveying a batch before committing to imports.
 
 If `$ARGUMENTS` is empty, ask the user what they want to triage.
 
-## Hard rules (mirror RUNBOOK.md)
+## Hard rules
 
-- Working tree must be clean. Refuse if dirty.
-- Current branch should be `main`. If not, ask.
-- Never push to upstream `manaflow-ai/cmux` (already blocked at git config).
+- Working tree must be clean for any apply step. If main is dirty, prefer running in a worktree (`git worktree add /tmp/c11-triage main`); if you must stash, get explicit operator OK first.
+- Never push to `manaflow-ai/cmux` (already blocked at git-config level).
 - Never auto-merge c11 PRs.
 - Never force-push triage branches.
 - One PR at a time — sequential, not parallel.
+- Escalate before push when the c11 PR will visibly differ from upstream (rewrite, partial import, scope change). Surface the difference in the PR body so the operator never wonders why the diff doesn't match.
 
 ## After the run
 
-- Append decisions to `upstream-triage/triage-log/<YYYY-MM-DD>.md`.
-- If you discovered new divergent areas or a reusable resolve pattern, update `divergence-map.md` / `playbook.md` and commit those updates separately on `main`.
-- Surface a brief summary to the user: counts of LANDED / SKIPPED / NEEDS-HUMAN, with links to opened c11 PRs.
+- Append per-PR decisions to `upstream-triage/triage-log/<YYYY-MM-DD>.md`.
+- If you discovered a new adaptation pattern worth reusing → update `playbook.md`.
+- If you surfaced a new divergent area → update `divergence-map.md`.
+- Commit those updates as a separate commit on main: `chore(triage): update divergence map and playbook from <date> run`.
+- Surface a brief summary to the operator: counts of LANDED-cherry-pick / LANDED-rewrite / NEEDS-HUMAN / SKIPPED, with links to opened c11 PRs.

--- a/.claude/commands/upstream-triage.md
+++ b/.claude/commands/upstream-triage.md
@@ -1,0 +1,35 @@
+---
+description: Triage upstream cmux PRs into c11 — per-PR cherry-pick, conflict resolution, c11 PR open. Reads upstream-triage/RUNBOOK.md for the full flow.
+---
+
+# /upstream-triage
+
+You are running c11's upstream-triage flow. **Read `upstream-triage/RUNBOOK.md` first** — it contains the full procedure. Then read `upstream-triage/divergence-map.md` and `upstream-triage/playbook.md` for current c11 hot zones and known resolve recipes.
+
+## Arguments
+
+The user invoked: `/upstream-triage $ARGUMENTS`
+
+Parse `$ARGUMENTS`:
+
+- One or more bare numbers → PRs to process (e.g., `3405 3400 3399`)
+- `--since <date-or-pr>` → list upstream PRs merged after that point and process each
+- `--catchup [--batch-size N]` → pull next N from `upstream-triage/catchup/backlog.md`
+- `--dry-run` → run DECIDE and PROBE only, do not push or open PRs
+
+If `$ARGUMENTS` is empty, ask the user what they want to triage.
+
+## Hard rules (mirror RUNBOOK.md)
+
+- Working tree must be clean. Refuse if dirty.
+- Current branch should be `main`. If not, ask.
+- Never push to upstream `manaflow-ai/cmux` (already blocked at git config).
+- Never auto-merge c11 PRs.
+- Never force-push triage branches.
+- One PR at a time — sequential, not parallel.
+
+## After the run
+
+- Append decisions to `upstream-triage/triage-log/<YYYY-MM-DD>.md`.
+- If you discovered new divergent areas or a reusable resolve pattern, update `divergence-map.md` / `playbook.md` and commit those updates separately on `main`.
+- Surface a brief summary to the user: counts of LANDED / SKIPPED / NEEDS-HUMAN, with links to opened c11 PRs.

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+artifacts/openai-cua-runs/
 
 # Claude Code per-session state and agent scratch worktrees
 .claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ The distinction matters. Socket/CLI commands are excellent for setup, orchestrat
 When validating c11 with computer use:
 
 - Launch only tagged builds (`./scripts/reload.sh --tag <tag>` and `./scripts/launch-tagged-automation.sh <tag>`). Never launch an untagged `c11 DEV.app`.
+- Default handoff is a fresh c11 surface running interactive Codex: create a new terminal pane/surface, run `codex --yolo`, then send a file-backed expert prompt. Do not use `codex exec` for watched validation panes.
+- The expert prompt should name the target tagged app/window, the scenario, success criteria, safety boundaries, artifact expectations, and the caller's workspace/surface refs so Codex can report back with `c11 send` or leave a readable result for `read-screen`.
+- This pattern is cross-agent: Claude Code can delegate visual validation to Codex, and Codex can delegate a clean computer-use pass to another Codex surface. Keep the handoff explicit so the validation context is fresh and inspectable.
 - Use the socket as setup/oracle infrastructure, not as a substitute for the UI path being tested.
 - Capture screenshots and scenario artifacts for claims about visible behavior.
 - Inspect `c11 tree --no-layout` before calling a run successful. If important panes are too small for a human to read, rebalance them and treat that as part of the validation, not cleanup.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,25 @@ c11's value to an agent is **the skill** — `skills/c11/SKILL.md` plus the peer
 
 **Therefore:** every change to the CLI, socket protocol, metadata schema, or surface model is incomplete until the skill is updated to match. If you add a command, add it to the skill. If you rename a command, rename it in the skill. If you change defaults, update the examples. The skill is the contract; let it rot and agents get worse at using c11. Invest there first, not last.
 
+## Computer use is a maintainer validation skill, not the c11 operating skill
+
+There are two different genres here; do not blur them:
+
+- **Agent operating skill (`c11`).** Teaches an agent inside c11 how to use the room: split panes, open surfaces, target handles, report status, drive browser/markdown surfaces, and compose its own working environment.
+- **Maintainer validation skill (`c11-computer-use`, planned).** Teaches a maintainer/developer agent how to test c11 as a product through the real macOS UI: screenshots, clicks, keyboard focus, pane readability, visual recovery, and user-path validation.
+
+The distinction matters. Socket/CLI commands are excellent for setup, orchestration, recovery, and deterministic oracle checks, but they do not prove that a human-visible workflow works. Computer use should validate behaviors that are visual, spatial, focus-sensitive, pointer-driven, or human-ergonomic.
+
+When validating c11 with computer use:
+
+- Launch only tagged builds (`./scripts/reload.sh --tag <tag>` and `./scripts/launch-tagged-automation.sh <tag>`). Never launch an untagged `c11 DEV.app`.
+- Use the socket as setup/oracle infrastructure, not as a substitute for the UI path being tested.
+- Capture screenshots and scenario artifacts for claims about visible behavior.
+- Inspect `c11 tree --no-layout` before calling a run successful. If important panes are too small for a human to read, rebalance them and treat that as part of the validation, not cleanup.
+- Prefer repeatable harness scenarios for comparisons across providers. Manual computer-use runs are useful, but they should feed back into reusable scenarios and skill guidance.
+
+The lesson from the OpenAI CUA runner work: "it executed" is not enough. If the resulting workspace is hard for the operator to read, the validation found a product/workflow issue worth preserving.
+
 ## Principle: unopinionated about the terminal
 
 c11 is **host and primitive, not configurator.** It provides surfaces, panes, a socket, a CLI, and a metadata seam — all scoped to c11's own runtime. The operator's tenant config files (`~/.claude/settings.json`, `~/.codex/*`, `~/.kimi/*`, shell rc files, etc.) are off-limits: c11 never reaches in to install hooks, persist configuration, or inject behavior into any TUI's on-disk state.

--- a/docs/openai-codex-computer-use-plan.md
+++ b/docs/openai-codex-computer-use-plan.md
@@ -1,6 +1,6 @@
 # OpenAI Codex Computer Use Plan
 
-Status: planning artifact only. No runner implementation has started in this branch.
+Status: implementation started. The initial provider-neutral Swift macOS adapter and OpenAI-specific Python runner live under `tools/computer-use/`.
 
 Branch/worktree:
 
@@ -36,6 +36,8 @@ Official references:
 - Codex app Computer Use: `https://developers.openai.com/codex/app/computer-use`
 - API Computer Use guide: `https://developers.openai.com/api/docs/guides/tools-computer-use`
 - CUA sample app: `https://github.com/openai/openai-cua-sample-app`
+
+Implementation note: the runner targets the current GA Responses API `computer` tool shape: `tools=[{"type": "computer"}]`, `computer_call` outputs, and follow-up `computer_call_output` items sent with `previous_response_id`.
 
 ## Non-goals
 
@@ -418,6 +420,8 @@ Deliverables:
 - JSON action/result schema.
 - Local artifact screenshots.
 
+Implementation status: initial adapter added at `tools/computer-use/mac-adapter`. It also includes `launch`, frontmost bundle guardrails for input, `double_click`, `move`, `drag`, and `scroll`.
+
 Validation:
 
 - Run `doctor`.
@@ -439,6 +443,8 @@ Deliverables:
 - Run artifacts.
 - `launch-window` scenario.
 
+Implementation status: initial runner added at `tools/computer-use/openai-runner`. It discovers `OPENAI_API_KEY` from the environment only, writes ignored artifact bundles, and handles current Responses API computer calls.
+
 Validation:
 
 - Complete Scenario 1 against tagged c11.
@@ -452,6 +458,8 @@ Deliverables:
 - Socket oracle integration with `C11_SOCKET`/`CMUX_SOCKET`.
 - Scenario definitions for launch, split, focus/type.
 - Failure bundles with screenshots, logs, socket snapshots, and model trace.
+
+Implementation status: `doctor`, `smoke`, `launch-window`, `create-split`, and `focus-and-type` CLI paths are implemented. Socket usage is limited to launch/oracle/artifact capture.
 
 Validation:
 
@@ -575,4 +583,3 @@ Start Phase 1 and Phase 2:
 2. Implement the provider-neutral Swift mac adapter `doctor` and `observe` commands.
 3. Launch tagged c11 with `openai-cua` and capture the first window screenshot.
 4. Add the OpenAI runner only after the local screenshot/action loop is reliable.
-

--- a/docs/openai-codex-computer-use-plan.md
+++ b/docs/openai-codex-computer-use-plan.md
@@ -1,0 +1,578 @@
+# OpenAI Codex Computer Use Plan
+
+Status: planning artifact only. No runner implementation has started in this branch.
+
+Branch/worktree:
+
+- Branch: `feat/openai-cua-runner`
+- Worktree: `/Users/atin/Projects/Stage11/code/c11-worktrees/openai-cua-runner`
+
+Date: 2026-04-30
+
+## Goal
+
+Build an OpenAI-backed computer-use path for testing c11 the way an operator uses it: through the real macOS app UI, with screenshots, clicks, keyboard input, focus changes, menus, panels, drag gestures, and visual recovery when the app is not in the expected state.
+
+This branch is the OpenAI side of an apples-to-apples comparison with the Anthropic computer-use effort running separately. The comparison should measure the agent's ability to operate c11 visually, not just mutate files or query the socket.
+
+## Current OpenAI Landscape
+
+There are two relevant OpenAI routes.
+
+1. Codex app Computer Use plugin
+
+   OpenAI's Codex app now has a macOS Computer Use plugin. The docs say to install it from Codex settings, then grant Screen Recording and Accessibility permissions. It lets Codex see and operate graphical macOS apps, including desktop apps and browser flows. It is currently documented as macOS-only at launch and unavailable in the EEA, UK, and Switzerland.
+
+   This is the fastest path to let Codex itself operate c11 visually in an interactive session.
+
+2. Responses API `computer` tool
+
+   The developer API exposes a `computer` tool. The model inspects screenshots and returns actions such as `click`, `double_click`, `scroll`, `type`, `wait`, `keypress`, `drag`, `move`, and `screenshot`. Our code executes those actions in a harness, captures the next screenshot, and sends it back as `computer_call_output`.
+
+   This is the right path for a reproducible comparison harness because we control the environment, artifacts, prompts, scenarios, scoring, retries, and state reset.
+
+Official references:
+
+- Codex app Computer Use: `https://developers.openai.com/codex/app/computer-use`
+- API Computer Use guide: `https://developers.openai.com/api/docs/guides/tools-computer-use`
+- CUA sample app: `https://github.com/openai/openai-cua-sample-app`
+
+## Non-goals
+
+- Do not replace c11 socket or CLI tests. Those remain the deterministic oracle and setup/reset layer.
+- Do not make the c11 app depend on OpenAI, Anthropic, or any computer-use SDK.
+- Do not add persistent writes to tenant configs such as `~/.codex`, `~/.claude`, shell rc files, or app-specific agent config.
+- Do not automate Codex itself or terminal security prompts through the Codex app Computer Use plugin. OpenAI's Codex Computer Use docs explicitly call out restrictions around automating terminal apps, Codex itself, admin authentication, and security/privacy permission prompts.
+- Do not treat screenshot-only success as enough when a deterministic state check exists.
+
+## Principle
+
+Computer use is the primary exercise path. The agent should complete workflows through the visible app UI whenever possible.
+
+Socket and CLI access are support infrastructure:
+
+- setup: launch tagged build, clean previous state, create deterministic initial conditions
+- oracle: assert workspace/pane/surface state after the visual action
+- artifact capture: collect logs, tree output, socket snapshots, and screenshots
+- recovery: help diagnose failures without pretending a socket-only operation proved user behavior
+
+The gold standard is: "Could a real operator have done this through the UI, and did the app visibly respond correctly?"
+
+## Recommended Shape
+
+Build a provider-neutral local macOS adapter and an OpenAI-specific orchestrator.
+
+```text
+tools/computer-use/
+  mac-adapter/
+    Package.swift
+    Sources/CUAMacAdapter/
+      main.swift
+      WindowTarget.swift
+      ScreenshotCapture.swift
+      InputEvents.swift
+      Accessibility.swift
+      Permissions.swift
+  openai-runner/
+    pyproject.toml
+    README.md
+    openai_cua_runner/
+      __main__.py
+      responses_loop.py
+      adapter_client.py
+      scenarios.py
+      artifacts.py
+      c11_oracle.py
+      safety.py
+```
+
+Rationale:
+
+- Swift is the cleanest local choice for native macOS APIs: AppKit, CoreGraphics, ApplicationServices, AXUIElement, and TCC permission checks.
+- Python is the fastest choice for the Responses API loop, JSON traces, scenario orchestration, and artifact handling.
+- Keeping `mac-adapter` provider-neutral lets the Anthropic branch reuse or mirror the same OS bridge later, which makes the OpenAI-vs-Anthropic comparison fairer.
+
+If the Anthropic branch independently creates a different adapter first, reconcile around a shared minimal JSON contract instead of rewriting both sides.
+
+## Adapter Contract
+
+The mac adapter should expose a small JSON-over-stdio CLI. Keep it boring and auditable.
+
+Commands:
+
+- `doctor`: report macOS version, TCC permissions, target app availability, screen scale, and whether the bundle id can be found.
+- `launch`: optionally launch or activate a target app by bundle id or path.
+- `observe`: capture a screenshot and return metadata.
+- `act`: execute one computer-use action.
+- `window-list`: list candidate windows for debugging target selection.
+- `quit`: shut down any adapter session state.
+
+Target selection:
+
+- Prefer bundle id. For tagged c11 builds this should be `com.stage11.c11.debug.<tag-id>`.
+- Fall back to app path only for launch.
+- Require a matching visible window before executing input.
+- Fail closed if the focused or frontmost app is not the allowed bundle id, unless the scenario explicitly permits a system dialog or permission prompt.
+
+Coordinate model:
+
+- The screenshot returned to the model defines the action coordinate space.
+- The adapter maps screenshot pixels to global display points using the captured window bounds and backing scale factor.
+- Store scale factor, window bounds, screenshot size, and display id with every observation artifact.
+
+Supported actions:
+
+- `click`
+- `double_click`
+- `move`
+- `drag`
+- `scroll`
+- `type`
+- `keypress`
+- `wait`
+- `screenshot`
+
+Action execution:
+
+- Mouse and keyboard events should use CoreGraphics events where practical.
+- Accessibility actions are allowed for window targeting, raising, permission diagnosis, and controls where CGEvent is insufficient.
+- Do not bypass the UI path for product behavior. For example, `AXPress` is acceptable for a known macOS permission prompt, but not as the default way to "test" c11 buttons if the user path is pointer hit-testing.
+
+## OpenAI Runner Contract
+
+The OpenAI runner should own:
+
+- `OPENAI_API_KEY` discovery from environment only.
+- Model/tool configuration for the Responses API `computer` tool.
+- Prompt construction for each scenario.
+- The computer-use loop: send task, receive `computer_call`, execute actions through the mac adapter, capture screenshot, send `computer_call_output`, repeat until final answer or failure.
+- Safety policy: max actions, max wall time, app allowlist, sensitive-action prompts, and fail-closed target checks.
+- Artifact writing.
+
+Initial CLI:
+
+```bash
+python -m openai_cua_runner doctor
+python -m openai_cua_runner smoke --tag openai-cua
+python -m openai_cua_runner scenario launch-window --tag openai-cua
+python -m openai_cua_runner scenario split-pane --tag openai-cua
+```
+
+Artifacts:
+
+```text
+artifacts/openai-cua-runs/<timestamp>-<scenario>/
+  run.json
+  prompt.md
+  final.md
+  actions.jsonl
+  observations.jsonl
+  screenshots/
+    000-initial.png
+    001-after-click.png
+  c11/
+    tree-before.json
+    tree-after.json
+    identify.json
+  logs/
+    c11-debug.log
+```
+
+Do not commit run artifacts. Add ignore rules when implementation begins.
+
+## c11 Launch and Runtime Discipline
+
+Use tagged builds only.
+
+Build:
+
+```bash
+./scripts/reload.sh --tag openai-cua
+```
+
+Launch existing tagged build for automation:
+
+```bash
+./scripts/launch-tagged-automation.sh openai-cua --wait-socket 10
+```
+
+Expected derived values:
+
+- App: `~/Library/Developer/Xcode/DerivedData/c11-openai-cua/Build/Products/Debug/c11 DEV openai-cua.app`
+- Bundle id: `com.stage11.c11.debug.openai.cua`
+- Socket: `/tmp/c11-debug-openai-cua.sock`
+- Log: `/tmp/c11-debug-openai-cua.log`
+
+The runner should not launch an untagged `c11 DEV.app`.
+
+## Permission Plan
+
+The first run will likely require human approval.
+
+Required macOS permissions:
+
+- Screen Recording, so screenshots include the target app.
+- Accessibility, so the adapter can click, type, scroll, and inspect windows.
+
+The runner must have a `doctor` command that detects missing permissions before attempting a scenario and prints exact remediation:
+
+```text
+System Settings > Privacy & Security > Screen Recording
+System Settings > Privacy & Security > Accessibility
+```
+
+The runner should stop at missing TCC permissions, not spin or guess. Security and privacy prompts are a legitimate human-in-the-loop boundary.
+
+## Safety Policy
+
+Default safety rules:
+
+- One target app per scenario.
+- Bundle-id allowlist is required.
+- Refuse to type into or click outside the allowed app window unless the step is explicitly marked as a system permission prompt.
+- Refuse scenarios involving credentials, payments, account settings, admin prompts, or destructive file operations.
+- Cap each run by action count and wall time.
+- Save every model action and screenshot for review.
+- Keep sensitive apps closed during runs.
+- Require explicit operator approval before enabling browser scenarios against signed-in sessions.
+
+The implementation should bias toward stopping with a high-quality artifact bundle rather than trying increasingly broad desktop interactions.
+
+## Scenario Design
+
+Scenarios should be small, observable, and repeatable. The initial suite should avoid fragile pixel-perfect coordinates and ask the model to inspect the screenshot before acting.
+
+### Scenario 0: Doctor
+
+Purpose: prove the environment is eligible.
+
+Steps:
+
+- Check `OPENAI_API_KEY`.
+- Check adapter executable availability.
+- Check Screen Recording and Accessibility.
+- Check tagged c11 app exists or explain build command.
+- Check target app window can be found after launch.
+- Check socket path exists after launch.
+
+Pass criteria:
+
+- Clear pass/fail report with no model call required.
+
+### Scenario 1: Launch Window
+
+Purpose: first full visual loop.
+
+Steps:
+
+- Launch tagged c11.
+- Use computer use to inspect the window.
+- Ask the model to report whether the app appears ready.
+
+Pass criteria:
+
+- Screenshot captured.
+- Model completes without needing actions or after a `wait`.
+- Socket tree confirms at least one workspace, pane, and terminal surface.
+
+### Scenario 2: Create Split
+
+Purpose: first real user-like app interaction.
+
+Preferred user path:
+
+- Use visible UI or menu/keyboard shortcut to create a split, depending on the current c11 UX.
+
+Pass criteria:
+
+- Computer use performs the action visually.
+- `c11 tree --json` against `/tmp/c11-debug-openai-cua.sock` shows pane count increased.
+- Artifact includes before/after screenshot and before/after tree.
+
+### Scenario 3: Focus and Type
+
+Purpose: verify real terminal focus, keyboard event routing, and rendering.
+
+Steps:
+
+- Use computer use to click a visible terminal pane.
+- Type a harmless command such as `printf 'openai-cua-ok\n'`.
+- Press Enter.
+
+Pass criteria:
+
+- The visible terminal renders the expected output.
+- `read-screen` or equivalent socket read confirms the output.
+- This scenario must not use `c11 send` for the typing step.
+
+### Scenario 4: Browser Surface
+
+Purpose: verify a non-terminal surface through user-facing UI.
+
+Steps:
+
+- Create or select a browser surface through the UI path available in c11.
+- Navigate to a deterministic local or data URL.
+
+Pass criteria:
+
+- Visual screenshot shows browser content.
+- Socket/browser API confirms URL or title where available.
+
+### Scenario 5: Markdown Surface
+
+Purpose: verify surface creation and non-terminal rendering.
+
+Steps:
+
+- Open a known local markdown file in a markdown surface through the user-facing path.
+
+Pass criteria:
+
+- Visual screenshot shows rendered markdown.
+- Socket tree confirms markdown surface type.
+
+### Scenario 6: Sidebar Metadata
+
+Purpose: compare model ability to inspect c11's agent-centric UI.
+
+Steps:
+
+- Use socket only to set up a deterministic metadata state.
+- Ask computer use to inspect the sidebar and summarize visible status/title/description.
+
+Pass criteria:
+
+- Model identifies the correct visible state from screenshot.
+- Socket remains the oracle for exact metadata.
+
+### Scenario 7: Drag/Resize
+
+Purpose: exercise pointer-drag behavior that socket tests cannot fully stand in for.
+
+Steps:
+
+- Ask computer use to drag a divider or resize affordance.
+
+Pass criteria:
+
+- Visual layout changes.
+- Socket tree reports changed pane geometry.
+
+This should come after launch/split/focus are stable because drag is the highest-fragility action class.
+
+## Comparison Metrics
+
+Capture the same metrics for OpenAI and Anthropic runs.
+
+- Scenario result: pass, fail, blocked, inconclusive.
+- Number of model turns.
+- Number of UI actions.
+- Wall-clock time.
+- Recovery quality when initial UI state differs.
+- Whether the model used visual evidence correctly.
+- Whether it clicked/typed outside the target app.
+- Whether it asked for clarification or stopped appropriately.
+- Artifact completeness.
+- Deterministic oracle result.
+
+Use identical scenario prompts where provider APIs allow it.
+
+## Implementation Phases
+
+### Phase 0: Plan and Branch
+
+Status: current phase.
+
+Deliverables:
+
+- Dedicated worktree and branch.
+- This plan committed as a markdown artifact.
+- No runner code yet.
+
+### Phase 1: Operator Enablement for Codex App Plugin
+
+Purpose: let the operator quickly try OpenAI's built-in Codex app computer use while the reproducible harness is being built.
+
+Steps:
+
+- In Codex app settings, open Computer Use and install the plugin.
+- Grant Screen Recording and Accessibility when macOS prompts.
+- Try one manual scoped task against the tagged c11 app:
+
+```text
+Use computer use to inspect the c11 DEV openai-cua app window and tell me whether the initial terminal surface is visible. Do not edit files.
+```
+
+Deliverables:
+
+- Short note in the plan or follow-up docs with observed behavior, permission prompts, and limitations.
+
+### Phase 2: Native Mac Adapter
+
+Deliverables:
+
+- Swift CLI with `doctor`, `window-list`, `observe`, and minimal `act`.
+- Window-targeted screenshot capture.
+- Click, keypress, type, wait.
+- JSON action/result schema.
+- Local artifact screenshots.
+
+Validation:
+
+- Run `doctor`.
+- Launch tagged c11.
+- Capture one screenshot.
+- Execute one harmless focus/click action.
+
+Expected human blocker:
+
+- macOS TCC permissions may require operator approval.
+
+### Phase 3: OpenAI Responses Loop
+
+Deliverables:
+
+- Python runner that calls the Responses API with `tools=[{"type": "computer"}]`.
+- Loop handling `computer_call` and `computer_call_output`.
+- Adapter subprocess client.
+- Run artifacts.
+- `launch-window` scenario.
+
+Validation:
+
+- Complete Scenario 1 against tagged c11.
+- Review trace for action correctness and screenshot fidelity.
+
+### Phase 4: c11 Scenario Harness
+
+Deliverables:
+
+- Tagged build launcher integration.
+- Socket oracle integration with `C11_SOCKET`/`CMUX_SOCKET`.
+- Scenario definitions for launch, split, focus/type.
+- Failure bundles with screenshots, logs, socket snapshots, and model trace.
+
+Validation:
+
+- Complete Scenarios 1-3.
+- Confirm typing scenario uses real keyboard events, not socket send.
+
+### Phase 5: Broaden UI Coverage
+
+Deliverables:
+
+- Browser surface scenario.
+- Markdown surface scenario.
+- Sidebar metadata inspection scenario.
+- Drag/resize scenario if stable.
+
+Validation:
+
+- Each scenario has both visual evidence and deterministic oracle where possible.
+
+### Phase 6: Apples-to-Apples Comparison
+
+Deliverables:
+
+- Shared scenario prompt set.
+- Shared scoring schema.
+- OpenAI run summary.
+- Comparison-ready artifact format for Anthropic branch.
+
+Validation:
+
+- At least three scenarios run through OpenAI with reusable artifacts.
+- Anthropic branch can consume or mirror the same scenario definitions.
+
+## Expected Files During Implementation
+
+Likely new files:
+
+- `docs/openai-codex-computer-use-plan.md`
+- `tools/computer-use/mac-adapter/Package.swift`
+- `tools/computer-use/mac-adapter/Sources/CUAMacAdapter/*.swift`
+- `tools/computer-use/openai-runner/pyproject.toml`
+- `tools/computer-use/openai-runner/README.md`
+- `tools/computer-use/openai-runner/openai_cua_runner/*.py`
+- `.gitignore` entries for `artifacts/openai-cua-runs/` if not already covered
+
+Likely untouched files:
+
+- c11 product source under `Sources/`
+- localization catalogs
+- build workflows
+- tenant config files
+
+## Testing and Validation Policy
+
+Respect this repo's testing policy.
+
+- Do not run the local test suite.
+- Use tagged app builds for local visual validation.
+- Use the runner's `doctor` and smoke scenarios for harness validation.
+- Use GitHub Actions or the VM for broader tests if code outside `tools/` changes.
+- Do not launch untagged DerivedData apps.
+
+For this feature, the main validation is an end-to-end tagged-build visual run plus artifact review.
+
+## Known Risks
+
+### TCC Permissions
+
+Screen Recording and Accessibility cannot be granted by the agent. The implementation must detect missing permissions and stop with clear instructions.
+
+### Coordinate Drift
+
+Screenshots are pixels; CGEvent coordinates are display points. Retina scaling and window title bars can cause off-by-scale or off-by-origin errors. Every observation must record scale and bounds.
+
+### Wrong-window Actions
+
+Computer use can interact with whatever is visible if guardrails are weak. The adapter must fail closed when the target bundle/window is not active or visible.
+
+### Visual Nondeterminism
+
+Animations, first-launch state, stale windows, and overlapping apps can confuse the model. Scenarios should start from a tagged launch, capture initial state, and keep instructions narrow.
+
+### Socket Oracle Overreach
+
+It is tempting to use socket commands for everything. The scenario definition must mark which steps are setup/oracle and which steps must be performed visually.
+
+### Provider Comparison Bias
+
+If OpenAI and Anthropic use different adapters, prompts, reset logic, or oracle checks, the comparison will be noisy. Keep scenario specs provider-neutral.
+
+### Cost and Latency
+
+Computer-use loops can be expensive because each step sends screenshots. Cap action count, screenshot detail, and wall time per scenario.
+
+## Definition of Done for Implementation
+
+The OpenAI implementation is done when:
+
+- A clean tagged c11 build can be launched from the runner.
+- `doctor` accurately reports API key, app, socket, and macOS permissions.
+- The runner completes at least:
+  - launch-window
+  - create-split
+  - focus-and-type
+- Each completed scenario has:
+  - prompt
+  - action trace
+  - screenshots
+  - c11 socket oracle before/after
+  - final result summary
+- The focus-and-type scenario uses real macOS input events.
+- Failures produce a useful artifact bundle instead of silent retries.
+- No run artifacts, API keys, or tenant config changes are committed.
+- The implementation is committed on `feat/openai-cua-runner`.
+
+## Immediate Next Step After Plan Approval
+
+Start Phase 1 and Phase 2:
+
+1. Have the operator install/enable Codex app Computer Use if they want the immediate Codex-app path.
+2. Implement the provider-neutral Swift mac adapter `doctor` and `observe` commands.
+3. Launch tagged c11 with `openai-cua` and capture the first window screenshot.
+4. Add the OpenAI runner only after the local screenshot/action loop is reliable.
+

--- a/scripts/launch-tagged-automation.sh
+++ b/scripts/launch-tagged-automation.sh
@@ -44,6 +44,7 @@ MODE="automation"
 SHELL_LOG=""
 WAIT_SOCKET="10"
 EXTRA_ENV=()
+EXTRA_ENV_COUNT=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -61,6 +62,7 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       EXTRA_ENV+=("${2}")
+      EXTRA_ENV_COUNT=$((EXTRA_ENV_COUNT + 1))
       shift 2
       ;;
     --shell-log)
@@ -152,9 +154,11 @@ OPEN_ENV=(
   "CMUX_DEBUG_LOG=${LOG}"
 )
 
-for kv in "${EXTRA_ENV[@]}"; do
-  OPEN_ENV+=("${kv}")
-done
+if [[ "$EXTRA_ENV_COUNT" -gt 0 ]]; then
+  for kv in "${EXTRA_ENV[@]}"; do
+    OPEN_ENV+=("${kv}")
+  done
+fi
 if [[ -n "$SHELL_LOG" ]]; then
   OPEN_ENV+=("GHOSTTY_ZSH_INTEGRATION_LOG=${SHELL_LOG}")
 fi
@@ -181,7 +185,7 @@ echo "socket_ready: $(if [[ -S "$SOCK" ]]; then echo yes; else echo no; fi)"
 if [[ -n "$SHELL_LOG" ]]; then
   echo "shell_log: $SHELL_LOG"
 fi
-if [[ "${#EXTRA_ENV[@]}" -gt 0 ]]; then
+if [[ "$EXTRA_ENV_COUNT" -gt 0 ]]; then
   echo "extra_env:"
   for kv in "${EXTRA_ENV[@]}"; do
     echo "  $kv"

--- a/tools/computer-use/mac-adapter/Package.swift
+++ b/tools/computer-use/mac-adapter/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "CUAMacAdapter",
+    platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "cua-mac-adapter", targets: ["CUAMacAdapter"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "CUAMacAdapter"
+        ),
+    ]
+)

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Accessibility.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Accessibility.swift
@@ -1,0 +1,24 @@
+import AppKit
+import ApplicationServices
+import Foundation
+
+enum AccessibilitySupport {
+    static func raise(pid: pid_t) -> Bool {
+        let app = AXUIElementCreateApplication(pid)
+        return AXUIElementPerformAction(app, kAXRaiseAction as CFString) == .success
+    }
+
+    static func windowTitle(pid: pid_t) -> String? {
+        let app = AXUIElementCreateApplication(pid)
+        var focused: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXFocusedWindowAttribute as CFString, &focused) == .success,
+              let window = focused else {
+            return nil
+        }
+        var title: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window as! AXUIElement, kAXTitleAttribute as CFString, &title) == .success else {
+            return nil
+        }
+        return title as? String
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/InputEvents.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/InputEvents.swift
@@ -1,0 +1,241 @@
+import CoreGraphics
+import Foundation
+
+struct ComputerAction: Codable {
+    let type: String
+    let x: Double?
+    let y: Double?
+    let button: String?
+    let dx: Double?
+    let dy: Double?
+    let text: String?
+    let keys: [String]?
+    let durationMs: Int?
+    let path: [ActionPoint]?
+}
+
+struct ActionPoint: Codable {
+    let x: Double
+    let y: Double
+}
+
+struct ActionResult: Codable {
+    let ok: Bool
+    let action: String
+    let message: String
+}
+
+enum InputEventError: Error, CustomStringConvertible {
+    case missingCoordinate(String)
+    case missingText
+    case unsupportedAction(String)
+    case unsupportedKey(String)
+
+    var description: String {
+        switch self {
+        case .missingCoordinate(let action):
+            return "\(action) requires x and y"
+        case .missingText:
+            return "type requires text"
+        case .unsupportedAction(let action):
+            return "unsupported action: \(action)"
+        case .unsupportedKey(let key):
+            return "unsupported key: \(key)"
+        }
+    }
+}
+
+enum InputEvents {
+    static func perform(_ action: ComputerAction, observation: Observation) throws -> ActionResult {
+        switch action.type {
+        case "click":
+            try click(action, observation: observation, clickCount: 1)
+        case "double_click", "doubleClick":
+            try click(action, observation: observation, clickCount: 2)
+        case "move":
+            try move(action, observation: observation)
+        case "drag":
+            try drag(action, observation: observation)
+        case "scroll":
+            try scroll(action)
+        case "type":
+            try typeText(action.text)
+        case "keypress", "key":
+            try keypress(action.keys)
+        case "wait":
+            Thread.sleep(forTimeInterval: Double(action.durationMs ?? 1000) / 1000.0)
+        case "screenshot":
+            break
+        default:
+            throw InputEventError.unsupportedAction(action.type)
+        }
+        return ActionResult(ok: true, action: action.type, message: "executed")
+    }
+
+    private static func click(_ action: ComputerAction, observation: Observation, clickCount: Int) throws {
+        guard let x = action.x, let y = action.y else {
+            throw InputEventError.missingCoordinate(action.type)
+        }
+        let point = ScreenshotCapture.pointInWindow(x: x, y: y, observation: observation)
+        let button = mouseButton(action.button)
+        let down = mouseType(button: button, down: true)
+        let up = mouseType(button: button, down: false)
+        for index in 1...clickCount {
+            let clickState = Int64(index)
+            postMouse(type: .mouseMoved, point: point, button: button, clickState: clickState)
+            postMouse(type: down, point: point, button: button, clickState: clickState)
+            usleep(45_000)
+            postMouse(type: up, point: point, button: button, clickState: clickState)
+            usleep(80_000)
+        }
+    }
+
+    private static func move(_ action: ComputerAction, observation: Observation) throws {
+        guard let x = action.x, let y = action.y else {
+            throw InputEventError.missingCoordinate(action.type)
+        }
+        let point = ScreenshotCapture.pointInWindow(x: x, y: y, observation: observation)
+        postMouse(type: .mouseMoved, point: point, button: .left, clickState: 0)
+    }
+
+    private static func drag(_ action: ComputerAction, observation: Observation) throws {
+        let points: [ActionPoint]
+        if let path = action.path, path.count >= 2 {
+            points = path
+        } else if let x = action.x, let y = action.y, let dx = action.dx, let dy = action.dy {
+            points = [ActionPoint(x: x, y: y), ActionPoint(x: x + dx, y: y + dy)]
+        } else {
+            throw InputEventError.missingCoordinate(action.type)
+        }
+        let mapped = points.map { ScreenshotCapture.pointInWindow(x: $0.x, y: $0.y, observation: observation) }
+        guard let first = mapped.first, let last = mapped.last else { return }
+        postMouse(type: .mouseMoved, point: first, button: .left, clickState: 0)
+        postMouse(type: .leftMouseDown, point: first, button: .left, clickState: 1)
+        usleep(80_000)
+        for point in mapped.dropFirst().dropLast() {
+            postMouse(type: .leftMouseDragged, point: point, button: .left, clickState: 1)
+            usleep(35_000)
+        }
+        postMouse(type: .leftMouseDragged, point: last, button: .left, clickState: 1)
+        usleep(50_000)
+        postMouse(type: .leftMouseUp, point: last, button: .left, clickState: 1)
+    }
+
+    private static func scroll(_ action: ComputerAction) throws {
+        let dx = Int32(action.dx ?? 0)
+        let dy = Int32(action.dy ?? 0)
+        guard let event = CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 2, wheel1: dy, wheel2: dx, wheel3: 0) else {
+            return
+        }
+        event.post(tap: .cghidEventTap)
+    }
+
+    private static func typeText(_ text: String?) throws {
+        guard let text else { throw InputEventError.missingText }
+        for scalar in text.unicodeScalars {
+            var value = UniChar(scalar.value)
+            guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else {
+                continue
+            }
+            down.keyboardSetUnicodeString(stringLength: 1, unicodeString: &value)
+            up.keyboardSetUnicodeString(stringLength: 1, unicodeString: &value)
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+            usleep(8_000)
+        }
+    }
+
+    private static func keypress(_ keys: [String]?) throws {
+        let rawKeys = keys ?? []
+        let events: [[String]]
+        if rawKeys.count > 1 && rawKeys.dropLast().allSatisfy({ isModifier($0) }) {
+            events = [rawKeys.map { $0.lowercased() }]
+        } else {
+            events = rawKeys.map { $0.split(separator: "+").map { String($0).lowercased() } }
+        }
+        for combo in events {
+            let modifiers = modifierFlags(combo)
+            guard let keyName = combo.last else { continue }
+            guard let keyCode = keyCode(for: keyName) else {
+                throw InputEventError.unsupportedKey(combo.joined(separator: "+"))
+            }
+            guard let down = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true),
+                  let up = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false) else {
+                continue
+            }
+            down.flags = modifiers
+            up.flags = modifiers
+            down.post(tap: .cghidEventTap)
+            up.post(tap: .cghidEventTap)
+            usleep(20_000)
+        }
+    }
+
+    private static func isModifier(_ raw: String) -> Bool {
+        ["cmd", "command", "meta", "shift", "option", "alt", "ctrl", "control"].contains(raw.lowercased())
+    }
+
+    private static func postMouse(type: CGEventType, point: CGPoint, button: CGMouseButton, clickState: Int64) {
+        guard let event = CGEvent(mouseEventSource: nil, mouseType: type, mouseCursorPosition: point, mouseButton: button) else {
+            return
+        }
+        event.setIntegerValueField(.mouseEventClickState, value: clickState)
+        event.post(tap: .cghidEventTap)
+    }
+
+    private static func mouseButton(_ value: String?) -> CGMouseButton {
+        switch value?.lowercased() {
+        case "right":
+            return .right
+        case "middle":
+            return .center
+        default:
+            return .left
+        }
+    }
+
+    private static func mouseType(button: CGMouseButton, down: Bool) -> CGEventType {
+        switch (button, down) {
+        case (.right, true): return .rightMouseDown
+        case (.right, false): return .rightMouseUp
+        case (.center, true): return .otherMouseDown
+        case (.center, false): return .otherMouseUp
+        case (_, true): return .leftMouseDown
+        case (_, false): return .leftMouseUp
+        }
+    }
+
+    private static func modifierFlags(_ parts: [String]) -> CGEventFlags {
+        var flags: CGEventFlags = []
+        if parts.contains("cmd") || parts.contains("command") || parts.contains("meta") { flags.insert(.maskCommand) }
+        if parts.contains("shift") { flags.insert(.maskShift) }
+        if parts.contains("option") || parts.contains("alt") { flags.insert(.maskAlternate) }
+        if parts.contains("ctrl") || parts.contains("control") { flags.insert(.maskControl) }
+        return flags
+    }
+
+    private static func keyCode(for key: String) -> CGKeyCode? {
+        let normalized = key.lowercased()
+        if normalized.count == 1, let scalar = normalized.unicodeScalars.first {
+            return letterAndDigitKeyCodes[CharacterSet(charactersIn: String(scalar)).description] ?? letterAndDigitKeyCodes[String(scalar)]
+        }
+        return specialKeyCodes[normalized]
+    }
+
+    private static let specialKeyCodes: [String: CGKeyCode] = [
+        "return": 36, "enter": 36, "tab": 48, "space": 49, "escape": 53, "esc": 53,
+        "delete": 51, "backspace": 51, "forwarddelete": 117,
+        "left": 123, "right": 124, "down": 125, "up": 126,
+        "home": 115, "end": 119, "pageup": 116, "pagedown": 121
+    ]
+
+    private static let letterAndDigitKeyCodes: [String: CGKeyCode] = [
+        "a": 0, "s": 1, "d": 2, "f": 3, "h": 4, "g": 5, "z": 6, "x": 7, "c": 8, "v": 9,
+        "b": 11, "q": 12, "w": 13, "e": 14, "r": 15, "y": 16, "t": 17,
+        "1": 18, "2": 19, "3": 20, "4": 21, "6": 22, "5": 23, "=": 24, "9": 25, "7": 26, "-": 27,
+        "8": 28, "0": 29, "]": 30, "o": 31, "u": 32, "[": 33, "i": 34, "p": 35,
+        "l": 37, "j": 38, "'": 39, "k": 40, ";": 41, "\\": 42, ",": 43, "/": 44, "n": 45, "m": 46,
+        ".": 47, "`": 50
+    ]
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Permissions.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/Permissions.swift
@@ -1,0 +1,22 @@
+import ApplicationServices
+import CoreGraphics
+import Foundation
+
+struct PermissionStatus: Codable {
+    let screenRecording: Bool
+    let accessibility: Bool
+    let remediation: [String]
+
+    static func current() -> PermissionStatus {
+        let screen = CGPreflightScreenCaptureAccess()
+        let ax = AXIsProcessTrusted()
+        var remediation: [String] = []
+        if !screen {
+            remediation.append("Grant Screen Recording to the terminal or adapter host in System Settings > Privacy & Security > Screen Recording.")
+        }
+        if !ax {
+            remediation.append("Grant Accessibility to the terminal or adapter host in System Settings > Privacy & Security > Accessibility.")
+        }
+        return PermissionStatus(screenRecording: screen, accessibility: ax, remediation: remediation)
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/ScreenshotCapture.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/ScreenshotCapture.swift
@@ -1,0 +1,103 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import ImageIO
+import UniformTypeIdentifiers
+
+struct Observation: Codable {
+    let ok: Bool
+    let window: WindowInfo
+    let screenshotPath: String?
+    let screenshotBase64: String?
+    let screenshotWidth: Int
+    let screenshotHeight: Int
+    let scale: Double
+    let displayID: UInt32?
+    let capturedAt: String
+}
+
+enum ScreenshotError: Error, CustomStringConvertible {
+    case captureFailed(UInt32)
+    case writeFailed(String)
+
+    var description: String {
+        switch self {
+        case .captureFailed(let id):
+            return "failed to capture window \(id)"
+        case .writeFailed(let path):
+            return "failed to write screenshot to \(path)"
+        }
+    }
+}
+
+enum ScreenshotCapture {
+    static func observe(window: WindowInfo, outPath: String?, includeBase64: Bool) throws -> Observation {
+        guard let image = CGWindowListCreateImage(
+            .null,
+            .optionIncludingWindow,
+            CGWindowID(window.windowID),
+            [.boundsIgnoreFraming, .bestResolution]
+        ) else {
+            throw ScreenshotError.captureFailed(window.windowID)
+        }
+
+        let width = image.width
+        let height = image.height
+        let scale = window.bounds.width > 0 ? Double(width) / window.bounds.width : 1.0
+        var normalizedOut: String?
+        var base64: String?
+
+        if let outPath {
+            let expanded = NSString(string: outPath).expandingTildeInPath
+            let url = URL(fileURLWithPath: expanded)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            guard let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+                throw ScreenshotError.writeFailed(expanded)
+            }
+            CGImageDestinationAddImage(destination, image, nil)
+            guard CGImageDestinationFinalize(destination) else {
+                throw ScreenshotError.writeFailed(expanded)
+            }
+            normalizedOut = expanded
+            if includeBase64 {
+                base64 = try Data(contentsOf: url).base64EncodedString()
+            }
+        } else if includeBase64 {
+            let data = NSMutableData()
+            guard let destination = CGImageDestinationCreateWithData(data, UTType.png.identifier as CFString, 1, nil) else {
+                throw ScreenshotError.writeFailed("<memory>")
+            }
+            CGImageDestinationAddImage(destination, image, nil)
+            guard CGImageDestinationFinalize(destination) else {
+                throw ScreenshotError.writeFailed("<memory>")
+            }
+            base64 = (data as Data).base64EncodedString()
+        }
+
+        return Observation(
+            ok: true,
+            window: window,
+            screenshotPath: normalizedOut,
+            screenshotBase64: base64,
+            screenshotWidth: width,
+            screenshotHeight: height,
+            scale: scale,
+            displayID: displayID(for: window.bounds.cgRect),
+            capturedAt: ISO8601DateFormatter().string(from: Date())
+        )
+    }
+
+    static func pointInWindow(x: Double, y: Double, observation: Observation) -> CGPoint {
+        let scale = observation.scale == 0 ? 1 : observation.scale
+        let bounds = observation.window.bounds
+        return CGPoint(x: bounds.x + x / scale, y: bounds.y + y / scale)
+    }
+
+    private static func displayID(for rect: CGRect) -> UInt32? {
+        var count: UInt32 = 0
+        var displays = [CGDirectDisplayID](repeating: 0, count: 16)
+        let err = CGGetDisplaysWithRect(rect, UInt32(displays.count), &displays, &count)
+        guard err == .success, count > 0 else { return nil }
+        return displays[0]
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/WindowTarget.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/WindowTarget.swift
@@ -1,0 +1,202 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+struct RectInfo: Codable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(_ rect: CGRect) {
+        x = rect.origin.x
+        y = rect.origin.y
+        width = rect.size.width
+        height = rect.size.height
+    }
+
+    var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+}
+
+struct WindowInfo: Codable {
+    let windowID: UInt32
+    let pid: Int32
+    let ownerName: String
+    let bundleID: String?
+    let title: String?
+    let bounds: RectInfo
+    let layer: Int
+    let alpha: Double
+    let isOnscreen: Bool
+    let isFrontmostApp: Bool
+}
+
+struct TargetOptions {
+    let bundleID: String
+    let appPath: String?
+}
+
+enum WindowTargetError: Error, CustomStringConvertible {
+    case bundleNotRunning(String)
+    case noVisibleWindow(String)
+    case frontmostMismatch(expected: String, actual: String?)
+    case launchFailed(String)
+
+    var description: String {
+        switch self {
+        case .bundleNotRunning(let bundle):
+            return "target bundle is not running: \(bundle)"
+        case .noVisibleWindow(let bundle):
+            return "no visible window found for target bundle: \(bundle)"
+        case .frontmostMismatch(let expected, let actual):
+            return "frontmost app mismatch; expected \(expected), actual \(actual ?? "none")"
+        case .launchFailed(let reason):
+            return "launch failed: \(reason)"
+        }
+    }
+}
+
+final class WindowTarget {
+    let options: TargetOptions
+
+    init(options: TargetOptions) {
+        self.options = options
+    }
+
+    func launchOrActivate(waitSeconds: Double) throws -> WindowInfo {
+        if let app = runningApplications().first {
+            app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        } else if let path = options.appPath {
+            let url = URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            var launched: NSRunningApplication?
+            var launchError: Error?
+            let sema = DispatchSemaphore(value: 0)
+            NSWorkspace.shared.openApplication(at: url, configuration: config) { app, error in
+                launched = app
+                launchError = error
+                sema.signal()
+            }
+            _ = sema.wait(timeout: .now() + max(waitSeconds, 1))
+            if let launchError {
+                throw WindowTargetError.launchFailed(launchError.localizedDescription)
+            }
+            guard let launched else {
+                throw WindowTargetError.launchFailed("no NSRunningApplication returned for \(url.path)")
+            }
+            launched.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        } else {
+            guard let app = NSWorkspace.shared.urlForApplication(withBundleIdentifier: options.bundleID) else {
+                throw WindowTargetError.launchFailed("bundle id not found by LaunchServices and no --app-path supplied")
+            }
+            let config = NSWorkspace.OpenConfiguration()
+            config.activates = true
+            var launchError: Error?
+            let sema = DispatchSemaphore(value: 0)
+            NSWorkspace.shared.openApplication(at: app, configuration: config) { _, error in
+                launchError = error
+                sema.signal()
+            }
+            _ = sema.wait(timeout: .now() + max(waitSeconds, 1))
+            if let launchError {
+                throw WindowTargetError.launchFailed(launchError.localizedDescription)
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(waitSeconds)
+        var lastError: Error?
+        repeat {
+            do {
+                let window = try bestVisibleWindow()
+                if let app = NSRunningApplication(processIdentifier: window.pid) {
+                    app.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+                }
+                _ = AccessibilitySupport.raise(pid: window.pid)
+                if waitUntilFrontmost(deadline: deadline) {
+                    return try bestVisibleWindow()
+                }
+                return window
+            } catch {
+                lastError = error
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+        } while Date() < deadline
+        throw lastError ?? WindowTargetError.noVisibleWindow(options.bundleID)
+    }
+
+    func requireFrontmostTarget() throws -> WindowInfo {
+        guard let front = NSWorkspace.shared.frontmostApplication else {
+            throw WindowTargetError.frontmostMismatch(expected: options.bundleID, actual: nil)
+        }
+        guard front.bundleIdentifier == options.bundleID else {
+            throw WindowTargetError.frontmostMismatch(expected: options.bundleID, actual: front.bundleIdentifier)
+        }
+        return try bestVisibleWindow()
+    }
+
+    func bestVisibleWindow() throws -> WindowInfo {
+        let matches = windows().filter { $0.bundleID == options.bundleID && $0.isOnscreen && $0.layer == 0 && $0.alpha > 0 && $0.bounds.width > 80 && $0.bounds.height > 80 }
+        if matches.isEmpty {
+            if runningApplications().isEmpty {
+                throw WindowTargetError.bundleNotRunning(options.bundleID)
+            }
+            throw WindowTargetError.noVisibleWindow(options.bundleID)
+        }
+        if let front = NSWorkspace.shared.frontmostApplication?.processIdentifier,
+           let frontWindow = matches.first(where: { $0.pid == front }) {
+            return frontWindow
+        }
+        return matches[0]
+    }
+
+    func windows() -> [WindowInfo] {
+        guard let raw = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+        let frontPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
+        return raw.compactMap { item in
+            guard let windowID = item[kCGWindowNumber as String] as? UInt32,
+                  let pidNumber = item[kCGWindowOwnerPID as String] as? NSNumber,
+                  let owner = item[kCGWindowOwnerName as String] as? String,
+                  let boundsDict = item[kCGWindowBounds as String] as? [String: Any],
+                  let bounds = CGRect(dictionaryRepresentation: boundsDict as CFDictionary) else {
+                return nil
+            }
+            let pid = pidNumber.int32Value
+            let app = NSRunningApplication(processIdentifier: pid)
+            let layer = (item[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+            let alpha = (item[kCGWindowAlpha as String] as? NSNumber)?.doubleValue ?? 1
+            let title = item[kCGWindowName as String] as? String
+            let onscreen = (item[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? false
+            return WindowInfo(
+                windowID: windowID,
+                pid: pid,
+                ownerName: owner,
+                bundleID: app?.bundleIdentifier,
+                title: title,
+                bounds: RectInfo(bounds),
+                layer: layer,
+                alpha: alpha,
+                isOnscreen: onscreen,
+                isFrontmostApp: frontPid == pid
+            )
+        }
+    }
+
+    private func runningApplications() -> [NSRunningApplication] {
+        NSRunningApplication.runningApplications(withBundleIdentifier: options.bundleID)
+    }
+
+    private func waitUntilFrontmost(deadline: Date) -> Bool {
+        repeat {
+            if NSWorkspace.shared.frontmostApplication?.bundleIdentifier == options.bundleID {
+                return true
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        } while Date() < deadline
+        return false
+    }
+}

--- a/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/main.swift
+++ b/tools/computer-use/mac-adapter/Sources/CUAMacAdapter/main.swift
@@ -1,0 +1,149 @@
+import AppKit
+import Foundation
+
+struct Envelope<T: Codable>: Codable {
+    let ok: Bool
+    let value: T?
+    let error: String?
+}
+
+struct DoctorReport: Codable {
+    let ok: Bool
+    let macOSVersion: String
+    let permissions: PermissionStatus
+    let targetBundleID: String
+    let targetAppPath: String?
+    let targetAppExists: Bool?
+    let running: Bool
+    let frontmostBundleID: String?
+    let visibleWindow: WindowInfo?
+    let windows: [WindowInfo]
+}
+
+struct LaunchReport: Codable {
+    let ok: Bool
+    let window: WindowInfo
+}
+
+let encoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return encoder
+}()
+
+func printJSON<T: Encodable>(_ value: T) {
+    do {
+        let data = try encoder.encode(value)
+        FileHandle.standardOutput.write(data)
+        FileHandle.standardOutput.write(Data("\n".utf8))
+    } catch {
+        fputs("{\"ok\":false,\"error\":\"failed to encode JSON\"}\n", stderr)
+        exit(2)
+    }
+}
+
+func fail(_ error: Error, code: Int32 = 1) -> Never {
+    printJSON(Envelope<String>(ok: false, value: nil, error: String(describing: error)))
+    exit(code)
+}
+
+func value(after flag: String, in args: [String]) -> String? {
+    guard let index = args.firstIndex(of: flag), index + 1 < args.count else { return nil }
+    return args[index + 1]
+}
+
+func has(_ flag: String, in args: [String]) -> Bool {
+    args.contains(flag)
+}
+
+func targetOptions(args: [String]) -> TargetOptions {
+    let bundle = value(after: "--bundle-id", in: args) ?? "com.stage11.c11.debug.openai.cua"
+    let appPath = value(after: "--app-path", in: args)
+    return TargetOptions(bundleID: bundle, appPath: appPath)
+}
+
+func readAction(args: [String]) throws -> ComputerAction {
+    let data: Data
+    if let raw = value(after: "--json", in: args) {
+        data = Data(raw.utf8)
+    } else if let file = value(after: "--json-file", in: args) {
+        data = try Data(contentsOf: URL(fileURLWithPath: NSString(string: file).expandingTildeInPath))
+    } else {
+        data = FileHandle.standardInput.readDataToEndOfFile()
+    }
+    return try JSONDecoder().decode(ComputerAction.self, from: data)
+}
+
+let args = Array(CommandLine.arguments.dropFirst())
+guard let command = args.first, ["doctor", "window-list", "launch", "observe", "act", "quit", "help", "--help", "-h"].contains(command) else {
+    print("""
+    Usage: cua-mac-adapter <command> [options]
+
+    Commands:
+      doctor       Report permissions, target app/window, and display state as JSON.
+      window-list  List visible windows as JSON.
+      launch       Launch or activate the target app.
+      observe      Capture the target window screenshot.
+      act          Execute one computer action from --json, --json-file, or stdin.
+      quit         No-op placeholder for JSON command parity.
+
+    Options:
+      --bundle-id <id>       Target bundle id. Default: com.stage11.c11.debug.openai.cua
+      --app-path <path>      Tagged app path for launch fallback.
+      --out <path>           Screenshot PNG output path for observe/act.
+      --include-base64       Include screenshot base64 in observe output.
+      --wait <seconds>       Launch wait. Default: 10.
+    """)
+    exit(args.first == nil ? 1 : 0)
+}
+
+let target = WindowTarget(options: targetOptions(args: args))
+
+do {
+    switch command {
+    case "doctor":
+        let path = target.options.appPath.map { NSString(string: $0).expandingTildeInPath }
+        let appExists = path.map { FileManager.default.fileExists(atPath: $0) }
+        let visibleWindow = try? target.bestVisibleWindow()
+        let windows = target.windows()
+        let report = DoctorReport(
+            ok: PermissionStatus.current().screenRecording && PermissionStatus.current().accessibility,
+            macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString,
+            permissions: PermissionStatus.current(),
+            targetBundleID: target.options.bundleID,
+            targetAppPath: path,
+            targetAppExists: appExists,
+            running: NSRunningApplication.runningApplications(withBundleIdentifier: target.options.bundleID).isEmpty == false,
+            frontmostBundleID: NSWorkspace.shared.frontmostApplication?.bundleIdentifier,
+            visibleWindow: visibleWindow,
+            windows: windows.filter { $0.bundleID == target.options.bundleID }
+        )
+        printJSON(report)
+    case "window-list":
+        printJSON(Envelope(ok: true, value: target.windows(), error: nil))
+    case "launch":
+        let wait = Double(value(after: "--wait", in: args) ?? "10") ?? 10
+        let window = try target.launchOrActivate(waitSeconds: wait)
+        printJSON(LaunchReport(ok: true, window: window))
+    case "observe":
+        let window = has("--no-frontmost-required", in: args) ? try target.bestVisibleWindow() : try target.requireFrontmostTarget()
+        let observation = try ScreenshotCapture.observe(window: window, outPath: value(after: "--out", in: args), includeBase64: has("--include-base64", in: args))
+        printJSON(observation)
+    case "act":
+        guard PermissionStatus.current().accessibility else {
+            throw InputEventError.unsupportedAction("missing Accessibility permission; grant it in System Settings > Privacy & Security > Accessibility")
+        }
+        let action = try readAction(args: args)
+        let window = try target.requireFrontmostTarget()
+        let observation = try ScreenshotCapture.observe(window: window, outPath: nil, includeBase64: false)
+        let result = try InputEvents.perform(action, observation: observation)
+        printJSON(result)
+    case "quit":
+        printJSON(Envelope(ok: true, value: "quit", error: nil))
+    default:
+        print("unknown command \(command)")
+        exit(1)
+    }
+} catch {
+    fail(error)
+}

--- a/tools/computer-use/openai-runner/README.md
+++ b/tools/computer-use/openai-runner/README.md
@@ -1,0 +1,65 @@
+# OpenAI CUA Runner
+
+This harness drives tagged c11 debug builds through the OpenAI Responses API `computer` tool and a provider-neutral native macOS adapter. It keeps the UI action path visual: screenshots and CoreGraphics input events go through the target app window, while the c11 socket is used for setup, oracle checks, and artifact capture.
+
+Official API reference: <https://developers.openai.com/api/docs/guides/tools-computer-use>
+
+## Layout
+
+- `../mac-adapter`: Swift CLI for macOS window discovery, permission checks, screenshot capture, and input events.
+- `openai_cua_runner`: Python scenario runner, artifact writer, Responses API loop, and c11 socket oracle.
+- `artifacts/openai-cua-runs/`: ignored runtime output written from the repo root.
+
+## Build
+
+From the repo root:
+
+```bash
+swift build --package-path tools/computer-use/mac-adapter
+```
+
+Build the tagged c11 app only with a tag:
+
+```bash
+./scripts/reload.sh --tag openai-cua
+```
+
+The default target values are:
+
+- Bundle id: `com.stage11.c11.debug.openai.cua`
+- App: `~/Library/Developer/Xcode/DerivedData/c11-openai-cua/Build/Products/Debug/c11 DEV openai-cua.app`
+- Socket: `/tmp/c11-debug-openai-cua.sock`
+
+## Commands
+
+Run from the repo root with `PYTHONPATH` unless installed in a virtualenv:
+
+```bash
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner doctor --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner smoke --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner scenario launch-window --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner scenario create-split --tag openai-cua
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner scenario focus-and-type --tag openai-cua
+```
+
+Use `--build` on `smoke` or `scenario` to run `./scripts/reload.sh --tag <tag>` before launch. The runner reads `OPENAI_API_KEY` from the environment only. Override the model with `--model` or `OPENAI_CUA_MODEL`; override the per-request API timeout with `OPENAI_CUA_REQUEST_TIMEOUT`.
+
+## Permissions
+
+The adapter requires macOS Screen Recording and Accessibility permissions for the terminal or host process running it:
+
+- System Settings > Privacy & Security > Screen Recording
+- System Settings > Privacy & Security > Accessibility
+
+If either permission is missing, `doctor`, `smoke`, and scenarios stop with a remediation message instead of attempting broad desktop interaction.
+
+## Adapter CLI
+
+```bash
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter doctor --bundle-id com.stage11.c11.debug.openai.cua
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter window-list
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter launch --bundle-id com.stage11.c11.debug.openai.cua --app-path "$HOME/Library/Developer/Xcode/DerivedData/c11-openai-cua/Build/Products/Debug/c11 DEV openai-cua.app"
+tools/computer-use/mac-adapter/.build/debug/cua-mac-adapter observe --bundle-id com.stage11.c11.debug.openai.cua --out /tmp/c11-openai-cua.png
+```
+
+`act` accepts one JSON action from `--json`, `--json-file`, or stdin. Supported actions are `click`, `double_click`, `move`, `drag`, `scroll`, `type`, `keypress`, `wait`, and `screenshot`.

--- a/tools/computer-use/openai-runner/openai_cua_runner/__init__.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/__init__.py
@@ -1,0 +1,4 @@
+"""OpenAI computer-use runner for c11."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/tools/computer-use/openai-runner/openai_cua_runner/__main__.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/__main__.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+from .scenarios import ScenarioConfig, dependency_report, run_doctor, run_scenario, run_smoke
+
+
+DEFAULT_TAG = "openai-cua"
+DEFAULT_MODEL = os.environ.get("OPENAI_CUA_MODEL", "gpt-5.5")
+
+
+def repo_root_from_here() -> Path:
+    return Path(__file__).resolve().parents[4]
+
+
+def config_from_args(args: argparse.Namespace) -> ScenarioConfig:
+    return ScenarioConfig(
+        repo_root=Path(args.repo_root).resolve(),
+        tag=args.tag,
+        model=args.model,
+        build=args.build,
+        max_actions=args.max_actions,
+        max_seconds=args.max_seconds,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--repo-root", default=str(repo_root_from_here()))
+    common.add_argument("--tag", default=DEFAULT_TAG)
+    common.add_argument("--model", default=DEFAULT_MODEL)
+    common.add_argument("--build", action="store_true", help="Run ./scripts/reload.sh --tag before launch/smoke/scenario.")
+    common.add_argument("--max-actions", type=int, default=25)
+    common.add_argument("--max-seconds", type=int, default=180)
+
+    parser = argparse.ArgumentParser(prog="python -m openai_cua_runner")
+    sub = parser.add_subparsers(dest="command", required=True)
+    doctor = sub.add_parser("doctor", parents=[common], help="Check environment, adapter, target app, permissions, and API key.")
+    doctor.add_argument("--launch", action="store_true", help="Launch tagged c11 before adapter doctor checks.")
+    sub.add_parser("smoke", parents=[common], help="Launch tagged c11 and capture one screenshot without a model call.")
+    scenario = sub.add_parser("scenario", parents=[common], help="Run one OpenAI computer-use scenario.")
+    scenario.add_argument("name", choices=["launch-window", "create-split", "focus-and-type"])
+    sub.add_parser("deps", help="Show local dependency paths.")
+
+    args = parser.parse_args(argv)
+    if args.command == "deps":
+        print(json.dumps(dependency_report(), indent=2, sort_keys=True))
+        return 0
+
+    config = config_from_args(args)
+    try:
+        if args.command == "doctor":
+            result = run_doctor(config, launch=args.launch)
+        elif args.command == "smoke":
+            result = run_smoke(config)
+        elif args.command == "scenario":
+            result = run_scenario(args.name, config)
+        else:
+            raise AssertionError(args.command)
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if result.get("ok") is False and not result.get("blocked"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/computer-use/openai-runner/openai_cua_runner/adapter_client.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/adapter_client.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+class AdapterError(RuntimeError):
+    pass
+
+
+class AdapterClient:
+    def __init__(
+        self,
+        *,
+        bundle_id: str,
+        app_path: Path | None = None,
+        executable: Path | None = None,
+        repo_root: Path | None = None,
+    ) -> None:
+        self.bundle_id = bundle_id
+        self.app_path = app_path
+        self.repo_root = repo_root or Path.cwd()
+        self.package_dir = self.repo_root / "tools/computer-use/mac-adapter"
+        env_executable = os.environ.get("CUA_MAC_ADAPTER")
+        self.executable = executable or (Path(env_executable) if env_executable else self.package_dir / ".build/debug/cua-mac-adapter")
+
+    def available(self) -> bool:
+        return self.executable.exists() and os.access(self.executable, os.X_OK)
+
+    def build(self) -> None:
+        proc = subprocess.run(
+            ["swift", "build", "--package-path", str(self.package_dir)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise AdapterError(proc.stderr.strip() or proc.stdout.strip() or "swift build failed")
+
+    def doctor(self) -> dict[str, Any]:
+        return self._run("doctor")
+
+    def window_list(self) -> dict[str, Any]:
+        return self._run("window-list")
+
+    def launch(self, wait: int = 10) -> dict[str, Any]:
+        return self._run("launch", "--wait", str(wait))
+
+    def observe(self, *, out: Path | None = None, include_base64: bool = False, frontmost_required: bool = True) -> dict[str, Any]:
+        args: list[str] = []
+        if out is not None:
+            args += ["--out", str(out)]
+        if include_base64:
+            args.append("--include-base64")
+        if not frontmost_required:
+            args.append("--no-frontmost-required")
+        return self._run("observe", *args)
+
+    def act(self, action: dict[str, Any]) -> dict[str, Any]:
+        return self._run("act", "--json", json.dumps(action))
+
+    def _run(self, command: str, *args: str) -> dict[str, Any]:
+        if not self.available():
+            raise AdapterError(f"adapter executable is missing; run: swift build --package-path {self.package_dir}")
+        full = [str(self.executable), command, "--bundle-id", self.bundle_id]
+        if self.app_path is not None:
+            full += ["--app-path", str(self.app_path)]
+        full += list(args)
+        proc = subprocess.run(full, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)
+        if proc.returncode != 0:
+            try:
+                payload = json.loads(proc.stdout)
+            except json.JSONDecodeError:
+                payload = {"ok": False, "error": proc.stderr.strip() or proc.stdout.strip()}
+            raise AdapterError(payload.get("error") or json.dumps(payload))
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError as exc:
+            raise AdapterError(f"adapter returned non-JSON output: {proc.stdout[:500]}") from exc

--- a/tools/computer-use/openai-runner/openai_cua_runner/artifacts.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/artifacts.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+@dataclass
+class RunArtifacts:
+    root: Path
+
+    @classmethod
+    def create(cls, scenario: str, base_dir: Path | None = None) -> "RunArtifacts":
+        base = base_dir or Path("artifacts/openai-cua-runs")
+        root = base / f"{_timestamp()}-{scenario}"
+        for child in ["screenshots", "c11", "logs"]:
+            (root / child).mkdir(parents=True, exist_ok=True)
+        return cls(root=root)
+
+    def write_json(self, relative: str, value: Any) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+    def append_jsonl(self, relative: str, value: Any) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(value, sort_keys=True) + "\n")
+        return path
+
+    def write_text(self, relative: str, value: str) -> Path:
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(value, encoding="utf-8")
+        return path
+
+    def screenshot_path(self, index: int, label: str) -> Path:
+        safe = "".join(ch if ch.isalnum() or ch in "-_" else "-" for ch in label).strip("-") or "shot"
+        return self.root / "screenshots" / f"{index:03d}-{safe}.png"

--- a/tools/computer-use/openai-runner/openai_cua_runner/c11_oracle.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/c11_oracle.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+
+
+def sanitize_bundle(raw: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", ".", raw.lower()).strip(".")
+    cleaned = re.sub(r"\.+", ".", cleaned)
+    return cleaned or "agent"
+
+
+def sanitize_path(raw: str) -> str:
+    cleaned = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    cleaned = re.sub(r"-+", "-", cleaned)
+    return cleaned or "agent"
+
+
+@dataclass(frozen=True)
+class TaggedC11:
+    tag: str
+    repo_root: Path
+
+    @property
+    def tag_id(self) -> str:
+        return sanitize_bundle(self.tag)
+
+    @property
+    def slug(self) -> str:
+        return sanitize_path(self.tag)
+
+    @property
+    def bundle_id(self) -> str:
+        return f"com.stage11.c11.debug.{self.tag_id}"
+
+    @property
+    def app_path(self) -> Path:
+        return Path.home() / "Library/Developer/Xcode/DerivedData" / f"c11-{self.slug}" / "Build/Products/Debug" / f"c11 DEV {self.tag}.app"
+
+    @property
+    def socket_path(self) -> Path:
+        return Path(f"/tmp/c11-debug-{self.slug}.sock")
+
+    @property
+    def log_path(self) -> Path:
+        return Path(f"/tmp/c11-debug-{self.slug}.log")
+
+    def build(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["./scripts/reload.sh", "--tag", self.tag],
+            cwd=self.repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+    def launch(self, wait_socket: int = 10) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["./scripts/launch-tagged-automation.sh", self.tag, "--wait-socket", str(wait_socket)],
+            cwd=self.repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+
+
+class C11Oracle:
+    def __init__(self, tagged: TaggedC11) -> None:
+        self.tagged = tagged
+
+    def command(self, *args: str, expect_json: bool = True) -> Any:
+        env = os.environ.copy()
+        for key in [
+            "CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_TAB_ID", "CMUX_PANE_ID",
+            "C11_WORKSPACE_ID", "C11_SURFACE_ID", "C11_TAB_ID", "C11_PANE_ID",
+        ]:
+            env.pop(key, None)
+        env["CMUX_SOCKET_PATH"] = str(self.tagged.socket_path)
+        env["CMUX_SOCKET"] = str(self.tagged.socket_path)
+        proc = subprocess.run(
+            ["c11", "--socket", str(self.tagged.socket_path), *args],
+            cwd=self.tagged.repo_root,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if proc.returncode != 0:
+            return {"ok": False, "command": ["c11", *args], "stdout": proc.stdout, "stderr": proc.stderr, "returncode": proc.returncode}
+        if not expect_json:
+            return {"ok": True, "stdout": proc.stdout}
+        try:
+            return json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            return {"ok": True, "stdout": proc.stdout}
+
+    def tree(self) -> Any:
+        return self.command("tree", "--json")
+
+    def identify(self) -> Any:
+        return self.command("identify")
+
+    def read_screen(self, lines: int = 80) -> Any:
+        return self.command("read-screen", "--lines", str(lines), expect_json=False)
+
+
+def count_panes(tree: Any) -> int:
+    count = 0
+    if isinstance(tree, dict):
+        if "panes" in tree and isinstance(tree["panes"], list):
+            count += len(tree["panes"])
+        for value in tree.values():
+            count += count_panes(value)
+    elif isinstance(tree, list):
+        for item in tree:
+            count += count_panes(item)
+    return count

--- a/tools/computer-use/openai-runner/openai_cua_runner/responses_loop.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/responses_loop.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import base64
+import os
+from pathlib import Path
+from typing import Any
+
+from .adapter_client import AdapterClient
+from .artifacts import RunArtifacts
+from .safety import SafetyBudget, SafetyLimits
+
+
+def _dump(value: Any) -> Any:
+    if hasattr(value, "model_dump"):
+        return value.model_dump(mode="json")
+    if isinstance(value, list):
+        return [_dump(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _dump(item) for key, item in value.items()}
+    return value
+
+
+def _get(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _response_output(response: Any) -> list[Any]:
+    return list(_get(response, "output", []) or [])
+
+
+def _output_text(response: Any) -> str:
+    direct = _get(response, "output_text")
+    if isinstance(direct, str) and direct:
+        return direct
+    chunks: list[str] = []
+    for item in _response_output(response):
+        if _get(item, "type") == "message":
+            for content in _get(item, "content", []) or []:
+                text = _get(content, "text")
+                if text:
+                    chunks.append(text)
+    return "\n".join(chunks)
+
+
+def _computer_calls(response: Any) -> list[Any]:
+    return [item for item in _response_output(response) if _get(item, "type") == "computer_call"]
+
+
+def _normalize_action(action: dict[str, Any]) -> dict[str, Any]:
+    action_type = action.get("type") or action.get("action")
+    normalized: dict[str, Any] = {"type": action_type}
+    for src, dst in [
+        ("x", "x"), ("y", "y"), ("button", "button"), ("text", "text"),
+        ("dx", "dx"), ("dy", "dy"), ("scroll_x", "dx"), ("scroll_y", "dy"),
+        ("scrollX", "dx"), ("scrollY", "dy"), ("duration_ms", "durationMs"),
+        ("durationMs", "durationMs"), ("path", "path")
+    ]:
+        if src in action:
+            normalized[dst] = action[src]
+    if "keys" in action:
+        normalized["keys"] = action["keys"]
+    elif "key" in action:
+        normalized["keys"] = [action["key"]]
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _call_actions(call: Any) -> list[dict[str, Any]]:
+    actions = _get(call, "actions")
+    if actions:
+        return [_normalize_action(_dump(action)) for action in actions]
+    action = _get(call, "action")
+    if action:
+        return [_normalize_action(_dump(action))]
+    return []
+
+
+class ResponsesComputerLoop:
+    def __init__(
+        self,
+        *,
+        adapter: AdapterClient,
+        artifacts: RunArtifacts,
+        model: str,
+        limits: SafetyLimits | None = None,
+    ) -> None:
+        self.adapter = adapter
+        self.artifacts = artifacts
+        self.model = model
+        self.budget = SafetyBudget(limits or SafetyLimits())
+
+    def run(self, prompt: str) -> dict[str, Any]:
+        try:
+            from openai import OpenAI
+        except ImportError as exc:
+            raise RuntimeError("openai package is not installed; run from tools/computer-use/openai-runner with your Python env installed") from exc
+
+        request_timeout = float(os.environ.get("OPENAI_CUA_REQUEST_TIMEOUT", "120"))
+        client = OpenAI(timeout=request_timeout)
+        self.artifacts.write_text("prompt.md", prompt)
+        response = client.responses.create(
+            model=self.model,
+            tools=[{"type": "computer"}],
+            input=prompt,
+        )
+        self.artifacts.write_json("response-000.json", _dump(response))
+
+        turn = 0
+        while True:
+            calls = _computer_calls(response)
+            if not calls:
+                final = _output_text(response)
+                self.artifacts.write_text("final.md", final)
+                return {"ok": True, "final": final, "actions": self.budget.actions, "response_id": _get(response, "id")}
+
+            outputs: list[dict[str, Any]] = []
+            for call in calls:
+                call_id = _get(call, "call_id") or _get(call, "id")
+                pending_safety = _get(call, "pending_safety_checks") or []
+                if pending_safety:
+                    raise RuntimeError(f"computer call returned pending safety checks; stopping fail-closed: {pending_safety}")
+                actions = _call_actions(call)
+                if not actions:
+                    actions = [{"type": "screenshot"}]
+                for action in actions:
+                    self.budget.record_action()
+                    self.artifacts.append_jsonl("actions.jsonl", {"turn": turn, "call_id": call_id, "action": action})
+                    if action["type"] != "screenshot":
+                        self.adapter.launch(wait=2)
+                        result = self.adapter.act(action)
+                        self.artifacts.append_jsonl("actions.jsonl", {"turn": turn, "call_id": call_id, "result": result})
+                    self.adapter.launch(wait=2)
+                    shot = self.artifacts.screenshot_path(self.budget.actions, f"after-{action['type']}")
+                    obs = self.adapter.observe(out=shot, include_base64=False)
+                    self.artifacts.append_jsonl("observations.jsonl", {"turn": turn, "call_id": call_id, "observation": obs})
+                    image_url = self._image_data_url(shot)
+                    outputs.append({
+                        "type": "computer_call_output",
+                        "call_id": call_id,
+                        "output": {
+                            "type": "input_image",
+                            "image_url": image_url,
+                        },
+                    })
+
+            turn += 1
+            response = client.responses.create(
+                model=self.model,
+                tools=[{"type": "computer"}],
+                previous_response_id=_get(response, "id"),
+                input=outputs,
+            )
+            self.artifacts.write_json(f"response-{turn:03d}.json", _dump(response))
+
+    @staticmethod
+    def _image_data_url(path: Path) -> str:
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        return f"data:image/png;base64,{encoded}"

--- a/tools/computer-use/openai-runner/openai_cua_runner/safety.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/safety.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+
+
+class SafetyBlocked(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SafetyLimits:
+    max_actions: int = 25
+    max_seconds: int = 180
+    allow_system_prompts: bool = False
+
+
+class SafetyBudget:
+    def __init__(self, limits: SafetyLimits) -> None:
+        self.limits = limits
+        self.started = time.monotonic()
+        self.actions = 0
+
+    def record_action(self) -> None:
+        self.actions += 1
+        if self.actions > self.limits.max_actions:
+            raise SafetyBlocked(f"max action count exceeded: {self.limits.max_actions}")
+        elapsed = time.monotonic() - self.started
+        if elapsed > self.limits.max_seconds:
+            raise SafetyBlocked(f"max wall time exceeded: {self.limits.max_seconds}s")

--- a/tools/computer-use/openai-runner/openai_cua_runner/scenarios.py
+++ b/tools/computer-use/openai-runner/openai_cua_runner/scenarios.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from pathlib import Path
+import shutil
+from typing import Any
+
+from .adapter_client import AdapterClient
+from .artifacts import RunArtifacts
+from .c11_oracle import C11Oracle, TaggedC11, count_panes
+from .responses_loop import ResponsesComputerLoop
+from .safety import SafetyLimits
+
+
+@dataclass(frozen=True)
+class ScenarioConfig:
+    repo_root: Path
+    tag: str
+    model: str
+    build: bool = False
+    max_actions: int = 25
+    max_seconds: int = 180
+
+    @property
+    def tagged(self) -> TaggedC11:
+        return TaggedC11(tag=self.tag, repo_root=self.repo_root)
+
+
+SCENARIO_PROMPTS: dict[str, str] = {
+    "launch-window": """You are testing the c11 macOS app through a computer-use screenshot.
+
+Inspect the visible c11 window and report whether the app appears ready for operator use. Do not edit files. If the app is still launching, wait once and inspect again.
+""",
+    "create-split": """You are testing c11 through its visible macOS UI.
+
+Create one new terminal split using the visible UI or a normal user keyboard shortcut. Inspect the screen first. Do not use terminal commands, socket commands, or shell shortcuts as the action path. Stop and explain if no user-facing split affordance or shortcut is reasonably available from the visible state.
+""",
+    "focus-and-type": """You are testing c11 terminal focus and keyboard event routing through the visible macOS UI.
+
+Click inside the visible terminal surface, type exactly:
+printf 'openai-cua-ok\\n'
+
+Then press Enter. Do not use socket commands or paste through any out-of-band mechanism.
+""",
+}
+
+
+def make_adapter(config: ScenarioConfig) -> AdapterClient:
+    return AdapterClient(bundle_id=config.tagged.bundle_id, app_path=config.tagged.app_path, repo_root=config.repo_root)
+
+
+def run_doctor(config: ScenarioConfig, *, launch: bool = False) -> dict[str, Any]:
+    adapter = make_adapter(config)
+    result: dict[str, Any] = {
+        "openai_api_key_present": bool(os.environ.get("OPENAI_API_KEY")),
+        "openai_model": config.model,
+        "adapter_executable": str(adapter.executable),
+        "adapter_available": adapter.available(),
+        "tag": config.tag,
+        "bundle_id": config.tagged.bundle_id,
+        "app_path": str(config.tagged.app_path),
+        "app_exists": config.tagged.app_path.exists(),
+        "socket_path": str(config.tagged.socket_path),
+        "socket_exists": config.tagged.socket_path.exists(),
+        "build_command": f"./scripts/reload.sh --tag {config.tag}",
+        "launch_command": f"./scripts/launch-tagged-automation.sh {config.tag} --wait-socket 10",
+    }
+    if not adapter.available():
+        result["adapter_build_command"] = f"swift build --package-path {adapter.package_dir}"
+        return result
+    if launch:
+        result["launch_output"] = _launch_tagged(config)
+    try:
+        result["adapter_doctor"] = adapter.doctor()
+    except Exception as exc:
+        result["adapter_doctor_error"] = str(exc)
+    return result
+
+
+def run_smoke(config: ScenarioConfig) -> dict[str, Any]:
+    adapter = make_adapter(config)
+    if not adapter.available():
+        adapter.build()
+    artifacts = RunArtifacts.create("smoke", config.repo_root / "artifacts/openai-cua-runs")
+    doctor = adapter.doctor()
+    blocked = _permission_block(doctor)
+    if blocked:
+        run = {"ok": False, "blocked": True, "reason": blocked, "adapter_doctor": doctor, "artifacts": str(artifacts.root)}
+        artifacts.write_json("run.json", run)
+        return run
+    launch_result = _launch_tagged(config)
+    artifacts.write_text("logs/launch.txt", launch_result.get("stdout", ""))
+    adapter_launch = adapter.launch(wait=10)
+    shot = artifacts.screenshot_path(0, "initial")
+    observation = adapter.observe(out=shot, frontmost_required=False)
+    oracle = C11Oracle(config.tagged)
+    tree = oracle.tree()
+    identify = oracle.identify()
+    artifacts.write_json("c11/tree-before.json", tree)
+    artifacts.write_json("c11/identify.json", identify)
+    run = {
+        "ok": launch_result["returncode"] == 0 and bool(observation.get("ok")),
+        "artifacts": str(artifacts.root),
+        "launch": launch_result,
+        "adapter_launch": adapter_launch,
+        "observation": observation,
+        "tree_panes": count_panes(tree),
+    }
+    artifacts.write_json("run.json", run)
+    return run
+
+
+def run_scenario(name: str, config: ScenarioConfig) -> dict[str, Any]:
+    if name not in SCENARIO_PROMPTS:
+        raise ValueError(f"unknown scenario: {name}")
+    if not os.environ.get("OPENAI_API_KEY"):
+        return {"ok": False, "blocked": True, "reason": "OPENAI_API_KEY is not present in the environment"}
+
+    adapter = make_adapter(config)
+    if not adapter.available():
+        adapter.build()
+    artifacts = RunArtifacts.create(name, config.repo_root / "artifacts/openai-cua-runs")
+    doctor = adapter.doctor()
+    blocked = _permission_block(doctor)
+    if blocked:
+        run = {"ok": False, "blocked": True, "reason": blocked, "adapter_doctor": doctor, "artifacts": str(artifacts.root)}
+        artifacts.write_json("run.json", run)
+        return run
+    launch_result = _launch_tagged(config)
+    artifacts.write_text("logs/launch.txt", launch_result.get("stdout", ""))
+    if launch_result["returncode"] != 0:
+        run = {"ok": False, "blocked": True, "reason": "tagged c11 launch failed", "launch": launch_result, "artifacts": str(artifacts.root)}
+        artifacts.write_json("run.json", run)
+        return run
+
+    adapter.launch(wait=10)
+    initial_shot = artifacts.screenshot_path(0, "initial")
+    adapter.observe(out=initial_shot, frontmost_required=False)
+    oracle = C11Oracle(config.tagged)
+    before = oracle.tree()
+    artifacts.write_json("c11/tree-before.json", before)
+
+    loop = ResponsesComputerLoop(
+        adapter=adapter,
+        artifacts=artifacts,
+        model=config.model,
+        limits=SafetyLimits(max_actions=config.max_actions, max_seconds=config.max_seconds),
+    )
+    prompt = SCENARIO_PROMPTS[name]
+    try:
+        loop_result = loop.run(prompt)
+    except Exception as exc:
+        after_error = oracle.tree()
+        artifacts.write_json("c11/tree-after-error.json", after_error)
+        run = {
+            "ok": False,
+            "scenario": name,
+            "model": config.model,
+            "artifacts": str(artifacts.root),
+            "error": str(exc),
+        }
+        artifacts.write_json("run.json", run)
+        return run
+    after = oracle.tree()
+    artifacts.write_json("c11/tree-after.json", after)
+
+    oracle_result = _oracle_result(name, oracle, before, after)
+    run = {
+        "ok": bool(loop_result.get("ok")) and oracle_result.get("ok", True),
+        "scenario": name,
+        "model": config.model,
+        "artifacts": str(artifacts.root),
+        "loop": loop_result,
+        "oracle": oracle_result,
+    }
+    artifacts.write_json("run.json", run)
+    return run
+
+
+def _launch_tagged(config: ScenarioConfig) -> dict[str, Any]:
+    if config.build:
+        build = config.tagged.build()
+        if build.returncode != 0:
+            return {"returncode": build.returncode, "stdout": build.stdout, "phase": "build"}
+    if not config.tagged.app_path.exists():
+        return {
+            "returncode": 2,
+            "stdout": f"tagged app not found at {config.tagged.app_path}\nrun: ./scripts/reload.sh --tag {config.tag}\n",
+            "phase": "preflight",
+        }
+    launch = config.tagged.launch(wait_socket=10)
+    return {"returncode": launch.returncode, "stdout": launch.stdout, "phase": "launch"}
+
+
+def _oracle_result(name: str, oracle: C11Oracle, before: Any, after: Any) -> dict[str, Any]:
+    if name == "create-split":
+        before_count = count_panes(before)
+        after_count = count_panes(after)
+        return {"ok": after_count > before_count, "before_panes": before_count, "after_panes": after_count}
+    if name == "focus-and-type":
+        screen = oracle.read_screen(lines=120)
+        stdout = screen.get("stdout", "") if isinstance(screen, dict) else ""
+        return {"ok": "openai-cua-ok" in stdout, "read_screen_contains_expected": "openai-cua-ok" in stdout}
+    if name == "launch-window":
+        after_count = count_panes(after)
+        return {"ok": after_count >= 1, "after_panes": after_count}
+    return {"ok": True}
+
+
+def _permission_block(doctor: dict[str, Any]) -> str | None:
+    permissions = doctor.get("permissions", {})
+    missing: list[str] = []
+    if not permissions.get("screenRecording"):
+        missing.append("Screen Recording")
+    if not permissions.get("accessibility"):
+        missing.append("Accessibility")
+    if not missing:
+        return None
+    remediation = " ".join(permissions.get("remediation", []))
+    return f"missing macOS permission(s): {', '.join(missing)}. {remediation}".strip()
+
+
+def dependency_report() -> dict[str, Any]:
+    return {
+        "python": shutil.which("python3"),
+        "swift": shutil.which("swift"),
+        "c11": shutil.which("c11"),
+    }

--- a/tools/computer-use/openai-runner/pyproject.toml
+++ b/tools/computer-use/openai-runner/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "openai-cua-runner"
+version = "0.1.0"
+description = "OpenAI Responses API computer-use runner for c11 tagged macOS builds"
+requires-python = ">=3.11"
+dependencies = [
+  "openai>=1.109.0",
+]
+
+[project.scripts]
+openai-cua-runner = "openai_cua_runner.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["openai_cua_runner"]

--- a/upstream-triage/README.md
+++ b/upstream-triage/README.md
@@ -1,17 +1,26 @@
 # Upstream Triage
 
-Where c11 imports changes from `manaflow-ai/cmux`, one PR at a time, by hand-and-agent.
+Where c11 imports PRs from `manaflow-ai/cmux`, one at a time, by hand-and-agent. Open or closed, merged or unmerged.
 
 ## The frame
 
-c11 is a fork that has diverged meaningfully from upstream cmux: renamed entry points, custom theming, Lattice integration, c11-only panels, separate release flow. Most upstream changes don't drop in cleanly with `git cherry-pick`. The right tool for crossing that gap isn't a smarter merge algorithm — it's an agent that **reads the upstream change, understands what it wants to do, and writes the c11 version of it.**
+c11 is a fork that has diverged meaningfully from upstream cmux: renamed entry points, custom theming, Lattice integration, c11-only panels, separate release flow. Most upstream changes don't drop in cleanly with `git cherry-pick`. The right tool for crossing that gap isn't a smarter merge algorithm — it's an agent that **decides whether c11 wants this, judges how hard the import would be, and — if it's worth the effort — writes the c11 version of it.**
 
 The work happens through a partnership:
 
-- **The agent** reads upstream PRs, locates the equivalent code in c11, judges whether and how the change applies, and authors the c11 import (via cherry-pick when convenient, via rewrite when not). It surfaces non-trivial decisions before acting on them.
+- **The agent** evaluates desirability, reads the upstream PR, locates the equivalent code in c11, judges difficulty and approach, and authors the c11 import (via cherry-pick when convenient, via rewrite when not). It surfaces non-trivial decisions before acting on them.
 - **The operator** (you) sets direction, reviews the agent's judgment on edge cases, and merges the resulting c11 PRs.
 
 Cherry-pick, the probe script, the divergence map, the playbook — these are *aids to the agent's judgment*, not a pipeline the agent rides on rails.
+
+## Two triage axes
+
+Every upstream PR gets assessed on two independent dimensions:
+
+- **EVALUATE** — does c11 want this functionality? `yes / no / maybe`
+- **DIFFICULTY** — how hard to bring over? `easy / moderate / hard`
+
+The agent's bias is toward **easy + yes** — those land with minimal ceremony. **Moderate and hard** work goes through a scope-agreement step before any apply. Skips are logged with a one-sentence reason.
 
 ## What lives here
 
@@ -24,8 +33,8 @@ Cherry-pick, the probe script, the divergence map, the playbook — these are *a
 | `scripts/list-merged.sh`      | Listing of upstream PRs since a given point.                                 |
 | `scripts/analyze-hotspots.sh` | Scan c11's unique commits → hot files (seeds the divergence map).            |
 | `triage-log/<date>.md`        | The agent's reasoning and decisions, per PR, per day.                        |
-| `catchup/backlog.md`          | The 912-PR catch-up backlog, marked yes/no/maybe/done.                       |
-| `catchup/feature-catchup-plan.md` | Strategic plan for importing the foundational upstream features first.   |
+| `catchup/feature-catchup-plan.md` | Strategy for closing the 912-commit gap — forward-sweep first, foundations emerge from real triage signal. |
+| `in-flight/<feature>.md`      | Scope-and-approach notes for moderate/hard imports, written before apply.    |
 
 ## How to invoke
 
@@ -33,11 +42,12 @@ From inside Claude Code in this repo:
 
 ```
 /upstream-triage <pr-number> [<pr-number> ...]
-/upstream-triage --since 2026-04-15
-/upstream-triage --catchup            # walks the next batch from catchup/backlog.md
+/upstream-triage --since 2026-04-15 [--state merged|open|all]
+/upstream-triage --since 2026-04-15 --dry-run    # evaluate without applying
+/upstream-triage --catchup                        # walks next batch from catchup backlog
 ```
 
-The skill loads the agent into the right frame and points it at `RUNBOOK.md` for the working philosophy.
+The skill loads the agent into the right frame and points it at `RUNBOOK.md` for the working philosophy. The recommended entry point is a `--dry-run --since <recent-date> --state all` sweep — it produces a triage table without applying anything, so the operator can scan and redirect before any code lands.
 
 ## Two layers of accumulating knowledge
 

--- a/upstream-triage/README.md
+++ b/upstream-triage/README.md
@@ -61,6 +61,6 @@ These get updated by the agent at the end of each run. Without them, every sessi
 - **Live engagement.** The operator drives the sweep with the agent; the agent surfaces decisions in real time. Easy + yes / easy + no fly through; moderate / hard pause for nod.
 - **Local execution.** No cron yet. Cloud agent later.
 - **One c11 PR per upstream PR.** CI on the c11 PR catches build/test breakage.
-- **Computer-use validation for user-visible imports.** The c11 computer-use harness (`tools/computer-use/c11-cu`) drives a tagged build to confirm the imported feature works and looks right. Internal-only changes (refactors, build config) skip this step — CI is enough.
+- **Computer-use validation for user-visible imports.** The OpenAI CUA harness (`tools/computer-use/`, currently on `feat/openai-cua-runner` branch) drives a tagged c11 build via OpenAI Responses API to confirm the imported feature works and looks right. Internal-only changes (refactors, build config) skip this step — CI is enough. Harness needs to land on main before validation kicks in.
 - **Agent escalates before pushing on non-trivial adaptations.** Clean cherry-pick lands without check-in; rewrite or scope-cut surfaces first.
 - **No auto-merge.** Operator merges every c11 PR.

--- a/upstream-triage/README.md
+++ b/upstream-triage/README.md
@@ -1,0 +1,42 @@
+# Upstream Triage
+
+This folder is the home of c11's upstream-import workflow. Upstream is `manaflow-ai/cmux`. We are a fork: we want to pull in many of upstream's changes, but not all, and most need at least light rework before they fit.
+
+## What lives here
+
+| Path                    | Role                                                                         |
+| ----------------------- | ---------------------------------------------------------------------------- |
+| `RUNBOOK.md`            | The flow the `/upstream-triage` skill follows. The agent reads this each run. |
+| `divergence-map.md`     | c11 hot zones — areas where upstream changes need care or should be skipped. |
+| `playbook.md`           | Patterns the agent has learned over time for resolving common conflicts.     |
+| `scripts/probe.sh`      | Mechanical: try cherry-pick of an upstream PR, report status.                |
+| `scripts/list-merged.sh`| List upstream PRs merged since a given date or PR number.                    |
+| `scripts/analyze-hotspots.sh` | Scan c11's unique commits for hot files; output seeds the divergence map. |
+| `triage-log/<date>.md`  | Per-day decision log (one file per agent run-day).                           |
+| `catchup/backlog.md`    | The 912-commit backlog from the last common ancestor (2026-03-18). Marked yes/no/maybe/done. |
+
+## How to run
+
+From inside Claude Code in this repo:
+
+```
+/upstream-triage <pr-number> [<pr-number> ...]
+/upstream-triage --since 2026-04-15
+/upstream-triage --catchup    # walks the next batch from catchup/backlog.md
+```
+
+The skill drives the flow described in `RUNBOOK.md`.
+
+## Two layers of accumulating knowledge
+
+- **`divergence-map.md` = facts.** Where c11 has diverged from upstream. The agent uses it as a "skip or handle with care" map. Grows as we discover new divergent areas.
+- **`playbook.md` = patterns.** Resolve recipes for recurring conflict shapes. The agent adds entries when it learns something reusable.
+
+Without these, every run rediscovers the same lessons. With them, the process gets sharper.
+
+## Scope of v1
+
+- Manual invocation only (no cron yet). Build trust before automating.
+- Local execution. Move to a cloud agent later.
+- One c11 PR per upstream PR. CI on the c11 PR is the build verification — the agent does not build locally.
+- Skip filter is judgment-based, not just path-based — the agent reads the divergence map and decides.

--- a/upstream-triage/README.md
+++ b/upstream-triage/README.md
@@ -58,8 +58,9 @@ These get updated by the agent at the end of each run. Without them, every sessi
 
 ## Scope of v1
 
-- **Manual invocation only.** No cron yet. We build trust before automating.
-- **Local execution.** Cloud agent later.
-- **One c11 PR per upstream PR.** CI on the c11 PR is the build verification — the agent doesn't build locally.
-- **Agent escalates before pushing on non-trivial adaptations.** A clean cherry-pick can land without a check-in; a rewrite that touches multiple files or alters intent gets surfaced first.
+- **Live engagement.** The operator drives the sweep with the agent; the agent surfaces decisions in real time. Easy + yes / easy + no fly through; moderate / hard pause for nod.
+- **Local execution.** No cron yet. Cloud agent later.
+- **One c11 PR per upstream PR.** CI on the c11 PR catches build/test breakage.
+- **Computer-use validation for user-visible imports.** The c11 computer-use harness (`tools/computer-use/c11-cu`) drives a tagged build to confirm the imported feature works and looks right. Internal-only changes (refactors, build config) skip this step — CI is enough.
+- **Agent escalates before pushing on non-trivial adaptations.** Clean cherry-pick lands without check-in; rewrite or scope-cut surfaces first.
 - **No auto-merge.** Operator merges every c11 PR.

--- a/upstream-triage/README.md
+++ b/upstream-triage/README.md
@@ -1,42 +1,55 @@
 # Upstream Triage
 
-This folder is the home of c11's upstream-import workflow. Upstream is `manaflow-ai/cmux`. We are a fork: we want to pull in many of upstream's changes, but not all, and most need at least light rework before they fit.
+Where c11 imports changes from `manaflow-ai/cmux`, one PR at a time, by hand-and-agent.
+
+## The frame
+
+c11 is a fork that has diverged meaningfully from upstream cmux: renamed entry points, custom theming, Lattice integration, c11-only panels, separate release flow. Most upstream changes don't drop in cleanly with `git cherry-pick`. The right tool for crossing that gap isn't a smarter merge algorithm — it's an agent that **reads the upstream change, understands what it wants to do, and writes the c11 version of it.**
+
+The work happens through a partnership:
+
+- **The agent** reads upstream PRs, locates the equivalent code in c11, judges whether and how the change applies, and authors the c11 import (via cherry-pick when convenient, via rewrite when not). It surfaces non-trivial decisions before acting on them.
+- **The operator** (you) sets direction, reviews the agent's judgment on edge cases, and merges the resulting c11 PRs.
+
+Cherry-pick, the probe script, the divergence map, the playbook — these are *aids to the agent's judgment*, not a pipeline the agent rides on rails.
 
 ## What lives here
 
-| Path                    | Role                                                                         |
-| ----------------------- | ---------------------------------------------------------------------------- |
-| `RUNBOOK.md`            | The flow the `/upstream-triage` skill follows. The agent reads this each run. |
-| `divergence-map.md`     | c11 hot zones — areas where upstream changes need care or should be skipped. |
-| `playbook.md`           | Patterns the agent has learned over time for resolving common conflicts.     |
-| `scripts/probe.sh`      | Mechanical: try cherry-pick of an upstream PR, report status.                |
-| `scripts/list-merged.sh`| List upstream PRs merged since a given date or PR number.                    |
-| `scripts/analyze-hotspots.sh` | Scan c11's unique commits for hot files; output seeds the divergence map. |
-| `triage-log/<date>.md`  | Per-day decision log (one file per agent run-day).                           |
-| `catchup/backlog.md`    | The 912-commit backlog from the last common ancestor (2026-03-18). Marked yes/no/maybe/done. |
+| Path                          | Role                                                                         |
+| ----------------------------- | ---------------------------------------------------------------------------- |
+| `RUNBOOK.md`                  | How the agent thinks about an import. Read every run.                        |
+| `divergence-map.md`           | Facts about c11's hot zones — where to expect adaptation work.               |
+| `playbook.md`                 | Adaptation patterns the agent has worked out and may reuse.                  |
+| `scripts/probe.sh`            | Quick check: would this PR cherry-pick clean, or is rewrite called for?     |
+| `scripts/list-merged.sh`      | Listing of upstream PRs since a given point.                                 |
+| `scripts/analyze-hotspots.sh` | Scan c11's unique commits → hot files (seeds the divergence map).            |
+| `triage-log/<date>.md`        | The agent's reasoning and decisions, per PR, per day.                        |
+| `catchup/backlog.md`          | The 912-PR catch-up backlog, marked yes/no/maybe/done.                       |
+| `catchup/feature-catchup-plan.md` | Strategic plan for importing the foundational upstream features first.   |
 
-## How to run
+## How to invoke
 
 From inside Claude Code in this repo:
 
 ```
 /upstream-triage <pr-number> [<pr-number> ...]
 /upstream-triage --since 2026-04-15
-/upstream-triage --catchup    # walks the next batch from catchup/backlog.md
+/upstream-triage --catchup            # walks the next batch from catchup/backlog.md
 ```
 
-The skill drives the flow described in `RUNBOOK.md`.
+The skill loads the agent into the right frame and points it at `RUNBOOK.md` for the working philosophy.
 
 ## Two layers of accumulating knowledge
 
-- **`divergence-map.md` = facts.** Where c11 has diverged from upstream. The agent uses it as a "skip or handle with care" map. Grows as we discover new divergent areas.
-- **`playbook.md` = patterns.** Resolve recipes for recurring conflict shapes. The agent adds entries when it learns something reusable.
+- **`divergence-map.md` = facts.** Where c11 has diverged. The agent uses it to know where to look and what to expect.
+- **`playbook.md` = patterns.** Adaptation recipes the agent has worked out before. Grows when something non-obvious comes up that's likely to recur.
 
-Without these, every run rediscovers the same lessons. With them, the process gets sharper.
+These get updated by the agent at the end of each run. Without them, every session relearns the same lessons.
 
 ## Scope of v1
 
-- Manual invocation only (no cron yet). Build trust before automating.
-- Local execution. Move to a cloud agent later.
-- One c11 PR per upstream PR. CI on the c11 PR is the build verification — the agent does not build locally.
-- Skip filter is judgment-based, not just path-based — the agent reads the divergence map and decides.
+- **Manual invocation only.** No cron yet. We build trust before automating.
+- **Local execution.** Cloud agent later.
+- **One c11 PR per upstream PR.** CI on the c11 PR is the build verification — the agent doesn't build locally.
+- **Agent escalates before pushing on non-trivial adaptations.** A clean cherry-pick can land without a check-in; a rewrite that touches multiple files or alters intent gets surfaced first.
+- **No auto-merge.** Operator merges every c11 PR.

--- a/upstream-triage/RUNBOOK.md
+++ b/upstream-triage/RUNBOOK.md
@@ -1,130 +1,154 @@
 # RUNBOOK — `/upstream-triage`
 
-This is the flow the skill follows for each upstream PR. **Read this every run before doing anything.**
+You are an agent importing an upstream cmux change into c11. **You are doing the import, not orchestrating a pipeline.** The tools (probe, divergence map, playbook) help you think and act faster — they don't decide for you.
 
-## Inputs
-
-The skill is invoked one of three ways:
-
-1. `/upstream-triage <pr-number> [<pr-number> ...]` — explicit PRs.
-2. `/upstream-triage --since <date-or-pr>` — list all upstream PRs merged after this point.
-3. `/upstream-triage --catchup [--batch-size N]` — pull the next N "yes" or "maybe" entries from `catchup/backlog.md`.
+Your job per PR: *understand what upstream wants, decide whether it belongs in c11, and write the c11 version of it.*
 
 ## Setup (once per run)
 
-1. Confirm cwd is the c11 repo root.
-2. Confirm `git status` is clean. If not, **stop** and report — never operate on a dirty tree.
-3. Confirm current branch is `main`. If not, ask before continuing.
-4. `git fetch upstream main` and `git fetch origin main`.
-5. Confirm local `main` is up to date with `origin/main`. If not, fast-forward (or stop and ask if it's diverged).
-6. Open today's triage log at `upstream-triage/triage-log/<YYYY-MM-DD>.md` (create if missing). Append, don't overwrite.
-7. Read `divergence-map.md` and `playbook.md` into context.
+1. Confirm cwd is the c11 repo root (or a worktree of it).
+2. `git fetch upstream main` and `git fetch origin main`.
+3. Open today's triage log at `upstream-triage/triage-log/<YYYY-MM-DD>.md` (create if missing). Append, don't overwrite.
+4. Read `divergence-map.md` and `playbook.md` into context. These are the agent's prior knowledge about c11.
+5. Working tree must be clean for any apply step. If main is dirty, prefer running in a worktree (`git worktree add /tmp/c11-triage main`) or stashing the user's work *only with their explicit OK*.
 
-## Per-PR loop
+## The per-PR loop: READ → LOCATE → JUDGE → APPLY → REPORT
 
-For each PR number, run **DECIDE → PROBE → APPLY → REPORT.**
+This is a thinking shape, not a procedure. Skip steps when they're unnecessary; loop back when something surprises you.
 
-### 1. DECIDE
+### 1. READ
 
-Fetch PR metadata via `gh pr view <N> --repo manaflow-ai/cmux --json title,body,files,additions,deletions,author,mergeCommit,mergedAt`.
+Pull the full upstream context:
 
-Categorize. The decision is one of:
+```bash
+gh pr view <N> --repo manaflow-ai/cmux --json title,body,files,additions,deletions,author,mergeCommit,mergedAt,comments
+git fetch upstream <merge-sha>
+git show <merge-sha>
+```
 
-- **SKIP-divergence** — touches a file in `divergence-map.md` marked "skip". Log reason and move on.
-- **SKIP-low-reward** — pure infrastructure that doesn't apply to c11 (release flow, homebrew, branding, Sentry-cmux config, CHANGELOG, README, version bumps). Log and move on.
-- **SKIP-not-merged** — PR was closed without merge. Log and move on.
-- **SKIP-already-applied** — `mergeCommit.oid` is already reachable from c11/main. Log and move on.
-- **ATTEMPT** — looks landable. Continue to PROBE.
-- **ESCALATE** — agent is uncertain. Stop the per-PR loop, surface the question to the user with the relevant context.
+Form a one-sentence understanding of what this PR *does* — not the diff shape, the intent. ("Adds a backdrop layer behind the sidebar tint." "Renames a constant." "Bridges OpenCode permission asks into the Feed UI.")
 
-Bias: when in doubt, ATTEMPT. The probe is cheap; we'd rather see real conflicts than over-skip.
+If the intent isn't clear from title + body + diff, read the linked issue, the PR comments, or the related code. Don't proceed on a guess.
 
-### 2. PROBE
+### 2. LOCATE
 
-Run `upstream-triage/scripts/probe.sh <pr-number>`. It will:
+Find the c11 equivalents of the files upstream touched. Common cases:
 
-- Create branch `upstream-probe/pr-<N>` from `origin/main`.
-- Try `git cherry-pick <merge-commit>` (using `-m 1` if it's a merge commit, else direct).
-- Report one of: `clean`, `conflict <files>`, `empty` (no changes — already applied), `error <reason>`.
+- **Same path exists in c11** → standard case. Cherry-pick may apply directly or with conflicts.
+- **Path renamed** (e.g. `cmuxApp.swift` → `c11App.swift`) → see playbook entry "cmux→c11 rename". The code identity is the same; the path is not.
+- **Path doesn't exist on c11** → upstream introduced it after our merge-base. The PR likely depends on an upstream feature c11 hasn't imported yet. See playbook entry "Modify/delete — file doesn't exist on c11".
+- **Concept exists but in a different place** (e.g. upstream changes a setting that c11 has reorganized) → translate. Don't blindly drop changes into a structure they don't fit.
 
-The probe never pushes. It leaves the branch in whatever state for inspection.
+### 3. JUDGE
 
-### 3. APPLY
+Now you have the upstream intent and the c11 target shape. Answer three questions:
 
-Based on probe result:
+1. **Does this change make sense for c11?** Most do. But some upstream PRs adjust features c11 has replaced, deleted, or never wanted. If c11's equivalent is intentionally different, skip — log the reason.
+2. **What's the lightest path that preserves the change's intent?** Three options, in increasing cost:
+   - **Cherry-pick clean** — the upstream commit applies as-is. Use this when probe reports `STATUS=clean`. No rewrite needed.
+   - **Cherry-pick with manual conflict resolution** — small, mechanical conflicts (a few hunks). Resolve, continue, commit.
+   - **Rewrite** — read the upstream diff as a *spec*, then write the c11 version. Apply the same semantic change to c11's current code. Translate paths, naming, and any structural differences. The result is a c11-authored commit that quotes the upstream PR for lineage.
+3. **Is this within the agent's scope to do alone, or does it need a check-in?** Default to escalate when:
+   - Rewrite touches >5 c11 files.
+   - The change deletes or alters c11-specific behavior.
+   - The upstream PR is part of a feature chain (depends on un-imported PRs) and importing the chain isn't a small lift.
+   - You're not sure which c11 file is the right home for the change.
 
-- **clean** — the cherry-pick worked with no conflicts.
-  - Push the branch: `git push -u origin upstream-probe/pr-<N>:upstream/pr-<N>`
-  - Open c11 PR (see "PR shape" below).
-  - Delete the local probe branch.
-  - Switch back to main.
+### 4. APPLY
 
-- **conflict** — read each conflicted file. Decide:
-  - All conflicts in files marked "skip" in divergence map → abort, log as **SKIP-divergence-conflict**, clean up branch.
-  - Conflicts in shared code, scope is tractable (a few hunks, no architectural rework) → resolve, `git cherry-pick --continue`, push, open PR with a note in the body explaining the adaptation.
-  - Conflicts are heavy or beyond the agent's confident scope → abort, log as **NEEDS-HUMAN** with the conflict files and a one-paragraph diagnosis. Clean up branch.
+Choose the path matching your judge step.
 
-- **empty** — already in c11. Log SKIP-already-applied. Clean up branch.
+**Cherry-pick (clean or with conflict resolution):**
 
-- **error** — log the error verbatim, escalate to user.
+```bash
+./upstream-triage/scripts/probe.sh <N>
+# If STATUS=clean: branch ready, push and open PR.
+# If STATUS=conflict and conflicts are small/mechanical: resolve, git cherry-pick --continue, push, open PR.
+# If STATUS=conflict and conflicts are non-trivial: switch to rewrite path.
+```
 
-### 4. REPORT
+**Rewrite:**
 
-Append to `triage-log/<YYYY-MM-DD>.md` for every PR processed. One block per PR:
+1. Make sure you're on a fresh branch off main: `git checkout -b upstream/pr-<N> main`.
+2. Apply the same semantic change to c11. The upstream diff is a guide; the c11 codebase is the target. Write the change as if you were authoring it natively.
+3. Commit with the upstream author attribution preserved:
+   ```bash
+   git commit \
+     --author="<upstream-login> <upstream-email>" \
+     -m "[upstream #<N>] <upstream title>" \
+     -m "Adapted for c11. Original: https://github.com/manaflow-ai/cmux/pull/<N>"
+   ```
+4. The PR body **must** clearly state this is a rewrite (see "PR shape" below).
+
+**Either path** ends with: branch pushed, c11 PR opened, agent does *not* merge.
+
+### 5. REPORT
+
+Append a block to `triage-log/<YYYY-MM-DD>.md` for every PR processed:
 
 ```markdown
 ## #<N> — <title>
 
-- **Decision:** <SKIP-... | LANDED | NEEDS-HUMAN>
-- **Author:** <upstream author>
-- **Files:** <count> files, +<add> -<del>
-- **Probe:** <clean | conflict files | empty | error>
+- **Decision:** <LANDED-cherry-pick | LANDED-rewrite | LANDED-rewrite-partial | NEEDS-HUMAN | SKIP-<reason>>
+- **Author:** <upstream login>
+- **Files (upstream):** <count>, +<add> -<del>
+- **Files (c11 commit):** <count> — only when different from upstream (rewrite case)
 - **c11 PR:** <link if opened, else —>
-- **Reason:** <one sentence>
-- **Notes:** <optional adaptation notes, conflict description, etc.>
+- **Approach:** <one sentence — cherry-pick? rewrite? what was adapted?>
+- **Notes:** <anything that helps reconstruct the reasoning, links to playbook entries used, dependencies surfaced>
 ```
+
+If a non-obvious adaptation pattern came up, also update `playbook.md`. If a previously unmapped divergent area surfaced, also update `divergence-map.md`. Commit those updates as a separate commit on main: `chore(triage): update divergence map and playbook from <date> run`.
+
+## Working with the operator
+
+The agent works *with* the operator, not autonomously. The default mode is "do the work, surface decisions worth surfacing." Specifically:
+
+- **No surprises before push.** If the c11 PR will visibly differ from the upstream PR (rewrite, partial import, scope change), explain in the PR body. The operator should never be confused about why c11's version doesn't match upstream's.
+- **Escalate, don't guess.** If you're under 80% confident on a judgment call (which file is the right home? does this feature belong in c11?), pause and ask the operator. The cost of pausing is a sentence; the cost of a wrong import is a revert.
+- **Batch the small stuff.** Don't ask the operator to weigh in on every cherry-pick that lands clean. Do those, log them, move on. Surface only the calls that need a person.
 
 ## PR shape
 
-When opening a c11 PR for a clean or resolved import:
+**Branch name:** `upstream/pr-<N>`
 
-- **Branch name:** `upstream/pr-<N>` (so it's obvious in the branch list)
-- **Title:** `[upstream #<N>] <original title>`
-- **Body:**
+**Title:** `[upstream #<N>] <original title>`
 
-  ```markdown
-  Imports manaflow-ai/cmux#<N>: <title>
+**Body template:**
 
-  Original author: @<upstream-login>
-  Upstream PR: https://github.com/manaflow-ai/cmux/pull/<N>
-  Merge commit: <upstream-sha>
+```markdown
+Imports manaflow-ai/cmux#<N>: <title>
 
-  ## Original summary
-  <quote relevant parts of upstream PR body, trimmed>
+Original author: @<upstream-login>
+Upstream PR: https://github.com/manaflow-ai/cmux/pull/<N>
+Upstream commit: <sha>
 
-  ## Adaptation notes
-  <if any conflicts were resolved, describe; otherwise: "Cherry-picked clean.">
+## Approach
 
-  Triage log: upstream-triage/triage-log/<date>.md#<N>
-  ```
+<one of:>
 
-- **Labels:** `upstream-import` (create if missing).
-- **Do not** auto-merge. The c11 PR's CI runs; you (the human) review and merge.
+- **Cherry-pick (clean).** Applied without modification.
+- **Cherry-pick (resolved).** Conflicts in <files>; resolved by <one-line summary>.
+- **Rewrite.** Upstream diff was applied semantically to c11's structure. Differences from upstream:
+  - <bullet: e.g. "translated `cmuxApp.swift` references to `c11App.swift`">
+  - <bullet: e.g. "skipped the part touching homebrew-cmux/ — no c11 equivalent">
 
-## Updating the divergence map and playbook
+## What this changes in c11
 
-After processing a batch, **always**:
+<one paragraph in plain language: what behavior or surface this affects on c11. Helps the reviewer judge fit without re-reading both diffs.>
 
-1. If a SKIP-divergence reason came up that isn't in the divergence map yet, add it.
-2. If a conflict resolution was non-obvious and might recur, add a playbook entry.
-3. Commit the updates as a separate commit on main: `chore(triage): update divergence map and playbook from <date> run`.
+Triage log: upstream-triage/triage-log/<date>.md#<N>
+```
 
-This is how the system gets smarter. Don't skip it.
+**Labels:** `upstream-import` (create the label if missing).
+
+**Do not** auto-merge. The operator reviews and merges.
 
 ## Hard rules
 
-- **Never push to `manaflow-ai/cmux`.** That's already blocked at the git-config level, but be aware.
-- **Never force-push** the `upstream/pr-<N>` branches. Each PR gets one branch; if it needs revision, push a new commit on top.
-- **Never auto-merge** c11 PRs. Always leave to the human.
-- **Never operate on a dirty working tree.** Refuse and report.
-- **Never run more than one cherry-pick at a time.** The probe branches must be sequential or they trample each other.
+- Never push to `manaflow-ai/cmux`. (Already blocked at git-config level.)
+- Never force-push the `upstream/pr-<N>` branches.
+- Never auto-merge c11 PRs.
+- Never operate on a dirty working tree without operator OK. Prefer worktrees.
+- Never run more than one apply at a time. Probe branches and rewrite branches must be sequential or they trample.
+- When unsure, ask. Cheap to pause, expensive to revert.

--- a/upstream-triage/RUNBOOK.md
+++ b/upstream-triage/RUNBOOK.md
@@ -1,0 +1,130 @@
+# RUNBOOK — `/upstream-triage`
+
+This is the flow the skill follows for each upstream PR. **Read this every run before doing anything.**
+
+## Inputs
+
+The skill is invoked one of three ways:
+
+1. `/upstream-triage <pr-number> [<pr-number> ...]` — explicit PRs.
+2. `/upstream-triage --since <date-or-pr>` — list all upstream PRs merged after this point.
+3. `/upstream-triage --catchup [--batch-size N]` — pull the next N "yes" or "maybe" entries from `catchup/backlog.md`.
+
+## Setup (once per run)
+
+1. Confirm cwd is the c11 repo root.
+2. Confirm `git status` is clean. If not, **stop** and report — never operate on a dirty tree.
+3. Confirm current branch is `main`. If not, ask before continuing.
+4. `git fetch upstream main` and `git fetch origin main`.
+5. Confirm local `main` is up to date with `origin/main`. If not, fast-forward (or stop and ask if it's diverged).
+6. Open today's triage log at `upstream-triage/triage-log/<YYYY-MM-DD>.md` (create if missing). Append, don't overwrite.
+7. Read `divergence-map.md` and `playbook.md` into context.
+
+## Per-PR loop
+
+For each PR number, run **DECIDE → PROBE → APPLY → REPORT.**
+
+### 1. DECIDE
+
+Fetch PR metadata via `gh pr view <N> --repo manaflow-ai/cmux --json title,body,files,additions,deletions,author,mergeCommit,mergedAt`.
+
+Categorize. The decision is one of:
+
+- **SKIP-divergence** — touches a file in `divergence-map.md` marked "skip". Log reason and move on.
+- **SKIP-low-reward** — pure infrastructure that doesn't apply to c11 (release flow, homebrew, branding, Sentry-cmux config, CHANGELOG, README, version bumps). Log and move on.
+- **SKIP-not-merged** — PR was closed without merge. Log and move on.
+- **SKIP-already-applied** — `mergeCommit.oid` is already reachable from c11/main. Log and move on.
+- **ATTEMPT** — looks landable. Continue to PROBE.
+- **ESCALATE** — agent is uncertain. Stop the per-PR loop, surface the question to the user with the relevant context.
+
+Bias: when in doubt, ATTEMPT. The probe is cheap; we'd rather see real conflicts than over-skip.
+
+### 2. PROBE
+
+Run `upstream-triage/scripts/probe.sh <pr-number>`. It will:
+
+- Create branch `upstream-probe/pr-<N>` from `origin/main`.
+- Try `git cherry-pick <merge-commit>` (using `-m 1` if it's a merge commit, else direct).
+- Report one of: `clean`, `conflict <files>`, `empty` (no changes — already applied), `error <reason>`.
+
+The probe never pushes. It leaves the branch in whatever state for inspection.
+
+### 3. APPLY
+
+Based on probe result:
+
+- **clean** — the cherry-pick worked with no conflicts.
+  - Push the branch: `git push -u origin upstream-probe/pr-<N>:upstream/pr-<N>`
+  - Open c11 PR (see "PR shape" below).
+  - Delete the local probe branch.
+  - Switch back to main.
+
+- **conflict** — read each conflicted file. Decide:
+  - All conflicts in files marked "skip" in divergence map → abort, log as **SKIP-divergence-conflict**, clean up branch.
+  - Conflicts in shared code, scope is tractable (a few hunks, no architectural rework) → resolve, `git cherry-pick --continue`, push, open PR with a note in the body explaining the adaptation.
+  - Conflicts are heavy or beyond the agent's confident scope → abort, log as **NEEDS-HUMAN** with the conflict files and a one-paragraph diagnosis. Clean up branch.
+
+- **empty** — already in c11. Log SKIP-already-applied. Clean up branch.
+
+- **error** — log the error verbatim, escalate to user.
+
+### 4. REPORT
+
+Append to `triage-log/<YYYY-MM-DD>.md` for every PR processed. One block per PR:
+
+```markdown
+## #<N> — <title>
+
+- **Decision:** <SKIP-... | LANDED | NEEDS-HUMAN>
+- **Author:** <upstream author>
+- **Files:** <count> files, +<add> -<del>
+- **Probe:** <clean | conflict files | empty | error>
+- **c11 PR:** <link if opened, else —>
+- **Reason:** <one sentence>
+- **Notes:** <optional adaptation notes, conflict description, etc.>
+```
+
+## PR shape
+
+When opening a c11 PR for a clean or resolved import:
+
+- **Branch name:** `upstream/pr-<N>` (so it's obvious in the branch list)
+- **Title:** `[upstream #<N>] <original title>`
+- **Body:**
+
+  ```markdown
+  Imports manaflow-ai/cmux#<N>: <title>
+
+  Original author: @<upstream-login>
+  Upstream PR: https://github.com/manaflow-ai/cmux/pull/<N>
+  Merge commit: <upstream-sha>
+
+  ## Original summary
+  <quote relevant parts of upstream PR body, trimmed>
+
+  ## Adaptation notes
+  <if any conflicts were resolved, describe; otherwise: "Cherry-picked clean.">
+
+  Triage log: upstream-triage/triage-log/<date>.md#<N>
+  ```
+
+- **Labels:** `upstream-import` (create if missing).
+- **Do not** auto-merge. The c11 PR's CI runs; you (the human) review and merge.
+
+## Updating the divergence map and playbook
+
+After processing a batch, **always**:
+
+1. If a SKIP-divergence reason came up that isn't in the divergence map yet, add it.
+2. If a conflict resolution was non-obvious and might recur, add a playbook entry.
+3. Commit the updates as a separate commit on main: `chore(triage): update divergence map and playbook from <date> run`.
+
+This is how the system gets smarter. Don't skip it.
+
+## Hard rules
+
+- **Never push to `manaflow-ai/cmux`.** That's already blocked at the git-config level, but be aware.
+- **Never force-push** the `upstream/pr-<N>` branches. Each PR gets one branch; if it needs revision, push a new commit on top.
+- **Never auto-merge** c11 PRs. Always leave to the human.
+- **Never operate on a dirty working tree.** Refuse and report.
+- **Never run more than one cherry-pick at a time.** The probe branches must be sequential or they trample each other.

--- a/upstream-triage/RUNBOOK.md
+++ b/upstream-triage/RUNBOOK.md
@@ -130,39 +130,57 @@ After APPLY, before REPORT, run **VALIDATE** for any user-visible feature change
 
 Either path ends with: branch pushed, c11 PR opened, agent does *not* merge.
 
-### 6b. VALIDATE — drive the feature in c11.app via computer-use
+### 6b. VALIDATE — drive the feature in c11.app via the OpenAI CUA harness
 
-For any import that touches user-visible behavior (UI, settings, panels, terminal, browser surfaces, sidebar, menus, hotkeys), the agent runs the **c11 computer-use harness** to confirm the imported feature actually works *and looks right* in a real c11 build before declaring the PR ready.
+For any import that touches user-visible behavior (UI, settings, panels, terminal, browser surfaces, sidebar, menus, hotkeys), the agent runs the **OpenAI CUA harness** to confirm the imported feature actually works *and looks right* in a real c11 build before declaring the PR ready.
 
-The harness lives at `tools/computer-use/` (CLI: `c11-cu`). It uses Anthropic's Computer Use API (Claude Opus 4.7 + `computer_20251124`) to drive a tagged c11 build with real mouse, keystrokes, and screenshots. See `tools/computer-use/README.md` for setup; key commands:
+The harness has two parts, both at `tools/computer-use/`:
+
+- `mac-adapter/` — Swift CLI (`cua-mac-adapter`) for window discovery, screenshots, and input events on macOS.
+- `openai-runner/` — Python runner (`openai_cua_runner`) using OpenAI Responses API's `computer` tool, with pre-baked scenarios (`launch-window`, `create-split`, `focus-and-type`, etc.).
+
+It drives a tagged c11 DEV build (default bundle id `com.stage11.c11.debug.openai.cua`, default app path `~/Library/Developer/Xcode/DerivedData/c11-openai-cua/Build/Products/Debug/c11 DEV openai-cua.app`).
+
+Key commands (run from c11 repo root):
 
 ```bash
-c11-cu probe                                       # confirm permissions and harness wiring are healthy
-c11-cu task --tag <build-tag> --prompt <prompt>   # run a validation task; outputs transcript + screenshots
+# Build the mac adapter (one-time, then on adapter changes):
+swift build --package-path tools/computer-use/mac-adapter
+
+# Confirm permissions and harness wiring:
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner doctor --tag openai-cua
+
+# Run a pre-baked scenario (with --build to rebuild the tagged c11 app first):
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner scenario <name> --tag openai-cua --build
+
+# Run a custom validation task:
+PYTHONPATH=tools/computer-use/openai-runner python3 -m openai_cua_runner smoke --tag openai-cua --prompt "<validation prompt>"
 ```
+
+The runner reads `OPENAI_API_KEY` from the environment. Artifacts (transcripts, screenshots) write to `artifacts/openai-cua-runs/`.
 
 **When to validate (and when to skip):**
 
 - **Validate** — UI changes, new settings, sidebar/panel work, hotkeys, menus, browser/terminal surface behavior. Anything an operator would feel.
-- **Skip validate** — purely internal refactors, dependency bumps, build/CI config, agent-instruction docs, comment-only changes. CI catches breakage; computer-use adds no signal.
+- **Skip validate** — purely internal refactors, dependency bumps, build/CI config, agent-instruction docs, comment-only changes. CI catches breakage; CUA adds no signal.
 
 **How to validate:**
 
-1. Build the c11 PR's branch as a tagged dev build.
-2. Compose a validation prompt that names the feature and the path the operator would take to use it. Pull the language from the upstream PR body when useful.
-3. Run `c11-cu task` with the prompt. The harness produces a transcript + screenshots in `runs/<run-id>/`.
-4. Read the harness's verdict. Either:
+1. Build the c11 PR's branch as a tagged DEV build via `./scripts/reload.sh --tag openai-cua` (or pass `--build` to the runner).
+2. Compose a validation prompt that names the feature and the path the operator would take to use it. Pull the language from the upstream PR body when useful. If a pre-baked scenario fits, use it.
+3. Run the appropriate runner command. The harness produces a transcript + screenshots in `artifacts/openai-cua-runs/`.
+4. Read the verdict:
    - **Pass** — the feature works and looks right. Note this in the c11 PR body and proceed to REPORT.
-   - **Fail** — the import has a real problem. Investigate; either fix on the same branch and re-validate, or escalate as NEEDS-HUMAN if the fix is beyond scope.
+   - **Fail** — the import has a real problem. Either fix on the same branch and re-validate, or escalate as NEEDS-HUMAN if the fix is beyond scope.
 5. Attach the validation outcome to the c11 PR — either as a body section ("## Validation") or as a comment, including a link/path to the run artifacts.
 
 **Operational notes:**
 
-- The harness drives the operator's live desktop in v1. The agent should announce before running so the operator isn't surprised by the cursor moving.
+- The harness drives the operator's live desktop. The agent must announce before running so the operator isn't surprised by the cursor moving.
 - Don't validate trivial (purely internal) changes — the harness time isn't free and adds no signal.
-- If `c11-cu probe` fails, fix the harness setup before continuing the sweep — don't ship un-validated UI changes silently.
+- If `doctor` fails, fix the harness setup before continuing the sweep — don't ship un-validated UI changes silently.
 
-> **Status note:** as of 2026-05-01, `tools/computer-use/` lives on the `computer-use-harness` branch, not on c11/main. Either merge that branch first, or run `c11-cu` from a checkout of the `computer-use-harness` branch in a sibling worktree. Both work; the merge is cleaner.
+> **Status note:** as of 2026-05-01, the OpenAI CUA harness lives on the `feat/openai-cua-runner` branch (4 commits ahead of an older main, deletes some files that have since been added). It needs to be rebased onto current main and merged before the sweep can use validation. Until then, validation is `skipped (no harness)` — the operator's live review is the only safety net for UI behavior. Plan to merge before the first user-visible PR import lands.
 
 ### 7. REPORT
 

--- a/upstream-triage/RUNBOOK.md
+++ b/upstream-triage/RUNBOOK.md
@@ -105,6 +105,8 @@ For **easy + clear-yes** PRs, no scope note is required. Just land them. Batch t
 
 Choose the path matching the JUDGE step.
 
+After APPLY, before REPORT, run **VALIDATE** for any user-visible feature change.
+
 **Cherry-pick (clean or with conflict resolution):**
 
 ```bash
@@ -128,6 +130,40 @@ Choose the path matching the JUDGE step.
 
 Either path ends with: branch pushed, c11 PR opened, agent does *not* merge.
 
+### 6b. VALIDATE — drive the feature in c11.app via computer-use
+
+For any import that touches user-visible behavior (UI, settings, panels, terminal, browser surfaces, sidebar, menus, hotkeys), the agent runs the **c11 computer-use harness** to confirm the imported feature actually works *and looks right* in a real c11 build before declaring the PR ready.
+
+The harness lives at `tools/computer-use/` (CLI: `c11-cu`). It uses Anthropic's Computer Use API (Claude Opus 4.7 + `computer_20251124`) to drive a tagged c11 build with real mouse, keystrokes, and screenshots. See `tools/computer-use/README.md` for setup; key commands:
+
+```bash
+c11-cu probe                                       # confirm permissions and harness wiring are healthy
+c11-cu task --tag <build-tag> --prompt <prompt>   # run a validation task; outputs transcript + screenshots
+```
+
+**When to validate (and when to skip):**
+
+- **Validate** — UI changes, new settings, sidebar/panel work, hotkeys, menus, browser/terminal surface behavior. Anything an operator would feel.
+- **Skip validate** — purely internal refactors, dependency bumps, build/CI config, agent-instruction docs, comment-only changes. CI catches breakage; computer-use adds no signal.
+
+**How to validate:**
+
+1. Build the c11 PR's branch as a tagged dev build.
+2. Compose a validation prompt that names the feature and the path the operator would take to use it. Pull the language from the upstream PR body when useful.
+3. Run `c11-cu task` with the prompt. The harness produces a transcript + screenshots in `runs/<run-id>/`.
+4. Read the harness's verdict. Either:
+   - **Pass** — the feature works and looks right. Note this in the c11 PR body and proceed to REPORT.
+   - **Fail** — the import has a real problem. Investigate; either fix on the same branch and re-validate, or escalate as NEEDS-HUMAN if the fix is beyond scope.
+5. Attach the validation outcome to the c11 PR — either as a body section ("## Validation") or as a comment, including a link/path to the run artifacts.
+
+**Operational notes:**
+
+- The harness drives the operator's live desktop in v1. The agent should announce before running so the operator isn't surprised by the cursor moving.
+- Don't validate trivial (purely internal) changes — the harness time isn't free and adds no signal.
+- If `c11-cu probe` fails, fix the harness setup before continuing the sweep — don't ship un-validated UI changes silently.
+
+> **Status note:** as of 2026-05-01, `tools/computer-use/` lives on the `computer-use-harness` branch, not on c11/main. Either merge that branch first, or run `c11-cu` from a checkout of the `computer-use-harness` branch in a sibling worktree. Both work; the merge is cleaner.
+
 ### 7. REPORT
 
 Append a block to `triage-log/<YYYY-MM-DD>.md` for every PR processed:
@@ -143,7 +179,9 @@ Append a block to `triage-log/<YYYY-MM-DD>.md` for every PR processed:
 - **Files (upstream):** <count>, +<add> -<del>
 - **c11 PR:** <link if opened, else —>
 - **Approach:** <one sentence>
+- **Validation:** pass / fail / skipped (internal-only) / skipped (no harness)
 - **Notes:** <reasoning, links to playbook entries used, dependencies surfaced>
+- **Validation run:** <path or run-id, only when applicable>
 ```
 
 For **easy + yes** sweeps, batch the entries — one shared block can cover several PRs if they were all cherry-pick clean.

--- a/upstream-triage/RUNBOOK.md
+++ b/upstream-triage/RUNBOOK.md
@@ -1,8 +1,8 @@
 # RUNBOOK — `/upstream-triage`
 
-You are an agent importing an upstream cmux change into c11. **You are doing the import, not orchestrating a pipeline.** The tools (probe, divergence map, playbook) help you think and act faster — they don't decide for you.
+You are an agent importing upstream cmux PRs into c11. **You are doing the import, not orchestrating a pipeline.** The tools (probe, divergence map, playbook) help you think and act faster — they don't decide for you.
 
-Your job per PR: *understand what upstream wants, decide whether it belongs in c11, and write the c11 version of it.*
+Your job per PR: *decide whether c11 wants this, judge how hard it is, and — if it's worth the effort — write the c11 version of it.*
 
 ## Setup (once per run)
 
@@ -12,65 +12,112 @@ Your job per PR: *understand what upstream wants, decide whether it belongs in c
 4. Read `divergence-map.md` and `playbook.md` into context. These are the agent's prior knowledge about c11.
 5. Working tree must be clean for any apply step. If main is dirty, prefer running in a worktree (`git worktree add /tmp/c11-triage main`) or stashing the user's work *only with their explicit OK*.
 
-## The per-PR loop: READ → LOCATE → JUDGE → APPLY → REPORT
+## The per-PR loop
 
-This is a thinking shape, not a procedure. Skip steps when they're unnecessary; loop back when something surprises you.
+For every PR — open or closed, merged or unmerged — work through these steps in order. Skip later steps when an earlier one resolves the PR.
 
-### 1. READ
+### 1. EVALUATE — does c11 want this?
+
+Before any technical work, judge desirability. Read upstream PR title + body + linked issue.
+
+Three outcomes:
+
+- **Yes** — fits c11's direction. Continue.
+- **No** — doesn't fit. Log `SKIP-doesnt-fit` with a one-sentence reason. Move to next PR. Don't waste time on the technical analysis.
+- **Maybe** — gray area. Surface to the operator: "PR #N does X. c11 already has Y, which overlaps but differs in Z. Want it?" Wait for an answer before continuing.
+
+Common SKIP reasons:
+- Functionality c11 has chosen to do differently (different settings model, different panel system, etc.)
+- cmux-specific direction (branding, features tied to manaflow's product vision)
+- The PR is closed-without-merge upstream because it was a bad idea — usually, but not always, also a bad idea for c11
+
+EVALUATE is **not** about whether the change is technically clean. That's later.
+
+### 2. READ — understand intent
 
 Pull the full upstream context:
 
 ```bash
-gh pr view <N> --repo manaflow-ai/cmux --json title,body,files,additions,deletions,author,mergeCommit,mergedAt,comments
-git fetch upstream <merge-sha>
-git show <merge-sha>
+gh pr view <N> --repo manaflow-ai/cmux --json title,body,files,additions,deletions,author,state,mergeCommit,headRefOid,baseRefName,mergedAt,comments
 ```
 
-Form a one-sentence understanding of what this PR *does* — not the diff shape, the intent. ("Adds a backdrop layer behind the sidebar tint." "Renames a constant." "Bridges OpenCode permission asks into the Feed UI.")
+Form a one-sentence understanding of what this PR *does* — not the diff shape, the intent. ("Adds a backdrop layer behind the sidebar tint." "Adds a setting for terminal-background-matching.")
 
-If the intent isn't clear from title + body + diff, read the linked issue, the PR comments, or the related code. Don't proceed on a guess.
+If intent isn't clear from title + body + diff, read the linked issue, PR comments, or related code. Don't proceed on a guess.
 
-### 2. LOCATE
+### 3. LOCATE — find the c11 equivalents
 
-Find the c11 equivalents of the files upstream touched. Common cases:
+For each upstream file the PR touches, ask:
 
-- **Same path exists in c11** → standard case. Cherry-pick may apply directly or with conflicts.
-- **Path renamed** (e.g. `cmuxApp.swift` → `c11App.swift`) → see playbook entry "cmux→c11 rename". The code identity is the same; the path is not.
+- **Same path exists in c11** → standard case.
+- **Path renamed** (e.g. `cmuxApp.swift` → `c11App.swift`) → see playbook entry "cmux → c11 entry-point rename".
 - **Path doesn't exist on c11** → upstream introduced it after our merge-base. The PR likely depends on an upstream feature c11 hasn't imported yet. See playbook entry "Modify/delete — file doesn't exist on c11".
-- **Concept exists but in a different place** (e.g. upstream changes a setting that c11 has reorganized) → translate. Don't blindly drop changes into a structure they don't fit.
+- **Concept exists in a different place** (upstream changes a setting that c11 has reorganized) → translate.
 
-### 3. JUDGE
+### 4. JUDGE — how hard is this, and what's the right approach?
 
-Now you have the upstream intent and the c11 target shape. Answer three questions:
+Now you have the upstream intent and the c11 target shape. Assess two things:
 
-1. **Does this change make sense for c11?** Most do. But some upstream PRs adjust features c11 has replaced, deleted, or never wanted. If c11's equivalent is intentionally different, skip — log the reason.
-2. **What's the lightest path that preserves the change's intent?** Three options, in increasing cost:
-   - **Cherry-pick clean** — the upstream commit applies as-is. Use this when probe reports `STATUS=clean`. No rewrite needed.
-   - **Cherry-pick with manual conflict resolution** — small, mechanical conflicts (a few hunks). Resolve, continue, commit.
-   - **Rewrite** — read the upstream diff as a *spec*, then write the c11 version. Apply the same semantic change to c11's current code. Translate paths, naming, and any structural differences. The result is a c11-authored commit that quotes the upstream PR for lineage.
-3. **Is this within the agent's scope to do alone, or does it need a check-in?** Default to escalate when:
-   - Rewrite touches >5 c11 files.
-   - The change deletes or alters c11-specific behavior.
-   - The upstream PR is part of a feature chain (depends on un-imported PRs) and importing the chain isn't a small lift.
-   - You're not sure which c11 file is the right home for the change.
+#### Difficulty (easy / moderate / hard)
 
-### 4. APPLY
+- **Easy** — 1–3 files, no `adapt`-zone paths in divergence map, no rename pattern, no missing-on-c11 dependency, clean cherry-pick probable.
+- **Moderate** — 4–10 files, **or** touches one `adapt` zone, **or** has the cmux→c11 rename pattern, **or** small adaptations needed around c11's panel system / theming.
+- **Hard** — many files (>10), **or** multiple `adapt` zones, **or** depends on un-imported upstream features, **or** requires architectural rework.
 
-Choose the path matching your judge step.
+Atin biases toward easy work. Easy + Yes imports should land with minimal ceremony; hard ones get focused sessions.
+
+#### Approach (cherry-pick clean / cherry-pick with resolution / rewrite)
+
+Three paths, in increasing cost:
+
+- **Cherry-pick clean** — upstream commit applies as-is. Use this when probe reports `STATUS=clean`. No rewrite needed.
+- **Cherry-pick with manual conflict resolution** — small, mechanical conflicts (a few hunks). Resolve, continue, commit.
+- **Rewrite** — read the upstream diff as a *spec*, then write the c11 version. Apply the same semantic change to c11's current code. Translate paths, naming, and any structural differences. The result is a c11-authored commit that quotes the upstream PR for lineage.
+
+Probe the PR (`upstream-triage/scripts/probe.sh <N>`) to inform this call when the PR has a merge commit. For open PRs without a merge commit, the probe falls back to the head SHA.
+
+### 5. SCOPE AGREEMENT (conditional — non-trivial work only)
+
+For **moderate or hard** work, **or** for **maybe-fit** PRs, write a short scope-and-approach note in `upstream-triage/in-flight/<feature-or-pr>.md`:
+
+```markdown
+# upstream PR #<N> — <title>
+
+**Evaluate:** yes / maybe — <reason>
+**Difficulty:** moderate / hard
+**Approach:** cherry-pick with resolution / rewrite
+
+## What this PR does
+<one paragraph in plain language>
+
+## How I'd land it on c11
+<2–5 bullets — files I'd touch, anything I'd skip, any adaptation>
+
+## Open questions
+<bullets, if any>
+```
+
+Then wait for the operator's nod. Don't push.
+
+For **easy + clear-yes** PRs, no scope note is required. Just land them. Batch the `easy + yes` ones into the triage log without per-PR ceremony.
+
+### 6. APPLY
+
+Choose the path matching the JUDGE step.
 
 **Cherry-pick (clean or with conflict resolution):**
 
 ```bash
 ./upstream-triage/scripts/probe.sh <N>
-# If STATUS=clean: branch ready, push and open PR.
-# If STATUS=conflict and conflicts are small/mechanical: resolve, git cherry-pick --continue, push, open PR.
-# If STATUS=conflict and conflicts are non-trivial: switch to rewrite path.
+# STATUS=clean: branch ready, push and open PR.
+# STATUS=conflict, mechanical: resolve, git cherry-pick --continue, push, open PR.
+# STATUS=conflict, non-trivial: switch to rewrite path.
 ```
 
 **Rewrite:**
 
-1. Make sure you're on a fresh branch off main: `git checkout -b upstream/pr-<N> main`.
-2. Apply the same semantic change to c11. The upstream diff is a guide; the c11 codebase is the target. Write the change as if you were authoring it natively.
+1. Fresh branch off main: `git checkout -b upstream/pr-<N> main`.
+2. Apply the same semantic change to c11. The upstream diff is a guide; the c11 codebase is the target.
 3. Commit with the upstream author attribution preserved:
    ```bash
    git commit \
@@ -78,35 +125,47 @@ Choose the path matching your judge step.
      -m "[upstream #<N>] <upstream title>" \
      -m "Adapted for c11. Original: https://github.com/manaflow-ai/cmux/pull/<N>"
    ```
-4. The PR body **must** clearly state this is a rewrite (see "PR shape" below).
 
-**Either path** ends with: branch pushed, c11 PR opened, agent does *not* merge.
+Either path ends with: branch pushed, c11 PR opened, agent does *not* merge.
 
-### 5. REPORT
+### 7. REPORT
 
 Append a block to `triage-log/<YYYY-MM-DD>.md` for every PR processed:
 
 ```markdown
 ## #<N> — <title>
 
-- **Decision:** <LANDED-cherry-pick | LANDED-rewrite | LANDED-rewrite-partial | NEEDS-HUMAN | SKIP-<reason>>
+- **Evaluate:** yes / no / maybe
+- **Difficulty:** easy / moderate / hard (only for evaluate=yes/maybe)
+- **Decision:** LANDED-cherry-pick | LANDED-rewrite | NEEDS-HUMAN | SKIP-doesnt-fit | SKIP-blocked-by-#<N> | DEFERRED-hard
 - **Author:** <upstream login>
+- **State:** merged / open / closed-not-merged
 - **Files (upstream):** <count>, +<add> -<del>
-- **Files (c11 commit):** <count> — only when different from upstream (rewrite case)
 - **c11 PR:** <link if opened, else —>
-- **Approach:** <one sentence — cherry-pick? rewrite? what was adapted?>
-- **Notes:** <anything that helps reconstruct the reasoning, links to playbook entries used, dependencies surfaced>
+- **Approach:** <one sentence>
+- **Notes:** <reasoning, links to playbook entries used, dependencies surfaced>
 ```
+
+For **easy + yes** sweeps, batch the entries — one shared block can cover several PRs if they were all cherry-pick clean.
 
 If a non-obvious adaptation pattern came up, also update `playbook.md`. If a previously unmapped divergent area surfaced, also update `divergence-map.md`. Commit those updates as a separate commit on main: `chore(triage): update divergence map and playbook from <date> run`.
 
+## Open vs closed PRs
+
+The flow is the same regardless of PR state. Differences:
+
+- **Closed and merged** — has a `mergeCommit`. probe.sh uses that. Default lane.
+- **Closed without merge** — no merge commit. EVALUATE skews toward `no` (upstream didn't take it for a reason), but not always — sometimes the work is good, just blocked on cmux-specific concerns. Treat as a "maybe" at minimum and look at the PR's close-comments.
+- **Open** — no merge commit. probe.sh falls back to `headRefOid` and cherry-picks the range from the PR's `baseRefName`. Risk: the PR may evolve or be abandoned upstream after we import; flag this in the PR body.
+
 ## Working with the operator
 
-The agent works *with* the operator, not autonomously. The default mode is "do the work, surface decisions worth surfacing." Specifically:
+The agent works *with* the operator, not autonomously.
 
-- **No surprises before push.** If the c11 PR will visibly differ from the upstream PR (rewrite, partial import, scope change), explain in the PR body. The operator should never be confused about why c11's version doesn't match upstream's.
-- **Escalate, don't guess.** If you're under 80% confident on a judgment call (which file is the right home? does this feature belong in c11?), pause and ask the operator. The cost of pausing is a sentence; the cost of a wrong import is a revert.
-- **Batch the small stuff.** Don't ask the operator to weigh in on every cherry-pick that lands clean. Do those, log them, move on. Surface only the calls that need a person.
+- **No surprises before push.** If the c11 PR will visibly differ from the upstream PR (rewrite, partial import, scope cut), explain in the PR body.
+- **Escalate, don't guess.** If you're under 80% confident on a judgment call, pause and ask. Cost of pausing is a sentence; cost of a wrong import is a revert.
+- **Batch the small stuff.** Don't ask the operator to weigh in on every cherry-pick that lands clean. Easy + yes imports just land.
+- **Stack the hard stuff for focused sessions.** Don't try to drive a hard PR in the middle of an easy-sweep batch. Log it as DEFERRED-hard and surface as a candidate for its own session.
 
 ## PR shape
 
@@ -121,7 +180,8 @@ Imports manaflow-ai/cmux#<N>: <title>
 
 Original author: @<upstream-login>
 Upstream PR: https://github.com/manaflow-ai/cmux/pull/<N>
-Upstream commit: <sha>
+Upstream state: merged / open / closed-not-merged
+Upstream commit: <sha> (merge commit, or head if open)
 
 ## Approach
 
@@ -129,18 +189,17 @@ Upstream commit: <sha>
 
 - **Cherry-pick (clean).** Applied without modification.
 - **Cherry-pick (resolved).** Conflicts in <files>; resolved by <one-line summary>.
-- **Rewrite.** Upstream diff was applied semantically to c11's structure. Differences from upstream:
-  - <bullet: e.g. "translated `cmuxApp.swift` references to `c11App.swift`">
-  - <bullet: e.g. "skipped the part touching homebrew-cmux/ — no c11 equivalent">
+- **Rewrite.** Upstream diff applied semantically to c11's structure. Differences from upstream:
+  - <bullet>
 
 ## What this changes in c11
 
-<one paragraph in plain language: what behavior or surface this affects on c11. Helps the reviewer judge fit without re-reading both diffs.>
+<one paragraph in plain language. Helps the reviewer judge fit without re-reading both diffs.>
 
 Triage log: upstream-triage/triage-log/<date>.md#<N>
 ```
 
-**Labels:** `upstream-import` (create the label if missing).
+**Labels:** `upstream-import` (create if missing).
 
 **Do not** auto-merge. The operator reviews and merges.
 
@@ -150,5 +209,5 @@ Triage log: upstream-triage/triage-log/<date>.md#<N>
 - Never force-push the `upstream/pr-<N>` branches.
 - Never auto-merge c11 PRs.
 - Never operate on a dirty working tree without operator OK. Prefer worktrees.
-- Never run more than one apply at a time. Probe branches and rewrite branches must be sequential or they trample.
+- Never run more than one apply at a time.
 - When unsure, ask. Cheap to pause, expensive to revert.

--- a/upstream-triage/catchup/README.md
+++ b/upstream-triage/catchup/README.md
@@ -1,0 +1,23 @@
+# Catch-up
+
+The c11 fork last shared a common ancestor with upstream at commit `53910919` on 2026-03-18. Since then upstream has merged ~900+ PRs that c11 hasn't seen.
+
+`backlog.md` is the master list of those PRs, marked one of:
+
+- `[ ]` unreviewed
+- `[y]` yes — worth attempting
+- `[n]` no — skip (branding, infra, c11-divergent feature, etc.)
+- `[?]` maybe — needs a closer look
+- `[D]` done — already processed (landed, skipped, or escalated; see triage log)
+
+The catch-up flow:
+
+1. **Generate the backlog** (one time):
+   ```bash
+   ../scripts/list-merged.sh --since 53910919 > backlog.md
+   ```
+2. **Curate** — Atin walks the list, marks each row `y` / `n` / `?`. Don't try to do this in one sitting; spread over a few sessions.
+3. **Drive batches** — `/upstream-triage --catchup --batch-size 10` pulls the next 10 `[y]` rows and runs the standard per-PR flow. Each becomes a c11 PR or a triage-log entry.
+4. **Update** — as PRs are processed, the skill flips `[y]` to `[D]`. Re-curate `[?]` rows when more context arrives.
+
+The forward-triage and catch-up flows share the same per-PR machinery. The only difference is where the PR list comes from.

--- a/upstream-triage/catchup/feature-catchup-plan.md
+++ b/upstream-triage/catchup/feature-catchup-plan.md
@@ -4,116 +4,95 @@ Strategic plan for closing the gap between c11 and upstream cmux.
 
 ## The problem
 
-c11's last shared commit with upstream is `53910919` from 2026-03-18. Upstream has merged ~900+ PRs since then, many building on foundational features that don't yet exist on c11.
+c11's last shared commit with upstream is `53910919` from 2026-03-18. Upstream has merged ~900+ PRs since then, and there are ~30+ open PRs at any given time. Most recent upstream PRs depend on foundational features that don't yet exist on c11.
 
-A naive forward-triage hits a recurring failure mode: an upstream PR modifies a file c11 doesn't have because the file was introduced by an earlier upstream PR c11 hasn't imported. PR #3405 was the first concrete case (modifies `Resources/opencode-plugin.js`, introduced upstream in PR #3057).
+A naive forward-triage hits a recurring failure mode: an upstream PR modifies a file c11 doesn't have, because the file was introduced by an earlier upstream PR c11 hasn't imported. PR #3405 was the first concrete case (modified `Resources/opencode-plugin.js`, introduced upstream in PR #3057).
 
-## The approach
+## The approach: forward sweep first, foundations emerge from the work
 
-Rather than process every upstream PR forward in time, identify the **foundational feature PRs** c11 wants, import each one as a focused multi-PR session ("feature catch-up"), then resume forward-triage from a much closer base.
+Don't pre-curate a foundations list. Instead:
 
-Each feature catch-up is its own small project:
-1. The agent reads the foundational PR + its in-tree follow-ons end-to-end.
-2. The agent + operator decide together how the feature should land in c11 (sometimes 1:1, sometimes adapted to fit c11's panel system, sometimes split into stages).
-3. The result is one or a small number of c11 PRs that bring the feature in coherently — not a 1:1 replay of every upstream commit along the way.
+1. **Run forward-triage sweeps** on recent upstream PRs (e.g. `--since 2026-04-15 --state all`).
+2. The agent runs each PR through EVALUATE → READ → LOCATE → JUDGE.
+3. **Easy + yes PRs land** as quick wins (Atin's preferred work shape).
+4. **Hard + yes PRs surface their dependencies** — when a probe hits the modify/delete pattern, the missing-on-c11 file points at the foundation upstream introduced.
+5. **The foundations list builds itself** from these surfaced dependencies. We only chase a foundation when at least one downstream PR we want is blocked on it.
 
-This is a different shape from daily triage. Daily triage is "small change → small PR." Feature catch-up is "feature → feature."
+This is the difference between "guess which upstream features matter" and "let the actual work tell us." We end up importing only the foundations that block desirable downstream work, and the order is naturally driven by what we want to land.
 
-## Candidate foundations (initial seed list)
+## Naming
 
-Sampled from upstream merged PRs since 2026-03-18, filtered to feature-introducing titles. **This is a starting point, not a final list — every entry needs an operator yes/no/defer call.**
+A unit of work is a **PR import** (or **upstream PR import** in c11 docs). We import individual PRs — open or closed, merged or unmerged — through the same skill (`/upstream-triage`).
 
-### Agent & Feed system
+A **foundation** is a PR import that unblocks one or more downstream PRs. The label emerges from triage; it's not a property the PR has on its own.
 
-- [ ] **#3057 — Add Feed sidebar + cmux feed-hook + OpenCode plugin (workstream MVP)** (2026-04-26)
-  - The dependency that blocked PR #3405. Foundational for any Feed-related upstream import.
-  - c11 status: not present. Operator decision: import / skip / defer.
-- [ ] **#3252 — Add iMessage mode for agent prompts** (2026-04-30) — likely depends on Feed
-- [ ] **#3405 — Bridge OpenCode plan approvals into Feed** (2026-05-01) — blocked on #3057
-- [ ] Any Feed follow-ons between 3057 and 3405
+## Triage axes
 
-### Settings rework
+Every PR gets two assessments:
 
-- [ ] **#3024 — Add unified config settings utility window** (2026-04-20)
-- [ ] **#3244 — Add settings sidebar shell** (2026-04-29)
-- [ ] **#2514 — Add Claude Binary Path setting** (2026-04-01)
-- [ ] **#3400 — Consolidate sidebar settings** (2026-05-01) — likely depends on #3244
-- [ ] Operator decision: c11 may already have a divergent settings approach. Adapt or skip the whole stack.
+- **EVALUATE** — does c11 want this functionality? `yes / no / maybe`
+- **DIFFICULTY** — how hard to bring over? `easy / moderate / hard`
 
-### Dock TUI
+| | Easy | Moderate | Hard |
+|---|---|---|---|
+| **Want it** | ship it (often no scope check) | scope agreement, then ship | focused session, scope agreement |
+| **Maybe** | just do it (low cost to revert) | surface to operator | defer until clear yes |
+| **Skip** | skip | skip | skip |
 
-- [ ] **#3217 — Add Dock sidebar TUI controls** (2026-04-29)
-- [ ] **#3366 — Require explicit Dock config** (2026-04-30)
-- [ ] **#3376 — Add Dock documentation page** (2026-05-01)
-- [ ] **#3393 — Improve Dock agent prompt docs** (2026-05-01)
+The bias is toward **easy + yes** — those are the quick wins that build momentum. Hard work is deferred to dedicated sessions with their own scope agreements.
 
-### Sessions panel
+## Suspected foundations (informational; verify by triage)
 
-- [ ] **#2936 — Add Sessions panel to right sidebar** (2026-04-17)
-- [ ] **#3396 — Search Codex rollout content from sessions sidebar** (2026-05-01)
+These were sampled from upstream merged PRs since 2026-03-18. Listed here as **starting hypotheses** for what the foundations *might* be — but the actual foundation list is built by forward-sweep evidence, not this list.
 
-### File explorer sidebar
+If a forward-triage run hits a modify/delete blocked by one of these, we promote it to "foundation we want to chase." If no downstream PRs we care about depend on it, we never need to import it.
 
-- [ ] **#1963 — Add Finder-like file explorer sidebar with SSH support** (2026-04-13)
-- [ ] **#3139 — Add sidebar file preview panels** (2026-04-30)
+### Possible foundations
 
-### Task Manager / Snapshots
+- **#3057** — Add Feed sidebar + cmux feed-hook + OpenCode plugin (2026-04-26). Already confirmed as the dependency for #3405.
+- **#3024** — Add unified config settings utility window (2026-04-20).
+- **#3244** — Add settings sidebar shell (2026-04-29).
+- **#3217** — Add Dock sidebar TUI controls (2026-04-29).
+- **#2936** — Add Sessions panel to right sidebar (2026-04-17).
+- **#1963** — Add Finder-like file explorer sidebar with SSH support (2026-04-13).
+- **#3290** — Add top snapshots and Task Manager window (2026-04-30).
+- **#3181** — Add menu bar only mode (2026-04-27).
 
-- [ ] **#3290 — Add top snapshots and Task Manager window** (2026-04-30)
+### Possible quick-win imports (probably easy + yes)
 
-### Menu bar only mode
+These looked self-contained when sampled — small enough that they may land clean even at the current divergence level. Good candidates for the first forward-sweep run.
 
-- [ ] **#3181 — Add menu bar only mode** (2026-04-27)
+- **#2293** — Add Match Terminal Background sidebar setting.
+- **#2282** — Add copy-on-select setting.
+- **#2389** — Add a system-wide hotkey to show and hide cmux windows.
+- **#2475** — Add editable workspace descriptions.
+- **#3329** — Add hover tooltips to workspace and pane tabs.
+- **#3334** — Allow keyboard shortcuts to be unbound.
 
-### Workspace / CLI features
+### Skip candidates (probably evaluate=no)
 
-- [ ] **#2475 — Add editable workspace descriptions** (2026-04-03)
-- [ ] **#2916 — Add `--layout` to workspace.create for programmatic split layouts** (2026-04-16)
-- [ ] **#3084 — Add configurable cmux.json workspace and tab bar actions** (2026-04-23)
-- [ ] **#2389 — Add a system-wide hotkey to show and hide cmux windows** (2026-04-07)
+These look cmux-specific or don't fit c11's direction. The agent should still call EVALUATE on each, but these are likely skips.
 
-### Agent integrations
+- README / docs / blog post additions.
+- Korean localization (#1811).
+- AGPL + commercial dual-licensing changes (#2021) — c11 is its own license decision.
+- cmux-specific marketing or product PRs.
 
-- [ ] **#2103 — Add Codex CLI hooks integration** (2026-03-25)
-- [ ] **#2087 — Add `cmux omo` command for oh-my-openagent integration** (2026-03-26)
-- [ ] **#2619 — Add cmux omx and cmux omc agent integrations** (2026-04-06)
-- [ ] **#2717 — Add Cursor and Gemini CLI agent integrations + setup-hooks** (2026-04-09)
+## How to drive
 
-### Browser pane
+The first forward-sweep run is the action item. From a clean c11 worktree:
 
-- [ ] **#2660 — Add passkey, WebAuthn, and FIDO2 support to browser pane** (2026-04-07)
-- [ ] **#3256 — Add cmux browser disable switch** (2026-04-29)
-- [ ] **#2373 — Add React Grab inject button to browser toolbar** (2026-03-31)
+```
+/upstream-triage --since 2026-04-15 --state all --dry-run
+```
 
-### Misc
+Dry-run produces a triage table without applying anything. Operator scans the table, redirects the agent on any obvious miscalls, then runs again without `--dry-run` to land the easy+yes work. Hard cases stay in the triage log for focused sessions.
 
-- [ ] **#2293 — Add Match Terminal Background sidebar setting** (2026-03-28)
-- [ ] **#2282 — Add copy-on-select setting** (2026-03-30)
-- [ ] **#2127 — Cmd+N workspace creation crash regression coverage** (2026-03-25)
-
-## How to use this list
-
-1. **Curate.** Operator walks the list and marks each `[y]` (import), `[n]` (skip), or `[?]` (defer / needs more thought). Comment with reasoning if useful.
-2. **Sequence.** Once curated, the `[y]` items get an order. Default to date order; override when a later PR is a better fit for c11 (e.g. c11 may want #3400 "Consolidate sidebar settings" without first importing the original sidebar split).
-3. **Drive each catch-up.** For each foundation marked `[y]`:
-   - Open a focused `/upstream-triage` session named after the feature.
-   - Read the foundation PR + every follow-on that builds on it (use `git log --all -- <key-path>` to find them).
-   - Decide with the operator: import as one c11 PR, or split into stages?
-   - Author the c11 import. The agent does the writing; the operator nods on scope and approach.
-4. **Resume forward triage** from the new base once the major catch-ups are landed.
-
-## Selection criteria — when to mark `[y]`
-
-A foundation is worth importing if:
-
-- It's a feature c11 wants (not a cmux-specific direction c11 has chosen to deviate from).
-- Multiple later upstream PRs build on it (importing it unblocks a chain).
-- The cost to import is bounded — a multi-thousand-line refactor that conflicts with c11's panel system may not be worth it even if c11 wants the feature.
-
-Mark `[n]` when c11 already has its own equivalent (e.g., c11's panel system likely subsumes some upstream "sidebar X" features), or when the feature's a direction c11 isn't taking.
-
-Mark `[?]` when you don't have enough context to decide yet.
+After the first sweep we'll know:
+- What fraction of recent upstream is actually easy at the current divergence.
+- Which foundations are surfacing as real blockers (not just hypotheses).
+- Where the divergence map and playbook need new entries.
 
 ## Status
 
-- 2026-05-01: initial list seeded by sampling upstream merged PRs since merge-base. **Uncurated.** First operator pass needed before any catch-up sessions run.
+- 2026-05-01: catchup plan reframed around forward-sweep discovery. Initial hypotheses listed for context, not as a curated queue. **First forward-sweep run not yet executed.**

--- a/upstream-triage/catchup/feature-catchup-plan.md
+++ b/upstream-triage/catchup/feature-catchup-plan.md
@@ -1,0 +1,119 @@
+# Feature Catchup Plan
+
+Strategic plan for closing the gap between c11 and upstream cmux.
+
+## The problem
+
+c11's last shared commit with upstream is `53910919` from 2026-03-18. Upstream has merged ~900+ PRs since then, many building on foundational features that don't yet exist on c11.
+
+A naive forward-triage hits a recurring failure mode: an upstream PR modifies a file c11 doesn't have because the file was introduced by an earlier upstream PR c11 hasn't imported. PR #3405 was the first concrete case (modifies `Resources/opencode-plugin.js`, introduced upstream in PR #3057).
+
+## The approach
+
+Rather than process every upstream PR forward in time, identify the **foundational feature PRs** c11 wants, import each one as a focused multi-PR session ("feature catch-up"), then resume forward-triage from a much closer base.
+
+Each feature catch-up is its own small project:
+1. The agent reads the foundational PR + its in-tree follow-ons end-to-end.
+2. The agent + operator decide together how the feature should land in c11 (sometimes 1:1, sometimes adapted to fit c11's panel system, sometimes split into stages).
+3. The result is one or a small number of c11 PRs that bring the feature in coherently — not a 1:1 replay of every upstream commit along the way.
+
+This is a different shape from daily triage. Daily triage is "small change → small PR." Feature catch-up is "feature → feature."
+
+## Candidate foundations (initial seed list)
+
+Sampled from upstream merged PRs since 2026-03-18, filtered to feature-introducing titles. **This is a starting point, not a final list — every entry needs an operator yes/no/defer call.**
+
+### Agent & Feed system
+
+- [ ] **#3057 — Add Feed sidebar + cmux feed-hook + OpenCode plugin (workstream MVP)** (2026-04-26)
+  - The dependency that blocked PR #3405. Foundational for any Feed-related upstream import.
+  - c11 status: not present. Operator decision: import / skip / defer.
+- [ ] **#3252 — Add iMessage mode for agent prompts** (2026-04-30) — likely depends on Feed
+- [ ] **#3405 — Bridge OpenCode plan approvals into Feed** (2026-05-01) — blocked on #3057
+- [ ] Any Feed follow-ons between 3057 and 3405
+
+### Settings rework
+
+- [ ] **#3024 — Add unified config settings utility window** (2026-04-20)
+- [ ] **#3244 — Add settings sidebar shell** (2026-04-29)
+- [ ] **#2514 — Add Claude Binary Path setting** (2026-04-01)
+- [ ] **#3400 — Consolidate sidebar settings** (2026-05-01) — likely depends on #3244
+- [ ] Operator decision: c11 may already have a divergent settings approach. Adapt or skip the whole stack.
+
+### Dock TUI
+
+- [ ] **#3217 — Add Dock sidebar TUI controls** (2026-04-29)
+- [ ] **#3366 — Require explicit Dock config** (2026-04-30)
+- [ ] **#3376 — Add Dock documentation page** (2026-05-01)
+- [ ] **#3393 — Improve Dock agent prompt docs** (2026-05-01)
+
+### Sessions panel
+
+- [ ] **#2936 — Add Sessions panel to right sidebar** (2026-04-17)
+- [ ] **#3396 — Search Codex rollout content from sessions sidebar** (2026-05-01)
+
+### File explorer sidebar
+
+- [ ] **#1963 — Add Finder-like file explorer sidebar with SSH support** (2026-04-13)
+- [ ] **#3139 — Add sidebar file preview panels** (2026-04-30)
+
+### Task Manager / Snapshots
+
+- [ ] **#3290 — Add top snapshots and Task Manager window** (2026-04-30)
+
+### Menu bar only mode
+
+- [ ] **#3181 — Add menu bar only mode** (2026-04-27)
+
+### Workspace / CLI features
+
+- [ ] **#2475 — Add editable workspace descriptions** (2026-04-03)
+- [ ] **#2916 — Add `--layout` to workspace.create for programmatic split layouts** (2026-04-16)
+- [ ] **#3084 — Add configurable cmux.json workspace and tab bar actions** (2026-04-23)
+- [ ] **#2389 — Add a system-wide hotkey to show and hide cmux windows** (2026-04-07)
+
+### Agent integrations
+
+- [ ] **#2103 — Add Codex CLI hooks integration** (2026-03-25)
+- [ ] **#2087 — Add `cmux omo` command for oh-my-openagent integration** (2026-03-26)
+- [ ] **#2619 — Add cmux omx and cmux omc agent integrations** (2026-04-06)
+- [ ] **#2717 — Add Cursor and Gemini CLI agent integrations + setup-hooks** (2026-04-09)
+
+### Browser pane
+
+- [ ] **#2660 — Add passkey, WebAuthn, and FIDO2 support to browser pane** (2026-04-07)
+- [ ] **#3256 — Add cmux browser disable switch** (2026-04-29)
+- [ ] **#2373 — Add React Grab inject button to browser toolbar** (2026-03-31)
+
+### Misc
+
+- [ ] **#2293 — Add Match Terminal Background sidebar setting** (2026-03-28)
+- [ ] **#2282 — Add copy-on-select setting** (2026-03-30)
+- [ ] **#2127 — Cmd+N workspace creation crash regression coverage** (2026-03-25)
+
+## How to use this list
+
+1. **Curate.** Operator walks the list and marks each `[y]` (import), `[n]` (skip), or `[?]` (defer / needs more thought). Comment with reasoning if useful.
+2. **Sequence.** Once curated, the `[y]` items get an order. Default to date order; override when a later PR is a better fit for c11 (e.g. c11 may want #3400 "Consolidate sidebar settings" without first importing the original sidebar split).
+3. **Drive each catch-up.** For each foundation marked `[y]`:
+   - Open a focused `/upstream-triage` session named after the feature.
+   - Read the foundation PR + every follow-on that builds on it (use `git log --all -- <key-path>` to find them).
+   - Decide with the operator: import as one c11 PR, or split into stages?
+   - Author the c11 import. The agent does the writing; the operator nods on scope and approach.
+4. **Resume forward triage** from the new base once the major catch-ups are landed.
+
+## Selection criteria — when to mark `[y]`
+
+A foundation is worth importing if:
+
+- It's a feature c11 wants (not a cmux-specific direction c11 has chosen to deviate from).
+- Multiple later upstream PRs build on it (importing it unblocks a chain).
+- The cost to import is bounded — a multi-thousand-line refactor that conflicts with c11's panel system may not be worth it even if c11 wants the feature.
+
+Mark `[n]` when c11 already has its own equivalent (e.g., c11's panel system likely subsumes some upstream "sidebar X" features), or when the feature's a direction c11 isn't taking.
+
+Mark `[?]` when you don't have enough context to decide yet.
+
+## Status
+
+- 2026-05-01: initial list seeded by sampling upstream merged PRs since merge-base. **Uncurated.** First operator pass needed before any catch-up sessions run.

--- a/upstream-triage/divergence-map.md
+++ b/upstream-triage/divergence-map.md
@@ -1,0 +1,95 @@
+# Divergence Map
+
+Areas where c11 has diverged from `manaflow-ai/cmux`. Used by `/upstream-triage` to decide skip vs attempt.
+
+**Categories:**
+
+- **`skip`** — never cherry-pick changes here. Will always conflict, low reward.
+- **`careful`** — attempt the cherry-pick, but expect conflicts. Use the playbook patterns to resolve.
+
+Seeded from `analyze-hotspots.sh` on 2026-05-01 (c11 had 251 unique commits over upstream merge-base `53910919`). Re-run periodically and prune.
+
+---
+
+## skip
+
+Upstream changes here will conflict and the resolution is c11-specific or low-reward.
+
+| Path / glob                     | Reason                                                              |
+| ------------------------------- | ------------------------------------------------------------------- |
+| `README.md`                     | c11-specific tone and project description.                          |
+| `README.*.md`                   | c11-specific localized READMEs.                                     |
+| `CHANGELOG.md`                  | c11 maintains its own release notes.                                |
+| `TODO.md`                       | c11-only working file.                                              |
+| `C11_TODO.md`                   | c11-only.                                                           |
+| `CLAUDE.md`                     | c11-specific agent instructions.                                    |
+| `AGENTS.md`                     | symlink to CLAUDE.md.                                               |
+| `PHILOSOPHY.md`                 | c11-specific.                                                       |
+| `PROJECTS.md`                   | c11-specific.                                                       |
+| `LICENSE`                       | unchanged but not subject to upstream churn.                        |
+| `NOTICE`                        | unchanged.                                                          |
+| `CONTRIBUTING.md`               | c11-specific contributor flow.                                      |
+| `homebrew-c11/**`               | c11-only homebrew tap; no upstream equivalent.                      |
+| `.lattice/**`                   | Lattice (Stage-11 task system) is not present in upstream at all.    |
+| `skills/c11/**`                 | c11-specific Claude Code skill.                                     |
+| `skills/cmux/**`                | c11's wrapped cmux skill — diverged from upstream skill content.     |
+| `.github/ISSUE_TEMPLATE/**`     | c11 issue templates.                                                |
+| `.github/workflows/release.yml` | c11 release flow diverged (own version stream).                     |
+| `.github/workflows/nightly.yml` | c11 nightly diverged (own bucket, own signing).                     |
+| `.github/workflows/build-ghosttykit.yml` | c11-specific GhosttyKit build pipeline.                    |
+| `.github/workflows/update-homebrew.yml`  | c11-only homebrew tap updater.                              |
+| `vendor/bonsplit`               | Submodule pointer; c11 may track a different ref.                   |
+| `.gitmodules`                   | Submodule URLs — c11 vendors differ.                                |
+| `Sources/c11App.swift`          | Renamed from `cmuxApp.swift`. Upstream changes need path translation — see playbook entry "cmux→c11 rename". |
+| `Sources/cmuxApp.swift`         | No longer exists on c11. Upstream changes here are handled via path translation, not direct cherry-pick. |
+| `CLI/c11.swift`                 | Renamed from `cmux.swift`. Same path-translation rule.              |
+| `CLI/cmux.swift`                | No longer exists on c11. Same as above.                             |
+
+> Note: the four rename rows above are tagged `skip` because direct cherry-pick will fail or recreate stale paths. The actual upstream change still gets imported — via path translation. See `playbook.md` → "cmux→c11 rename".
+
+## careful
+
+Touched in c11's 251 commits. Cherry-picks will likely conflict; resolve by hand, with care.
+
+| Path / glob                              | Why it's hot in c11                                              |
+| ---------------------------------------- | ---------------------------------------------------------------- |
+| `GhosttyTabs.xcodeproj/project.pbxproj`  | 48 c11 commits. Xcode project files conflict on every PR. Stage-11 Sentry, target IDs, file refs all differ. |
+| `Resources/Localizable.xcstrings`        | 37 c11 commits, ~100k lines. String catalogs merge poorly; usually safe to take both sides and let Xcode regenerate. |
+| `Resources/InfoPlist.xcstrings`          | Same family.                                                     |
+| `Sources/AppDelegate.swift`              | 31 c11 commits — heavy customization.                            |
+| `Sources/Workspace.swift`                | 25 c11 commits — c11 workspace persistence and surface logic.    |
+| `Sources/ContentView.swift`              | 25 c11 commits.                                                  |
+| `Sources/TerminalController.swift`       | 18 c11 commits.                                                  |
+| `Sources/TabManager.swift`               | 15 c11 commits.                                                  |
+| `Sources/GhosttyTerminalView.swift`      | 14 c11 commits.                                                  |
+| `Sources/AgentSkillsView.swift`          | 10 c11 commits — c11 skills layer.                               |
+| `Sources/SessionPersistence.swift`       | c11 claude-session-resume work (PR #89).                         |
+| `Sources/SurfaceMetadataStore.swift`     | c11 surface metadata.                                            |
+| `Sources/SkillInstaller.swift`           | c11 skills installer.                                            |
+| `Sources/Theme/ThemeManager.swift`       | c11 custom theming. Most upstream theme PRs need adaptation.     |
+| `Sources/Panels/**`                      | c11-built panel system (Markdown, Browser, Mermaid, PaneInteraction). Upstream has none of this. |
+| `Sources/Update/UpdateViewModel.swift`   | c11 update flow routes to c11 release endpoint, not cmux.        |
+| `Sources/WorkspaceLayoutExecutor.swift`  | c11 workspace layout work.                                       |
+| `Sources/WorkspaceSnapshotCapture.swift` | c11 snapshot work.                                               |
+| `Sources/WorkspaceApplyPlan.swift`       | c11 apply-plan work.                                             |
+| `Sources/cmuxApp.swift` (legacy)         | Pre-rename file — see skip section above.                         |
+| `CLI/cmux.swift` (legacy)                | Pre-rename file — see skip section above.                         |
+| `.github/workflows/ci.yml`               | Shared CI but heavily customized by c11.                         |
+| `.github/workflows/ci-macos-compat.yml`  | c11 customizations.                                              |
+| `.github/workflows/test-e2e.yml`         | c11 customizations.                                              |
+| `c11Tests/**`                            | c11 test target (renamed from cmuxTests).                        |
+| `docs/socket-api-reference.md`           | c11 maintains its own copy with c11-specific notes.              |
+
+---
+
+## How to extend this file
+
+When a triage run hits a SKIP-divergence or NEEDS-HUMAN that isn't represented here:
+
+1. Add a row above explaining what about c11 makes upstream changes here troublesome.
+2. Keep the reason to one line. Detail belongs in `playbook.md`.
+3. Use globs over exact paths when the divergence is broad.
+
+When a previously-skip area is no longer divergent (we caught back up, or the c11 customization moved), remove the row.
+
+Re-run `scripts/analyze-hotspots.sh --top 80` quarterly to refresh.

--- a/upstream-triage/divergence-map.md
+++ b/upstream-triage/divergence-map.md
@@ -1,11 +1,11 @@
 # Divergence Map
 
-Areas where c11 has diverged from `manaflow-ai/cmux`. Used by `/upstream-triage` to decide skip vs attempt.
+Where c11 has diverged from `manaflow-ai/cmux`. The agent uses this as prior knowledge: it knows where to expect adaptation work, and where upstream changes simply don't apply.
 
 **Categories:**
 
-- **`skip`** — never cherry-pick changes here. Will always conflict, low reward.
-- **`careful`** — attempt the cherry-pick, but expect conflicts. Use the playbook patterns to resolve.
+- **`skip`** — there is no c11 equivalent. Upstream changes here have no home in c11. Don't try to land them, even via rewrite.
+- **`adapt`** — c11 has its own version, often heavily customized. Upstream changes here likely need rewrite, not cherry-pick. Read the upstream intent, find the c11 equivalent, write the c11 version.
 
 Seeded from `analyze-hotspots.sh` on 2026-05-01 (c11 had 251 unique commits over upstream merge-base `53910919`). Re-run periodically and prune.
 
@@ -13,83 +13,71 @@ Seeded from `analyze-hotspots.sh` on 2026-05-01 (c11 had 251 unique commits over
 
 ## skip
 
-Upstream changes here will conflict and the resolution is c11-specific or low-reward.
+No c11 equivalent. Upstream changes here are not landed.
 
-| Path / glob                     | Reason                                                              |
-| ------------------------------- | ------------------------------------------------------------------- |
-| `README.md`                     | c11-specific tone and project description.                          |
-| `README.*.md`                   | c11-specific localized READMEs.                                     |
-| `CHANGELOG.md`                  | c11 maintains its own release notes.                                |
-| `TODO.md`                       | c11-only working file.                                              |
-| `C11_TODO.md`                   | c11-only.                                                           |
-| `CLAUDE.md`                     | c11-specific agent instructions.                                    |
-| `AGENTS.md`                     | symlink to CLAUDE.md.                                               |
-| `PHILOSOPHY.md`                 | c11-specific.                                                       |
-| `PROJECTS.md`                   | c11-specific.                                                       |
-| `LICENSE`                       | unchanged but not subject to upstream churn.                        |
-| `NOTICE`                        | unchanged.                                                          |
-| `CONTRIBUTING.md`               | c11-specific contributor flow.                                      |
-| `homebrew-c11/**`               | c11-only homebrew tap; no upstream equivalent.                      |
-| `.lattice/**`                   | Lattice (Stage-11 task system) is not present in upstream at all.    |
-| `skills/c11/**`                 | c11-specific Claude Code skill.                                     |
-| `skills/cmux/**`                | c11's wrapped cmux skill — diverged from upstream skill content.     |
-| `.github/ISSUE_TEMPLATE/**`     | c11 issue templates.                                                |
-| `.github/workflows/release.yml` | c11 release flow diverged (own version stream).                     |
-| `.github/workflows/nightly.yml` | c11 nightly diverged (own bucket, own signing).                     |
-| `.github/workflows/build-ghosttykit.yml` | c11-specific GhosttyKit build pipeline.                    |
-| `.github/workflows/update-homebrew.yml`  | c11-only homebrew tap updater.                              |
-| `vendor/bonsplit`               | Submodule pointer; c11 may track a different ref.                   |
-| `.gitmodules`                   | Submodule URLs — c11 vendors differ.                                |
-| `Sources/c11App.swift`          | Renamed from `cmuxApp.swift`. Upstream changes need path translation — see playbook entry "cmux→c11 rename". |
-| `Sources/cmuxApp.swift`         | No longer exists on c11. Upstream changes here are handled via path translation, not direct cherry-pick. |
-| `CLI/c11.swift`                 | Renamed from `cmux.swift`. Same path-translation rule.              |
-| `CLI/cmux.swift`                | No longer exists on c11. Same as above.                             |
+| Path / glob                              | Why no c11 equivalent                                              |
+| ---------------------------------------- | ------------------------------------------------------------------ |
+| `homebrew-c11/**` and `homebrew-cmux/**` | c11 has its own homebrew tap; upstream's tap is irrelevant.        |
+| `.lattice/**`                            | Lattice (Stage-11 task system) is c11-only.                        |
+| `skills/c11/**`                          | c11-only Claude Code skill.                                        |
+| `.github/ISSUE_TEMPLATE/**`              | c11 issue templates.                                               |
+| `.github/workflows/release.yml`          | c11 has its own release stream and version scheme.                 |
+| `.github/workflows/nightly.yml`          | c11 has its own nightly bucket and signing.                        |
+| `.github/workflows/build-ghosttykit.yml` | c11-specific GhosttyKit build pipeline.                            |
+| `.github/workflows/update-homebrew.yml`  | c11-only homebrew tap updater.                                     |
+| `LICENSE`, `NOTICE`                      | Static files, c11 carries its own copies; not subject to upstream churn. |
 
-> Note: the four rename rows above are tagged `skip` because direct cherry-pick will fail or recreate stale paths. The actual upstream change still gets imported — via path translation. See `playbook.md` → "cmux→c11 rename".
+**Note:** identity files (`README.md`, `CHANGELOG.md`, `CLAUDE.md`, etc.) used to be on this list. They've moved to `adapt` — when an upstream README change is meaningful (e.g. documenting a new feature c11 also imports), the agent should adapt the doc change to c11's voice and shipping equivalent. When the change is purely cmux branding, the adapt step is "skip the change, don't bring it over."
 
-## careful
+## adapt
 
-Touched in c11's 251 commits. Cherry-picks will likely conflict; resolve by hand, with care.
+c11 has its own version. Upstream changes here usually need rewrite. The agent reads upstream intent, finds the c11 equivalent, writes the c11-shaped change. Often the playbook has a relevant entry.
 
-| Path / glob                              | Why it's hot in c11                                              |
-| ---------------------------------------- | ---------------------------------------------------------------- |
-| `GhosttyTabs.xcodeproj/project.pbxproj`  | 48 c11 commits. Xcode project files conflict on every PR. Stage-11 Sentry, target IDs, file refs all differ. |
-| `Resources/Localizable.xcstrings`        | 37 c11 commits, ~100k lines. String catalogs merge poorly; usually safe to take both sides and let Xcode regenerate. |
-| `Resources/InfoPlist.xcstrings`          | Same family.                                                     |
-| `Sources/AppDelegate.swift`              | 31 c11 commits — heavy customization.                            |
-| `Sources/Workspace.swift`                | 25 c11 commits — c11 workspace persistence and surface logic.    |
-| `Sources/ContentView.swift`              | 25 c11 commits.                                                  |
-| `Sources/TerminalController.swift`       | 18 c11 commits.                                                  |
-| `Sources/TabManager.swift`               | 15 c11 commits.                                                  |
-| `Sources/GhosttyTerminalView.swift`      | 14 c11 commits.                                                  |
-| `Sources/AgentSkillsView.swift`          | 10 c11 commits — c11 skills layer.                               |
-| `Sources/SessionPersistence.swift`       | c11 claude-session-resume work (PR #89).                         |
-| `Sources/SurfaceMetadataStore.swift`     | c11 surface metadata.                                            |
-| `Sources/SkillInstaller.swift`           | c11 skills installer.                                            |
-| `Sources/Theme/ThemeManager.swift`       | c11 custom theming. Most upstream theme PRs need adaptation.     |
-| `Sources/Panels/**`                      | c11-built panel system (Markdown, Browser, Mermaid, PaneInteraction). Upstream has none of this. |
-| `Sources/Update/UpdateViewModel.swift`   | c11 update flow routes to c11 release endpoint, not cmux.        |
-| `Sources/WorkspaceLayoutExecutor.swift`  | c11 workspace layout work.                                       |
-| `Sources/WorkspaceSnapshotCapture.swift` | c11 snapshot work.                                               |
-| `Sources/WorkspaceApplyPlan.swift`       | c11 apply-plan work.                                             |
-| `Sources/cmuxApp.swift` (legacy)         | Pre-rename file — see skip section above.                         |
-| `CLI/cmux.swift` (legacy)                | Pre-rename file — see skip section above.                         |
-| `.github/workflows/ci.yml`               | Shared CI but heavily customized by c11.                         |
-| `.github/workflows/ci-macos-compat.yml`  | c11 customizations.                                              |
-| `.github/workflows/test-e2e.yml`         | c11 customizations.                                              |
-| `c11Tests/**`                            | c11 test target (renamed from cmuxTests).                        |
-| `docs/socket-api-reference.md`           | c11 maintains its own copy with c11-specific notes.              |
+| Path / glob                              | What's different on c11                                            |
+| ---------------------------------------- | ------------------------------------------------------------------ |
+| `Sources/cmuxApp.swift` → `Sources/c11App.swift`  | Renamed entry point. See playbook: "cmux → c11 entry-point rename". |
+| `CLI/cmux.swift` → `CLI/c11.swift`        | Renamed. Same playbook entry.                                       |
+| `cmuxTests/**` → `c11Tests/**`            | Renamed test target.                                                |
+| `GhosttyTabs.xcodeproj/project.pbxproj`   | 48 c11 commits — Stage-11 Sentry, c11 target rename, extra source files. See playbook: "Xcode project file changes". |
+| `Resources/Localizable.xcstrings`         | 37 c11 commits, ~100k lines. Auto-merge poorly. See playbook: "String catalog changes". |
+| `Resources/InfoPlist.xcstrings`           | Same family.                                                        |
+| `Sources/AppDelegate.swift`               | 31 c11 commits — heavy customization (Sentry, lifecycle hooks).     |
+| `Sources/Workspace.swift`                 | 25 c11 commits — c11 workspace persistence and surface logic.       |
+| `Sources/ContentView.swift`               | 25 c11 commits.                                                     |
+| `Sources/TerminalController.swift`        | 18 c11 commits.                                                     |
+| `Sources/TabManager.swift`                | 15 c11 commits.                                                     |
+| `Sources/GhosttyTerminalView.swift`       | 14 c11 commits.                                                     |
+| `Sources/AgentSkillsView.swift`           | c11 skills layer.                                                   |
+| `Sources/SessionPersistence.swift`        | c11 claude-session-resume work (PR #89).                            |
+| `Sources/SurfaceMetadataStore.swift`      | c11 surface metadata.                                               |
+| `Sources/SkillInstaller.swift`            | c11 skills installer.                                               |
+| `Sources/Theme/ThemeManager.swift`        | c11 custom theming.                                                 |
+| `Sources/Panels/**`                       | c11-built panel system (Markdown, Browser, Mermaid, PaneInteraction). Upstream has none of this. |
+| `Sources/Update/UpdateViewModel.swift`    | c11 update flow routes to c11 release endpoint.                     |
+| `Sources/WorkspaceLayoutExecutor.swift`   | c11 workspace layout work.                                          |
+| `Sources/WorkspaceSnapshotCapture.swift`  | c11 snapshot work.                                                  |
+| `Sources/WorkspaceApplyPlan.swift`        | c11 apply-plan work.                                                |
+| `.github/workflows/ci.yml`                | Shared CI but customized.                                           |
+| `.github/workflows/ci-macos-compat.yml`   | c11 customizations.                                                 |
+| `.github/workflows/test-e2e.yml`          | c11 customizations.                                                 |
+| `docs/socket-api-reference.md`            | c11 maintains its own copy with c11-specific notes.                 |
+| `vendor/bonsplit`, `.gitmodules`          | Submodule pointer / URL divergence. See playbook: "Submodule pointer changes". |
+| `README.md`, `README.*.md`                | c11 voice; adapt only when the upstream change is content-meaningful, not branding. |
+| `CHANGELOG.md`                            | c11 release notes; adapt only when the change documents a feature c11 is also landing. |
+| `CLAUDE.md`, `AGENTS.md`                  | c11 agent instructions; rarely need an upstream change.             |
+| `CONTRIBUTING.md`                         | c11 contributor flow.                                               |
+| `TODO.md`, `C11_TODO.md`                  | c11 working notes; upstream `TODO.md` changes are rarely meaningful. |
 
 ---
 
 ## How to extend this file
 
-When a triage run hits a SKIP-divergence or NEEDS-HUMAN that isn't represented here:
+When a triage run hits an adaptation pattern that isn't represented here:
 
-1. Add a row above explaining what about c11 makes upstream changes here troublesome.
+1. Add a row under `adapt` (or `skip` if there's truly no c11 equivalent).
 2. Keep the reason to one line. Detail belongs in `playbook.md`.
 3. Use globs over exact paths when the divergence is broad.
 
-When a previously-skip area is no longer divergent (we caught back up, or the c11 customization moved), remove the row.
+When a previously-listed area is no longer divergent (we caught back up, or the c11 customization moved), remove the row.
 
 Re-run `scripts/analyze-hotspots.sh --top 80` quarterly to refresh.

--- a/upstream-triage/playbook.md
+++ b/upstream-triage/playbook.md
@@ -1,91 +1,110 @@
 # Playbook
 
-Resolve recipes for recurring conflict shapes. Add an entry whenever a non-obvious resolution might come up again. Skip entries that are obvious or one-shot.
+Adaptation patterns the agent uses when bringing upstream cmux PRs into c11. Add an entry whenever a non-obvious pattern comes up that's likely to recur. Skip entries that are obvious or one-shot.
+
+These are not conflict-resolution recipes. They're knowledge the agent carries about *how upstream changes typically land in c11*. The agent reads these every run.
 
 **Entry format:**
 
 ```markdown
 ## <short title>
 
-**When you see:** <conflict pattern>
+**When you see:** <upstream change shape that triggers this pattern>
 
-**Apply:** <the resolution recipe, in steps>
+**Adapt by:** <how to land the change on c11 — written as agent guidance, not a script>
 
-**Why:** <the underlying reason — what about c11 makes this conflict shape recur>
+**Why:** <what about c11 makes this pattern recur — the underlying divergence>
 
 **Last seen:** <PR# / date>
 ```
 
 ---
 
-## cmux → c11 rename
+## cmux → c11 entry-point rename
 
-**When you see:** an upstream PR touches `Sources/cmuxApp.swift` or `CLI/cmux.swift`. Direct cherry-pick will fail (file doesn't exist on c11) or recreate stale paths.
+**When you see:** an upstream PR touches `Sources/cmuxApp.swift` or `CLI/cmux.swift`. These files don't exist on c11 — they were renamed to `Sources/c11App.swift` and `CLI/c11.swift` during the fork's identity change.
 
-**Apply:**
+**Adapt by:**
 
-1. Run the probe normally. Note the failure mode (`error: <path>: does not exist in index` is the typical signal).
-2. Fetch the diff: `git show <merge-commit> -- Sources/cmuxApp.swift CLI/cmux.swift`
-3. Translate paths: re-apply the diff to `Sources/c11App.swift` / `CLI/c11.swift` instead. The simplest approach is `git show <sha> -- <old-path> | sed 's|<old-path>|<new-path>|g' | git apply -3`.
-4. If the translated apply succeeds, stage and commit using the original PR's author and message: `git commit --author="$ORIG_AUTHOR" -m "[upstream #<N>] <orig-title>"`.
-5. If the translated apply has hunk failures, the upstream change touches code that's been rewritten on c11 — fall back to NEEDS-HUMAN, do not guess.
+1. Read the upstream diff against the cmux file. Understand what it changes — a new SwiftUI scene, a new command, a config refactor, etc.
+2. Apply the same change to the c11 equivalent (`Sources/c11App.swift` / `CLI/c11.swift`). The class/struct names already differ (`c11App` vs `cmuxApp`); preserve c11's naming throughout.
+3. If the upstream change references other identifiers that have been renamed (e.g., a method name that changed), translate those references too.
+4. Cherry-pick will fail here — don't try to coerce it. Rewrite is the right path.
 
-**Why:** c11 renamed the entry-point files when the project name changed. The code identity is the same; the path is not. This will keep recurring forever — the rename is permanent.
+**Why:** c11 renamed the entry-point files when the project name changed. The code identity is the same; the path and a few identifiers are not. Permanent divergence, not catch-up-able.
 
-**Last seen:** (none yet — pattern observed during initial divergence map seeding 2026-05-01)
-
----
-
-## Xcode project file conflicts
-
-**When you see:** any cherry-pick conflict in `GhosttyTabs.xcodeproj/project.pbxproj`.
-
-**Apply:**
-
-1. **Do not** try to hand-merge `pbxproj` content. The format is positional and one-character mistakes break the project.
-2. If the upstream change is purely *adding* file references (most common): take ours (`git checkout --ours GhosttyTabs.xcodeproj/project.pbxproj`), then add the new source files manually via Xcode (or the appropriate script), then `git add` and continue.
-3. If the upstream change is structural (target settings, build phases): NEEDS-HUMAN. The c11 Stage-11 Sentry config and target IDs are baked in here.
-4. Stage the resolution: `git add GhosttyTabs.xcodeproj/project.pbxproj` then `git cherry-pick --continue`.
-
-**Why:** c11 has 48 commits worth of changes here — Stage-11 Sentry config, c11 target rename, additional file references. Most upstream pbxproj changes are file-list additions, which can be replayed by adding the files Xcode-side.
-
-**Last seen:** (pattern from divergence map; not yet exercised)
+**Last seen:** —
 
 ---
 
-## String catalog merges (`.xcstrings`)
+## Xcode project file (`pbxproj`) changes
 
-**When you see:** conflict in `Resources/Localizable.xcstrings` or `Resources/InfoPlist.xcstrings`.
+**When you see:** an upstream PR adds, removes, or moves entries in `GhosttyTabs.xcodeproj/project.pbxproj`.
 
-**Apply:**
+**Adapt by:**
 
-1. These files are JSON; conflicts usually appear as overlapping key additions.
-2. Take ours, then re-apply the upstream change: `git checkout --ours <file>`, then `git show <sha> -- <file> | git apply --3way -`.
-3. If still conflicting, open the file and manually merge the new keys at the JSON level — the conflicts are almost always *additive*.
-4. Run a build locally to confirm the JSON is still valid; if you can't build, at minimum run `python3 -c 'import json; json.load(open("<file>"))'` to validate.
+- **If upstream is just adding new source files:** identify the new files. In c11, the simplest reliable path is to add them via Xcode (or its scripting equivalent) so the file references and build phase memberships are wired correctly. Don't hand-edit `pbxproj` JSON-style — its format is positional and brittle.
+- **If upstream is changing target settings, signing, build configurations:** stop. c11 has Stage-11 Sentry, c11 target rename, and signing identity baked into its pbxproj. These are intentional divergence. Surface to the operator before touching.
+- **If upstream is moving file groups around:** judge whether c11's organization should follow. Often it shouldn't — c11 has its own sub-organization (Panels/, Theme/, etc.). Do the file additions, skip the reorganization.
 
-**Why:** Xcode auto-generates these and merges them poorly. The actual content (translated strings) almost never has semantic conflicts; it's the JSON structure that fights.
+**Why:** 48 of c11's unique commits touch this file. Most are c11-specific (Sentry, target renames, additional source files for c11-only features). Upstream pbxproj churn is mostly file-list additions, which can be replayed by adding the files Xcode-side without merging the pbxproj diff.
 
-**Last seen:** (pattern from divergence map; not yet exercised)
+**Last seen:** —
 
 ---
 
-## Modify/delete conflict — file doesn't exist on c11
+## String catalog (`.xcstrings`) changes
 
-**When you see:** probe reports `STATUS=conflict` with `git status` showing `DU <path>` (deleted-by-us, updated-by-them) on a file that c11/main does not contain. Often the only conflicting "file" in an otherwise small PR.
+**When you see:** an upstream PR adds or modifies entries in `Resources/Localizable.xcstrings` or `Resources/InfoPlist.xcstrings`.
+
+**Adapt by:**
+
+1. These files are JSON; the change is almost always *additive* (new keys for new strings).
+2. If the strings are for upstream-only features (Feed sidebar, OpenCode plugin, etc.) and c11 isn't importing those features → skip the string additions.
+3. If the strings are for shared features (theme picker, settings) → take ours, then merge in the new keys at the JSON level. Validate with `python3 -c 'import json; json.load(open("<file>"))'`.
+4. Don't try to merge with `git checkout --ours` followed by `git apply` — the JSON structure conflicts more than the actual key contents do, and the apply will spuriously fail.
+
+**Why:** Xcode auto-generates these and they merge poorly. The semantic content (the localized strings themselves) is rarely in real conflict — only the surrounding JSON structure is.
+
+**Last seen:** —
+
+---
+
+## Modify/delete — file doesn't exist on c11
+
+**When you see:** the upstream PR modifies a file that c11/main does not contain. The probe reports `STATUS=conflict` with `git status` showing `DU <path>` (deleted-by-us, updated-by-them).
 
 **Diagnose:**
 
-1. `git ls-tree main:<path>` — if it returns nothing, c11/main genuinely doesn't have the file.
+1. `git ls-tree main:<path>` — confirms c11/main doesn't have it.
 2. `git log --all --format='%h %ai %s' -- <path> | head` — find the upstream commit that *introduced* the file. That commit's PR is the dependency.
-3. Walk back: `gh search prs --repo manaflow-ai/cmux 'in:title <feature-name>'` to confirm the dependency PR.
+3. Read the introducing PR's title — that names the upstream feature this PR builds on.
 
-**Apply:**
+**Adapt by:**
 
-Mark the PR **NEEDS-HUMAN** with a clear note: "Depends on upstream PR #<dep>, which introduced `<path>`. To import, either import #<dep> first, or skip both."
+In almost every case, this is a **NEEDS-HUMAN** call. The upstream PR depends on a feature c11 hasn't imported. Importing this PR alone leaves a dangling reference; importing the whole feature chain is a meaningful scope expansion.
 
-**Do not** auto-import the dependency — that's a judgment call for the operator. A single-file PR that turns into a five-PR import chain is a meaningful scope change.
+The agent should:
+1. Surface the dependency clearly: "PR #<N> modifies `<file>`, introduced upstream in PR #<dep> (<feature>). c11 doesn't have this feature. To import, import #<dep> first or skip both."
+2. **Not** silently bring the file over. That makes c11 carry orphan code with no caller, and obscures the dependency from the operator.
+3. If the operator chooses to import the feature chain, that becomes a separate triage session with its own scope.
 
-**Why:** c11 forks the upstream tree at a moment in time and follows selectively. Any upstream PR that modifies a file introduced *after* the merge-base will fail this way. The pattern is going to be very common during catch-up — most upstream PRs after April 2026 modify code that didn't exist at our merge-base.
+**Why:** c11 selectively follows upstream; it never sees most upstream PRs at the time they're merged. Any upstream PR that builds on a post-merge-base feature will fail this way. Going to be common during catch-up.
 
-**Last seen:** PR #3405 (2026-05-01) — modifies `Resources/opencode-plugin.js`, which was introduced upstream in PR #3057 (2026-04-26). c11 doesn't have the file or the Feed sidebar feature.
+**Last seen:** PR #3405 (2026-05-01) — modified `Resources/opencode-plugin.js`, introduced in PR #3057 (2026-04-26).
+
+---
+
+## Submodule pointer changes
+
+**When you see:** an upstream PR bumps `vendor/bonsplit`, `ghostty`, or another submodule, often via `.gitmodules` changes.
+
+**Adapt by:**
+
+1. Check whether c11 tracks the same submodule remote. If c11 has its own fork of the submodule (e.g., `homebrew-c11` instead of `homebrew-cmux`), the URL change doesn't apply.
+2. If the remote is shared, the bump is usually safe — but verify via `git submodule update --remote --merge` after applying.
+3. Don't import upstream's `.gitmodules` wholesale; c11 has divergence in submodule URLs that must be preserved.
+
+**Why:** c11 maintains its own homebrew tap (`homebrew-c11`) and may track different submodule revisions for vendored deps. `.gitmodules` is on the divergence map's skip list for this reason.
+
+**Last seen:** —

--- a/upstream-triage/playbook.md
+++ b/upstream-triage/playbook.md
@@ -1,0 +1,69 @@
+# Playbook
+
+Resolve recipes for recurring conflict shapes. Add an entry whenever a non-obvious resolution might come up again. Skip entries that are obvious or one-shot.
+
+**Entry format:**
+
+```markdown
+## <short title>
+
+**When you see:** <conflict pattern>
+
+**Apply:** <the resolution recipe, in steps>
+
+**Why:** <the underlying reason — what about c11 makes this conflict shape recur>
+
+**Last seen:** <PR# / date>
+```
+
+---
+
+## cmux → c11 rename
+
+**When you see:** an upstream PR touches `Sources/cmuxApp.swift` or `CLI/cmux.swift`. Direct cherry-pick will fail (file doesn't exist on c11) or recreate stale paths.
+
+**Apply:**
+
+1. Run the probe normally. Note the failure mode (`error: <path>: does not exist in index` is the typical signal).
+2. Fetch the diff: `git show <merge-commit> -- Sources/cmuxApp.swift CLI/cmux.swift`
+3. Translate paths: re-apply the diff to `Sources/c11App.swift` / `CLI/c11.swift` instead. The simplest approach is `git show <sha> -- <old-path> | sed 's|<old-path>|<new-path>|g' | git apply -3`.
+4. If the translated apply succeeds, stage and commit using the original PR's author and message: `git commit --author="$ORIG_AUTHOR" -m "[upstream #<N>] <orig-title>"`.
+5. If the translated apply has hunk failures, the upstream change touches code that's been rewritten on c11 — fall back to NEEDS-HUMAN, do not guess.
+
+**Why:** c11 renamed the entry-point files when the project name changed. The code identity is the same; the path is not. This will keep recurring forever — the rename is permanent.
+
+**Last seen:** (none yet — pattern observed during initial divergence map seeding 2026-05-01)
+
+---
+
+## Xcode project file conflicts
+
+**When you see:** any cherry-pick conflict in `GhosttyTabs.xcodeproj/project.pbxproj`.
+
+**Apply:**
+
+1. **Do not** try to hand-merge `pbxproj` content. The format is positional and one-character mistakes break the project.
+2. If the upstream change is purely *adding* file references (most common): take ours (`git checkout --ours GhosttyTabs.xcodeproj/project.pbxproj`), then add the new source files manually via Xcode (or the appropriate script), then `git add` and continue.
+3. If the upstream change is structural (target settings, build phases): NEEDS-HUMAN. The c11 Stage-11 Sentry config and target IDs are baked in here.
+4. Stage the resolution: `git add GhosttyTabs.xcodeproj/project.pbxproj` then `git cherry-pick --continue`.
+
+**Why:** c11 has 48 commits worth of changes here — Stage-11 Sentry config, c11 target rename, additional file references. Most upstream pbxproj changes are file-list additions, which can be replayed by adding the files Xcode-side.
+
+**Last seen:** (pattern from divergence map; not yet exercised)
+
+---
+
+## String catalog merges (`.xcstrings`)
+
+**When you see:** conflict in `Resources/Localizable.xcstrings` or `Resources/InfoPlist.xcstrings`.
+
+**Apply:**
+
+1. These files are JSON; conflicts usually appear as overlapping key additions.
+2. Take ours, then re-apply the upstream change: `git checkout --ours <file>`, then `git show <sha> -- <file> | git apply --3way -`.
+3. If still conflicting, open the file and manually merge the new keys at the JSON level — the conflicts are almost always *additive*.
+4. Run a build locally to confirm the JSON is still valid; if you can't build, at minimum run `python3 -c 'import json; json.load(open("<file>"))'` to validate.
+
+**Why:** Xcode auto-generates these and merges them poorly. The actual content (translated strings) almost never has semantic conflicts; it's the JSON structure that fights.
+
+**Last seen:** (pattern from divergence map; not yet exercised)

--- a/upstream-triage/playbook.md
+++ b/upstream-triage/playbook.md
@@ -67,3 +67,25 @@ Resolve recipes for recurring conflict shapes. Add an entry whenever a non-obvio
 **Why:** Xcode auto-generates these and merges them poorly. The actual content (translated strings) almost never has semantic conflicts; it's the JSON structure that fights.
 
 **Last seen:** (pattern from divergence map; not yet exercised)
+
+---
+
+## Modify/delete conflict — file doesn't exist on c11
+
+**When you see:** probe reports `STATUS=conflict` with `git status` showing `DU <path>` (deleted-by-us, updated-by-them) on a file that c11/main does not contain. Often the only conflicting "file" in an otherwise small PR.
+
+**Diagnose:**
+
+1. `git ls-tree main:<path>` — if it returns nothing, c11/main genuinely doesn't have the file.
+2. `git log --all --format='%h %ai %s' -- <path> | head` — find the upstream commit that *introduced* the file. That commit's PR is the dependency.
+3. Walk back: `gh search prs --repo manaflow-ai/cmux 'in:title <feature-name>'` to confirm the dependency PR.
+
+**Apply:**
+
+Mark the PR **NEEDS-HUMAN** with a clear note: "Depends on upstream PR #<dep>, which introduced `<path>`. To import, either import #<dep> first, or skip both."
+
+**Do not** auto-import the dependency — that's a judgment call for the operator. A single-file PR that turns into a five-PR import chain is a meaningful scope change.
+
+**Why:** c11 forks the upstream tree at a moment in time and follows selectively. Any upstream PR that modifies a file introduced *after* the merge-base will fail this way. The pattern is going to be very common during catch-up — most upstream PRs after April 2026 modify code that didn't exist at our merge-base.
+
+**Last seen:** PR #3405 (2026-05-01) — modifies `Resources/opencode-plugin.js`, which was introduced upstream in PR #3057 (2026-04-26). c11 doesn't have the file or the Feed sidebar feature.

--- a/upstream-triage/scripts/analyze-hotspots.sh
+++ b/upstream-triage/scripts/analyze-hotspots.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# analyze-hotspots.sh — find files heavily modified in c11's unique commits.
+# These are the "hot zones" where upstream cherry-picks are most likely to conflict.
+#
+# Usage:
+#   analyze-hotspots.sh [--top N]
+#
+# Output (stdout, sorted by churn descending):
+#   <commits-touching>  <lines-changed>  <path>
+
+set -euo pipefail
+
+TOP="${TOP:-50}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --top) TOP="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,10p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Find merge-base of HEAD with upstream/main.
+if ! git rev-parse --verify upstream/main >/dev/null 2>&1; then
+  echo "error: upstream/main not found. Run: git fetch upstream main" >&2
+  exit 1
+fi
+
+BASE="$(git merge-base HEAD upstream/main)"
+
+# For each c11-unique commit, list files changed with +/- counts.
+# Aggregate: count of commits touching each file, and total lines changed.
+git log --no-merges --numstat --format='format:__commit__' "${BASE}..HEAD" \
+  | awk '
+      /^__commit__/ { next }
+      NF == 3 {
+        adds = ($1 == "-") ? 0 : $1
+        dels = ($2 == "-") ? 0 : $2
+        commits[$3]++
+        lines[$3] += adds + dels
+      }
+      END {
+        for (f in commits) {
+          printf "%d\t%d\t%s\n", commits[f], lines[f], f
+        }
+      }
+    ' \
+  | sort -k1,1nr -k2,2nr \
+  | head -n "$TOP"

--- a/upstream-triage/scripts/list-merged.sh
+++ b/upstream-triage/scripts/list-merged.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# list-merged.sh — list upstream cmux PRs merged after a given point.
+#
+# Usage:
+#   list-merged.sh --since <YYYY-MM-DD>
+#   list-merged.sh --since <commit-sha>      (uses commit's date)
+#   list-merged.sh --since <pr-number>       (uses that PR's mergedAt)
+#
+# Output: TSV — one row per PR.
+#   <pr-number>\t<merged-at>\t<author>\t<title>
+#
+# Sorted oldest-first so processing order matches upstream timeline.
+
+set -euo pipefail
+
+SINCE=""
+LIMIT="${LIMIT:-500}"
+UPSTREAM_REPO="manaflow-ai/cmux"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --since) SINCE="$2"; shift 2 ;;
+    --limit) LIMIT="$2"; shift 2 ;;
+    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$SINCE" ]]; then
+  echo "error: --since is required" >&2
+  exit 2
+fi
+
+# Resolve SINCE to an ISO timestamp.
+SINCE_ISO=""
+if [[ "$SINCE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+  # Bare date — assume start of UTC day.
+  SINCE_ISO="${SINCE}T00:00:00Z"
+elif [[ "$SINCE" =~ ^[0-9]+$ ]]; then
+  # PR number.
+  SINCE_ISO="$(gh pr view "$SINCE" --repo "$UPSTREAM_REPO" --json mergedAt -q '.mergedAt' 2>/dev/null || echo '')"
+  if [[ -z "$SINCE_ISO" || "$SINCE_ISO" == "null" ]]; then
+    echo "error: PR $SINCE has no mergedAt timestamp" >&2
+    exit 1
+  fi
+elif [[ "$SINCE" =~ ^[0-9a-f]{7,40}$ ]]; then
+  # Commit SHA — use commit date.
+  SINCE_ISO="$(git show -s --format='%cI' "$SINCE" 2>/dev/null || echo '')"
+  if [[ -z "$SINCE_ISO" ]]; then
+    echo "error: commit $SINCE not found" >&2
+    exit 1
+  fi
+else
+  # Pass through as-is and hope GH parses it.
+  SINCE_ISO="$SINCE"
+fi
+
+# Use gh pr list with the search qualifier — exposes mergedAt directly.
+# Strip time portion if present; GH search accepts date-level granularity well.
+SINCE_DATE="${SINCE_ISO%%T*}"
+
+gh pr list \
+  --repo "$UPSTREAM_REPO" \
+  --state merged \
+  --search "merged:>${SINCE_DATE}" \
+  --limit "$LIMIT" \
+  --json number,title,author,mergedAt \
+  | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+for pr in sorted(data, key=lambda p: p.get("mergedAt") or ""):
+    n = pr["number"]
+    merged = pr.get("mergedAt") or ""
+    author = (pr.get("author") or {}).get("login", "")
+    title = (pr.get("title") or "").replace("\t", " ").replace("\n", " ")
+    print(f"{n}\t{merged}\t{author}\t{title}")
+'

--- a/upstream-triage/scripts/list-merged.sh
+++ b/upstream-triage/scripts/list-merged.sh
@@ -1,77 +1,114 @@
 #!/usr/bin/env bash
-# list-merged.sh — list upstream cmux PRs merged after a given point.
+# list-merged.sh — list upstream cmux PRs since a given point.
 #
 # Usage:
-#   list-merged.sh --since <YYYY-MM-DD>
+#   list-merged.sh --since <YYYY-MM-DD> [--state merged|open|all]
 #   list-merged.sh --since <commit-sha>      (uses commit's date)
 #   list-merged.sh --since <pr-number>       (uses that PR's mergedAt)
 #
+# State filter:
+#   merged (default) — only merged PRs, ordered by mergedAt
+#   open             — only open PRs, ordered by createdAt
+#   all              — merged + open, deduped, ordered chronologically
+#
 # Output: TSV — one row per PR.
-#   <pr-number>\t<merged-at>\t<author>\t<title>
+#   <pr-number>\t<when>\t<state>\t<author>\t<title>
+#   where <when> = mergedAt for merged PRs, createdAt for open PRs.
 #
 # Sorted oldest-first so processing order matches upstream timeline.
 
 set -euo pipefail
 
 SINCE=""
+STATE="merged"
 LIMIT="${LIMIT:-500}"
 UPSTREAM_REPO="manaflow-ai/cmux"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --since) SINCE="$2"; shift 2 ;;
+    --state) STATE="$2"; shift 2 ;;
     --limit) LIMIT="$2"; shift 2 ;;
-    -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
-if [[ -z "$SINCE" ]]; then
-  echo "error: --since is required" >&2
-  exit 2
-fi
+[[ -z "$SINCE" ]] && { echo "error: --since is required" >&2; exit 2; }
+
+case "$STATE" in
+  merged|open|all) ;;
+  *) echo "error: --state must be merged, open, or all" >&2; exit 2 ;;
+esac
 
 # Resolve SINCE to an ISO timestamp.
-SINCE_ISO=""
 if [[ "$SINCE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-  # Bare date — assume start of UTC day.
   SINCE_ISO="${SINCE}T00:00:00Z"
 elif [[ "$SINCE" =~ ^[0-9]+$ ]]; then
-  # PR number.
   SINCE_ISO="$(gh pr view "$SINCE" --repo "$UPSTREAM_REPO" --json mergedAt -q '.mergedAt' 2>/dev/null || echo '')"
-  if [[ -z "$SINCE_ISO" || "$SINCE_ISO" == "null" ]]; then
-    echo "error: PR $SINCE has no mergedAt timestamp" >&2
-    exit 1
-  fi
+  [[ -z "$SINCE_ISO" || "$SINCE_ISO" == "null" ]] && { echo "error: PR $SINCE has no mergedAt" >&2; exit 1; }
 elif [[ "$SINCE" =~ ^[0-9a-f]{7,40}$ ]]; then
-  # Commit SHA — use commit date.
   SINCE_ISO="$(git show -s --format='%cI' "$SINCE" 2>/dev/null || echo '')"
-  if [[ -z "$SINCE_ISO" ]]; then
-    echo "error: commit $SINCE not found" >&2
-    exit 1
-  fi
+  [[ -z "$SINCE_ISO" ]] && { echo "error: commit $SINCE not found" >&2; exit 1; }
 else
-  # Pass through as-is and hope GH parses it.
   SINCE_ISO="$SINCE"
 fi
 
-# Use gh pr list with the search qualifier — exposes mergedAt directly.
-# Strip time portion if present; GH search accepts date-level granularity well.
 SINCE_DATE="${SINCE_ISO%%T*}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 
-gh pr list \
-  --repo "$UPSTREAM_REPO" \
-  --state merged \
-  --search "merged:>${SINCE_DATE}" \
-  --limit "$LIMIT" \
-  --json number,title,author,mergedAt \
-  | python3 -c '
-import json, sys
-data = json.load(sys.stdin)
-for pr in sorted(data, key=lambda p: p.get("mergedAt") or ""):
+fetch_state() {
+  local state="$1" search="$2" out="$3"
+  gh pr list \
+    --repo "$UPSTREAM_REPO" \
+    --state "$state" \
+    --search "$search" \
+    --limit "$LIMIT" \
+    --json number,title,author,state,mergedAt,createdAt \
+    > "$out" 2>/dev/null
+}
+
+case "$STATE" in
+  merged) fetch_state merged "merged:>${SINCE_DATE}" "$TMP/merged.json" ;;
+  open)   fetch_state open   "created:>${SINCE_DATE}" "$TMP/open.json" ;;
+  all)
+    fetch_state merged "merged:>${SINCE_DATE}"  "$TMP/merged.json"
+    fetch_state open   "created:>${SINCE_DATE}" "$TMP/open.json"
+    ;;
+esac
+
+python3 - "$TMP" "$STATE" <<'PY'
+import json, os, sys
+tmp_dir, state = sys.argv[1], sys.argv[2]
+combined = []
+for name in ("merged.json", "open.json"):
+    path = os.path.join(tmp_dir, name)
+    if not os.path.exists(path):
+        continue
+    with open(path) as f:
+        try:
+            combined.extend(json.load(f))
+        except json.JSONDecodeError:
+            pass
+
+# Dedupe by PR number.
+seen, uniq = set(), []
+for pr in combined:
+    n = pr.get("number")
+    if n in seen:
+        continue
+    seen.add(n)
+    uniq.append(pr)
+
+def sort_key(p):
+    return p.get("mergedAt") or p.get("createdAt") or ""
+
+for pr in sorted(uniq, key=sort_key):
     n = pr["number"]
-    merged = pr.get("mergedAt") or ""
+    pr_state = (pr.get("state") or "").lower()
+    when = pr.get("mergedAt") or pr.get("createdAt") or ""
     author = (pr.get("author") or {}).get("login", "")
     title = (pr.get("title") or "").replace("\t", " ").replace("\n", " ")
-    print(f"{n}\t{merged}\t{author}\t{title}")
-'
+    print(f"{n}\t{when}\t{pr_state}\t{author}\t{title}")
+PY

--- a/upstream-triage/scripts/probe.sh
+++ b/upstream-triage/scripts/probe.sh
@@ -169,7 +169,7 @@ if [[ "$PARENT_COUNT" -gt 1 ]]; then
   CHERRY_ARGS+=("-m" "1")
 fi
 
-if git cherry-pick "${CHERRY_ARGS[@]}" "$MERGE_SHA" >/tmp/probe-${PR}.log 2>&1; then
+if git cherry-pick ${CHERRY_ARGS[@]+"${CHERRY_ARGS[@]}"} "$MERGE_SHA" >/tmp/probe-${PR}.log 2>&1; then
   # Cherry-pick succeeded with no conflicts.
   # But: if the result is empty (no diff vs main), treat as empty.
   if git diff --quiet HEAD~1 HEAD 2>/dev/null; then

--- a/upstream-triage/scripts/probe.sh
+++ b/upstream-triage/scripts/probe.sh
@@ -89,7 +89,7 @@ fi
 # --- gather PR metadata ---
 
 # Fetch PR info. Tolerate transient gh failures with a clear error.
-PR_JSON="$(gh pr view "$PR" --repo "$UPSTREAM_REPO" --json mergeCommit,state,mergedAt,title 2>/dev/null || echo '')"
+PR_JSON="$(gh pr view "$PR" --repo "$UPSTREAM_REPO" --json mergeCommit,state,mergedAt,title,headRefOid,baseRefName 2>/dev/null || echo '')"
 if [[ -z "$PR_JSON" ]]; then
   echo "STATUS=error"
   echo "BRANCH="
@@ -98,50 +98,88 @@ if [[ -z "$PR_JSON" ]]; then
 fi
 
 MERGE_SHA="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;d=json.load(sys.stdin);mc=d.get("mergeCommit");print(mc["oid"] if mc else "")')"
+HEAD_OID="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("headRefOid","") or "")')"
+BASE_REF="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("baseRefName","") or "main")')"
 PR_STATE="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("state",""))')"
 PR_TITLE="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("title",""))')"
 
-if [[ -z "$MERGE_SHA" ]]; then
-  echo "STATUS=error"
-  echo "BRANCH="
-  echo "DETAIL=PR ${PR} has no merge commit (state=${PR_STATE})"
-  exit 1
+# Pick the SHA we'll apply.
+# - If the PR was merged, use the merge commit.
+# - Otherwise (open or closed-not-merged), use the head commit and we'll
+#   cherry-pick the range from its merge-base with the PR's base branch.
+APPLY_MODE=""
+APPLY_SHA=""
+if [[ -n "$MERGE_SHA" ]]; then
+  APPLY_MODE="merge-commit"
+  APPLY_SHA="$MERGE_SHA"
+else
+  if [[ -z "$HEAD_OID" ]]; then
+    echo "STATUS=error"
+    echo "BRANCH="
+    echo "DETAIL=PR ${PR} has neither mergeCommit nor headRefOid (state=${PR_STATE})"
+    exit 1
+  fi
+  APPLY_MODE="range"
+  APPLY_SHA="$HEAD_OID"
 fi
 
-# --- ensure we have the merge commit locally ---
+# --- ensure we have the necessary commits locally ---
 
-if ! git cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null; then
-  # Fetch upstream main first; if still missing, fetch the specific commit.
+# Fetch the PR's head ref via the GitHub PR refspec — works for both open and merged PRs.
+if ! git cat-file -e "${APPLY_SHA}^{commit}" 2>/dev/null; then
+  git fetch upstream "pull/${PR}/head:refs/upstream-prs/pr-${PR}" >/dev/null 2>&1 || true
   git fetch upstream main >/dev/null 2>&1 || true
-  if ! git cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null; then
-    git fetch upstream "$MERGE_SHA" >/dev/null 2>&1 || {
+  if ! git cat-file -e "${APPLY_SHA}^{commit}" 2>/dev/null; then
+    git fetch upstream "$APPLY_SHA" >/dev/null 2>&1 || {
       echo "STATUS=error"
       echo "BRANCH="
-      echo "DETAIL=could not fetch merge commit ${MERGE_SHA} from upstream"
+      echo "DETAIL=could not fetch ${APPLY_MODE} sha ${APPLY_SHA} from upstream"
       exit 1
     }
   fi
 fi
 
-# --- already-applied check ---
-
-# If the merge commit is already reachable from main, nothing to do.
-if git merge-base --is-ancestor "$MERGE_SHA" HEAD 2>/dev/null; then
-  echo "STATUS=empty"
-  echo "BRANCH="
-  echo "DETAIL=merge commit ${MERGE_SHA} already in main"
-  exit 0
+# For range mode, we also need the merge-base with the PR's base branch.
+RANGE_BASE=""
+if [[ "$APPLY_MODE" == "range" ]]; then
+  if ! git rev-parse --verify "upstream/${BASE_REF}" >/dev/null 2>&1; then
+    git fetch upstream "$BASE_REF" >/dev/null 2>&1 || true
+  fi
+  RANGE_BASE="$(git merge-base "$APPLY_SHA" "upstream/${BASE_REF}" 2>/dev/null || echo '')"
+  if [[ -z "$RANGE_BASE" ]]; then
+    echo "STATUS=error"
+    echo "BRANCH="
+    echo "DETAIL=could not find merge-base of ${APPLY_SHA} with upstream/${BASE_REF}"
+    exit 1
+  fi
 fi
 
-# Check via cherry-pick equivalence too — a squash-merge or rebase might have
-# brought the patch in under a different SHA.
-# git cherry returns lines starting with '-' for upstream commits already in HEAD.
-CHERRY="$(git cherry HEAD "$MERGE_SHA" "${MERGE_SHA}^" 2>/dev/null | head -1 || echo '')"
-if [[ "$CHERRY" == -* ]]; then
-  echo "STATUS=empty"
-  echo "BRANCH="
-  echo "DETAIL=patch ${MERGE_SHA} equivalent already in main (cherry detected)"
-  exit 0
+# --- already-applied check ---
+
+if [[ "$APPLY_MODE" == "merge-commit" ]]; then
+  if git merge-base --is-ancestor "$APPLY_SHA" HEAD 2>/dev/null; then
+    echo "STATUS=empty"
+    echo "BRANCH="
+    echo "DETAIL=merge commit ${APPLY_SHA} already in main"
+    exit 0
+  fi
+  CHERRY="$(git cherry HEAD "$APPLY_SHA" "${APPLY_SHA}^" 2>/dev/null | head -1 || echo '')"
+  if [[ "$CHERRY" == -* ]]; then
+    echo "STATUS=empty"
+    echo "BRANCH="
+    echo "DETAIL=patch ${APPLY_SHA} equivalent already in main (cherry detected)"
+    exit 0
+  fi
+else
+  # Range mode: if every commit in (RANGE_BASE..APPLY_SHA] is already in HEAD,
+  # treat as empty. Use git cherry to detect.
+  REMAINING="$(git cherry HEAD "$APPLY_SHA" "$RANGE_BASE" 2>/dev/null | grep -c '^+' || echo 0)"
+  if [[ "$REMAINING" == "0" ]]; then
+    echo "STATUS=empty"
+    echo "BRANCH="
+    echo "DETAIL=all commits in ${RANGE_BASE}..${APPLY_SHA} equivalent already in main"
+    exit 0
+  fi
 fi
 
 # Capture original ref so we can restore it on cleanup paths.
@@ -162,18 +200,27 @@ git checkout -b "$BRANCH" main >/dev/null 2>&1
 
 # --- attempt cherry-pick ---
 
-# Determine if the merge commit is a merge (multiple parents).
-PARENT_COUNT="$(git cat-file -p "$MERGE_SHA" | grep -c '^parent ')"
+# Build the cherry-pick spec.
+# - merge-commit mode: a single commit, with -m 1 if it has multiple parents.
+# - range mode: every commit in (RANGE_BASE..APPLY_SHA].
 CHERRY_ARGS=()
-if [[ "$PARENT_COUNT" -gt 1 ]]; then
-  CHERRY_ARGS+=("-m" "1")
+CHERRY_TARGET=""
+if [[ "$APPLY_MODE" == "merge-commit" ]]; then
+  PARENT_COUNT="$(git cat-file -p "$APPLY_SHA" | grep -c '^parent ')"
+  if [[ "$PARENT_COUNT" -gt 1 ]]; then
+    CHERRY_ARGS+=("-m" "1")
+  fi
+  CHERRY_TARGET="$APPLY_SHA"
+else
+  CHERRY_TARGET="${RANGE_BASE}..${APPLY_SHA}"
 fi
 
-if git cherry-pick ${CHERRY_ARGS[@]+"${CHERRY_ARGS[@]}"} "$MERGE_SHA" >/tmp/probe-${PR}.log 2>&1; then
-  # Cherry-pick succeeded with no conflicts.
-  # But: if the result is empty (no diff vs main), treat as empty.
-  if git diff --quiet HEAD~1 HEAD 2>/dev/null; then
-    git reset --hard HEAD~1 >/dev/null 2>&1
+if git cherry-pick ${CHERRY_ARGS[@]+"${CHERRY_ARGS[@]}"} "$CHERRY_TARGET" >/tmp/probe-${PR}.log 2>&1; then
+  # Cherry-pick succeeded.
+  # Empty-result check: count new commits and verify there's a real diff vs main.
+  NEW_COMMITS="$(git rev-list --count main..HEAD 2>/dev/null || echo 0)"
+  if [[ "$NEW_COMMITS" == "0" ]] || git diff --quiet "main..HEAD" 2>/dev/null; then
+    git reset --hard main >/dev/null 2>&1
     git checkout "$ORIGINAL_REF" >/dev/null 2>&1
     git branch -D "$BRANCH" >/dev/null 2>&1
     echo "STATUS=empty"
@@ -183,7 +230,11 @@ if git cherry-pick ${CHERRY_ARGS[@]+"${CHERRY_ARGS[@]}"} "$MERGE_SHA" >/tmp/prob
   fi
   echo "STATUS=clean"
   echo "BRANCH=$BRANCH"
-  echo "DETAIL=cherry-pick clean: ${PR_TITLE}"
+  if [[ "$APPLY_MODE" == "merge-commit" ]]; then
+    echo "DETAIL=cherry-pick clean: ${PR_TITLE}"
+  else
+    echo "DETAIL=cherry-pick clean (range, ${NEW_COMMITS} commits): ${PR_TITLE}"
+  fi
   exit 0
 fi
 

--- a/upstream-triage/scripts/probe.sh
+++ b/upstream-triage/scripts/probe.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# probe.sh — try cherry-picking an upstream cmux PR onto a probe branch.
+# Reports status (clean | conflict | empty | error) without pushing.
+#
+# Usage:
+#   probe.sh <pr-number>
+#
+# On `clean`: leaves probe branch checked out, ready for push.
+# On `conflict`: leaves probe branch in conflicted state for inspection.
+# On `empty`: aborts the cherry-pick and switches back to main.
+# On `error`: prints diagnosis and switches back to main.
+#
+# The script never pushes. It never modifies main. It never force-deletes anything.
+#
+# Output format (last line, stable for parsing):
+#   STATUS=<clean|conflict|empty|error>
+#   BRANCH=<probe-branch-or-empty>
+#   FILES=<conflict-file-1,conflict-file-2,...>  (only when STATUS=conflict)
+#   DETAIL=<one-line-detail>
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <pr-number>" >&2
+  exit 2
+fi
+
+PR="$1"
+if ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+  echo "error: PR number must be numeric, got: $PR" >&2
+  exit 2
+fi
+
+UPSTREAM_REPO="manaflow-ai/cmux"
+BRANCH="upstream-probe/pr-${PR}"
+
+# --- preconditions ---
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=gh CLI not found"
+  exit 1
+fi
+
+# Must be inside the c11 repo.
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=not in a git repo"
+  exit 1
+fi
+
+# Working tree must be clean.
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=working tree dirty; refusing to probe"
+  exit 1
+fi
+
+# Must be on main (or detached from it).
+CURRENT_BRANCH="$(git symbolic-ref --quiet --short HEAD || echo '')"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=must run from main branch (current: ${CURRENT_BRANCH:-detached})"
+  exit 1
+fi
+
+# Must have an upstream remote pointing at manaflow-ai/cmux.
+UPSTREAM_URL="$(git remote get-url upstream 2>/dev/null || echo '')"
+if [[ ! "$UPSTREAM_URL" =~ manaflow-ai/cmux ]]; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=upstream remote missing or not pointing at manaflow-ai/cmux"
+  exit 1
+fi
+
+# --- gather PR metadata ---
+
+# Fetch PR info. Tolerate transient gh failures with a clear error.
+PR_JSON="$(gh pr view "$PR" --repo "$UPSTREAM_REPO" --json mergeCommit,state,mergedAt,title 2>/dev/null || echo '')"
+if [[ -z "$PR_JSON" ]]; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=could not fetch PR ${PR} from ${UPSTREAM_REPO}"
+  exit 1
+fi
+
+MERGE_SHA="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;d=json.load(sys.stdin);mc=d.get("mergeCommit");print(mc["oid"] if mc else "")')"
+PR_STATE="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("state",""))')"
+PR_TITLE="$(printf '%s' "$PR_JSON" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("title",""))')"
+
+if [[ -z "$MERGE_SHA" ]]; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=PR ${PR} has no merge commit (state=${PR_STATE})"
+  exit 1
+fi
+
+# --- ensure we have the merge commit locally ---
+
+if ! git cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null; then
+  # Fetch upstream main first; if still missing, fetch the specific commit.
+  git fetch upstream main >/dev/null 2>&1 || true
+  if ! git cat-file -e "${MERGE_SHA}^{commit}" 2>/dev/null; then
+    git fetch upstream "$MERGE_SHA" >/dev/null 2>&1 || {
+      echo "STATUS=error"
+      echo "BRANCH="
+      echo "DETAIL=could not fetch merge commit ${MERGE_SHA} from upstream"
+      exit 1
+    }
+  fi
+fi
+
+# --- already-applied check ---
+
+# If the merge commit is already reachable from main, nothing to do.
+if git merge-base --is-ancestor "$MERGE_SHA" HEAD 2>/dev/null; then
+  echo "STATUS=empty"
+  echo "BRANCH="
+  echo "DETAIL=merge commit ${MERGE_SHA} already in main"
+  exit 0
+fi
+
+# Check via cherry-pick equivalence too — a squash-merge or rebase might have
+# brought the patch in under a different SHA.
+# git cherry returns lines starting with '-' for upstream commits already in HEAD.
+CHERRY="$(git cherry HEAD "$MERGE_SHA" "${MERGE_SHA}^" 2>/dev/null | head -1 || echo '')"
+if [[ "$CHERRY" == -* ]]; then
+  echo "STATUS=empty"
+  echo "BRANCH="
+  echo "DETAIL=patch ${MERGE_SHA} equivalent already in main (cherry detected)"
+  exit 0
+fi
+
+# --- create probe branch ---
+
+# If a stale probe branch exists, refuse — caller must clean up.
+if git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+  echo "STATUS=error"
+  echo "BRANCH=$BRANCH"
+  echo "DETAIL=probe branch ${BRANCH} already exists; delete or push before retrying"
+  exit 1
+fi
+
+git checkout -b "$BRANCH" main >/dev/null 2>&1
+
+# --- attempt cherry-pick ---
+
+# Determine if the merge commit is a merge (multiple parents).
+PARENT_COUNT="$(git cat-file -p "$MERGE_SHA" | grep -c '^parent ')"
+CHERRY_ARGS=()
+if [[ "$PARENT_COUNT" -gt 1 ]]; then
+  CHERRY_ARGS+=("-m" "1")
+fi
+
+if git cherry-pick "${CHERRY_ARGS[@]}" "$MERGE_SHA" >/tmp/probe-${PR}.log 2>&1; then
+  # Cherry-pick succeeded with no conflicts.
+  # But: if the result is empty (no diff vs main), treat as empty.
+  if git diff --quiet HEAD~1 HEAD 2>/dev/null; then
+    git reset --hard HEAD~1 >/dev/null 2>&1
+    git checkout main >/dev/null 2>&1
+    git branch -D "$BRANCH" >/dev/null 2>&1
+    echo "STATUS=empty"
+    echo "BRANCH="
+    echo "DETAIL=cherry-pick produced no changes"
+    exit 0
+  fi
+  echo "STATUS=clean"
+  echo "BRANCH=$BRANCH"
+  echo "DETAIL=cherry-pick clean: ${PR_TITLE}"
+  exit 0
+fi
+
+# Cherry-pick failed. Determine why.
+CONFLICT_FILES="$(git diff --name-only --diff-filter=U 2>/dev/null | tr '\n' ',' | sed 's/,$//')"
+
+if [[ -n "$CONFLICT_FILES" ]]; then
+  echo "STATUS=conflict"
+  echo "BRANCH=$BRANCH"
+  echo "FILES=$CONFLICT_FILES"
+  echo "DETAIL=conflicts in $(echo "$CONFLICT_FILES" | tr ',' '\n' | wc -l | tr -d ' ') file(s)"
+  exit 0
+fi
+
+# No conflict markers but cherry-pick failed — usually a missing-path case.
+# Abort the cherry-pick to leave the branch clean for inspection.
+git cherry-pick --abort >/dev/null 2>&1 || true
+ERROR_LINE="$(tail -3 /tmp/probe-${PR}.log | tr '\n' ' ' | sed 's/  */ /g' | head -c 240)"
+git checkout main >/dev/null 2>&1
+git branch -D "$BRANCH" >/dev/null 2>&1
+echo "STATUS=error"
+echo "BRANCH="
+echo "DETAIL=cherry-pick failed: ${ERROR_LINE}"
+exit 0

--- a/upstream-triage/scripts/probe.sh
+++ b/upstream-triage/scripts/probe.sh
@@ -59,12 +59,20 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-# Must be on main (or detached from it).
-CURRENT_BRANCH="$(git symbolic-ref --quiet --short HEAD || echo '')"
-if [[ "$CURRENT_BRANCH" != "main" ]]; then
+# HEAD must point at the tip of origin/main. Branch name is incidental
+# (worktrees may be detached or use a different branch name pointing at main).
+HEAD_SHA="$(git rev-parse HEAD)"
+ORIGIN_MAIN_SHA="$(git rev-parse origin/main 2>/dev/null || echo '')"
+if [[ -z "$ORIGIN_MAIN_SHA" ]]; then
   echo "STATUS=error"
   echo "BRANCH="
-  echo "DETAIL=must run from main branch (current: ${CURRENT_BRANCH:-detached})"
+  echo "DETAIL=origin/main not found; run: git fetch origin"
+  exit 1
+fi
+if [[ "$HEAD_SHA" != "$ORIGIN_MAIN_SHA" ]]; then
+  echo "STATUS=error"
+  echo "BRANCH="
+  echo "DETAIL=HEAD ($HEAD_SHA) is not at origin/main tip ($ORIGIN_MAIN_SHA)"
   exit 1
 fi
 

--- a/upstream-triage/scripts/probe.sh
+++ b/upstream-triage/scripts/probe.sh
@@ -59,20 +59,21 @@ if [[ -n "$(git status --porcelain)" ]]; then
   exit 1
 fi
 
-# HEAD must point at the tip of origin/main. Branch name is incidental
-# (worktrees may be detached or use a different branch name pointing at main).
+# HEAD must point at the tip of local `main`. Branch name is incidental —
+# worktrees may use a different branch name (e.g. `probe-main`) that tracks
+# main. The invariant is the commit, not the branch label.
 HEAD_SHA="$(git rev-parse HEAD)"
-ORIGIN_MAIN_SHA="$(git rev-parse origin/main 2>/dev/null || echo '')"
-if [[ -z "$ORIGIN_MAIN_SHA" ]]; then
+MAIN_SHA="$(git rev-parse main 2>/dev/null || echo '')"
+if [[ -z "$MAIN_SHA" ]]; then
   echo "STATUS=error"
   echo "BRANCH="
-  echo "DETAIL=origin/main not found; run: git fetch origin"
+  echo "DETAIL=local main branch not found"
   exit 1
 fi
-if [[ "$HEAD_SHA" != "$ORIGIN_MAIN_SHA" ]]; then
+if [[ "$HEAD_SHA" != "$MAIN_SHA" ]]; then
   echo "STATUS=error"
   echo "BRANCH="
-  echo "DETAIL=HEAD ($HEAD_SHA) is not at origin/main tip ($ORIGIN_MAIN_SHA)"
+  echo "DETAIL=HEAD ($HEAD_SHA) is not at local main tip ($MAIN_SHA); run on main or a worktree at main's tip"
   exit 1
 fi
 
@@ -143,6 +144,10 @@ if [[ "$CHERRY" == -* ]]; then
   exit 0
 fi
 
+# Capture original ref so we can restore it on cleanup paths.
+# Use the symbolic name if we're on a branch, else the SHA.
+ORIGINAL_REF="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || git rev-parse HEAD)"
+
 # --- create probe branch ---
 
 # If a stale probe branch exists, refuse — caller must clean up.
@@ -169,7 +174,7 @@ if git cherry-pick "${CHERRY_ARGS[@]}" "$MERGE_SHA" >/tmp/probe-${PR}.log 2>&1; 
   # But: if the result is empty (no diff vs main), treat as empty.
   if git diff --quiet HEAD~1 HEAD 2>/dev/null; then
     git reset --hard HEAD~1 >/dev/null 2>&1
-    git checkout main >/dev/null 2>&1
+    git checkout "$ORIGINAL_REF" >/dev/null 2>&1
     git branch -D "$BRANCH" >/dev/null 2>&1
     echo "STATUS=empty"
     echo "BRANCH="

--- a/upstream-triage/triage-log/2026-05-01.md
+++ b/upstream-triage/triage-log/2026-05-01.md
@@ -1,0 +1,52 @@
+# Triage log — 2026-05-01
+
+First end-to-end exercise of `/upstream-triage`. Single PR processed: #3405.
+
+---
+
+## #3405 — Bridge OpenCode plan approvals into Feed
+
+- **Decision:** NEEDS-HUMAN
+- **Author:** lawrencecchen
+- **Files:** 1 file (`Resources/opencode-plugin.js`), +350 -14
+- **Probe:** conflict — `DU Resources/opencode-plugin.js` (modify/delete)
+- **c11 PR:** —
+- **Reason:** depends on upstream PR #3057, which introduced `Resources/opencode-plugin.js` on 2026-04-26. c11/main does not contain that file or the Feed sidebar feature it's part of.
+- **Notes:**
+
+  This is the canonical "depends on un-imported upstream history" case (now in playbook). Walking the file's upstream history:
+
+  - PR #3057 (2026-04-26): introduces `Resources/opencode-plugin.js` along with the Feed sidebar
+  - PR #3057 → #3405: at least four intermediate commits modify the file (10e12279, 12554958, 6beb3dbe, e1336506, e4d56105)
+
+  To import #3405, c11 would need the Feed sidebar feature first, which means a multi-PR import chain. That's an operator decision — flagged for review.
+
+  No probe branch left behind; cherry-pick aborted, worktree reset.
+
+---
+
+## Run summary
+
+| Outcome      | Count | PRs   |
+| ------------ | ----- | ----- |
+| LANDED       | 0     | —     |
+| SKIPPED      | 0     | —     |
+| NEEDS-HUMAN  | 1     | #3405 |
+
+## Lessons captured
+
+- **playbook.md**: added entry "Modify/delete conflict — file doesn't exist on c11". Expected to recur often during catch-up.
+- **probe.sh refinements during this run** (committed as separate commits on main):
+  - HEAD-tip check now compares against local `main` (not `origin/main`) — works in worktrees.
+  - Restores `ORIGINAL_REF` on cleanup paths instead of hardcoded `main` — works when main is checked out elsewhere.
+  - Empty-array expansion fixed for `set -u` mode.
+
+## Open question for follow-up
+
+The catch-up sweep is almost certain to hit the modify/delete pattern frequently — most upstream PRs since 2026-04-26 build on the Feed sidebar (PR #3057) or other post-merge-base features. Worth deciding upfront whether to:
+
+1. Import the major feature PRs first (#3057 and a few siblings) as discrete "feature catch-ups", then forward-triage from a closer base.
+2. Continue per-PR with NEEDS-HUMAN flagging the dependency chains.
+3. Rebase c11's 251 commits onto a more recent upstream snapshot (high effort, high payoff).
+
+This isn't a v1 question — defer until we've processed enough forward PRs to feel the pattern.


### PR DESCRIPTION
Re-applies the OpenAI CUA runner work merged in #100 (2026-04-30, commit `8189d57a`), which was lost when origin/main was rolled back. Branch rebased onto current main; same 4 commits, new SHAs.

## What this is
- `tools/computer-use/mac-adapter/` — Swift CLI for window discovery, screenshots, and input events.
- `tools/computer-use/openai-runner/` — Python runner using OpenAI Responses API's `computer` tool. Pre-baked scenarios.
- Modifications to AppDelegate.swift, SentryHelper.swift, several CI workflows.
- `docs/openai-codex-computer-use-plan.md` — design rationale.

## Why now
The upstream-triage skill (`/upstream-triage`) added today references this harness for validating user-visible PR imports. Without the harness on main, every UI import lands without behavioral verification.

## Re-merge context
- #100 merged this work on 2026-04-30, then origin/main was rolled back to before the merge (cause unclear; likely accidental force-push).
- Today's main commits (the upstream-triage scaffolding) sit on top of the *pre-merge* base, which is why the rebase was needed.
- This PR's diff is identical in intent to #100. The 4 commits replay the same content with new SHAs after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)