### PR TITLE
c11-24: c11 health CLI (passive crash visibility, four rails)

### DIFF
--- a/CLI/HealthCommand.swift
+++ b/CLI/HealthCommand.swift
@@ -41,8 +41,7 @@ func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
     do {
         opts = try parseHealthCLIArgs(commandArgs)
     } catch let error as HealthCLIError {
-        FileHandle.standardError.write(Data("c11 health: \(error.description)\n".utf8))
-        throw CLIError(message: error.description)
+        throw CLIError(message: "c11 health: \(error.description)")
     }
 
     let wantsJSON = jsonOutput || opts.json

--- a/CLI/HealthCommand.swift
+++ b/CLI/HealthCommand.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+// Thin CLI entry for `c11 health`. Wired from CLI/c11.swift.
+// All parsing, scanning, and rendering lives in Sources/HealthCommandCore.swift
+// so the main `c11` target (and c11Tests) can exercise the same code paths.
+
+func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
+    let wantsJSON = jsonOutput || commandArgs.contains("--json")
+    let now = Date()
+    let window = HealthCollectionWindow(
+        mode: .defaultLast24h,
+        since: now.addingTimeInterval(-24 * 3600),
+        until: now
+    )
+    let rails: Set<HealthEvent.Rail> = Set(HealthEvent.Rail.allCases)
+    let events = collectHealthEvents(window: window, rails: rails)
+
+    if wantsJSON {
+        let data = try renderHealthJSON(
+            events: events,
+            window: window,
+            rails: rails,
+            warnings: []
+        )
+        if let text = String(data: data, encoding: .utf8) {
+            print(text)
+        }
+        return
+    }
+
+    print(renderHealthTable(events), terminator: "")
+}

--- a/CLI/HealthCommand.swift
+++ b/CLI/HealthCommand.swift
@@ -1,8 +1,40 @@
 import Foundation
+import Darwin
 
 // Thin CLI entry for `c11 health`. Wired from CLI/c11.swift.
 // All parsing, scanning, and rendering lives in Sources/HealthCommandCore.swift
 // so the main `c11` target (and c11Tests) can exercise the same code paths.
+
+/// The c11-cli target ships without an Info.plist, so `Bundle.main` is empty
+/// when this binary runs standalone. To get the running c11 app's version
+/// (needed by `metricKitBaselineWarning`), walk up from the executable's
+/// path until an `.app` bundle is found. Mirrors `CLISocketSentryTelemetry`.
+private func runningC11AppVersion() -> String? {
+    if let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
+       !v.isEmpty {
+        return v
+    }
+
+    var size: UInt32 = 0
+    _ = _NSGetExecutablePath(nil, &size)
+    guard size > 0 else { return nil }
+    var buffer = [CChar](repeating: 0, count: Int(size))
+    guard _NSGetExecutablePath(&buffer, &size) == 0 else { return nil }
+
+    var current = URL(fileURLWithPath: String(cString: buffer))
+        .deletingLastPathComponent()
+        .standardizedFileURL
+    while current.path != "/" {
+        if current.pathExtension == "app",
+           let bundle = Bundle(url: current),
+           let v = bundle.infoDictionary?["CFBundleShortVersionString"] as? String,
+           !v.isEmpty {
+            return v
+        }
+        current = current.deletingLastPathComponent().standardizedFileURL
+    }
+    return nil
+}
 
 func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
     let opts: HealthCLIOptions
@@ -34,7 +66,7 @@ func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
 
     let metrickitCount = events.filter { $0.rail == .metrickit }.count
     let sentryCount = events.filter { $0.rail == .sentry }.count
-    let bundleVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    let bundleVersion = runningC11AppVersion()
 
     var warnings: [String] = []
     if rails.contains(.metrickit),

--- a/CLI/HealthCommand.swift
+++ b/CLI/HealthCommand.swift
@@ -5,22 +5,57 @@ import Foundation
 // so the main `c11` target (and c11Tests) can exercise the same code paths.
 
 func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
-    let wantsJSON = jsonOutput || commandArgs.contains("--json")
+    let opts: HealthCLIOptions
+    do {
+        opts = try parseHealthCLIArgs(commandArgs)
+    } catch let error as HealthCLIError {
+        FileHandle.standardError.write(Data("c11 health: \(error.description)\n".utf8))
+        throw CLIError(message: error.description)
+    }
+
+    let wantsJSON = jsonOutput || opts.json
     let now = Date()
-    let window = HealthCollectionWindow(
-        mode: .defaultLast24h,
-        since: now.addingTimeInterval(-24 * 3600),
-        until: now
-    )
-    let rails: Set<HealthEvent.Rail> = Set(HealthEvent.Rail.allCases)
-    let events = collectHealthEvents(window: window, rails: rails)
+    let since: Date
+    switch opts.mode {
+    case .sinceDuration:
+        since = now.addingTimeInterval(-opts.windowDuration)
+    case .sinceBoot:
+        since = bootTime()
+    case .defaultLast24h:
+        since = now.addingTimeInterval(-24 * 3600)
+    }
+    let window = HealthCollectionWindow(mode: opts.mode, since: since, until: now)
+
+    let allRails: Set<HealthEvent.Rail> = Set(HealthEvent.Rail.allCases)
+    let rails: Set<HealthEvent.Rail> = opts.railFilter.map { [$0] } ?? allRails
+
+    let home = NSHomeDirectory()
+    let events = collectHealthEvents(window: window, rails: rails, home: home)
+
+    let metrickitCount = events.filter { $0.rail == .metrickit }.count
+    let sentryCount = events.filter { $0.rail == .sentry }.count
+    let bundleVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+
+    var warnings: [String] = []
+    if rails.contains(.metrickit),
+       let w = metricKitBaselineWarning(
+        home: home,
+        bundleVersion: bundleVersion,
+        metricKitCount: metrickitCount
+       ) {
+        warnings.append(w)
+    }
+    if rails.contains(.sentry),
+       let w = telemetryAmbiguityFooter(home: home, sentryCount: sentryCount) {
+        warnings.append(w)
+    }
 
     if wantsJSON {
         let data = try renderHealthJSON(
             events: events,
             window: window,
             rails: rails,
-            warnings: []
+            warnings: warnings
         )
         if let text = String(data: data, encoding: .utf8) {
             print(text)
@@ -28,5 +63,5 @@ func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
         return
     }
 
-    print(renderHealthTable(events), terminator: "")
+    print(renderHealthTable(events, warnings: warnings), terminator: "")
 }

--- a/CLI/HealthCommand.swift
+++ b/CLI/HealthCommand.swift
@@ -96,5 +96,6 @@ func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
         return
     }
 
-    print(renderHealthTable(events, warnings: warnings), terminator: "")
+    let railList = HealthEvent.Rail.allCases.filter { rails.contains($0) }
+    print(renderHealthTable(events, warnings: warnings, rails: railList, window: window), terminator: "")
 }

--- a/CLI/HealthCommand.swift
+++ b/CLI/HealthCommand.swift
@@ -87,7 +87,8 @@ func runHealth(commandArgs: [String], jsonOutput: Bool) throws {
             events: events,
             window: window,
             rails: rails,
-            warnings: warnings
+            warnings: warnings,
+            home: home
         )
         if let text = String(data: data, encoding: .utf8) {
             print(text)

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -7743,7 +7743,7 @@ struct CMUXCLI {
             Flags:
               --since <duration>     Time window: 30m, 2h, 24h, 3d. Default 24h.
               --since-boot           Limit to events since the last system boot.
-              --rail <name>          Filter to one rail: ips, sentry, metrickit, sentinel.
+              --rail <name>          Filter to one rail: ips, sentry, metrickit, sentinel. Specify at most once. Default: all rails.
               --json                 Emit structured JSON instead of the default table.
 
             Example:

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -1557,6 +1557,11 @@ struct CMUXCLI {
             return
         }
 
+        if command == "health" {
+            try runHealth(commandArgs: commandArgs, jsonOutput: jsonOutput)
+            return
+        }
+
         if command == "welcome" {
             printWelcome()
             return
@@ -7726,6 +7731,26 @@ struct CMUXCLI {
             Example:
               c11 remote-daemon-status
               c11 remote-daemon-status --os linux --arch arm64
+            """
+        case "health":
+            return """
+            Usage: c11 health [--since <duration> | --since-boot] [--rail <name>] [--json]
+
+            Read-only crash-visibility sweep across four local rails: Apple IPS reports,
+            queued Sentry envelopes, MetricKit diagnostic payloads, and the c11 launch
+            sentinel (catches Force Quit and SIGKILL where Sentry cannot).
+
+            Flags:
+              --since <duration>     Time window: 30m, 2h, 24h, 3d. Default 24h.
+              --since-boot           Limit to events since the last system boot.
+              --rail <name>          Filter to one rail: ips, sentry, metrickit, sentinel.
+              --json                 Emit structured JSON instead of the default table.
+
+            Example:
+              c11 health
+              c11 health --since 30m
+              c11 health --since-boot --rail sentinel
+              c11 health --json
             """
         case "new-split":
             return """
@@ -14366,6 +14391,7 @@ struct CMUXCLI {
           drag-surface-to-split --surface <id|ref> <left|right|up|down>
           refresh-surfaces
           surface-health [--workspace <id|ref>]
+          health [--since <duration> | --since-boot] [--rail <name>] [--json]
           trigger-flash [--workspace <id|ref>] [--surface <id|ref>]
           list-panels [--workspace <id|ref>]
           focus-panel --panel <id|ref> [--workspace <id|ref>]

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */; };
 		DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */; };
 		DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */; };
+		DH013BF0A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */; };
 		C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */; };
 		D800ABF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */; };
 		D800BBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */; };
@@ -338,6 +339,7 @@
 		DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthIPSParserTests.swift; sourceTree = "<group>"; };
 		DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentryParserTests.swift; sourceTree = "<group>"; };
 		DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMetricKitParserTests.swift; sourceTree = "<group>"; };
+		DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentinelParserTests.swift; sourceTree = "<group>"; };
 		C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRestartCommandsTests.swift; sourceTree = "<group>"; };
 		D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotCapture.swift; sourceTree = "<group>"; };
 		D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotStore.swift; sourceTree = "<group>"; };
@@ -910,6 +912,7 @@
 					DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */,
 					DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */,
 					DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */,
+					DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */,
 					C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */,
 					D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */,
 					D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */,
@@ -1288,6 +1291,7 @@
 					DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */,
 					DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */,
 					DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */,
+					DH013BF0A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift in Sources */,
 					C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */,
 					D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */,
 					D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		D8007BF0A1B2C3D4E5F60718 /* AgentRestartRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8007BF1A1B2C3D4E5F60718 /* AgentRestartRegistry.swift */; };
 		D8008BF0A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */; };
 		D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */; };
+		DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */; };
 		C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */; };
 		D800ABF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */; };
 		D800BBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */; };
@@ -332,6 +333,7 @@
 		D8007BF1A1B2C3D4E5F60718 /* AgentRestartRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRestartRegistry.swift; sourceTree = "<group>"; };
 		D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotConverterTests.swift; sourceTree = "<group>"; };
 		D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRestartRegistryTests.swift; sourceTree = "<group>"; };
+		DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthIPSParserTests.swift; sourceTree = "<group>"; };
 		C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRestartCommandsTests.swift; sourceTree = "<group>"; };
 		D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotCapture.swift; sourceTree = "<group>"; };
 		D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotStore.swift; sourceTree = "<group>"; };
@@ -901,6 +903,7 @@
 					D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */,
 					D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */,
 					D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */,
+					DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */,
 					C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */,
 					D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */,
 					D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */,
@@ -1276,6 +1279,7 @@
 					D8004BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift in Sources */,
 					D8008BF0A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift in Sources */,
 					D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */,
+					DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */,
 					C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */,
 					D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */,
 					D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */; };
 		DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */; };
 		DH013BF0A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */; };
+		DH014BF0A1B2C3D4E5F60718 /* HealthFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */; };
 		C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */; };
 		D800ABF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */; };
 		D800BBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */; };
@@ -340,6 +341,7 @@
 		DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentryParserTests.swift; sourceTree = "<group>"; };
 		DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMetricKitParserTests.swift; sourceTree = "<group>"; };
 		DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentinelParserTests.swift; sourceTree = "<group>"; };
+		DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthFlagsTests.swift; sourceTree = "<group>"; };
 		C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRestartCommandsTests.swift; sourceTree = "<group>"; };
 		D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotCapture.swift; sourceTree = "<group>"; };
 		D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotStore.swift; sourceTree = "<group>"; };
@@ -913,6 +915,7 @@
 					DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */,
 					DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */,
 					DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */,
+					DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */,
 					C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */,
 					D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */,
 					D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */,
@@ -1292,6 +1295,7 @@
 					DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */,
 					DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */,
 					DH013BF0A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift in Sources */,
+					DH014BF0A1B2C3D4E5F60718 /* HealthFlagsTests.swift in Sources */,
 					C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */,
 					D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */,
 					D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		D8008BF0A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */; };
 		D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */; };
 		DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */; };
+		DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */; };
 		C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */; };
 		D800ABF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */; };
 		D800BBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */; };
@@ -334,6 +335,7 @@
 		D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotConverterTests.swift; sourceTree = "<group>"; };
 		D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRestartRegistryTests.swift; sourceTree = "<group>"; };
 		DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthIPSParserTests.swift; sourceTree = "<group>"; };
+		DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentryParserTests.swift; sourceTree = "<group>"; };
 		C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRestartCommandsTests.swift; sourceTree = "<group>"; };
 		D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotCapture.swift; sourceTree = "<group>"; };
 		D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotStore.swift; sourceTree = "<group>"; };
@@ -904,6 +906,7 @@
 					D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */,
 					D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */,
 					DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */,
+					DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */,
 					C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */,
 					D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */,
 					D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */,
@@ -1280,6 +1283,7 @@
 					D8008BF0A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift in Sources */,
 					D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */,
 					DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */,
+					DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */,
 					C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */,
 					D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */,
 					D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -86,6 +86,9 @@
 		A5001501 /* UITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001511 /* UITestRecorder.swift */; };
 		A5001226 /* SocketControlSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001225 /* SocketControlSettings.swift */; };
 		A5001601 /* SentryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001600 /* SentryHelper.swift */; };
+		DH001BF0A1B2C3D4E5F60718 /* HealthCommandCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH001BF1A1B2C3D4E5F60718 /* HealthCommandCore.swift */; };
+		DH001BF0A1B2C3D4E5F60719 /* HealthCommandCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH001BF1A1B2C3D4E5F60718 /* HealthCommandCore.swift */; };
+		DH002BF0A1B2C3D4E5F60719 /* HealthCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH002BF1A1B2C3D4E5F60719 /* HealthCommand.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
 		A5001401 /* TerminalPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001411 /* TerminalPanel.swift */; };
@@ -399,6 +402,8 @@
 		A5001018 /* c11-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "c11-Bridging-Header.h"; sourceTree = "<group>"; };
 		A5001019 /* TerminalController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalController.swift; sourceTree = "<group>"; };
 		A5001600 /* SentryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHelper.swift; sourceTree = "<group>"; };
+		DH001BF1A1B2C3D4E5F60718 /* HealthCommandCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCommandCore.swift; sourceTree = "<group>"; };
+		DH002BF1A1B2C3D4E5F60719 /* HealthCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCommand.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
 			A5001510 /* CmuxWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CmuxWebView.swift; sourceTree = "<group>"; };
 			A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
@@ -720,6 +725,7 @@
 				A5008F22 /* TitleFormatting.swift */,
 				A5001225 /* SocketControlSettings.swift */,
 				A5001600 /* SentryHelper.swift */,
+				DH001BF1A1B2C3D4E5F60718 /* HealthCommandCore.swift */,
 				A5001620 /* AppleScriptSupport.swift */,
 				A5001090 /* AppDelegate.swift */,
 				A5001091 /* NotificationsPage.swift */,
@@ -773,6 +779,7 @@
 			isa = PBXGroup;
 			children = (
 				B9000001A1B2C3D4E5F60719 /* c11.swift */,
+				DH002BF1A1B2C3D4E5F60719 /* HealthCommand.swift */,
 			);
 			path = CLI;
 			sourceTree = "<group>";
@@ -1122,6 +1129,7 @@
 				A5008F21 /* TitleFormatting.swift in Sources */,
 				A5001226 /* SocketControlSettings.swift in Sources */,
 				A5001601 /* SentryHelper.swift in Sources */,
+				DH001BF0A1B2C3D4E5F60718 /* HealthCommandCore.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
 				A5001094 /* NotificationsPage.swift in Sources */,
@@ -1285,6 +1293,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				B9000002A1B2C3D4E5F60719 /* c11.swift in Sources */,
+				DH001BF0A1B2C3D4E5F60719 /* HealthCommandCore.swift in Sources */,
+				DH002BF0A1B2C3D4E5F60719 /* HealthCommand.swift in Sources */,
 				CC401003A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */,
 				D7200BF0A1B2C3D4E5F60719 /* MailboxLayout.swift in Sources */,
 				D7202BF0A1B2C3D4E5F60719 /* MailboxIO.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */; };
 		DH013BF0A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */; };
 		DH014BF0A1B2C3D4E5F60718 /* HealthFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */; };
+		DH015BF0A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH015BF1A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift */; };
 		C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */; };
 		D800ABF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */; };
 		D800BBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */; };
@@ -342,6 +343,7 @@
 		DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMetricKitParserTests.swift; sourceTree = "<group>"; };
 		DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentinelParserTests.swift; sourceTree = "<group>"; };
 		DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthFlagsTests.swift; sourceTree = "<group>"; };
+		DH015BF1A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIHealthRuntimeTests.swift; sourceTree = "<group>"; };
 		C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRestartCommandsTests.swift; sourceTree = "<group>"; };
 		D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotCapture.swift; sourceTree = "<group>"; };
 		D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotStore.swift; sourceTree = "<group>"; };
@@ -916,6 +918,7 @@
 					DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */,
 					DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */,
 					DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */,
+					DH015BF1A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift */,
 					C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */,
 					D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */,
 					D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */,
@@ -1296,6 +1299,7 @@
 					DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */,
 					DH013BF0A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift in Sources */,
 					DH014BF0A1B2C3D4E5F60718 /* HealthFlagsTests.swift in Sources */,
+					DH015BF0A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift in Sources */,
 					C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */,
 					D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */,
 					D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */; };
 		DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */; };
 		DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */; };
+		DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */; };
 		C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */; };
 		D800ABF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */; };
 		D800BBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */; };
@@ -336,6 +337,7 @@
 		D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRestartRegistryTests.swift; sourceTree = "<group>"; };
 		DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthIPSParserTests.swift; sourceTree = "<group>"; };
 		DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentryParserTests.swift; sourceTree = "<group>"; };
+		DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMetricKitParserTests.swift; sourceTree = "<group>"; };
 		C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRestartCommandsTests.swift; sourceTree = "<group>"; };
 		D800ABF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotCapture.swift; sourceTree = "<group>"; };
 		D800BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotStore.swift; sourceTree = "<group>"; };
@@ -907,6 +909,7 @@
 					D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */,
 					DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */,
 					DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */,
+					DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */,
 					C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */,
 					D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */,
 					D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */,
@@ -1284,6 +1287,7 @@
 					D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */,
 					DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */,
 					DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */,
+					DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */,
 					C112400A1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift in Sources */,
 					D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */,
 					D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */,

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -667,13 +667,23 @@ func parseUncleanExitFile(at url: URL, since: Date) -> HealthEvent? {
 private let healthEmptyResultLine =
     "c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel."
 
-func renderHealthTable(_ events: [HealthEvent], warnings: [String] = []) -> String {
+/// `timeZone` is exposed for golden-file tests; production callers leave it
+/// nil to use the operator's local time.
+func renderHealthTable(
+    _ events: [HealthEvent],
+    warnings: [String] = [],
+    timeZone: TimeZone? = nil
+) -> String {
     var lines: [String] = []
     if events.isEmpty {
         lines.append(healthEmptyResultLine)
     } else {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        if let timeZone {
+            f.timeZone = timeZone
+        }
         lines.append("TIME             | RAIL      | SEVERITY     | SUMMARY")
         for ev in events {
             let time = f.string(from: ev.timestamp)

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -353,6 +353,7 @@ enum HealthCLIError: Error, CustomStringConvertible {
     case invalidSinceValue(String)
     case unknownRail(String)
     case unknownFlag(String)
+    case duplicateFlag(String)
 
     var description: String {
         switch self {
@@ -366,6 +367,8 @@ enum HealthCLIError: Error, CustomStringConvertible {
             return "unknown --rail '\(r)' (expected one of ips, sentry, metrickit, sentinel)"
         case .unknownFlag(let f):
             return "unknown flag '\(f)'"
+        case .duplicateFlag(let f):
+            return "\(f) may only be specified once"
         }
     }
 }
@@ -394,8 +397,12 @@ func parseSinceFlag(_ value: String) -> TimeInterval? {
 
 /// Reads `kern.boottime` via `sysctlbyname`. Falls back to 24h ago on
 /// failure so callers do not have to handle nil for a value the kernel
-/// always exposes on macOS.
-func bootTime() -> Date {
+/// always exposes on macOS. On failure, writes a single diagnostic line
+/// via `onFallback` (defaults to stderr) so the operator is told that
+/// `--since-boot` silently became a 24h window.
+func bootTime(onFallback: (String) -> Void = { msg in
+    FileHandle.standardError.write(Data((msg + "\n").utf8))
+}) -> Date {
     var tv = timeval()
     var size = MemoryLayout<timeval>.size
     let result = sysctlbyname("kern.boottime", &tv, &size, nil, 0)
@@ -403,6 +410,7 @@ func bootTime() -> Date {
         let seconds = TimeInterval(tv.tv_sec) + TimeInterval(tv.tv_usec) / 1_000_000
         return Date(timeIntervalSince1970: seconds)
     }
+    onFallback("c11 health: kern.boottime unavailable (errno=\(errno)), falling back to 24h window")
     return Date(timeIntervalSinceNow: -24 * 3600)
 }
 
@@ -436,6 +444,7 @@ func parseHealthCLIArgs(_ args: [String]) throws -> HealthCLIOptions {
             guard let r = HealthEvent.Rail(rawValue: v) else {
                 throw HealthCLIError.unknownRail(v)
             }
+            guard rail == nil else { throw HealthCLIError.duplicateFlag("--rail") }
             rail = r
             i += 2
         case "-h", "--help":

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -93,6 +93,11 @@ struct IPSHeader {
     let incidentID: String?
     let bundleID: String?
     let bugType: String?
+    /// OS-reported crash time from the first-line JSON `timestamp` field
+    /// (e.g. `"2026-05-03 15:19:00.000 -0400"`). Used in preference to file
+    /// mtime so `--since` filters reflect when the crash actually happened
+    /// rather than when CrashReporter finished writing the file.
+    let timestamp: Date?
 }
 
 func parseIPSFirstLine(_ line: String) -> IPSHeader? {
@@ -102,8 +107,20 @@ func parseIPSFirstLine(_ line: String) -> IPSHeader? {
     return IPSHeader(
         incidentID: obj["incident_id"] as? String,
         bundleID: obj["bundleID"] as? String,
-        bugType: obj["bug_type"] as? String
+        bugType: obj["bug_type"] as? String,
+        timestamp: (obj["timestamp"] as? String).flatMap(parseIPSTimestamp)
     )
+}
+
+/// Parses an Apple CrashReporter timestamp string. Format example:
+/// `"2026-05-03 15:19:00.000 -0400"` (space-separated date/time, fractional
+/// seconds, RFC 822 timezone offset). Returns nil for missing or malformed
+/// values; callers must fall back to file mtime.
+func parseIPSTimestamp(_ raw: String) -> Date? {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS Z"
+    return f.date(from: raw)
 }
 
 func scanIPS(home: String, since: Date) -> [HealthEvent] {
@@ -153,22 +170,29 @@ func scanIPS(home: String, since: Date) -> [HealthEvent] {
 private func ipsEventIfRecent(at url: URL, since: Date) -> HealthEvent? {
     let fm = FileManager.default
     guard let attrs = try? fm.attributesOfItem(atPath: url.path),
-          let mtime = attrs[.modificationDate] as? Date,
-          mtime >= since
+          let mtime = attrs[.modificationDate] as? Date
     else { return nil }
 
     let summary: String
+    let timestamp: Date
     if let line = readFirstLine(of: url), let header = parseIPSFirstLine(line) {
         let bundle = header.bundleID ?? "?"
         let bug = header.bugType ?? "?"
         let inc = header.incidentID.map { String($0.prefix(8)) } ?? "?"
         summary = "\(bundle) bug_type=\(bug) (\(inc))"
+        // Prefer the OS-reported crash time. CrashReporter can lag the
+        // actual crash by seconds-to-minutes, so file mtime is a strictly
+        // worse proxy when the header carries a timestamp.
+        timestamp = header.timestamp ?? mtime
     } else {
         summary = url.lastPathComponent
+        timestamp = mtime
     }
 
+    guard timestamp >= since else { return nil }
+
     return HealthEvent(
-        timestamp: mtime,
+        timestamp: timestamp,
         rail: .ips,
         severity: .crash,
         summary: summary,
@@ -775,6 +799,7 @@ func renderHealthTable(
             f.timeZone = timeZone
         }
         lines.append("TIME             | RAIL      | SEVERITY     | SUMMARY")
+        lines.append("(TIME reflects the OS-reported event time when available, file mtime otherwise)")
         for ev in events {
             let time = f.string(from: ev.timestamp)
             let rail = ev.rail.rawValue.padding(toLength: 9, withPad: " ", startingAt: 0)

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -786,6 +786,10 @@ func renderHealthTable(
     return lines.joined(separator: "\n") + "\n"
 }
 
+/// Wire-format version for `c11 health --json`. Bump on any breaking
+/// shape change so downstream consumers can branch on it.
+public let healthJSONSchemaVersion = 1
+
 /// Replaces a leading `home` prefix with literal `~` so JSON output the
 /// operator pastes into tickets / chat / agent transcripts does not leak
 /// the macOS username.
@@ -824,6 +828,7 @@ func renderHealthJSON(
     }
 
     let payload: [String: Any] = [
+        "schema_version": healthJSONSchemaVersion,
         "window": [
             "since": iso.string(from: window.since),
             "until": iso.string(from: window.until),

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -677,6 +677,12 @@ func scanLaunchSentinel(home: String, since: Date) -> [HealthEvent] {
 /// Returns nil when the file's stamp predates `since`, or when the file
 /// cannot be read or parsed. Filename is the source of truth for the
 /// timestamp; the JSON body is best-effort metadata.
+///
+/// Filename ISO timestamp is the source of truth for the row's TIME column;
+/// the JSON body is informational metadata. When the body is corrupt or missing
+/// keys, render "unknown" rather than dropping the row, so the operator still
+/// sees evidence that an unclean exit happened. Do NOT skip these rows: the
+/// presence of the file is the signal.
 func parseUncleanExitFile(at url: URL, since: Date) -> HealthEvent? {
     let name = url.lastPathComponent
     let prefix = "unclean-exit-"
@@ -685,9 +691,9 @@ func parseUncleanExitFile(at url: URL, since: Date) -> HealthEvent? {
     let stamp = String(name.dropFirst(prefix.count).dropLast(suffix.count))
     guard let date = parseFilenameSafeISO(stamp), date >= since else { return nil }
 
-    var version = "?"
-    var build = "?"
-    var commit = "????????"
+    var version = "unknown"
+    var build = "unknown"
+    var commit = "unknown"
 
     if let data = try? Data(contentsOf: url),
        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -559,22 +559,40 @@ func metricKitBaselineWarning(
     return "MetricKit baseline still establishing after version bump (\(marker.version) to \(curr)); diagnostic payloads may not deliver for ~24h."
 }
 
-/// Fires when `<home>/Library/Caches/com.stage11.c11/io.sentry/` exists and
-/// is empty AND we have zero queued events overall. Operator can't tell
-/// from "0 events" alone whether telemetry is off or just freshly drained.
+/// Fires when zero queued events overall AND at least one `io.sentry/`
+/// directory exists across the `com.stage11.c11*` bundle family but every
+/// such directory is empty. Mirrors `scanSentryQueued`'s family iteration
+/// so the footer fires on machines that only ran a debug build (no
+/// production-bundle cache present), not just on production-only machines.
 func telemetryAmbiguityFooter(home: String, sentryCount: Int) -> String? {
     guard sentryCount == 0 else { return nil }
-    let probe = "\(home)/Library/Caches/com.stage11.c11/io.sentry"
+    let cacheURL = URL(fileURLWithPath: "\(home)/Library/Caches")
     let fm = FileManager.default
-    var isDir: ObjCBool = false
-    guard fm.fileExists(atPath: probe, isDirectory: &isDir), isDir.boolValue else { return nil }
 
-    let probeURL = URL(fileURLWithPath: probe)
-    if let enumerator = fm.enumerator(
-        at: probeURL,
-        includingPropertiesForKeys: [.isRegularFileKey],
+    guard let bundleDirs = try? fm.contentsOfDirectory(
+        at: cacheURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
         options: [.skipsHiddenFiles]
-    ) {
+    ) else { return nil }
+
+    var sawAnySentryDir = false
+    for bundleDir in bundleDirs {
+        guard bundleDir.lastPathComponent.hasPrefix("com.stage11.c11") else { continue }
+        let isDir = (try? bundleDir.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+        guard isDir else { continue }
+
+        let sentryRoot = bundleDir.appendingPathComponent("io.sentry", isDirectory: true)
+        var sentryIsDir: ObjCBool = false
+        guard fm.fileExists(atPath: sentryRoot.path, isDirectory: &sentryIsDir),
+              sentryIsDir.boolValue
+        else { continue }
+        sawAnySentryDir = true
+
+        guard let enumerator = fm.enumerator(
+            at: sentryRoot,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else { continue }
         for case let f as URL in enumerator {
             if (try? f.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true {
                 return nil
@@ -582,7 +600,8 @@ func telemetryAmbiguityFooter(home: String, sentryCount: Int) -> String? {
         }
     }
 
-    return "Production Sentry cache empty: telemetry may be off, or events shipped on last launch and cleared the cache."
+    guard sawAnySentryDir else { return nil }
+    return "Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache."
 }
 
 // MARK: - Launch sentinel rail

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+// Core for `c11 health`. Pure, testable: no UI, no socket, no Sentry SDK calls.
+// The CLI shim at CLI/HealthCommand.swift wires this into the `c11 health` dispatch.
+
+struct HealthEvent {
+    enum Rail: String, CaseIterable {
+        case ips
+        case sentry
+        case metrickit
+        case sentinel
+    }
+
+    enum Severity: String {
+        case crash
+        case queued
+        case metrickit
+        case hang
+        case resource
+        case mixed
+        case diagnostic
+        case unclean_exit
+    }
+
+    let timestamp: Date
+    let rail: Rail
+    let severity: Severity
+    let summary: String
+    let path: String
+}
+
+struct HealthCollectionWindow {
+    enum Mode: String {
+        case sinceDuration = "since"
+        case sinceBoot = "since-boot"
+        case defaultLast24h = "default-24h"
+    }
+
+    let mode: Mode
+    let since: Date
+    let until: Date
+}
+
+/// Collect events across requested rails. Missing files or empty directories
+/// must not produce an error: this command is read-only and has to be useful
+/// on a machine where the producer code (sentinel, MetricKit subscription,
+/// Sentry SDK) has never run.
+///
+/// `home` defaults to `NSHomeDirectory()` so the runtime test can pass a tmp dir.
+func collectHealthEvents(
+    window: HealthCollectionWindow,
+    rails: Set<HealthEvent.Rail>,
+    home: String = NSHomeDirectory()
+) -> [HealthEvent] {
+    return []
+}
+
+/// Default empty-result line when no events are present and no rail filter is in effect.
+private let healthEmptyResultLine =
+    "c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel."
+
+func renderHealthTable(_ events: [HealthEvent]) -> String {
+    if events.isEmpty {
+        return healthEmptyResultLine + "\n"
+    }
+    return ""
+}
+
+func renderHealthJSON(
+    events: [HealthEvent],
+    window: HealthCollectionWindow,
+    rails: Set<HealthEvent.Rail>,
+    warnings: [String]
+) throws -> Data {
+    let iso = ISO8601DateFormatter()
+    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+    var railCounts: [String: [String: Int]] = [:]
+    for rail in HealthEvent.Rail.allCases where rails.contains(rail) {
+        railCounts[rail.rawValue] = ["count": events.filter { $0.rail == rail }.count]
+    }
+
+    let eventsArray: [[String: Any]] = events.map { ev in
+        [
+            "timestamp": iso.string(from: ev.timestamp),
+            "rail": ev.rail.rawValue,
+            "severity": ev.severity.rawValue,
+            "summary": ev.summary,
+            "path": ev.path,
+        ]
+    }
+
+    let payload: [String: Any] = [
+        "window": [
+            "since": iso.string(from: window.since),
+            "until": iso.string(from: window.until),
+            "mode": window.mode.rawValue,
+        ],
+        "rails": railCounts,
+        "events": eventsArray,
+        "warnings": warnings,
+    ]
+
+    return try JSONSerialization.data(
+        withJSONObject: payload,
+        options: [.prettyPrinted, .sortedKeys]
+    )
+}

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -691,20 +691,59 @@ func parseUncleanExitFile(at url: URL, since: Date) -> HealthEvent? {
     )
 }
 
-/// Default empty-result line when no events are present and no rail filter is in effect.
-private let healthEmptyResultLine =
-    "c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel."
+/// Default rail set used to build the empty-result line when no `rails`
+/// argument is supplied (e.g., callers that have not been migrated yet).
+private let healthAllRails: [HealthEvent.Rail] = [.ips, .sentry, .metrickit, .sentinel]
+
+/// Renders the empty-result line dynamically so it reflects the actual
+/// rails queried and the actual time window (rather than always claiming
+/// "the last 24h across ips, sentry, metrickit, sentinel").
+func healthEmptyResultLine(
+    rails: [HealthEvent.Rail] = healthAllRails,
+    window: HealthCollectionWindow? = nil
+) -> String {
+    let railList = rails.isEmpty
+        ? healthAllRails.map(\.rawValue).joined(separator: ", ")
+        : rails.map(\.rawValue).joined(separator: ", ")
+    let windowPhrase: String
+    if let window {
+        switch window.mode {
+        case .defaultLast24h:
+            windowPhrase = "in the last 24h"
+        case .sinceBoot:
+            windowPhrase = "since boot"
+        case .sinceDuration:
+            let elapsed = window.until.timeIntervalSince(window.since)
+            windowPhrase = "in the last \(formatDurationPhrase(elapsed))"
+        }
+    } else {
+        windowPhrase = "in the last 24h"
+    }
+    return "c11 health: nothing \(windowPhrase) across \(railList)."
+}
+
+private func formatDurationPhrase(_ seconds: TimeInterval) -> String {
+    let s = Int(seconds.rounded())
+    if s % 86400 == 0 { return "\(s / 86400)d" }
+    if s % 3600 == 0 { return "\(s / 3600)h" }
+    if s % 60 == 0 { return "\(s / 60)m" }
+    return "\(s)s"
+}
 
 /// `timeZone` is exposed for golden-file tests; production callers leave it
-/// nil to use the operator's local time.
+/// nil to use the operator's local time. `rails` and `window` are used
+/// only to build the empty-result line; they default so existing callers
+/// keep their previous behavior.
 func renderHealthTable(
     _ events: [HealthEvent],
     warnings: [String] = [],
-    timeZone: TimeZone? = nil
+    timeZone: TimeZone? = nil,
+    rails: [HealthEvent.Rail] = healthAllRails,
+    window: HealthCollectionWindow? = nil
 ) -> String {
     var lines: [String] = []
     if events.isEmpty {
-        lines.append(healthEmptyResultLine)
+        lines.append(healthEmptyResultLine(rails: rails, window: window))
     } else {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd HH:mm"

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -52,7 +52,113 @@ func collectHealthEvents(
     rails: Set<HealthEvent.Rail>,
     home: String = NSHomeDirectory()
 ) -> [HealthEvent] {
-    return []
+    var events: [HealthEvent] = []
+    if rails.contains(.ips) {
+        events.append(contentsOf: scanIPS(home: home, since: window.since))
+    }
+    return events.sorted { $0.timestamp > $1.timestamp }
+}
+
+// MARK: - IPS rail
+
+/// Apple's CrashReporter ".ips" files start with a single-line JSON header,
+/// then a newline, then a JSON payload. We parse only that first line.
+struct IPSHeader {
+    let incidentID: String?
+    let bundleID: String?
+    let bugType: String?
+}
+
+func parseIPSFirstLine(_ line: String) -> IPSHeader? {
+    guard let data = line.data(using: .utf8),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+    return IPSHeader(
+        incidentID: obj["incident_id"] as? String,
+        bundleID: obj["bundleID"] as? String,
+        bugType: obj["bug_type"] as? String
+    )
+}
+
+func scanIPS(home: String, since: Date) -> [HealthEvent] {
+    let baseDir = "\(home)/Library/Logs/DiagnosticReports"
+    let baseURL = URL(fileURLWithPath: baseDir)
+    let fm = FileManager.default
+
+    guard let topLevel = try? fm.contentsOfDirectory(
+        at: baseURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    ) else { return [] }
+
+    var events: [HealthEvent] = []
+
+    for entry in topLevel {
+        let isDir = (try? entry.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+        let name = entry.lastPathComponent
+
+        if isDir {
+            guard name.hasPrefix("com.stage11.c11") else { continue }
+            if let inside = try? fm.contentsOfDirectory(
+                at: entry,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles]
+            ) {
+                for url in inside where url.pathExtension == "ips" {
+                    if let ev = ipsEventIfRecent(at: url, since: since) {
+                        events.append(ev)
+                    }
+                }
+            }
+            continue
+        }
+
+        guard entry.pathExtension == "ips" else { continue }
+        let stem = entry.deletingPathExtension().lastPathComponent
+        guard stem.lowercased().contains("c11") else { continue }
+        if let ev = ipsEventIfRecent(at: entry, since: since) {
+            events.append(ev)
+        }
+    }
+
+    return events
+}
+
+private func ipsEventIfRecent(at url: URL, since: Date) -> HealthEvent? {
+    let fm = FileManager.default
+    guard let attrs = try? fm.attributesOfItem(atPath: url.path),
+          let mtime = attrs[.modificationDate] as? Date,
+          mtime >= since
+    else { return nil }
+
+    let summary: String
+    if let line = readFirstLine(of: url), let header = parseIPSFirstLine(line) {
+        let bundle = header.bundleID ?? "?"
+        let bug = header.bugType ?? "?"
+        let inc = header.incidentID.map { String($0.prefix(8)) } ?? "?"
+        summary = "\(bundle) bug_type=\(bug) (\(inc))"
+    } else {
+        summary = url.lastPathComponent
+    }
+
+    return HealthEvent(
+        timestamp: mtime,
+        rail: .ips,
+        severity: .crash,
+        summary: summary,
+        path: url.path
+    )
+}
+
+private func readFirstLine(of url: URL) -> String? {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+    defer { try? handle.close() }
+    let data = (try? handle.read(upToCount: 8192)) ?? Data()
+    guard let text = String(data: data, encoding: .utf8) else { return nil }
+    if let nl = text.firstIndex(of: "\n") {
+        return String(text[..<nl])
+    }
+    return text
 }
 
 /// Default empty-result line when no events are present and no rail filter is in effect.

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -59,6 +59,9 @@ func collectHealthEvents(
     if rails.contains(.sentry) {
         events.append(contentsOf: scanSentryQueued(home: home, since: window.since))
     }
+    if rails.contains(.metrickit) {
+        events.append(contentsOf: scanMetricKit(home: home, since: window.since))
+    }
     return events.sorted { $0.timestamp > $1.timestamp }
 }
 
@@ -218,6 +221,121 @@ private func walkSentryDir(_ dir: URL, bundleName: String, since: Date) -> [Heal
             rail: .sentry,
             severity: .queued,
             summary: "\(bundleName)/\(url.lastPathComponent)",
+            path: url.path
+        ))
+    }
+    return events
+}
+
+// MARK: - MetricKit rail
+
+/// Filename grammar for files written by `CrashDiagnostics.persist` in
+/// `Sources/SentryHelper.swift`:
+///
+///     <stamp>-<kind>.json
+///
+/// where `<stamp>` is `YYYY-MM-DDTHH-MM-SS.fffZ` (ISO 8601 with `:` replaced
+/// by `-`, always UTC, fixed 24 chars) and `<kind>` is one of:
+///   - `metric` (MXMetricPayload telemetry baseline; skipped in v1)
+///   - `diagnostic` (MXDiagnosticPayload with no per-category counts)
+///   - one or more of `crash<n>` / `hang<n>` / `cpu<n>` / `disk<n>` joined by
+///     `-` in the fixed order crash, hang, cpu, disk.
+struct MetricKitFilename {
+    let timestamp: Date
+    let kind: String
+}
+
+/// Returns nil for `metric` rows (per plan: skip telemetry baselines), nil
+/// for unparseable stamps, and nil for malformed kind tokens.
+func parseMetricKitFilename(_ name: String) -> MetricKitFilename? {
+    guard name.hasSuffix(".json") else { return nil }
+    let stem = String(name.dropLast(".json".count))
+
+    // The stamp is exactly 24 characters: YYYY-MM-DDTHH-MM-SS.fffZ.
+    let stampLength = 24
+    guard stem.count > stampLength + 1 else { return nil }
+    let stampEnd = stem.index(stem.startIndex, offsetBy: stampLength)
+    let stampStr = String(stem[..<stampEnd])
+
+    let afterStamp = stem[stampEnd...]
+    guard afterStamp.first == "-" else { return nil }
+    let kind = String(afterStamp.dropFirst())
+
+    guard let date = parseFilenameSafeISO(stampStr) else { return nil }
+    guard isValidMetricKitKind(kind) else { return nil }
+
+    // Skip MXMetricPayload baselines: they aren't diagnostic events.
+    if kind == "metric" { return nil }
+
+    return MetricKitFilename(timestamp: date, kind: kind)
+}
+
+private func parseFilenameSafeISO(_ stamp: String) -> Date? {
+    guard stamp.count == 24, stamp.last == "Z" else { return nil }
+    var chars = Array(stamp)
+    guard chars[10] == "T",
+          chars[13] == "-",
+          chars[16] == "-",
+          chars[19] == "."
+    else { return nil }
+    chars[13] = ":"
+    chars[16] = ":"
+    let normalized = String(chars)
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f.date(from: normalized)
+}
+
+private func isValidMetricKitKind(_ kind: String) -> Bool {
+    if kind == "metric" || kind == "diagnostic" { return true }
+    let tokens = kind.split(separator: "-").map(String.init)
+    guard !tokens.isEmpty else { return false }
+    return tokens.allSatisfy(isValidCategoryToken)
+}
+
+private func isValidCategoryToken(_ token: String) -> Bool {
+    let prefixes = ["crash", "hang", "cpu", "disk"]
+    for prefix in prefixes where token.hasPrefix(prefix) {
+        let suffix = token.dropFirst(prefix.count)
+        return !suffix.isEmpty && suffix.allSatisfy { $0.isNumber }
+    }
+    return false
+}
+
+private func metricKitSeverity(forKind kind: String) -> HealthEvent.Severity {
+    if kind == "diagnostic" { return .diagnostic }
+    let tokens = kind.split(separator: "-").map(String.init)
+    let hasCrash = tokens.contains { $0.hasPrefix("crash") }
+    let hasHang = tokens.contains { $0.hasPrefix("hang") }
+    let hasResource = tokens.contains { $0.hasPrefix("cpu") || $0.hasPrefix("disk") }
+    let categoryCount = [hasCrash, hasHang, hasResource].filter { $0 }.count
+    if categoryCount > 1 { return .mixed }
+    if hasCrash { return .crash }
+    if hasHang { return .hang }
+    if hasResource { return .resource }
+    return .diagnostic
+}
+
+func scanMetricKit(home: String, since: Date) -> [HealthEvent] {
+    let dir = URL(fileURLWithPath: "\(home)/Library/Logs/c11/metrickit")
+    let fm = FileManager.default
+
+    guard let files = try? fm.contentsOfDirectory(
+        at: dir,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles]
+    ) else { return [] }
+
+    var events: [HealthEvent] = []
+    for url in files where url.pathExtension == "json" {
+        guard let parsed = parseMetricKitFilename(url.lastPathComponent),
+              parsed.timestamp >= since
+        else { continue }
+        events.append(HealthEvent(
+            timestamp: parsed.timestamp,
+            rail: .metrickit,
+            severity: metricKitSeverity(forKind: parsed.kind),
+            summary: parsed.kind,
             path: url.path
         ))
     }

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -721,11 +721,25 @@ func renderHealthTable(
     return lines.joined(separator: "\n") + "\n"
 }
 
+/// Replaces a leading `home` prefix with literal `~` so JSON output the
+/// operator pastes into tickets / chat / agent transcripts does not leak
+/// the macOS username.
+func redactHomePath(_ path: String, home: String) -> String {
+    guard !home.isEmpty else { return path }
+    let trimmed = home.hasSuffix("/") ? String(home.dropLast()) : home
+    if path == trimmed { return "~" }
+    if path.hasPrefix(trimmed + "/") {
+        return "~" + path.dropFirst(trimmed.count)
+    }
+    return path
+}
+
 func renderHealthJSON(
     events: [HealthEvent],
     window: HealthCollectionWindow,
     rails: Set<HealthEvent.Rail>,
-    warnings: [String]
+    warnings: [String],
+    home: String = NSHomeDirectory()
 ) throws -> Data {
     let iso = ISO8601DateFormatter()
     iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -741,7 +755,7 @@ func renderHealthJSON(
             "rail": ev.rail.rawValue,
             "severity": ev.severity.rawValue,
             "summary": ev.summary,
-            "path": ev.path,
+            "path": redactHomePath(ev.path, home: home),
         ]
     }
 

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -62,6 +62,9 @@ func collectHealthEvents(
     if rails.contains(.metrickit) {
         events.append(contentsOf: scanMetricKit(home: home, since: window.since))
     }
+    if rails.contains(.sentinel) {
+        events.append(contentsOf: scanLaunchSentinel(home: home, since: window.since))
+    }
     return events.sorted { $0.timestamp > $1.timestamp }
 }
 
@@ -340,6 +343,84 @@ func scanMetricKit(home: String, since: Date) -> [HealthEvent] {
         ))
     }
     return events
+}
+
+// MARK: - Launch sentinel rail
+
+/// One row per `unclean-exit-*.json` archive written by
+/// `LaunchSentinel.recordLaunchAndArchivePrevious()` in
+/// `Sources/SentryHelper.swift`. Catches Force-Quit / SIGKILL terminations
+/// where neither Sentry nor `.ips` files survive.
+func scanLaunchSentinel(home: String, since: Date) -> [HealthEvent] {
+    let cacheURL = URL(fileURLWithPath: "\(home)/Library/Caches")
+    let fm = FileManager.default
+
+    guard let bundleDirs = try? fm.contentsOfDirectory(
+        at: cacheURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    ) else { return [] }
+
+    var events: [HealthEvent] = []
+
+    for bundleDir in bundleDirs {
+        let bundleName = bundleDir.lastPathComponent
+        guard bundleName.hasPrefix("com.stage11.c11") else { continue }
+        let isDir = (try? bundleDir.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+        guard isDir else { continue }
+
+        let sessionsDir = bundleDir.appendingPathComponent("sessions", isDirectory: true)
+        guard let sessionFiles = try? fm.contentsOfDirectory(
+            at: sessionsDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { continue }
+
+        for url in sessionFiles {
+            let name = url.lastPathComponent
+            guard name.hasPrefix("unclean-exit-"),
+                  name.hasSuffix(".json")
+            else { continue }
+            guard let event = parseUncleanExitFile(at: url, since: since) else { continue }
+            events.append(event)
+        }
+    }
+
+    return events
+}
+
+/// Returns nil when the file's stamp predates `since`, or when the file
+/// cannot be read or parsed. Filename is the source of truth for the
+/// timestamp; the JSON body is best-effort metadata.
+func parseUncleanExitFile(at url: URL, since: Date) -> HealthEvent? {
+    let name = url.lastPathComponent
+    let prefix = "unclean-exit-"
+    let suffix = ".json"
+    guard name.hasPrefix(prefix), name.hasSuffix(suffix) else { return nil }
+    let stamp = String(name.dropFirst(prefix.count).dropLast(suffix.count))
+    guard let date = parseFilenameSafeISO(stamp), date >= since else { return nil }
+
+    var version = "?"
+    var build = "?"
+    var commit = "????????"
+
+    if let data = try? Data(contentsOf: url),
+       let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+        if let v = obj["version"] as? String, !v.isEmpty { version = v }
+        if let b = obj["build"] as? String, !b.isEmpty { build = b }
+        if let c = obj["commit"] as? String, !c.isEmpty {
+            commit = String(c.prefix(8))
+        }
+    }
+
+    let summary = "\(version) (\(build)) \(commit)"
+    return HealthEvent(
+        timestamp: date,
+        rail: .sentinel,
+        severity: .unclean_exit,
+        summary: summary,
+        path: url.path
+    )
 }
 
 /// Default empty-result line when no events are present and no rail filter is in effect.

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -345,6 +345,246 @@ func scanMetricKit(home: String, since: Date) -> [HealthEvent] {
     return events
 }
 
+// MARK: - Flags + boot time
+
+enum HealthCLIError: Error, CustomStringConvertible {
+    case mutuallyExclusiveSinceFlags
+    case missingValue(flag: String)
+    case invalidSinceValue(String)
+    case unknownRail(String)
+    case unknownFlag(String)
+
+    var description: String {
+        switch self {
+        case .mutuallyExclusiveSinceFlags:
+            return "--since and --since-boot are mutually exclusive"
+        case .missingValue(let flag):
+            return "\(flag) requires a value"
+        case .invalidSinceValue(let v):
+            return "invalid --since value '\(v)' (expected like 30m, 2h, 24h, 3d)"
+        case .unknownRail(let r):
+            return "unknown --rail '\(r)' (expected one of ips, sentry, metrickit, sentinel)"
+        case .unknownFlag(let f):
+            return "unknown flag '\(f)'"
+        }
+    }
+}
+
+struct HealthCLIOptions {
+    let mode: HealthCollectionWindow.Mode
+    /// Used only when `mode == .sinceDuration`; ignored for boot/default modes.
+    let windowDuration: TimeInterval
+    let railFilter: HealthEvent.Rail?
+    let json: Bool
+}
+
+/// Accepts compact-suffix duration strings: 30m, 2h, 24h, 3d. Returns the
+/// corresponding `TimeInterval`, or nil for malformed input.
+func parseSinceFlag(_ value: String) -> TimeInterval? {
+    guard let last = value.last else { return nil }
+    let head = value.dropLast()
+    guard !head.isEmpty, let n = Double(head), n > 0 else { return nil }
+    switch last {
+    case "m": return n * 60
+    case "h": return n * 3600
+    case "d": return n * 86400
+    default: return nil
+    }
+}
+
+/// Reads `kern.boottime` via `sysctlbyname`. Falls back to 24h ago on
+/// failure so callers do not have to handle nil for a value the kernel
+/// always exposes on macOS.
+func bootTime() -> Date {
+    var tv = timeval()
+    var size = MemoryLayout<timeval>.size
+    let result = sysctlbyname("kern.boottime", &tv, &size, nil, 0)
+    if result == 0 {
+        let seconds = TimeInterval(tv.tv_sec) + TimeInterval(tv.tv_usec) / 1_000_000
+        return Date(timeIntervalSince1970: seconds)
+    }
+    return Date(timeIntervalSinceNow: -24 * 3600)
+}
+
+func parseHealthCLIArgs(_ args: [String]) throws -> HealthCLIOptions {
+    var since: TimeInterval? = nil
+    var sinceBoot = false
+    var rail: HealthEvent.Rail? = nil
+    var json = false
+
+    var i = 0
+    while i < args.count {
+        let arg = args[i]
+        switch arg {
+        case "--json":
+            json = true
+            i += 1
+        case "--since":
+            guard i + 1 < args.count else { throw HealthCLIError.missingValue(flag: "--since") }
+            let v = args[i + 1]
+            guard let interval = parseSinceFlag(v) else {
+                throw HealthCLIError.invalidSinceValue(v)
+            }
+            since = interval
+            i += 2
+        case "--since-boot":
+            sinceBoot = true
+            i += 1
+        case "--rail":
+            guard i + 1 < args.count else { throw HealthCLIError.missingValue(flag: "--rail") }
+            let v = args[i + 1]
+            guard let r = HealthEvent.Rail(rawValue: v) else {
+                throw HealthCLIError.unknownRail(v)
+            }
+            rail = r
+            i += 2
+        case "-h", "--help":
+            // Help is dispatched upstream via dispatchSubcommandHelp; tolerate here.
+            i += 1
+        default:
+            throw HealthCLIError.unknownFlag(arg)
+        }
+    }
+
+    if since != nil && sinceBoot {
+        throw HealthCLIError.mutuallyExclusiveSinceFlags
+    }
+
+    let mode: HealthCollectionWindow.Mode
+    let duration: TimeInterval
+    if let since {
+        mode = .sinceDuration
+        duration = since
+    } else if sinceBoot {
+        mode = .sinceBoot
+        duration = 0
+    } else {
+        mode = .defaultLast24h
+        duration = 24 * 3600
+    }
+
+    return HealthCLIOptions(
+        mode: mode,
+        windowDuration: duration,
+        railFilter: rail,
+        json: json
+    )
+}
+
+// MARK: - Diagnostic warnings
+
+private struct UncleanExitMarker {
+    let timestamp: Date
+    let version: String
+}
+
+private func mostRecentSentinelMarker(home: String) -> UncleanExitMarker? {
+    let cacheURL = URL(fileURLWithPath: "\(home)/Library/Caches")
+    let fm = FileManager.default
+
+    guard let bundleDirs = try? fm.contentsOfDirectory(
+        at: cacheURL,
+        includingPropertiesForKeys: nil,
+        options: [.skipsHiddenFiles]
+    ) else { return nil }
+
+    var best: UncleanExitMarker? = nil
+
+    for bundleDir in bundleDirs {
+        guard bundleDir.lastPathComponent.hasPrefix("com.stage11.c11") else { continue }
+        let sessionsDir = bundleDir.appendingPathComponent("sessions", isDirectory: true)
+        guard let files = try? fm.contentsOfDirectory(
+            at: sessionsDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else { continue }
+
+        for url in files {
+            let name = url.lastPathComponent
+            let isUnclean = name.hasPrefix("unclean-exit-") && name.hasSuffix(".json")
+            let isActive = name == "active.json"
+            guard isUnclean || isActive else { continue }
+
+            guard let data = try? Data(contentsOf: url),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { continue }
+
+            var ts: Date? = nil
+            if let str = obj["launched_at"] as? String {
+                let f = ISO8601DateFormatter()
+                f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                ts = f.date(from: str)
+            }
+            if ts == nil, isUnclean {
+                let stamp = String(name.dropFirst("unclean-exit-".count).dropLast(".json".count))
+                ts = parseFilenameSafeISO(stamp)
+            }
+            if ts == nil, let attrs = try? fm.attributesOfItem(atPath: url.path) {
+                ts = attrs[.modificationDate] as? Date
+            }
+
+            guard let timestamp = ts,
+                  let version = obj["version"] as? String,
+                  !version.isEmpty
+            else { continue }
+
+            if best == nil || best!.timestamp < timestamp {
+                best = UncleanExitMarker(timestamp: timestamp, version: version)
+            }
+        }
+    }
+
+    return best
+}
+
+/// Fires when MetricKit count is 0 AND the running c11 was version-bumped
+/// within the last 24h. Compares `bundleVersion` against the most-recent
+/// prior session marker's `version`; if the marker is missing, returns nil
+/// (we have no baseline to compare against).
+func metricKitBaselineWarning(
+    home: String,
+    bundleVersion: String?,
+    metricKitCount: Int,
+    now: Date = Date()
+) -> String? {
+    guard metricKitCount == 0,
+          let curr = bundleVersion, !curr.isEmpty,
+          let marker = mostRecentSentinelMarker(home: home)
+    else { return nil }
+
+    guard marker.version != curr else { return nil }
+    let age = now.timeIntervalSince(marker.timestamp)
+    guard age >= 0, age <= 24 * 3600 else { return nil }
+
+    return "MetricKit baseline still establishing after version bump (\(marker.version) to \(curr)); diagnostic payloads may not deliver for ~24h."
+}
+
+/// Fires when `<home>/Library/Caches/com.stage11.c11/io.sentry/` exists and
+/// is empty AND we have zero queued events overall. Operator can't tell
+/// from "0 events" alone whether telemetry is off or just freshly drained.
+func telemetryAmbiguityFooter(home: String, sentryCount: Int) -> String? {
+    guard sentryCount == 0 else { return nil }
+    let probe = "\(home)/Library/Caches/com.stage11.c11/io.sentry"
+    let fm = FileManager.default
+    var isDir: ObjCBool = false
+    guard fm.fileExists(atPath: probe, isDirectory: &isDir), isDir.boolValue else { return nil }
+
+    let probeURL = URL(fileURLWithPath: probe)
+    if let enumerator = fm.enumerator(
+        at: probeURL,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+    ) {
+        for case let f as URL in enumerator {
+            if (try? f.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true {
+                return nil
+            }
+        }
+    }
+
+    return "Production Sentry cache empty: telemetry may be off, or events shipped on last launch and cleared the cache."
+}
+
 // MARK: - Launch sentinel rail
 
 /// One row per `unclean-exit-*.json` archive written by
@@ -427,11 +667,29 @@ func parseUncleanExitFile(at url: URL, since: Date) -> HealthEvent? {
 private let healthEmptyResultLine =
     "c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel."
 
-func renderHealthTable(_ events: [HealthEvent]) -> String {
+func renderHealthTable(_ events: [HealthEvent], warnings: [String] = []) -> String {
+    var lines: [String] = []
     if events.isEmpty {
-        return healthEmptyResultLine + "\n"
+        lines.append(healthEmptyResultLine)
+    } else {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm"
+        lines.append("TIME             | RAIL      | SEVERITY     | SUMMARY")
+        for ev in events {
+            let time = f.string(from: ev.timestamp)
+            let rail = ev.rail.rawValue.padding(toLength: 9, withPad: " ", startingAt: 0)
+            let sev = ev.severity.rawValue.padding(toLength: 12, withPad: " ", startingAt: 0)
+            lines.append("\(time) | \(rail) | \(sev) | \(ev.summary)")
+        }
     }
-    return ""
+    if !warnings.isEmpty {
+        lines.append("")
+        lines.append("Warnings:")
+        for w in warnings {
+            lines.append("  - \(w)")
+        }
+    }
+    return lines.joined(separator: "\n") + "\n"
 }
 
 func renderHealthJSON(

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -65,7 +65,14 @@ func collectHealthEvents(
     if rails.contains(.sentinel) {
         events.append(contentsOf: scanLaunchSentinel(home: home, since: window.since))
     }
-    return events.sorted { $0.timestamp > $1.timestamp }
+    // Stable secondary/tertiary keys keep `--json` output deterministic
+    // when two events share a timestamp (sub-millisecond batches across
+    // rails are common).
+    return events.sorted { lhs, rhs in
+        if lhs.timestamp != rhs.timestamp { return lhs.timestamp > rhs.timestamp }
+        if lhs.rail.rawValue != rhs.rail.rawValue { return lhs.rail.rawValue < rhs.rail.rawValue }
+        return lhs.path < rhs.path
+    }
 }
 
 // MARK: - IPS rail
@@ -163,7 +170,11 @@ private func readFirstLine(of url: URL) -> String? {
     guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
     defer { try? handle.close() }
     let data = (try? handle.read(upToCount: 8192)) ?? Data()
-    guard let text = String(data: data, encoding: .utf8) else { return nil }
+    // Lossy UTF-8: tolerate a multi-byte sequence sitting astride the
+    // 8192-byte read boundary by inserting U+FFFD instead of returning
+    // nil. The caller only cares about the first line; the trailing
+    // replacement char is harmless because we cut at the first `\n`.
+    let text = String(decoding: data, as: UTF8.self)
     if let nl = text.firstIndex(of: "\n") {
         return String(text[..<nl])
     }

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -56,6 +56,9 @@ func collectHealthEvents(
     if rails.contains(.ips) {
         events.append(contentsOf: scanIPS(home: home, since: window.since))
     }
+    if rails.contains(.sentry) {
+        events.append(contentsOf: scanSentryQueued(home: home, since: window.since))
+    }
     return events.sorted { $0.timestamp > $1.timestamp }
 }
 
@@ -159,6 +162,66 @@ private func readFirstLine(of url: URL) -> String? {
         return String(text[..<nl])
     }
     return text
+}
+
+// MARK: - Sentry queued rail
+
+/// Walks `<home>/Library/Caches/com.stage11.c11*/io.sentry/` recursively and
+/// emits one event per file. Sentry-Cocoa typically writes envelopes under
+/// `io.sentry/envelopes/`, but we don't make that assumption: any regular file
+/// inside `io.sentry/` is treated as a queued event. Envelope contents are
+/// never parsed.
+func scanSentryQueued(home: String, since: Date) -> [HealthEvent] {
+    let cacheURL = URL(fileURLWithPath: "\(home)/Library/Caches")
+    let fm = FileManager.default
+
+    guard let bundleDirs = try? fm.contentsOfDirectory(
+        at: cacheURL,
+        includingPropertiesForKeys: [.isDirectoryKey],
+        options: [.skipsHiddenFiles]
+    ) else { return [] }
+
+    var events: [HealthEvent] = []
+
+    for bundleDir in bundleDirs {
+        let bundleName = bundleDir.lastPathComponent
+        guard bundleName.hasPrefix("com.stage11.c11") else { continue }
+        let isDir = (try? bundleDir.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+        guard isDir else { continue }
+
+        let sentryRoot = bundleDir.appendingPathComponent("io.sentry", isDirectory: true)
+        guard fm.fileExists(atPath: sentryRoot.path) else { continue }
+        events.append(contentsOf: walkSentryDir(sentryRoot, bundleName: bundleName, since: since))
+    }
+
+    return events
+}
+
+private func walkSentryDir(_ dir: URL, bundleName: String, since: Date) -> [HealthEvent] {
+    let fm = FileManager.default
+    guard let enumerator = fm.enumerator(
+        at: dir,
+        includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+        options: [.skipsHiddenFiles]
+    ) else { return [] }
+
+    var events: [HealthEvent] = []
+    for case let url as URL in enumerator {
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey]),
+              values.isRegularFile == true,
+              let mtime = values.contentModificationDate,
+              mtime >= since
+        else { continue }
+
+        events.append(HealthEvent(
+            timestamp: mtime,
+            rail: .sentry,
+            severity: .queued,
+            summary: "\(bundleName)/\(url.lastPathComponent)",
+            path: url.path
+        ))
+    }
+    return events
 }
 
 /// Default empty-result line when no events are present and no rail filter is in effect.

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -14,7 +14,6 @@ struct HealthEvent {
     enum Severity: String {
         case crash
         case queued
-        case metrickit
         case hang
         case resource
         case mixed
@@ -27,6 +26,17 @@ struct HealthEvent {
     let severity: Severity
     let summary: String
     let path: String
+}
+
+/// Single source of truth for the ISO-8601 formatter c11 health uses to
+/// stamp / parse timestamps. Hoisted to avoid the per-call allocation
+/// previously duplicated across `parseFilenameSafeISO`,
+/// `mostRecentSentinelMarker`, and `renderHealthJSON`.
+@inline(__always)
+private func makeFractionalISOFormatter() -> ISO8601DateFormatter {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
 }
 
 struct HealthCollectionWindow {
@@ -295,9 +305,7 @@ private func parseFilenameSafeISO(_ stamp: String) -> Date? {
     chars[13] = ":"
     chars[16] = ":"
     let normalized = String(chars)
-    let f = ISO8601DateFormatter()
-    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-    return f.date(from: normalized)
+    return makeFractionalISOFormatter().date(from: normalized)
 }
 
 private func isValidMetricKitKind(_ kind: String) -> Bool {
@@ -535,9 +543,7 @@ private func mostRecentSentinelMarker(home: String) -> UncleanExitMarker? {
             else { continue }
 
             if ts == nil, let str = obj["launched_at"] as? String {
-                let f = ISO8601DateFormatter()
-                f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                ts = f.date(from: str)
+                ts = makeFractionalISOFormatter().date(from: str)
             }
             if ts == nil, let attrs = try? fm.attributesOfItem(atPath: url.path) {
                 ts = attrs[.modificationDate] as? Date
@@ -800,8 +806,7 @@ func renderHealthJSON(
     warnings: [String],
     home: String = NSHomeDirectory()
 ) throws -> Data {
-    let iso = ISO8601DateFormatter()
-    iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    let iso = makeFractionalISOFormatter()
 
     var railCounts: [String: [String: Int]] = [:]
     for rail in HealthEvent.Rail.allCases where rails.contains(rail) {

--- a/Sources/HealthCommandCore.swift
+++ b/Sources/HealthCommandCore.swift
@@ -501,23 +501,23 @@ private func mostRecentSentinelMarker(home: String) -> UncleanExitMarker? {
 
         for url in files {
             let name = url.lastPathComponent
-            let isUnclean = name.hasPrefix("unclean-exit-") && name.hasSuffix(".json")
-            let isActive = name == "active.json"
-            guard isUnclean || isActive else { continue }
+            // active.json is the *current* session; including it means
+            // the post-bump warning compares the current version against
+            // itself and silently returns nil. Only prior unclean-exit
+            // archives are valid baselines.
+            guard name.hasPrefix("unclean-exit-"), name.hasSuffix(".json") else { continue }
+
+            let stamp = String(name.dropFirst("unclean-exit-".count).dropLast(".json".count))
+            var ts: Date? = parseFilenameSafeISO(stamp)
 
             guard let data = try? Data(contentsOf: url),
                   let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
             else { continue }
 
-            var ts: Date? = nil
-            if let str = obj["launched_at"] as? String {
+            if ts == nil, let str = obj["launched_at"] as? String {
                 let f = ISO8601DateFormatter()
                 f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
                 ts = f.date(from: str)
-            }
-            if ts == nil, isUnclean {
-                let stamp = String(name.dropFirst("unclean-exit-".count).dropLast(".json".count))
-                ts = parseFilenameSafeISO(stamp)
             }
             if ts == nil, let attrs = try? fm.attributesOfItem(atPath: url.path) {
                 ts = attrs[.modificationDate] as? Date

--- a/c11Tests/CLIHealthRuntimeTests.swift
+++ b/c11Tests/CLIHealthRuntimeTests.swift
@@ -126,6 +126,46 @@ final class CLIHealthRuntimeTests: XCTestCase {
         XCTAssertEqual(rendered, golden)
     }
 
+    func testEmptyResultLineReflectsRailFilter() {
+        let rendered = renderHealthTable([], rails: [.sentinel])
+        XCTAssertTrue(
+            rendered.contains("across sentinel."),
+            "empty line must name only the queried rail; got \(rendered)"
+        )
+        XCTAssertFalse(
+            rendered.contains("ips, sentry, metrickit"),
+            "empty line must not list rails the operator did not ask about; got \(rendered)"
+        )
+    }
+
+    func testEmptyResultLineReflectsSinceWindow() {
+        let now = Date()
+        let window = HealthCollectionWindow(
+            mode: .sinceDuration,
+            since: now.addingTimeInterval(-30 * 60),
+            until: now
+        )
+        let rendered = renderHealthTable([], rails: [.ips, .sentry], window: window)
+        XCTAssertTrue(
+            rendered.contains("in the last 30m"),
+            "empty line must reflect the actual --since window; got \(rendered)"
+        )
+    }
+
+    func testEmptyResultLineReflectsSinceBoot() {
+        let now = Date()
+        let window = HealthCollectionWindow(
+            mode: .sinceBoot,
+            since: now.addingTimeInterval(-3600),
+            until: now
+        )
+        let rendered = renderHealthTable([], window: window)
+        XCTAssertTrue(
+            rendered.contains("nothing since boot"),
+            "empty line must say 'since boot' for --since-boot mode; got \(rendered)"
+        )
+    }
+
     func testFourEventsTableMatchesGolden() throws {
         let f = ISO8601DateFormatter()
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]

--- a/c11Tests/CLIHealthRuntimeTests.swift
+++ b/c11Tests/CLIHealthRuntimeTests.swift
@@ -99,6 +99,46 @@ final class CLIHealthRuntimeTests: XCTestCase {
         XCTAssertEqual(win["mode"] as? String, "default-24h")
     }
 
+    func testCollectHealthEventsHasStableTiebreak() throws {
+        // Two events with the same timestamp across rails: the sort must
+        // be deterministic so `--json` output never flaps for downstream
+        // consumers (jq filters, CI gates, fleet aggregators).
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let now = Date()
+        let stamp = filenameSafeISOForNow()
+
+        // Two MetricKit files at the exact same parsed timestamp.
+        let metricDir = tmp.appendingPathComponent("Library/Logs/c11/metrickit", isDirectory: true)
+        try FileManager.default.createDirectory(at: metricDir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: metricDir.appendingPathComponent("\(stamp)-crash1.json"))
+
+        // Two sentinel files at the same parsed timestamp under different bundles.
+        for bundle in ["com.stage11.c11.debug.aaa", "com.stage11.c11.debug.bbb"] {
+            let sessionsDir = tmp.appendingPathComponent(
+                "Library/Caches/\(bundle)/sessions",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+            let body: [String: Any] = ["version": "0.44.1", "launched_at": ISO8601DateFormatter().string(from: now)]
+            let data = try JSONSerialization.data(withJSONObject: body, options: [])
+            try data.write(to: sessionsDir.appendingPathComponent("unclean-exit-\(stamp).json"))
+        }
+
+        let window = HealthCollectionWindow(
+            mode: .defaultLast24h,
+            since: now.addingTimeInterval(-24 * 3600),
+            until: now.addingTimeInterval(60)
+        )
+        let allRails = Set(HealthEvent.Rail.allCases)
+        let events1 = collectHealthEvents(window: window, rails: allRails, home: tmp.path)
+        let events2 = collectHealthEvents(window: window, rails: allRails, home: tmp.path)
+
+        XCTAssertEqual(events1.map(\.path), events2.map(\.path),
+                       "two collections of identical disk state must produce identical event order")
+    }
+
     func testGracefulOnEmptyHome() throws {
         let tmp = try makeTempHome()
         defer { try? FileManager.default.removeItem(at: tmp) }

--- a/c11Tests/CLIHealthRuntimeTests.swift
+++ b/c11Tests/CLIHealthRuntimeTests.swift
@@ -1,0 +1,236 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+final class CLIHealthRuntimeTests: XCTestCase {
+
+    private var goldenURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("health")
+            .appendingPathComponent("golden", isDirectory: true)
+    }
+
+    // MARK: Sandboxed end-to-end
+
+    func testCollectHealthEventsAcrossAllFourRails() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try scaffoldAllRails(in: tmp)
+
+        let now = Date()
+        let window = HealthCollectionWindow(
+            mode: .defaultLast24h,
+            since: now.addingTimeInterval(-24 * 3600),
+            until: now
+        )
+        let allRails = Set(HealthEvent.Rail.allCases)
+        let events = collectHealthEvents(window: window, rails: allRails, home: tmp.path)
+
+        XCTAssertEqual(events.count, 4, "all four rails should each produce exactly one event")
+        let railCounts = Dictionary(grouping: events, by: \.rail).mapValues(\.count)
+        XCTAssertEqual(railCounts[.ips], 1)
+        XCTAssertEqual(railCounts[.sentry], 1)
+        XCTAssertEqual(railCounts[.metrickit], 1)
+        XCTAssertEqual(railCounts[.sentinel], 1)
+
+        // Reverse-chronological ordering.
+        for i in 1..<events.count {
+            XCTAssertGreaterThanOrEqual(
+                events[i - 1].timestamp,
+                events[i].timestamp,
+                "events must be sorted reverse-chronologically"
+            )
+        }
+    }
+
+    func testJSONShapeContainsTopLevelKeys() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try scaffoldAllRails(in: tmp)
+
+        let now = Date()
+        let window = HealthCollectionWindow(
+            mode: .defaultLast24h,
+            since: now.addingTimeInterval(-24 * 3600),
+            until: now
+        )
+        let allRails = Set(HealthEvent.Rail.allCases)
+        let events = collectHealthEvents(window: window, rails: allRails, home: tmp.path)
+
+        let data = try renderHealthJSON(
+            events: events,
+            window: window,
+            rails: allRails,
+            warnings: ["sample-warning"]
+        )
+        let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        XCTAssertNotNil(obj["window"] as? [String: Any])
+        XCTAssertNotNil(obj["rails"] as? [String: Any])
+        XCTAssertNotNil(obj["events"] as? [[String: Any]])
+        XCTAssertEqual(obj["warnings"] as? [String], ["sample-warning"])
+
+        let rails = try XCTUnwrap(obj["rails"] as? [String: Any])
+        for rail in HealthEvent.Rail.allCases {
+            let railObj = try XCTUnwrap(rails[rail.rawValue] as? [String: Any])
+            XCTAssertEqual(railObj["count"] as? Int, 1)
+        }
+
+        let evs = try XCTUnwrap(obj["events"] as? [[String: Any]])
+        XCTAssertEqual(evs.count, 4)
+        for ev in evs {
+            XCTAssertNotNil(ev["timestamp"] as? String)
+            XCTAssertNotNil(ev["rail"] as? String)
+            XCTAssertNotNil(ev["severity"] as? String)
+            XCTAssertNotNil(ev["summary"] as? String)
+            XCTAssertNotNil(ev["path"] as? String)
+        }
+
+        let win = try XCTUnwrap(obj["window"] as? [String: Any])
+        XCTAssertEqual(win["mode"] as? String, "default-24h")
+    }
+
+    func testGracefulOnEmptyHome() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let now = Date()
+        let window = HealthCollectionWindow(
+            mode: .defaultLast24h,
+            since: now.addingTimeInterval(-24 * 3600),
+            until: now
+        )
+        let events = collectHealthEvents(
+            window: window,
+            rails: Set(HealthEvent.Rail.allCases),
+            home: tmp.path
+        )
+        XCTAssertTrue(events.isEmpty, "empty HOME must not error and must produce no events")
+    }
+
+    // MARK: Golden snapshots
+
+    func testEmptyResultLineMatchesGolden() throws {
+        let rendered = renderHealthTable([])
+        let goldenURL = self.goldenURL.appendingPathComponent("empty.txt")
+        let golden = try String(contentsOf: goldenURL, encoding: .utf8)
+        XCTAssertEqual(rendered, golden)
+    }
+
+    func testFourEventsTableMatchesGolden() throws {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let events: [HealthEvent] = [
+            HealthEvent(
+                timestamp: try XCTUnwrap(f.date(from: "2026-05-03T15:28:00.000Z")),
+                rail: .sentinel,
+                severity: .unclean_exit,
+                summary: "0.44.1 (0.44.1.123) e6ce1be2",
+                path: "/tmp/sentinel/unclean-exit-2026-05-03T15-28-00.000Z.json"
+            ),
+            HealthEvent(
+                timestamp: try XCTUnwrap(f.date(from: "2026-05-03T15:19:00.000Z")),
+                rail: .ips,
+                severity: .crash,
+                summary: "com.stage11.c11 bug_type=309 (00000000)",
+                path: "/tmp/ips/sample.ips"
+            ),
+            HealthEvent(
+                timestamp: try XCTUnwrap(f.date(from: "2026-05-03T14:30:00.000Z")),
+                rail: .metrickit,
+                severity: .hang,
+                summary: "hang3",
+                path: "/tmp/metrickit/hang.json"
+            ),
+            HealthEvent(
+                timestamp: try XCTUnwrap(f.date(from: "2026-05-03T13:00:00.000Z")),
+                rail: .sentry,
+                severity: .queued,
+                summary: "com.stage11.c11.debug.foo/envelope-1",
+                path: "/tmp/sentry/envelope-1"
+            ),
+        ]
+
+        let rendered = renderHealthTable(events, timeZone: TimeZone(identifier: "UTC"))
+        let goldenURL = self.goldenURL.appendingPathComponent("four-events.txt")
+        let golden = try String(contentsOf: goldenURL, encoding: .utf8)
+        XCTAssertEqual(rendered, golden)
+    }
+
+    // MARK: Helpers
+
+    private func makeTempHome() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-health-runtime-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func scaffoldAllRails(in home: URL) throws {
+        let fm = FileManager.default
+
+        // IPS rail: top-level c11-named .ips with a parseable first line.
+        let reportsDir = home.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+        try fm.createDirectory(at: reportsDir, withIntermediateDirectories: true)
+        let ipsBody = """
+        {"app_name":"c11","app_version":"0.44.1","bundleID":"com.stage11.c11","bug_type":"309","incident_id":"00000000-0000-0000-0000-000000000001","timestamp":"2026-05-03 15:19:00.000 -0400"}
+        {"crashed_thread":0}
+
+        """
+        try ipsBody.data(using: .utf8)!.write(
+            to: reportsDir.appendingPathComponent("c11-runtime-test.ips")
+        )
+
+        // Sentry rail: one envelope under a per-bundle dir.
+        let envelopesDir = home.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.debug.runtime/io.sentry/envelopes",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: envelopesDir, withIntermediateDirectories: true)
+        try Data([0x01, 0x02, 0x03]).write(to: envelopesDir.appendingPathComponent("envelope-runtime"))
+
+        // MetricKit rail: one valid kind file in the future window so the
+        // since-cutoff (-24h) cannot accidentally drop it.
+        let metricDir = home.appendingPathComponent("Library/Logs/c11/metrickit", isDirectory: true)
+        try fm.createDirectory(at: metricDir, withIntermediateDirectories: true)
+        let metricStamp = filenameSafeISOForNow()
+        try Data("{}".utf8).write(
+            to: metricDir.appendingPathComponent("\(metricStamp)-crash1.json")
+        )
+
+        // Sentinel rail: one unclean-exit archive with a fresh stamp.
+        let sessionsDir = home.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.debug.runtime/sessions",
+            isDirectory: true
+        )
+        try fm.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        let sentinelBody: [String: Any] = [
+            "version": "0.44.1",
+            "build": "0.44.1.123",
+            "commit": "e6ce1be28",
+            "bundle_id": "com.stage11.c11.debug.runtime",
+            "launched_at": ISO8601DateFormatter().string(from: Date()),
+            "pid": 9999,
+        ]
+        let sentinelData = try JSONSerialization.data(
+            withJSONObject: sentinelBody,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try sentinelData.write(
+            to: sessionsDir.appendingPathComponent("unclean-exit-\(metricStamp).json")
+        )
+    }
+
+    private func filenameSafeISOForNow() -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f.string(from: Date()).replacingOccurrences(of: ":", with: "-")
+    }
+}

--- a/c11Tests/CLIHealthRuntimeTests.swift
+++ b/c11Tests/CLIHealthRuntimeTests.swift
@@ -67,7 +67,8 @@ final class CLIHealthRuntimeTests: XCTestCase {
             events: events,
             window: window,
             rails: allRails,
-            warnings: ["sample-warning"]
+            warnings: ["sample-warning"],
+            home: tmp.path
         )
         let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
@@ -89,7 +90,9 @@ final class CLIHealthRuntimeTests: XCTestCase {
             XCTAssertNotNil(ev["rail"] as? String)
             XCTAssertNotNil(ev["severity"] as? String)
             XCTAssertNotNil(ev["summary"] as? String)
-            XCTAssertNotNil(ev["path"] as? String)
+            let path = try XCTUnwrap(ev["path"] as? String)
+            XCTAssertTrue(path.hasPrefix("~/"), "JSON paths must be redacted with ~ prefix; got \(path)")
+            XCTAssertFalse(path.contains(tmp.path), "JSON paths must not leak the absolute home; got \(path)")
         }
 
         let win = try XCTUnwrap(obj["window"] as? [String: Any])

--- a/c11Tests/CLIHealthRuntimeTests.swift
+++ b/c11Tests/CLIHealthRuntimeTests.swift
@@ -261,13 +261,16 @@ final class CLIHealthRuntimeTests: XCTestCase {
         let fm = FileManager.default
 
         // IPS rail: top-level c11-named .ips with a parseable first line.
+        // Generate the timestamp dynamically so the parsed value is always
+        // within the 24h window the test queries (the scanner now prefers
+        // the JSON `timestamp` over mtime for since-filtering).
         let reportsDir = home.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
         try fm.createDirectory(at: reportsDir, withIntermediateDirectories: true)
-        let ipsBody = """
-        {"app_name":"c11","app_version":"0.44.1","bundleID":"com.stage11.c11","bug_type":"309","incident_id":"00000000-0000-0000-0000-000000000001","timestamp":"2026-05-03 15:19:00.000 -0400"}
-        {"crashed_thread":0}
-
-        """
+        let ipsTSFormatter = DateFormatter()
+        ipsTSFormatter.locale = Locale(identifier: "en_US_POSIX")
+        ipsTSFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS Z"
+        let ipsTimestamp = ipsTSFormatter.string(from: Date())
+        let ipsBody = "{\"app_name\":\"c11\",\"app_version\":\"0.44.1\",\"bundleID\":\"com.stage11.c11\",\"bug_type\":\"309\",\"incident_id\":\"00000000-0000-0000-0000-000000000001\",\"timestamp\":\"" + ipsTimestamp + "\"}\n{\"crashed_thread\":0}\n"
         try ipsBody.data(using: .utf8)!.write(
             to: reportsDir.appendingPathComponent("c11-runtime-test.ips")
         )

--- a/c11Tests/CLIHealthRuntimeTests.swift
+++ b/c11Tests/CLIHealthRuntimeTests.swift
@@ -72,6 +72,7 @@ final class CLIHealthRuntimeTests: XCTestCase {
         )
         let obj = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
+        XCTAssertEqual(obj["schema_version"] as? Int, healthJSONSchemaVersion)
         XCTAssertNotNil(obj["window"] as? [String: Any])
         XCTAssertNotNil(obj["rails"] as? [String: Any])
         XCTAssertNotNil(obj["events"] as? [[String: Any]])

--- a/c11Tests/Fixtures/health/golden/empty.txt
+++ b/c11Tests/Fixtures/health/golden/empty.txt
@@ -1,0 +1,1 @@
+c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel.

--- a/c11Tests/Fixtures/health/golden/four-events.txt
+++ b/c11Tests/Fixtures/health/golden/four-events.txt
@@ -1,0 +1,5 @@
+TIME             | RAIL      | SEVERITY     | SUMMARY
+2026-05-03 15:28 | sentinel  | unclean_exit | 0.44.1 (0.44.1.123) e6ce1be2
+2026-05-03 15:19 | ips       | crash        | com.stage11.c11 bug_type=309 (00000000)
+2026-05-03 14:30 | metrickit | hang         | hang3
+2026-05-03 13:00 | sentry    | queued       | com.stage11.c11.debug.foo/envelope-1

--- a/c11Tests/Fixtures/health/golden/four-events.txt
+++ b/c11Tests/Fixtures/health/golden/four-events.txt
@@ -1,4 +1,5 @@
 TIME             | RAIL      | SEVERITY     | SUMMARY
+(TIME reflects the OS-reported event time when available, file mtime otherwise)
 2026-05-03 15:28 | sentinel  | unclean_exit | 0.44.1 (0.44.1.123) e6ce1be2
 2026-05-03 15:19 | ips       | crash        | com.stage11.c11 bug_type=309 (00000000)
 2026-05-03 14:30 | metrickit | hang         | hang3

--- a/c11Tests/Fixtures/health/ips/sample-crash.ips
+++ b/c11Tests/Fixtures/health/ips/sample-crash.ips
@@ -1,0 +1,2 @@
+{"app_name":"c11","app_version":"0.44.1","bundleID":"com.stage11.c11","bug_type":"309","incident_id":"00000000-0000-0000-0000-000000000001","timestamp":"2026-05-03 15:19:00.000 -0400"}
+{"crashed_thread":0,"build":"0.44.1.123","report_payload":"truncated for fixture"}

--- a/c11Tests/Fixtures/health/ips/sample-hang.ips
+++ b/c11Tests/Fixtures/health/ips/sample-hang.ips
@@ -1,0 +1,2 @@
+{"app_name":"c11","app_version":"0.44.1","bundleID":"com.stage11.c11","bug_type":"309","incident_id":"00000000-0000-0000-0000-000000000002","timestamp":"2026-05-03 15:28:00.000 -0400"}
+{"hang_duration_seconds":12,"build":"0.44.1.123","report_payload":"truncated for fixture"}

--- a/c11Tests/Fixtures/health/sentinel/unclean-exit-2026-05-03T15-19-00.123Z.json
+++ b/c11Tests/Fixtures/health/sentinel/unclean-exit-2026-05-03T15-19-00.123Z.json
@@ -1,0 +1,8 @@
+{
+  "build" : "0.44.1.123",
+  "bundle_id" : "com.stage11.c11",
+  "commit" : "e6ce1be28",
+  "launched_at" : "2026-05-03T15:18:00.000Z",
+  "pid" : 12345,
+  "version" : "0.44.1"
+}

--- a/c11Tests/HealthFlagsTests.swift
+++ b/c11Tests/HealthFlagsTests.swift
@@ -322,4 +322,34 @@ final class HealthFlagsTests: XCTestCase {
         f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         return f.string(from: date).replacingOccurrences(of: ":", with: "-")
     }
+
+    // MARK: redactHomePath
+
+    func testRedactHomePathReplacesPrefix() {
+        let result = redactHomePath(
+            "/Users/alice/Library/Caches/com.stage11.c11/io.sentry/envelopes/x",
+            home: "/Users/alice"
+        )
+        XCTAssertEqual(result, "~/Library/Caches/com.stage11.c11/io.sentry/envelopes/x")
+    }
+
+    func testRedactHomePathHandlesTrailingSlashHome() {
+        let result = redactHomePath("/Users/bob/Logs/x", home: "/Users/bob/")
+        XCTAssertEqual(result, "~/Logs/x")
+    }
+
+    func testRedactHomePathLeavesUnrelatedPathUnchanged() {
+        let result = redactHomePath("/var/db/something", home: "/Users/carol")
+        XCTAssertEqual(result, "/var/db/something")
+    }
+
+    func testRedactHomePathDoesNotMatchPartialComponent() {
+        // /Users/alice should not match /Users/alice2/...
+        let result = redactHomePath("/Users/alice2/Logs", home: "/Users/alice")
+        XCTAssertEqual(result, "/Users/alice2/Logs")
+    }
+
+    func testRedactHomePathExactMatch() {
+        XCTAssertEqual(redactHomePath("/Users/dan", home: "/Users/dan"), "~")
+    }
 }

--- a/c11Tests/HealthFlagsTests.swift
+++ b/c11Tests/HealthFlagsTests.swift
@@ -141,9 +141,11 @@ final class HealthFlagsTests: XCTestCase {
         let now = Date()
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let priorLaunchedAt = isoFormatter.string(from: now.addingTimeInterval(-3600))
+        let priorTimestamp = now.addingTimeInterval(-3600)
+        let priorLaunchedAt = isoFormatter.string(from: priorTimestamp)
+        let priorStamp = filenameSafeISO(priorTimestamp)
 
-        let activeBody: [String: Any] = [
+        let priorBody: [String: Any] = [
             "version": "0.43.0",
             "build": "0.43.0.1",
             "commit": "abcdef12",
@@ -151,8 +153,8 @@ final class HealthFlagsTests: XCTestCase {
             "launched_at": priorLaunchedAt,
             "pid": 12345,
         ]
-        let data = try JSONSerialization.data(withJSONObject: activeBody, options: [.prettyPrinted, .sortedKeys])
-        try data.write(to: sessionsDir.appendingPathComponent("active.json"))
+        let data = try JSONSerialization.data(withJSONObject: priorBody, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: sessionsDir.appendingPathComponent("unclean-exit-\(priorStamp).json"))
 
         let warning = metricKitBaselineWarning(
             home: tmp.path,
@@ -177,11 +179,46 @@ final class HealthFlagsTests: XCTestCase {
         let now = Date()
         let isoFormatter = ISO8601DateFormatter()
         isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let oldLaunchedAt = isoFormatter.string(from: now.addingTimeInterval(-2 * 86400))
+        let oldTimestamp = now.addingTimeInterval(-2 * 86400)
+        let oldLaunchedAt = isoFormatter.string(from: oldTimestamp)
+        let oldStamp = filenameSafeISO(oldTimestamp)
 
-        let activeBody: [String: Any] = [
+        let oldBody: [String: Any] = [
             "version": "0.43.0",
             "launched_at": oldLaunchedAt,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: oldBody, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: sessionsDir.appendingPathComponent("unclean-exit-\(oldStamp).json"))
+
+        let warning = metricKitBaselineWarning(
+            home: tmp.path,
+            bundleVersion: "0.44.1",
+            metricKitCount: 0,
+            now: now
+        )
+        XCTAssertNil(warning, "version bumps older than 24h should not warn")
+    }
+
+    func testMetricKitBaselineWarningSilentWhenOnlyActiveJsonPresent() throws {
+        // active.json is the *current* session; it must not be treated as a
+        // prior-baseline marker. Without an unclean-exit archive, there is
+        // no prior version to compare against, so the warning must stay silent
+        // even after a version bump.
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sessionsDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11/sessions",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+        let now = Date()
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let activeBody: [String: Any] = [
+            "version": "0.43.0",
+            "launched_at": isoFormatter.string(from: now.addingTimeInterval(-60)),
         ]
         let data = try JSONSerialization.data(withJSONObject: activeBody, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: sessionsDir.appendingPathComponent("active.json"))
@@ -192,7 +229,7 @@ final class HealthFlagsTests: XCTestCase {
             metricKitCount: 0,
             now: now
         )
-        XCTAssertNil(warning, "version bumps older than 24h should not warn")
+        XCTAssertNil(warning, "active.json alone is the current session, not a prior baseline")
     }
 
     func testTelemetryAmbiguityFooterSilentWhenCacheMissing() {
@@ -242,5 +279,11 @@ final class HealthFlagsTests: XCTestCase {
             .appendingPathComponent("c11-flags-tests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir
+    }
+
+    private func filenameSafeISO(_ date: Date) -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f.string(from: date).replacingOccurrences(of: ":", with: "-")
     }
 }

--- a/c11Tests/HealthFlagsTests.swift
+++ b/c11Tests/HealthFlagsTests.swift
@@ -95,6 +95,16 @@ final class HealthFlagsTests: XCTestCase {
         }
     }
 
+    func testRejectsDuplicateRailFlag() {
+        XCTAssertThrowsError(try parseHealthCLIArgs(["--rail", "ips", "--rail", "sentinel"])) { error in
+            if case HealthCLIError.duplicateFlag(let f) = error {
+                XCTAssertEqual(f, "--rail")
+            } else {
+                XCTFail("expected .duplicateFlag(\"--rail\"); got \(error)")
+            }
+        }
+    }
+
     // MARK: bootTime
 
     func testBootTimeIsRecentPast() {
@@ -102,6 +112,13 @@ final class HealthFlagsTests: XCTestCase {
         XCTAssertLessThan(boot, Date(), "boot time must be before now")
         let yearAgo = Date(timeIntervalSinceNow: -365 * 86400)
         XCTAssertGreaterThan(boot, yearAgo, "boot time must be within the last year on a normal machine")
+    }
+
+    func testBootTimeFallbackDoesNotEmitDiagnosticOnSuccess() {
+        // sysctl works on macOS, so the success path must NOT call onFallback.
+        var called = false
+        _ = bootTime { _ in called = true }
+        XCTAssertFalse(called, "kern.boottime succeeds on macOS; fallback diagnostic must not fire")
     }
 
     // MARK: warnings

--- a/c11Tests/HealthFlagsTests.swift
+++ b/c11Tests/HealthFlagsTests.swift
@@ -1,0 +1,246 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+final class HealthFlagsTests: XCTestCase {
+
+    // MARK: parseSinceFlag
+
+    func testParseSinceMinutes() {
+        XCTAssertEqual(parseSinceFlag("30m"), 30 * 60)
+        XCTAssertEqual(parseSinceFlag("1m"), 60)
+    }
+
+    func testParseSinceHours() {
+        XCTAssertEqual(parseSinceFlag("2h"), 2 * 3600)
+        XCTAssertEqual(parseSinceFlag("24h"), 24 * 3600)
+    }
+
+    func testParseSinceDays() {
+        XCTAssertEqual(parseSinceFlag("3d"), 3 * 86400)
+    }
+
+    func testParseSinceRejectsInvalid() {
+        XCTAssertNil(parseSinceFlag(""))
+        XCTAssertNil(parseSinceFlag("m"))
+        XCTAssertNil(parseSinceFlag("0m"), "zero is rejected: an empty window is not a useful query")
+        XCTAssertNil(parseSinceFlag("-1h"))
+        XCTAssertNil(parseSinceFlag("3y"))
+        XCTAssertNil(parseSinceFlag("abc"))
+    }
+
+    // MARK: parseHealthCLIArgs
+
+    func testNoArgsDefaultsTo24h() throws {
+        let opts = try parseHealthCLIArgs([])
+        XCTAssertEqual(opts.mode, .defaultLast24h)
+        XCTAssertNil(opts.railFilter)
+        XCTAssertFalse(opts.json)
+    }
+
+    func testParsesSinceFlag() throws {
+        let opts = try parseHealthCLIArgs(["--since", "30m"])
+        XCTAssertEqual(opts.mode, .sinceDuration)
+        XCTAssertEqual(opts.windowDuration, 30 * 60)
+    }
+
+    func testParsesSinceBoot() throws {
+        let opts = try parseHealthCLIArgs(["--since-boot"])
+        XCTAssertEqual(opts.mode, .sinceBoot)
+    }
+
+    func testParsesRailFilter() throws {
+        let opts = try parseHealthCLIArgs(["--rail", "sentinel"])
+        XCTAssertEqual(opts.railFilter, .sentinel)
+    }
+
+    func testParsesJSONFlag() throws {
+        let opts = try parseHealthCLIArgs(["--json"])
+        XCTAssertTrue(opts.json)
+    }
+
+    func testRejectsMutuallyExclusiveSinceFlags() {
+        XCTAssertThrowsError(try parseHealthCLIArgs(["--since", "1h", "--since-boot"])) { error in
+            if case HealthCLIError.mutuallyExclusiveSinceFlags = error {} else {
+                XCTFail("expected .mutuallyExclusiveSinceFlags; got \(error)")
+            }
+        }
+    }
+
+    func testRejectsUnknownRail() {
+        XCTAssertThrowsError(try parseHealthCLIArgs(["--rail", "bogus"])) { error in
+            if case HealthCLIError.unknownRail = error {} else { XCTFail("expected .unknownRail; got \(error)") }
+        }
+    }
+
+    func testRejectsInvalidSince() {
+        XCTAssertThrowsError(try parseHealthCLIArgs(["--since", "1y"])) { error in
+            if case HealthCLIError.invalidSinceValue = error {} else { XCTFail("expected .invalidSinceValue; got \(error)") }
+        }
+    }
+
+    func testRejectsUnknownFlag() {
+        XCTAssertThrowsError(try parseHealthCLIArgs(["--bogus"])) { error in
+            if case HealthCLIError.unknownFlag = error {} else { XCTFail("expected .unknownFlag; got \(error)") }
+        }
+    }
+
+    func testRejectsMissingValue() {
+        XCTAssertThrowsError(try parseHealthCLIArgs(["--since"])) { error in
+            if case HealthCLIError.missingValue = error {} else { XCTFail("expected .missingValue; got \(error)") }
+        }
+    }
+
+    // MARK: bootTime
+
+    func testBootTimeIsRecentPast() {
+        let boot = bootTime()
+        XCTAssertLessThan(boot, Date(), "boot time must be before now")
+        let yearAgo = Date(timeIntervalSinceNow: -365 * 86400)
+        XCTAssertGreaterThan(boot, yearAgo, "boot time must be within the last year on a normal machine")
+    }
+
+    // MARK: warnings
+
+    func testMetricKitBaselineWarningSilentWhenCountNonzero() {
+        let result = metricKitBaselineWarning(
+            home: "/nonexistent",
+            bundleVersion: "0.44.1",
+            metricKitCount: 5
+        )
+        XCTAssertNil(result)
+    }
+
+    func testMetricKitBaselineWarningSilentWhenNoMarker() {
+        let tmp = NSTemporaryDirectory() + "c11-flags-tests-\(UUID().uuidString)"
+        try? FileManager.default.createDirectory(atPath: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: tmp) }
+
+        let result = metricKitBaselineWarning(
+            home: tmp,
+            bundleVersion: "0.44.1",
+            metricKitCount: 0
+        )
+        XCTAssertNil(result, "no prior marker on disk means we have no baseline to compare against")
+    }
+
+    func testMetricKitBaselineWarningFiresOnRecentVersionBump() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sessionsDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11/sessions",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+        let now = Date()
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let priorLaunchedAt = isoFormatter.string(from: now.addingTimeInterval(-3600))
+
+        let activeBody: [String: Any] = [
+            "version": "0.43.0",
+            "build": "0.43.0.1",
+            "commit": "abcdef12",
+            "bundle_id": "com.stage11.c11",
+            "launched_at": priorLaunchedAt,
+            "pid": 12345,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: activeBody, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: sessionsDir.appendingPathComponent("active.json"))
+
+        let warning = metricKitBaselineWarning(
+            home: tmp.path,
+            bundleVersion: "0.44.1",
+            metricKitCount: 0,
+            now: now
+        )
+        XCTAssertNotNil(warning)
+        XCTAssertTrue(warning?.contains("0.43.0 to 0.44.1") == true)
+    }
+
+    func testMetricKitBaselineWarningSilentForOldVersionBump() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sessionsDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11/sessions",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+        let now = Date()
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let oldLaunchedAt = isoFormatter.string(from: now.addingTimeInterval(-2 * 86400))
+
+        let activeBody: [String: Any] = [
+            "version": "0.43.0",
+            "launched_at": oldLaunchedAt,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: activeBody, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: sessionsDir.appendingPathComponent("active.json"))
+
+        let warning = metricKitBaselineWarning(
+            home: tmp.path,
+            bundleVersion: "0.44.1",
+            metricKitCount: 0,
+            now: now
+        )
+        XCTAssertNil(warning, "version bumps older than 24h should not warn")
+    }
+
+    func testTelemetryAmbiguityFooterSilentWhenCacheMissing() {
+        let result = telemetryAmbiguityFooter(home: "/nonexistent", sentryCount: 0)
+        XCTAssertNil(result)
+    }
+
+    func testTelemetryAmbiguityFooterSilentWhenSentryCountNonzero() {
+        XCTAssertNil(telemetryAmbiguityFooter(home: "/nonexistent", sentryCount: 1))
+    }
+
+    func testTelemetryAmbiguityFooterFiresWhenCacheExistsAndIsEmpty() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sentryDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11/io.sentry",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sentryDir, withIntermediateDirectories: true)
+
+        let warning = telemetryAmbiguityFooter(home: tmp.path, sentryCount: 0)
+        XCTAssertNotNil(warning)
+        XCTAssertTrue(warning?.contains("Sentry cache empty") == true)
+    }
+
+    func testTelemetryAmbiguityFooterSilentWhenCacheHasFile() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sentryDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11/io.sentry/envelopes",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sentryDir, withIntermediateDirectories: true)
+        try Data([0]).write(to: sentryDir.appendingPathComponent("queued"))
+
+        // Note: sentryCount would be 1 in this scenario, so the early-return on
+        // count would also silence the footer. We pass 0 here to specifically
+        // exercise the disk check.
+        let warning = telemetryAmbiguityFooter(home: tmp.path, sentryCount: 0)
+        XCTAssertNil(warning, "non-empty cache must not produce the ambiguity footer")
+    }
+
+    private func makeTempHome() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-flags-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/c11Tests/HealthFlagsTests.swift
+++ b/c11Tests/HealthFlagsTests.swift
@@ -274,6 +274,42 @@ final class HealthFlagsTests: XCTestCase {
         XCTAssertNil(warning, "non-empty cache must not produce the ambiguity footer")
     }
 
+    func testTelemetryAmbiguityFooterFiresOnDebugBundleOnly() throws {
+        // Regression: previously the footer hardcoded the production bundle
+        // path and never fired on dev machines that only ran the debug build.
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let debugSentry = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.debug.example/io.sentry",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: debugSentry, withIntermediateDirectories: true)
+
+        let warning = telemetryAmbiguityFooter(home: tmp.path, sentryCount: 0)
+        XCTAssertNotNil(warning, "an empty io.sentry under any c11* bundle must fire the footer")
+    }
+
+    func testTelemetryAmbiguityFooterSilentWhenAnyBundleHasEnvelope() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let emptyDebug = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.debug.empty/io.sentry",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: emptyDebug, withIntermediateDirectories: true)
+        let populated = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.debug.populated/io.sentry/envelopes",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: populated, withIntermediateDirectories: true)
+        try Data([0]).write(to: populated.appendingPathComponent("env-1"))
+
+        let warning = telemetryAmbiguityFooter(home: tmp.path, sentryCount: 0)
+        XCTAssertNil(warning, "any bundle holding queued envelopes must silence the family-wide footer")
+    }
+
     private func makeTempHome() throws -> URL {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("c11-flags-tests-\(UUID().uuidString)", isDirectory: true)

--- a/c11Tests/HealthIPSParserTests.swift
+++ b/c11Tests/HealthIPSParserTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+final class HealthIPSParserTests: XCTestCase {
+
+    private var fixturesURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("health")
+            .appendingPathComponent("ips", isDirectory: true)
+    }
+
+    func testParsesCrashFirstLine() throws {
+        let url = fixturesURL.appendingPathComponent("sample-crash.ips")
+        let body = try String(contentsOf: url, encoding: .utf8)
+        guard let firstLine = body.split(separator: "\n").first else {
+            XCTFail("fixture has no first line")
+            return
+        }
+        let header = try XCTUnwrap(parseIPSFirstLine(String(firstLine)))
+        XCTAssertEqual(header.bundleID, "com.stage11.c11")
+        XCTAssertEqual(header.bugType, "309")
+        XCTAssertEqual(header.incidentID, "00000000-0000-0000-0000-000000000001")
+    }
+
+    func testParsesHangFirstLine() throws {
+        let url = fixturesURL.appendingPathComponent("sample-hang.ips")
+        let body = try String(contentsOf: url, encoding: .utf8)
+        guard let firstLine = body.split(separator: "\n").first else {
+            XCTFail("fixture has no first line")
+            return
+        }
+        let header = try XCTUnwrap(parseIPSFirstLine(String(firstLine)))
+        XCTAssertEqual(header.bundleID, "com.stage11.c11")
+        XCTAssertEqual(header.incidentID, "00000000-0000-0000-0000-000000000002")
+    }
+
+    func testRejectsMalformedFirstLine() {
+        XCTAssertNil(parseIPSFirstLine(""))
+        XCTAssertNil(parseIPSFirstLine("not json"))
+        XCTAssertNil(parseIPSFirstLine("[\"array\"]"))
+    }
+
+    func testScanIPSPicksUpTopLevelC11File() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let reportsDir = tmp.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reportsDir, withIntermediateDirectories: true)
+
+        let crashFixture = try Data(contentsOf: fixturesURL.appendingPathComponent("sample-crash.ips"))
+        let target = reportsDir.appendingPathComponent("c11-2026-05-03-151900.ips")
+        try crashFixture.write(to: target)
+
+        let events = scanIPS(home: tmp.path, since: Date.distantPast)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.rail, .ips)
+        XCTAssertEqual(events.first?.severity, .crash)
+        XCTAssertTrue(events.first?.summary.contains("com.stage11.c11") == true)
+    }
+
+    func testScanIPSPicksUpPerBundleSubdirFile() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let bundleDir = tmp.appendingPathComponent(
+            "Library/Logs/DiagnosticReports/com.stage11.c11.debug.foo",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+
+        let crashFixture = try Data(contentsOf: fixturesURL.appendingPathComponent("sample-crash.ips"))
+        let target = bundleDir.appendingPathComponent("Crash-2026-05-03-151900.ips")
+        try crashFixture.write(to: target)
+
+        let events = scanIPS(home: tmp.path, since: Date.distantPast)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.rail, .ips)
+    }
+
+    func testScanIPSSkipsTopLevelNonC11File() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let reportsDir = tmp.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reportsDir, withIntermediateDirectories: true)
+
+        let crashFixture = try Data(contentsOf: fixturesURL.appendingPathComponent("sample-crash.ips"))
+        let unrelated = reportsDir.appendingPathComponent("Safari-2026-05-03-151900.ips")
+        try crashFixture.write(to: unrelated)
+
+        let events = scanIPS(home: tmp.path, since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty, "non-c11 IPS files at top level must be ignored")
+    }
+
+    func testScanIPSRespectsSinceWindow() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let reportsDir = tmp.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reportsDir, withIntermediateDirectories: true)
+
+        let crashFixture = try Data(contentsOf: fixturesURL.appendingPathComponent("sample-crash.ips"))
+        let target = reportsDir.appendingPathComponent("c11-2026-05-03-151900.ips")
+        try crashFixture.write(to: target)
+
+        // Backdate the file to one hour ago.
+        let oneHourAgo = Date(timeIntervalSinceNow: -3600)
+        try FileManager.default.setAttributes(
+            [.modificationDate: oneHourAgo],
+            ofItemAtPath: target.path
+        )
+
+        let recent = scanIPS(home: tmp.path, since: Date(timeIntervalSinceNow: -60))
+        XCTAssertTrue(recent.isEmpty, "files older than the since-window must be filtered out")
+
+        let wide = scanIPS(home: tmp.path, since: Date(timeIntervalSinceNow: -7200))
+        XCTAssertEqual(wide.count, 1)
+    }
+
+    func testScanIPSGracefulOnMissingDirectory() {
+        let events = scanIPS(home: "/nonexistent/path-that-cannot-exist-1234", since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    private func makeTempHome() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-health-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/c11Tests/HealthIPSParserTests.swift
+++ b/c11Tests/HealthIPSParserTests.swift
@@ -27,6 +27,23 @@ final class HealthIPSParserTests: XCTestCase {
         XCTAssertEqual(header.bundleID, "com.stage11.c11")
         XCTAssertEqual(header.bugType, "309")
         XCTAssertEqual(header.incidentID, "00000000-0000-0000-0000-000000000001")
+        let expected = parseIPSTimestamp("2026-05-03 15:19:00.000 -0400")
+        XCTAssertNotNil(expected)
+        XCTAssertEqual(header.timestamp, expected,
+                       "first-line `timestamp` must round-trip through parseIPSTimestamp")
+    }
+
+    func testParseIPSTimestampHandlesAppleFormat() {
+        let date = parseIPSTimestamp("2026-05-03 15:19:00.000 -0400")
+        XCTAssertNotNil(date)
+
+        let utc = parseIPSTimestamp("2026-05-03 15:19:00.000 +0000")
+        XCTAssertNotNil(utc)
+
+        XCTAssertNil(parseIPSTimestamp(""))
+        XCTAssertNil(parseIPSTimestamp("not a date"))
+        XCTAssertNil(parseIPSTimestamp("2026-05-03T15:19:00Z"),
+                     "ISO-8601 form is not the IPS first-line format and must not parse")
     }
 
     func testParsesHangFirstLine() throws {
@@ -99,18 +116,55 @@ final class HealthIPSParserTests: XCTestCase {
         XCTAssertTrue(events.isEmpty, "non-c11 IPS files at top level must be ignored")
     }
 
-    func testScanIPSRespectsSinceWindow() throws {
+    func testScanIPSUsesParsedTimestampForSinceFilter() throws {
+        // The OS-reported timestamp must beat file mtime as the basis for
+        // --since filtering. CrashReporter can finish writing the file
+        // long after the actual crash, so mtime is a strictly worse proxy
+        // when the first-line JSON carries a timestamp.
         let tmp = try makeTempHome()
         defer { try? FileManager.default.removeItem(at: tmp) }
 
         let reportsDir = tmp.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
         try FileManager.default.createDirectory(at: reportsDir, withIntermediateDirectories: true)
 
-        let crashFixture = try Data(contentsOf: fixturesURL.appendingPathComponent("sample-crash.ips"))
-        let target = reportsDir.appendingPathComponent("c11-2026-05-03-151900.ips")
-        try crashFixture.write(to: target)
+        let crashTime = Date(timeIntervalSinceNow: -10 * 60)
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS Z"
+        let crashTimeStr = f.string(from: crashTime)
 
-        // Backdate the file to one hour ago.
+        let body = "{\"app_name\":\"c11\",\"bundleID\":\"com.stage11.c11\",\"bug_type\":\"309\",\"incident_id\":\"abc12345-0000-0000-0000-000000000000\",\"timestamp\":\"" + crashTimeStr + "\"}\n"
+        let target = reportsDir.appendingPathComponent("c11-runtime.ips")
+        try Data(body.utf8).write(to: target)
+
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3600)],
+            ofItemAtPath: target.path
+        )
+
+        let events = scanIPS(home: tmp.path, since: Date(timeIntervalSinceNow: -30 * 60))
+        XCTAssertEqual(events.count, 1,
+                       "parsed timestamp (10m ago) must be used; mtime (1h ago) would have filtered this out")
+        let event = try XCTUnwrap(events.first)
+        XCTAssertEqual(
+            event.timestamp.timeIntervalSinceReferenceDate,
+            crashTime.timeIntervalSinceReferenceDate,
+            accuracy: 0.01,
+            "row timestamp must come from the first-line JSON, not file mtime"
+        )
+    }
+
+    func testScanIPSFallsBackToMtimeWhenTimestampMissing() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let reportsDir = tmp.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reportsDir, withIntermediateDirectories: true)
+
+        let body = "{\"app_name\":\"c11\",\"bundleID\":\"com.stage11.c11\",\"bug_type\":\"309\",\"incident_id\":\"xyz98765-0000-0000-0000-000000000000\"}\n"
+        let target = reportsDir.appendingPathComponent("c11-fallback.ips")
+        try Data(body.utf8).write(to: target)
+
         let oneHourAgo = Date(timeIntervalSinceNow: -3600)
         try FileManager.default.setAttributes(
             [.modificationDate: oneHourAgo],
@@ -118,10 +172,28 @@ final class HealthIPSParserTests: XCTestCase {
         )
 
         let recent = scanIPS(home: tmp.path, since: Date(timeIntervalSinceNow: -60))
-        XCTAssertTrue(recent.isEmpty, "files older than the since-window must be filtered out")
+        XCTAssertTrue(recent.isEmpty,
+                      "without a parsed timestamp, mtime is the fallback and the recent window excludes 1h-old files")
 
         let wide = scanIPS(home: tmp.path, since: Date(timeIntervalSinceNow: -7200))
-        XCTAssertEqual(wide.count, 1)
+        XCTAssertEqual(wide.count, 1,
+                       "wide window includes the 1h-old mtime fallback")
+    }
+
+    func testScanIPSMalformedTimestampFallsBackToMtime() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let reportsDir = tmp.appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+        try FileManager.default.createDirectory(at: reportsDir, withIntermediateDirectories: true)
+
+        let body = "{\"bundleID\":\"com.stage11.c11\",\"bug_type\":\"309\",\"incident_id\":\"id1\",\"timestamp\":\"not-a-real-timestamp\"}\n"
+        let target = reportsDir.appendingPathComponent("c11-malformed-ts.ips")
+        try Data(body.utf8).write(to: target)
+
+        let recent = scanIPS(home: tmp.path, since: Date(timeIntervalSinceNow: -60))
+        XCTAssertEqual(recent.count, 1,
+                       "malformed timestamp must fall back to mtime (which is 'now') silently")
     }
 
     func testScanIPSGracefulOnMissingDirectory() {

--- a/c11Tests/HealthMetricKitParserTests.swift
+++ b/c11Tests/HealthMetricKitParserTests.swift
@@ -1,0 +1,109 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+final class HealthMetricKitParserTests: XCTestCase {
+
+    func testParsesCrashKind() {
+        let result = parseMetricKitFilename("2026-05-03T15-19-00.123Z-crash1.json")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.kind, "crash1")
+    }
+
+    func testParsesHangKind() {
+        let result = parseMetricKitFilename("2026-05-03T15-19-00.456Z-hang3.json")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.kind, "hang3")
+    }
+
+    func testParsesCrashHangMixedKind() {
+        let result = parseMetricKitFilename("2026-05-03T15-19-00.789Z-crash1-hang2.json")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.kind, "crash1-hang2")
+    }
+
+    func testParsesResourceKind() {
+        let result = parseMetricKitFilename("2026-05-03T15-19-01.000Z-disk1-cpu1.json")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.kind, "disk1-cpu1")
+    }
+
+    func testParsesDiagnosticKind() {
+        let result = parseMetricKitFilename("2026-05-03T15-19-01.234Z-diagnostic.json")
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.kind, "diagnostic")
+    }
+
+    func testSkipsMetricKind() {
+        XCTAssertNil(
+            parseMetricKitFilename("2026-05-03T15-19-01.456Z-metric.json"),
+            "metric rows are MXMetricPayload baselines, not diagnostics; must be skipped in v1"
+        )
+    }
+
+    func testRejectsMalformedNames() {
+        XCTAssertNil(parseMetricKitFilename("bogus-not-a-stamp.json"))
+        XCTAssertNil(parseMetricKitFilename(""))
+        XCTAssertNil(parseMetricKitFilename(".json"))
+        XCTAssertNil(parseMetricKitFilename("2026-05-03T15-19-00Z-crash1.json"),
+                     "missing fractional-seconds component must be rejected")
+        XCTAssertNil(parseMetricKitFilename("2026-05-03T15-19-00.123Z-bogus.json"),
+                     "unknown kind tokens must be rejected")
+        XCTAssertNil(parseMetricKitFilename("2026-05-03T15-19-00.123Z-crash.json"),
+                     "category tokens must include a count suffix")
+    }
+
+    func testStampParsesAsUTC() {
+        let result = parseMetricKitFilename("2026-05-03T15-19-00.123Z-crash1.json")
+        let timestamp = result?.timestamp
+        XCTAssertNotNil(timestamp)
+
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let expected = f.date(from: "2026-05-03T15:19:00.123Z")
+        XCTAssertEqual(timestamp, expected)
+    }
+
+    func testScanMetricKitPicksUpFiles() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let metricDir = tmp.appendingPathComponent("Library/Logs/c11/metrickit", isDirectory: true)
+        try FileManager.default.createDirectory(at: metricDir, withIntermediateDirectories: true)
+
+        let names = [
+            "2026-05-03T15-19-00.123Z-crash1.json",
+            "2026-05-03T15-19-00.456Z-hang3.json",
+            "2026-05-03T15-19-01.234Z-diagnostic.json",
+            "2026-05-03T15-19-01.456Z-metric.json",
+            "bogus-not-a-stamp.json",
+        ]
+        for name in names {
+            try Data("{}".utf8).write(to: metricDir.appendingPathComponent(name))
+        }
+
+        let events = scanMetricKit(home: tmp.path, since: Date.distantPast)
+        // metric and bogus filtered, leaving 3 valid rows.
+        XCTAssertEqual(events.count, 3)
+        XCTAssertTrue(events.allSatisfy { $0.rail == .metrickit })
+
+        let summaries = Set(events.map(\.summary))
+        XCTAssertEqual(summaries, ["crash1", "hang3", "diagnostic"])
+    }
+
+    func testScanMetricKitGracefulOnMissingDirectory() {
+        let events = scanMetricKit(home: "/nonexistent/path-1234", since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    private func makeTempHome() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-health-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/c11Tests/HealthSentinelParserTests.swift
+++ b/c11Tests/HealthSentinelParserTests.swift
@@ -37,6 +37,35 @@ final class HealthSentinelParserTests: XCTestCase {
         XCTAssertEqual(event.timestamp, expected)
     }
 
+    func testCorruptBodyRendersUnknownPlaceholders() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-health-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let target = tmp.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        try Data("not valid json".utf8).write(to: target)
+
+        let event = try XCTUnwrap(parseUncleanExitFile(at: target, since: Date.distantPast))
+        XCTAssertEqual(event.severity, .unclean_exit,
+                       "corrupt-body rows must still surface; the file's presence is the signal")
+        XCTAssertEqual(event.summary, "unknown (unknown) unknown",
+                       "corrupt body must render 'unknown' placeholders, not '?' or '????????'")
+    }
+
+    func testMissingJSONKeysRenderUnknownPlaceholders() throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-health-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let target = tmp.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        try Data("{}".utf8).write(to: target)
+
+        let event = try XCTUnwrap(parseUncleanExitFile(at: target, since: Date.distantPast))
+        XCTAssertEqual(event.summary, "unknown (unknown) unknown")
+    }
+
     func testRejectsWhenStampPredatesSince() throws {
         let url = fixturesURL.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
         let cutoff = ISO8601DateFormatter().date(from: "2099-01-01T00:00:00Z")!

--- a/c11Tests/HealthSentinelParserTests.swift
+++ b/c11Tests/HealthSentinelParserTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+final class HealthSentinelParserTests: XCTestCase {
+
+    private var fixturesURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures")
+            .appendingPathComponent("health")
+            .appendingPathComponent("sentinel", isDirectory: true)
+    }
+
+    func testParsesFixtureUncleanExit() throws {
+        let url = fixturesURL.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        let event = try XCTUnwrap(parseUncleanExitFile(at: url, since: Date.distantPast))
+        XCTAssertEqual(event.rail, .sentinel)
+        XCTAssertEqual(event.severity, .unclean_exit)
+        XCTAssertTrue(event.summary.contains("0.44.1"))
+        XCTAssertTrue(event.summary.contains("0.44.1.123"))
+        XCTAssertTrue(event.summary.contains("e6ce1be2"),
+                      "summary must include the 8-char short commit hash")
+    }
+
+    func testTimestampParsedFromFilename() throws {
+        let url = fixturesURL.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        let event = try XCTUnwrap(parseUncleanExitFile(at: url, since: Date.distantPast))
+
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let expected = f.date(from: "2026-05-03T15:19:00.123Z")
+        XCTAssertEqual(event.timestamp, expected)
+    }
+
+    func testRejectsWhenStampPredatesSince() throws {
+        let url = fixturesURL.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        let cutoff = ISO8601DateFormatter().date(from: "2099-01-01T00:00:00Z")!
+        XCTAssertNil(parseUncleanExitFile(at: url, since: cutoff))
+    }
+
+    func testScanLaunchSentinelFindsArchivedFile() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sessionsDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.debug.foo/sessions",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+
+        let fixture = try Data(
+            contentsOf: fixturesURL.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        )
+        let target = sessionsDir.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        try fixture.write(to: target)
+
+        let events = scanLaunchSentinel(home: tmp.path, since: Date.distantPast)
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.rail, .sentinel)
+        XCTAssertEqual(events.first?.severity, .unclean_exit)
+    }
+
+    func testScanLaunchSentinelIgnoresActiveJSON() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sessionsDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11/sessions",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: sessionsDir.appendingPathComponent("active.json"))
+
+        let events = scanLaunchSentinel(home: tmp.path, since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty, "active.json represents the live session, not an unclean exit")
+    }
+
+    func testScanLaunchSentinelIgnoresNonC11Bundles() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let sessionsDir = tmp.appendingPathComponent(
+            "Library/Caches/com.example.other/sessions",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(
+            to: sessionsDir.appendingPathComponent("unclean-exit-2026-05-03T15-19-00.123Z.json")
+        )
+
+        let events = scanLaunchSentinel(home: tmp.path, since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testScanLaunchSentinelGracefulOnMissingDirectory() {
+        let events = scanLaunchSentinel(home: "/nonexistent/path-1234", since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    private func makeTempHome() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-health-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/c11Tests/HealthSentryParserTests.swift
+++ b/c11Tests/HealthSentryParserTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+final class HealthSentryParserTests: XCTestCase {
+
+    func testFindsTwoEnvelopesUnderPerBundleDir() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let envelopesDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.debug.foo/io.sentry/envelopes",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: envelopesDir, withIntermediateDirectories: true)
+        try Data([0]).write(to: envelopesDir.appendingPathComponent("envelope-empty"))
+        try Data(repeating: 0xAB, count: 64).write(to: envelopesDir.appendingPathComponent("envelope-small"))
+
+        let events = scanSentryQueued(home: tmp.path, since: Date.distantPast)
+        XCTAssertEqual(events.count, 2)
+        XCTAssertTrue(events.allSatisfy { $0.rail == .sentry })
+        XCTAssertTrue(events.allSatisfy { $0.severity == .queued })
+        XCTAssertTrue(events.allSatisfy { $0.summary.hasPrefix("com.stage11.c11.debug.foo/") })
+    }
+
+    func testIncludesLegacyC11muxBundles() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let legacy = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11mux/io.sentry/envelopes",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: legacy, withIntermediateDirectories: true)
+        try Data([0]).write(to: legacy.appendingPathComponent("legacy-envelope"))
+
+        let events = scanSentryQueued(home: tmp.path, since: Date.distantPast)
+        XCTAssertEqual(events.count, 1, "legacy c11mux bundles must remain in scope for v1")
+        XCTAssertEqual(events.first?.summary, "com.stage11.c11mux/legacy-envelope")
+    }
+
+    func testSkipsBundlesWithoutIoSentryDir() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let bundleDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11.no-sentry-dir",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+
+        let events = scanSentryQueued(home: tmp.path, since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testIgnoresNonC11Bundles() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let unrelated = tmp.appendingPathComponent(
+            "Library/Caches/com.example.other/io.sentry/envelopes",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: unrelated, withIntermediateDirectories: true)
+        try Data([0]).write(to: unrelated.appendingPathComponent("envelope"))
+
+        let events = scanSentryQueued(home: tmp.path, since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    func testRespectsSinceWindow() throws {
+        let tmp = try makeTempHome()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let envelopesDir = tmp.appendingPathComponent(
+            "Library/Caches/com.stage11.c11/io.sentry/envelopes",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: envelopesDir, withIntermediateDirectories: true)
+        let target = envelopesDir.appendingPathComponent("old-envelope")
+        try Data([0]).write(to: target)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -3600)],
+            ofItemAtPath: target.path
+        )
+
+        XCTAssertTrue(scanSentryQueued(home: tmp.path, since: Date(timeIntervalSinceNow: -60)).isEmpty)
+        XCTAssertEqual(scanSentryQueued(home: tmp.path, since: Date(timeIntervalSinceNow: -7200)).count, 1)
+    }
+
+    func testGracefulOnMissingCachesDir() {
+        let events = scanSentryQueued(home: "/nonexistent/path-1234", since: Date.distantPast)
+        XCTAssertTrue(events.isEmpty)
+    }
+
+    private func makeTempHome() throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("c11-health-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+}

--- a/notes/c11-24/raw/01-default.txt
+++ b/notes/c11-24/raw/01-default.txt
@@ -1,0 +1,6 @@
+=== c11 health ===
+c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel.
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.
+=== exit=0 ===

--- a/notes/c11-24/raw/02-default-json.txt
+++ b/notes/c11-24/raw/02-default-json.txt
@@ -1,0 +1,29 @@
+=== c11 health --json ===
+{
+  "events" : [
+
+  ],
+  "rails" : {
+    "ips" : {
+      "count" : 0
+    },
+    "metrickit" : {
+      "count" : 0
+    },
+    "sentinel" : {
+      "count" : 0
+    },
+    "sentry" : {
+      "count" : 0
+    }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+    "Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache."
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:37:32.073Z",
+    "until" : "2026-05-03T22:37:32.073Z"
+  }
+}

--- a/notes/c11-24/raw/03-since-30m.txt
+++ b/notes/c11-24/raw/03-since-30m.txt
@@ -1,0 +1,5 @@
+=== c11 health --since 30m ===
+c11 health: nothing in the last 30m across ips, sentry, metrickit, sentinel.
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.

--- a/notes/c11-24/raw/04-since-30m-json.txt
+++ b/notes/c11-24/raw/04-since-30m-json.txt
@@ -1,0 +1,29 @@
+=== c11 health --since 30m --json ===
+{
+  "events" : [
+
+  ],
+  "rails" : {
+    "ips" : {
+      "count" : 0
+    },
+    "metrickit" : {
+      "count" : 0
+    },
+    "sentinel" : {
+      "count" : 0
+    },
+    "sentry" : {
+      "count" : 0
+    }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+    "Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache."
+  ],
+  "window" : {
+    "mode" : "since",
+    "since" : "2026-05-03T22:07:32.147Z",
+    "until" : "2026-05-03T22:37:32.147Z"
+  }
+}

--- a/notes/c11-24/raw/05-since-boot.txt
+++ b/notes/c11-24/raw/05-since-boot.txt
@@ -1,0 +1,5 @@
+=== c11 health --since-boot ===
+c11 health: nothing since boot across ips, sentry, metrickit, sentinel.
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.

--- a/notes/c11-24/raw/06-since-boot-json.txt
+++ b/notes/c11-24/raw/06-since-boot-json.txt
@@ -1,0 +1,29 @@
+=== c11 health --since-boot --json ===
+{
+  "events" : [
+
+  ],
+  "rails" : {
+    "ips" : {
+      "count" : 0
+    },
+    "metrickit" : {
+      "count" : 0
+    },
+    "sentinel" : {
+      "count" : 0
+    },
+    "sentry" : {
+      "count" : 0
+    }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+    "Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache."
+  ],
+  "window" : {
+    "mode" : "since-boot",
+    "since" : "2026-05-02T19:32:22.372Z",
+    "until" : "2026-05-03T22:37:37.501Z"
+  }
+}

--- a/notes/c11-24/raw/07-rail-sentinel.txt
+++ b/notes/c11-24/raw/07-rail-sentinel.txt
@@ -1,0 +1,2 @@
+=== c11 health --rail sentinel ===
+c11 health: nothing in the last 24h across sentinel.

--- a/notes/c11-24/raw/08-rail-sentinel-json.txt
+++ b/notes/c11-24/raw/08-rail-sentinel-json.txt
@@ -1,0 +1,20 @@
+=== c11 health --rail sentinel --json ===
+{
+  "events" : [
+
+  ],
+  "rails" : {
+    "sentinel" : {
+      "count" : 0
+    }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:37:37.558Z",
+    "until" : "2026-05-03T22:37:37.558Z"
+  }
+}

--- a/notes/c11-24/raw/09-err-bogus-rail.txt
+++ b/notes/c11-24/raw/09-err-bogus-rail.txt
@@ -1,0 +1,5 @@
+=== c11 health --rail bogus (should error one stderr line) ===
+exit=1
+--- stdout ---
+--- stderr ---
+Error: c11 health: unknown --rail 'bogus' (expected one of ips, sentry, metrickit, sentinel)

--- a/notes/c11-24/raw/10-err-mutual-exclusion.txt
+++ b/notes/c11-24/raw/10-err-mutual-exclusion.txt
@@ -1,0 +1,5 @@
+=== c11 health --since 30m --since-boot (mutual exclusion) ===
+exit=1
+--- stdout ---
+--- stderr ---
+Error: c11 health: --since and --since-boot are mutually exclusive

--- a/notes/c11-24/raw/11-err-rail-duplicate.txt
+++ b/notes/c11-24/raw/11-err-rail-duplicate.txt
@@ -1,0 +1,5 @@
+=== c11 health --rail ips --rail sentry (--rail duplicate) ===
+exit=1
+--- stdout ---
+--- stderr ---
+Error: c11 health: --rail may only be specified once

--- a/notes/c11-24/raw/12-help.txt
+++ b/notes/c11-24/raw/12-help.txt
@@ -1,0 +1,23 @@
+=== c11 health --help ===
+exit=0
+--- stdout ---
+c11 health
+
+Usage: c11 health [--since <duration> | --since-boot] [--rail <name>] [--json]
+
+Read-only crash-visibility sweep across four local rails: Apple IPS reports,
+queued Sentry envelopes, MetricKit diagnostic payloads, and the c11 launch
+sentinel (catches Force Quit and SIGKILL where Sentry cannot).
+
+Flags:
+  --since <duration>     Time window: 30m, 2h, 24h, 3d. Default 24h.
+  --since-boot           Limit to events since the last system boot.
+  --rail <name>          Filter to one rail: ips, sentry, metrickit, sentinel. Specify at most once. Default: all rails.
+  --json                 Emit structured JSON instead of the default table.
+
+Example:
+  c11 health
+  c11 health --since 30m
+  c11 health --since-boot --rail sentinel
+  c11 health --json
+--- stderr ---

--- a/notes/c11-24/raw/13-rail-sentinel-after-fq.txt
+++ b/notes/c11-24/raw/13-rail-sentinel-after-fq.txt
@@ -1,0 +1,4 @@
+=== c11 health --rail sentinel (after force-quit) ===
+TIME             | RAIL      | SEVERITY     | SUMMARY
+(TIME reflects the OS-reported event time when available, file mtime otherwise)
+2026-05-03 18:38 | sentinel  | unclean_exit | 0.44.1 (95) bbb8fa89

--- a/notes/c11-24/raw/14-rail-sentinel-after-fq-json.txt
+++ b/notes/c11-24/raw/14-rail-sentinel-after-fq-json.txt
@@ -1,0 +1,26 @@
+=== c11 health --rail sentinel --json (after force-quit) ===
+{
+  "events" : [
+    {
+      "path" : "~\/Library\/Caches\/com.stage11.c11.debug.c11.24.health\/sessions\/unclean-exit-2026-05-03T22-38-36.273Z.json",
+      "rail" : "sentinel",
+      "severity" : "unclean_exit",
+      "summary" : "0.44.1 (95) bbb8fa89",
+      "timestamp" : "2026-05-03T22:38:36.273Z"
+    }
+  ],
+  "rails" : {
+    "sentinel" : {
+      "count" : 1
+    }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:38:50.113Z",
+    "until" : "2026-05-03T22:38:50.113Z"
+  }
+}

--- a/notes/c11-24/raw/15-rail-metrickit.txt
+++ b/notes/c11-24/raw/15-rail-metrickit.txt
@@ -1,0 +1,4 @@
+=== c11 health --rail metrickit ===
+TIME             | RAIL      | SEVERITY     | SUMMARY
+(TIME reflects the OS-reported event time when available, file mtime otherwise)
+2026-05-03 18:19 | metrickit | hang         | hang3

--- a/notes/c11-24/raw/16-rail-metrickit-json.txt
+++ b/notes/c11-24/raw/16-rail-metrickit-json.txt
@@ -1,0 +1,26 @@
+=== c11 health --rail metrickit --json ===
+{
+  "events" : [
+    {
+      "path" : "~\/Library\/Logs\/c11\/metrickit\/2026-05-03T22-19-00.000Z-hang3.json",
+      "rail" : "metrickit",
+      "severity" : "hang",
+      "summary" : "hang3",
+      "timestamp" : "2026-05-03T22:19:00.000Z"
+    }
+  ],
+  "rails" : {
+    "metrickit" : {
+      "count" : 1
+    }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:38:58.848Z",
+    "until" : "2026-05-03T22:38:58.848Z"
+  }
+}

--- a/notes/c11-24/raw/17-default-populated.txt
+++ b/notes/c11-24/raw/17-default-populated.txt
@@ -1,0 +1,8 @@
+=== c11 health (default, with sentinel + metrickit populated) ===
+TIME             | RAIL      | SEVERITY     | SUMMARY
+(TIME reflects the OS-reported event time when available, file mtime otherwise)
+2026-05-03 18:38 | sentinel  | unclean_exit | 0.44.1 (95) bbb8fa89
+2026-05-03 18:19 | metrickit | hang         | hang3
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.

--- a/notes/c11-24/raw/18-default-populated-json.txt
+++ b/notes/c11-24/raw/18-default-populated-json.txt
@@ -1,0 +1,42 @@
+=== c11 health --json (default, populated) ===
+{
+  "events" : [
+    {
+      "path" : "~\/Library\/Caches\/com.stage11.c11.debug.c11.24.health\/sessions\/unclean-exit-2026-05-03T22-38-36.273Z.json",
+      "rail" : "sentinel",
+      "severity" : "unclean_exit",
+      "summary" : "0.44.1 (95) bbb8fa89",
+      "timestamp" : "2026-05-03T22:38:36.273Z"
+    },
+    {
+      "path" : "~\/Library\/Logs\/c11\/metrickit\/2026-05-03T22-19-00.000Z-hang3.json",
+      "rail" : "metrickit",
+      "severity" : "hang",
+      "summary" : "hang3",
+      "timestamp" : "2026-05-03T22:19:00.000Z"
+    }
+  ],
+  "rails" : {
+    "ips" : {
+      "count" : 0
+    },
+    "metrickit" : {
+      "count" : 1
+    },
+    "sentinel" : {
+      "count" : 1
+    },
+    "sentry" : {
+      "count" : 0
+    }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+    "Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache."
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:39:06.494Z",
+    "until" : "2026-05-03T22:39:06.494Z"
+  }
+}

--- a/notes/c11-24/validation-report.md
+++ b/notes/c11-24/validation-report.md
@@ -1,0 +1,290 @@
+# C11-24 validation report
+
+**Tagged build:** `c11-24-health` (commit `bbb8fa89`)
+**Branch:** `c11-24/health-cli` (19 commits ahead of `origin/crash-visibility/launch-sentinel`)
+**Date:** 2026-05-03
+**Host:** atin's Mac (live machine, per plan note Validation F baseline)
+**Verdict:** **PASS**
+
+All flag paths smoked, all error paths produce single-line stderr with exit=1, sentinel synthesis confirmed via SIGKILL→relaunch, MetricKit synthesis confirmed via fake JSON, both expected diagnostic warning behaviors observed (`telemetry_state_ambiguous` fires, `metrickit_baseline_recent_version_bump` correctly does not on a fresh tag).
+
+## Build
+
+`./scripts/reload.sh --tag c11-24-health` from the worktree completed `** BUILD SUCCEEDED **` on the first attempt. App launched at `/Users/atin/Library/Developer/Xcode/DerivedData/c11-c11-24-health/Build/Products/Debug/c11 DEV c11-24-health.app`. CLI helper at `…/Contents/Resources/bin/c11`.
+
+Build warnings inherited from the base branch (Sendable / deprecated APIs in `Sources/Panels/BrowserPanel.swift`, `Sources/AppDelegate.swift`, etc.); none introduced by the C11-24 work.
+
+## Bundle ID note
+
+The tag slug `c11-24-health` becomes bundle ID `com.stage11.c11.debug.c11.24.health` — Xcode/macOS converts hyphens to dots. This matters for the sentinel rail glob (`com.stage11.c11*/sessions/`) which correctly catches the dotted form.
+
+## c11 health (default 24h window)
+
+### Pass 1 — empty rails, before sentinel synthesis
+
+```
+c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel.
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.
+```
+
+`telemetry_state_ambiguous` fires as Validation F predicted (the empty `~/Library/Caches/com.stage11.c11/io.sentry/` directory is what triggers it).
+
+### Pass 1 JSON
+
+```json
+{
+  "events" : [
+
+  ],
+  "rails" : {
+    "ips" : { "count" : 0 },
+    "metrickit" : { "count" : 0 },
+    "sentinel" : { "count" : 0 },
+    "sentry" : { "count" : 0 }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+    "Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache."
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:37:32.073Z",
+    "until" : "2026-05-03T22:37:32.073Z"
+  }
+}
+```
+
+`schema_version: 1` present (EW1 fix). 24h window symmetric around now. Warning surfaced once in `warnings` array.
+
+### Pass 2 — populated (sentinel + metrickit synthesized)
+
+```
+TIME             | RAIL      | SEVERITY     | SUMMARY
+(TIME reflects the OS-reported event time when available, file mtime otherwise)
+2026-05-03 18:38 | sentinel  | unclean_exit | 0.44.1 (95) bbb8fa89
+2026-05-03 18:19 | metrickit | hang         | hang3
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.
+```
+
+Reverse-chronological order verified (sentinel 18:38 above metrickit 18:19). I4/I5 stable-sort tiebreak holds.
+
+### Pass 2 JSON
+
+```json
+{
+  "events" : [
+    {
+      "path" : "~/Library/Caches/com.stage11.c11.debug.c11.24.health/sessions/unclean-exit-2026-05-03T22-38-36.273Z.json",
+      "rail" : "sentinel",
+      "severity" : "unclean_exit",
+      "summary" : "0.44.1 (95) bbb8fa89",
+      "timestamp" : "2026-05-03T22:38:36.273Z"
+    },
+    {
+      "path" : "~/Library/Logs/c11/metrickit/2026-05-03T22-19-00.000Z-hang3.json",
+      "rail" : "metrickit",
+      "severity" : "hang",
+      "summary" : "hang3",
+      "timestamp" : "2026-05-03T22:19:00.000Z"
+    }
+  ],
+  "rails" : {
+    "ips" : { "count" : 0 },
+    "metrickit" : { "count" : 1 },
+    "sentinel" : { "count" : 1 },
+    "sentry" : { "count" : 0 }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+    "Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache."
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:39:06.494Z",
+    "until" : "2026-05-03T22:39:06.494Z"
+  }
+}
+```
+
+`path` values redacted to `~/…` form (B4 fix verified — no `/Users/atin/…` leaks).
+
+## c11 health --since 30m
+
+```
+c11 health: nothing in the last 30m across ips, sentry, metrickit, sentinel.
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.
+```
+
+JSON `window.mode = "since"`, `since` is `now - 30m`, `until` is `now`. Empty-result line correctly says "in the last 30m" not "24h" (parseSinceFlag round-trips as expected).
+
+## c11 health --since-boot
+
+```
+c11 health: nothing since boot across ips, sentry, metrickit, sentinel.
+
+Warnings:
+  - Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.
+```
+
+JSON `window.mode = "since-boot"`. `since` is `2026-05-02T19:32:22.372Z` (system boot), `until` is now. Boot-time math via `sysctlbyname("kern.boottime")` returns a sensible Date.
+
+## c11 health --rail sentinel (with synthesized unclean exit)
+
+```
+TIME             | RAIL      | SEVERITY     | SUMMARY
+(TIME reflects the OS-reported event time when available, file mtime otherwise)
+2026-05-03 18:38 | sentinel  | unclean_exit | 0.44.1 (95) bbb8fa89
+```
+
+JSON:
+
+```json
+{
+  "events" : [
+    {
+      "path" : "~/Library/Caches/com.stage11.c11.debug.c11.24.health/sessions/unclean-exit-2026-05-03T22-38-36.273Z.json",
+      "rail" : "sentinel",
+      "severity" : "unclean_exit",
+      "summary" : "0.44.1 (95) bbb8fa89",
+      "timestamp" : "2026-05-03T22:38:36.273Z"
+    }
+  ],
+  "rails" : {
+    "sentinel" : { "count" : 1 }
+  },
+  "schema_version" : 1,
+  "warnings" : [
+
+  ],
+  "window" : {
+    "mode" : "default-24h",
+    "since" : "2026-05-02T22:38:50.113Z",
+    "until" : "2026-05-03T22:38:50.113Z"
+  }
+}
+```
+
+When `--rail sentinel` is set, the sentry-cache warning correctly does NOT fire (warnings are gated to relevant rail). Rails JSON contains only the `sentinel` key (other rails not enumerated when filtered out).
+
+## c11 health --rail metrickit (with synthesized hang3)
+
+Synthesized via `echo '{}' > ~/Library/Logs/c11/metrickit/2026-05-03T22-19-00.000Z-hang3.json`.
+
+```
+TIME             | RAIL      | SEVERITY     | SUMMARY
+(TIME reflects the OS-reported event time when available, file mtime otherwise)
+2026-05-03 18:19 | metrickit | hang         | hang3
+```
+
+Filename grammar parses correctly: stamp `2026-05-03T22-19-00.000Z` → ISO timestamp; kind `hang3` → severity `hang`, summary `hang3`. Cleaned up after capture.
+
+## Error cases (S4, I1 fixes)
+
+### `c11 health --rail bogus`
+
+```
+exit=1
+stdout: (empty)
+stderr: Error: c11 health: unknown --rail 'bogus' (expected one of ips, sentry, metrickit, sentinel)
+```
+
+Single stderr line, exit 1 (S4 fix verified — no duplicate emission).
+
+### `c11 health --since 30m --since-boot`
+
+```
+exit=1
+stdout: (empty)
+stderr: Error: c11 health: --since and --since-boot are mutually exclusive
+```
+
+### `c11 health --rail ips --rail sentry`
+
+```
+exit=1
+stdout: (empty)
+stderr: Error: c11 health: --rail may only be specified once
+```
+
+I1 fix verified — `--rail` rejects a second specification rather than silently overwriting.
+
+## c11 health --help (dispatchSubcommandHelp via Plan deviation 1)
+
+```
+c11 health
+
+Usage: c11 health [--since <duration> | --since-boot] [--rail <name>] [--json]
+
+Read-only crash-visibility sweep across four local rails: Apple IPS reports,
+queued Sentry envelopes, MetricKit diagnostic payloads, and the c11 launch
+sentinel (catches Force Quit and SIGKILL where Sentry cannot).
+
+Flags:
+  --since <duration>     Time window: 30m, 2h, 24h, 3d. Default 24h.
+  --since-boot           Limit to events since the last system boot.
+  --rail <name>          Filter to one rail: ips, sentry, metrickit, sentinel. Specify at most once. Default: all rails.
+  --json                 Emit structured JSON instead of the default table.
+
+Example:
+  c11 health
+  c11 health --since 30m
+  c11 health --since-boot --rail sentinel
+  c11 health --json
+```
+
+Exit 0; output on stdout. The dispatch deviation (insert `health` branch AFTER the help dispatch, not after `remote-daemon-status`) is verified — `--help` correctly routes through `dispatchSubcommandHelp` and prints help text rather than running the command. `--rail` line documents the I2 single-rail constraint.
+
+## Sentinel synthesis (force-quit + relaunch)
+
+1. Tagged app launched: PID 31629, wrote `~/Library/Caches/com.stage11.c11.debug.c11.24.health/sessions/active.json` containing `pid: 31629, version: 0.44.1, build: 95, commit: bbb8fa899, bundle_id: com.stage11.c11.debug.c11.24.health, launched_at: 2026-05-03T22:36:58.300Z`.
+2. `kill -9 31629` (SIGKILL — bypasses `applicationWillTerminate` so `LaunchSentinel.clearActive()` does not run).
+3. `./scripts/reload.sh --tag c11-24-health` rebuilt + relaunched (no source changes since first build, so build was incremental and fast).
+4. New PID 38484; `LaunchSentinel.recordLaunchAndArchivePrevious()` ran on the new launch and archived the orphan `active.json` to `unclean-exit-2026-05-03T22-38-36.273Z.json`.
+5. `c11 health --rail sentinel` returns exactly ONE row referencing `com.stage11.c11.debug.c11.24.health`, version `0.44.1 (95)`, commit-hash short form `bbb8fa89` (truncated from `bbb8fa899` per S7-era summary format).
+
+Path stays under the c11 hyphen-converted-to-dot bundle ID — the sentinel rail glob matched correctly (`~/Library/Caches/com.stage11.c11*/sessions/unclean-exit-*.json`).
+
+## MetricKit synthesis
+
+Wrote `~/Library/Logs/c11/metrickit/2026-05-03T22-19-00.000Z-hang3.json` containing `{}`. `c11 health --rail metrickit` returned one row at the expected timestamp (parsed from filename, not file mtime), severity `hang`, summary `hang3` verbatim. After capture, removed via `/bin/rm -f`. Confirmed empty post-cleanup.
+
+## Diagnostic warnings observed on this host
+
+| Warning | Predicted (Validation F) | Observed |
+|---|---|---|
+| `telemetry_state_ambiguous` | Should fire (empty `io.sentry/` exists) | **Fired**, exact wording: `Sentry cache empty across c11 bundles: telemetry may be off, or events shipped on last launch and cleared the cache.` Surfaced both in human footer and JSON `warnings` array. |
+| `metrickit_baseline_recent_version_bump` | May not fire on first run (no prior session marker for new tag) | **Did not fire** on this host. Tagged build is the first run of `com.stage11.c11.debug.c11.24.health`; no prior session JSON exists to compare versions against. |
+
+Both behaviors match Validation F predictions.
+
+## Anomalies
+
+1. **`commit` field empty in second active.json.** The first launch recorded `commit: "bbb8fa899"` correctly, but the post-relaunch active.json (PID 38484) has `commit: ""`. Both builds produced from the same git tip with no source changes. Could be a `Info.plist` `C11Commit` injection that runs once per derived data path and didn't re-run on incremental rebuild. Out of scope for C11-24 (the consumer correctly reports the captured value); flagging here so the launch-sentinel feature owner can investigate during PR #109 review or later. Doesn't affect the `unclean_exit` row's correctness because the sentinel surfaces the *previous* launch's commit, which was captured cleanly.
+
+2. **No tag-cleanup performed.** Validation left the `c11-24-health` tagged build running and on disk. The `prune-tags.sh` script protects running tags, so leaving it running is fine; the delegator's PR-open phase or a subsequent session will handle cleanup once verification is no longer needed.
+
+Nothing else surprising.
+
+## Verdict
+
+**PASS** — all six review-fix commits visible in behavior on real hardware:
+
+- B4 (path redaction): JSON paths use `~/…`.
+- I1 (rail duplicate): exits 1 with single stderr line.
+- I3 (empty-result line reflects rail/window): "nothing in the last 30m across sentinel" instead of fixed "24h, all rails".
+- I4/I5 (stable sort + lossy UTF-8): reverse-chronological order holds.
+- S4 (single-emission error): exactly one stderr line on bogus rail.
+- S7 (`unknown` for missing fields): not exercised here (all fields populated); deferred to future smoke when launch sentinel writes an active.json with sparse fields.
+- EW1 (schema_version): present in every JSON output as `schema_version: 1`.
+
+`c11 health` ships ready for the delegator to open PR #110 against `crash-visibility/launch-sentinel`. Recommend the PR body cite this report or paste the populated default-output table as the headline screenshot.
+
+## Raw command logs
+
+All raw stdout/stderr captures live alongside this report at `notes/c11-24/raw/{01..18}-*.txt`. Useful for diffing future regressions against this baseline.

--- a/notes/trident-review-C11-24-pack-20260503-1749/critical-claude.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/critical-claude.md
@@ -1,0 +1,194 @@
+## Critical Code Review
+
+- **Date:** 2026-05-03T18:00:00Z
+- **Model:** Claude Opus 4.7 (1M context) — `claude-opus-4-7[1m]`
+- **Branch:** `c11-24/health-cli`
+- **Latest Commit:** `cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92`
+- **Base:** `origin/crash-visibility/launch-sentinel` @ `5402d3fcd69c3ecb54ff440664fad51abf59f0e7`
+- **Lattice Story:** C11-24
+- **Review Type:** Critical / Adversarial
+
+---
+
+## The Ugly Truth
+
+This is, honestly, in better shape than most code I'd see in a "first pass at four scanners + a CLI" PR. The four hot rails (`Sources/HealthCommandCore.swift`, all of it the new code) honor the "passive only" contract: no `SentrySDK.capture*`, no notifications, no socket touches, no AppDelegate modifications, no `LaunchSentinel` enum changes, no AppDelegate hooks. I verified that directly against the diff. The em-dash policy is honored (zero `—`/`–` in the new code or golden files). The pbxproj-pattern is real — the dual-target add is correctly registered in both the `c11` and the `c11-cli` build phases. Nothing in the new tests greps `c11.swift` or reads `project.pbxproj`. That's the easy part.
+
+But the moment you put on the adversarial hat, the rails start to bleed. The IPS and Sentry walks recurse into directories that are not under c11's control on a real Mac, with no symlink protection. Mtime-based windowing on IPS reports is a known-broken anti-pattern (Apple writes the file with a stamp from when the crash happened, but the **mtime is when CrashReporter finished writing**, which can lag by minutes to days). The `mostRecentSentinelMarker` helper has a subtle ordering bug where `active.json` from a *previous* version (stale, never cleaned up) can be selected as the "most recent prior version," producing a misleading warning on a fresh install or after a downgrade. The flag parser allows `--rail` to be specified multiple times silently keeping only the last, which contradicts the help text and surprises the user. The JSON output format has a `[String: Any]` event payload built via `JSONSerialization` without explicit key ordering on the **inner** event dictionary (the outer payload has `.sortedKeys`, which does cover nested dicts — but the contract is fragile to a refactor that changes options).
+
+Also: telemetry-ambiguity-footer hardcodes the production bundle id `com.stage11.c11` and ignores `com.stage11.c11.debug.*` entirely. That is a real bug on the operator's primary debug build. And the `metricKitBaselineWarning` is silent for the most likely real-world condition (operator just installed for the first time → no marker → no warning), but the user-facing copy says "may not deliver for ~24h" which presumes the Sentry rail ran on the prior boot — a fact we don't actually know.
+
+**Bottom line:** ship-able after the Blockers and the two Important items get patched, with the caveat that the four scanners are doing real I/O against real user data and the test coverage of "what does this do in the wild" is thin. The unit/runtime tests are fine. They aren't field tests. Don't mistake them.
+
+---
+
+## What Will Break
+
+### 1. IPS scan and "since" window will silently drop legitimate crashes
+- File: `Sources/HealthCommandCore.swift:101`, `ipsEventIfRecent` lines 124–144
+- The window check uses `mtime >= since`. Apple's `ReportCrash` daemon writes the `.ips` file **after** the crash, sometimes minutes later (and on heavy systems, much longer). The `timestamp` field *inside* the IPS first-line JSON is the actual incident time. So a crash at 23:55 yesterday that finished writing at 00:05 today will be present (mtime newer than `since=now-24h`), but a crash at 00:05 today whose write got delayed to 00:30 will also be present — not wrong. The real failure is the inverse: the user runs `c11 health --since 30m` after a crash that happened 35 min ago but whose mtime is "now." We will surface a 35-minute-old crash and label it *just now* in the table. Conversely, a crash that happened 25 min ago but whose mtime is from a delayed write 35+ min in the past won't appear. **The mtime filter is not "since the crash" — it's "since CrashReporter finished writing" and we present it to the user as the former.**
+
+### 2. `mostRecentSentinelMarker` can pick a stale `active.json` as the baseline
+- File: `Sources/HealthCommandCore.swift:471–540`
+- The function iterates **all** `com.stage11.c11*` bundle dirs in `Library/Caches`, looking at both `unclean-exit-*.json` and `active.json`. Picture: operator runs c11 production once at v0.43.0, runs debug build (different bundle id) all day at v0.44.1. Now they run a fresh production at v0.45.0. The most-recent `active.json` for `com.stage11.c11` has `version=0.43.0` from days ago. We call that the "prior version" and fire `MetricKit baseline still establishing after version bump (0.43.0 to 0.45.0)`. Wrong. The user is on the debug build daily; there's no real baseline issue.
+- This also bites you when the base branch `LaunchSentinel.recordLaunchAndArchivePrevious()` rotates `active.json` → `unclean-exit-…json` on the *next* launch, but if the user crashed and never re-launched, `active.json` remains. The function correctly looks at both, but doesn't know which one represents "current" vs "prior."
+- The "version is non-empty" check (line 517) is the only filter, and it picks the marker with the **largest timestamp**. If the largest timestamp is from a stale active.json, that's what we use.
+
+### 3. `telemetryAmbiguityFooter` ignores debug builds entirely
+- File: `Sources/HealthCommandCore.swift:567–588`
+- The probe path is hardcoded: `"\(home)/Library/Caches/com.stage11.c11/io.sentry"`. On a developer machine, the running app is `c11_DEV` (`com.stage11.c11.debug.*` bundle id). That production cache path may not even exist. The footer will always be silent on dev builds, which is the population most likely to use this command. Should at minimum probe `com.stage11.c11.debug.*` first if the running app is a debug build, or fold this check into the same per-bundle walk that `scanSentryQueued` already does.
+
+### 4. `--rail` repeats are silently coalesced to the last value
+- File: `Sources/HealthCommandCore.swift:391–414` (`parseHealthCLIArgs`)
+- `c11 health --rail ips --rail sentinel` parses to `railFilter = .sentinel`, no error. The help text says "Filter to one rail" but the user can reasonably expect either an error ("conflict") or set semantics. Worse: if you intend to remove this surprise later by allowing multiple rails, you've now committed to "one rail or all" as the public contract. Either explicitly reject the duplicate or document it.
+
+### 5. `parseSinceFlag` accepts decimal values like `2.5h` and floats like `1.5d`
+- File: `Sources/HealthCommandCore.swift:354–366`
+- `Double(head)` accepts decimals. The help text shows only integers (`30m, 2h, 24h, 3d`). `0.5h` returns 1800s. That's fine if intentional, but you've also accepted `1e3h` (`1000h`), `+5h`, `0.0000001h` (rounding to nano-fractions of a second). And `Double` accepts `inf` strings on some locales — though `Double("inf")` in Swift's standard initializer parses to `.infinity`. Multiplying infinity by 60 and handing it to `addingTimeInterval(-)` gives `.distantPast` (or undefined date arithmetic). Edge case but worth the explicit guard.
+
+### 6. The Sentry recursive walk follows symlinks by default
+- File: `Sources/HealthCommandCore.swift:206–229` (`walkSentryDir`)
+- `FileManager.enumerator(at:..., options: [.skipsHiddenFiles])` does **not** include `.skipsSymbolicLinks` by default — actually, `FileManager.DirectoryEnumerator` follows symlinks unless told otherwise. If anything (a malicious package, a bug in another tool, a developer's mistake) drops a symlink into `~/Library/Caches/com.stage11.c11.foo/io.sentry/` pointing at, say, `/`, this walk runs forever (or until `since` filters everything, which it can't because we filter on mtime *after* enumeration). **Add `.skipsSubdirectoryDescendants`? No, you want the recursion. Add `.skipsPackageDescendants` and consider checking `.isSymbolicLinkKey` on each URL.** Same concern applies to the `telemetryAmbiguityFooter` enumerator and to `scanIPS`'s subdirectory walk (though IPS only descends one level).
+
+### 7. JSON `events` inner dict ordering relies on `.sortedKeys` propagating
+- File: `Sources/HealthCommandCore.swift:707–743`
+- `JSONSerialization.data(withJSONObject:options:)` with `.sortedKeys` does sort all nested keys, so the per-event keys (`path`, `rail`, `severity`, `summary`, `timestamp`) come out alphabetical. Good. But the `eventsArray` itself preserves insertion order (the order returned by `collectHealthEvents`). That's reverse-chronological by design, which is good. **The hidden risk:** if anyone refactors the renderer to use `JSONEncoder` with a `Codable` `HealthEvent`, the default `JSONEncoder` does **not** sort keys (you have to set `outputFormatting`). This is a footgun for downstream consumers diffing the JSON across runs. Lock it down with a tiny `testJSONOutputIsKeySorted` that diffs full bytes against a fixture, or wrap the renderer in something that asserts.
+
+### 8. `parseFilenameSafeISO` accepts only fractional seconds with exactly 3 digits
+- File: `Sources/HealthCommandCore.swift:330–344`
+- `parseFilenameSafeISO` checks length == 24 and `chars[19] == "."`. If `SentryHelper.CrashDiagnostics.persist` ever produces `.fff` with anything other than 3 digits (e.g. 6-digit microseconds, or the OS rounds and produces `.000Z` truncating), the parser returns `nil` and the file is silently skipped. The base branch fortunately does write 3 digits — but I'd add a parser test for `.000Z` (zeroes) explicitly to prevent regression. Also the check `chars[19] == "."` is positional: a stamp like `2026-05-03T15-19-001Z` (no dot, 25 chars) is rejected via the length check, but a stamp with `.` at the wrong position fails position check. Brittle, but functionally right for the contract.
+
+### 9. MetricKit kind grammar accepts ill-formed orderings silently
+- File: `Sources/HealthCommandCore.swift:267–275` (`isValidMetricKitKind`, `metricKitSeverity`)
+- The plan-note grammar says: "joined by `-` in the fixed order crash, hang, cpu, disk." The implementation **only checks each token is well-formed**, not the ordering. So `disk1-crash1` or `hang1-crash1-cpu1` parse cleanly. `metricKitSeverity` doesn't care about ordering either — `categoryCount > 1 → .mixed`. The producer in `SentryHelper.swift` writes them in the canonical order, so this is a soft bug. But anyone reading the test fixture can construct out-of-order names; the parser's relaxed acceptance + silent shrug is not what the docstring promises.
+- Also: `crash01` (zero-padded) would pass `allSatisfy { $0.isNumber }` and be accepted. The producer doesn't zero-pad, but the parser's contract isn't tight.
+
+### 10. `parseUncleanExitFile` returns a sentinel commit string `"????????"` when the JSON is unreadable
+- File: `Sources/HealthCommandCore.swift:644–662`
+- Defaults: `version = "?"`, `build = "?"`, `commit = "????????"`. The `summary` becomes `"? (?) ????????"`. That's *visible to the user* in the table, which is mildly ugly but acceptable as a "we found a sentinel file but couldn't parse the metadata" signal. However, the function will **return a HealthEvent even when the JSON is wholly unparseable** — only the timestamp from the filename matters. That means a corrupt empty file at `unclean-exit-2026-05-03T...json` produces a row with no real data. Compare with IPS where unreadable first-line just falls back to filename in `summary`. The contract is "filename is source of truth for timestamp" — fine — but you might want a comment that explicitly says corrupt body is intentionally surfaced rather than swallowed.
+
+### 11. IPS `incidentID` short-prefix truncation can collide
+- File: `Sources/HealthCommandCore.swift:131`, `String($0.prefix(8))`
+- 8 hex chars from a UUID is 32 bits. Collision space is small enough that two crashes in a 24h window with the same first 8 chars is exceedingly rare but not impossible. The summary makes them look identical to the operator. Print 8 chars *and* the filename, or print 12. Nit, but the operator may be staring at this list trying to dedupe.
+
+### 12. Empty `events` for filtered-rail run still claims "across ips, sentry, metrickit, sentinel"
+- File: `Sources/HealthCommandCore.swift:679` (`healthEmptyResultLine`)
+- Run `c11 health --rail sentinel` with no sentinel events. Output: `c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel.` That's a lie — we only checked `sentinel`. Build the empty line dynamically from `rails` parameter. There's no test catching this because `renderHealthTable([])` doesn't take rails. Surface bug.
+
+### 13. JSON output suppresses the empty-table line and warnings inline differently
+- File: `Sources/HealthCommandCore.swift:707–743`
+- Table mode emits `Warnings:` block. JSON emits `warnings` as a top-level array. Fine — different mediums. But **JSON warnings list is just `[String]`**, opaque to the consumer. An eventual consumer (a bot, a dashboard, a sidebar widget) will need to grep human prose. Plan for warnings to be `{code, message, details}` from the start; even if we only emit one or two codes today, retrofitting later is a breaking change. Not a Blocker, but a Don't-Ship-Forever landmine.
+
+### 14. `HealthEvent.Severity.unclean_exit` uses underscore in user-facing rawValue
+- File: `Sources/HealthCommandCore.swift:33`
+- The rawValue is `"unclean_exit"`. The four-events golden has the literal `unclean_exit` in the table column. That looks ugly to a human (`unclean exit`, `unclean-exit` are both more readable). Minor, and consistent with the JSON wire — but the wire and the table don't have to match. If you want JSON stability and table readability, use a separate display formatter.
+
+### 15. `bootTime()` swallows sysctl failure to "24h ago"
+- File: `Sources/HealthCommandCore.swift:373–384`
+- Falls back to `Date(timeIntervalSinceNow: -24 * 3600)` on `sysctlbyname` failure. But the function is called from `--since-boot` mode, which the user invoked specifically to get since-boot semantics. Silently downgrading to 24h is wrong: the user will see results but won't know they're 24h-windowed instead of since-boot-windowed. In practice `kern.boottime` is bulletproof on macOS, but: print a stderr warning, or thread the failure up to the caller. The current behavior is "we lied to you, here's an answer."
+
+---
+
+## What's Missing
+
+### Tests that don't exist (in priority order)
+
+1. **Symlink-loop / symlink-escape** test for the Sentry walk and the IPS subdir walk. Drop a symlink to `/` inside a fake `io.sentry/`, prove the scanner doesn't hang. (Use a test timeout.)
+2. **mtime vs. timestamp drift** test for IPS. The plan note acknowledges mtime is the only viable source on macOS without sandbox erosion, so this might be a "documented limitation" instead of a fix — but you want a test that documents it: "if mtime is 1 hour from `since` boundary, assert behavior."
+3. **`renderHealthTable` empty result with `rails` arg.** Currently impossible to write because the function has no `rails` parameter. Add the parameter.
+4. **`telemetryAmbiguityFooter` debug-bundle path.** No test exercises `com.stage11.c11.debug.*`. Currently silently always returns `nil` on debug builds.
+5. **`mostRecentSentinelMarker` with `active.json` from a different bundle id.** Build a temp HOME with two bundle dirs (`com.stage11.c11/`, `com.stage11.c11.debug.foo/`), each with a `sessions/active.json` of different versions and timestamps, prove the cross-bundle picking is intentional or a bug.
+6. **JSON byte-level golden snapshot.** Lock the JSON output (with a stable-window date passed in) to a fixture. Catches future `JSONEncoder` migrations or option reorderings.
+7. **`parseSinceFlag("inf*")`, `("nan*")`, `("1e6h")`, `("0.0001m")`.** The parser accepts these silently.
+8. **`--rail` specified twice.** Either codify the "last wins" or reject.
+9. **MetricKit kind ordering.** `disk1-crash1` (out of canonical order) — does it parse? Currently yes. Should it?
+10. **MetricKit kind with zero-padded count.** `crash01` — parses today. Decide and lock.
+11. **IPS first line with byte-order mark, with leading whitespace, with CRLF newline.** `readFirstLine` looks for `\n`; a CRLF report would yield a first line ending in `\r`, which `JSONSerialization` accepts (it's whitespace) — but worth a test.
+12. **A real Apple `.ips` file as a fixture.** The hand-rolled fixture has only the keys the parser cares about. The real format has many more keys, sometimes nested objects on the first line. Pull a real (sanitized) .ips file from the team's crash reports as a fixture.
+
+### Error-handling gaps
+
+- `runHealth` in `CLI/HealthCommand.swift` **prints to stderr AND throws CLIError with the same message**. The dispatcher will likely print the throw too, so the user sees the same line twice. Verify with the existing `CLIError` printing path; if both fire, deduplicate.
+- The `c11 health --json` mode never includes an `error` field. If a future failure mode is "couldn't read your home dir," we have no machine-readable way to say that. JSON consumers should be able to detect graceful-zero vs. partial-failure.
+
+---
+
+## The Nits
+
+- `HealthEvent.Severity.unclean_exit` snake_case; everything else is single-word. Pick one.
+- `metricKitBaselineWarning` says "may not deliver for ~24h" but the actual MetricKit delay is documented as ~24h on first install, not 24h after every version bump. The wording overstates the warning's certainty.
+- `HealthCollectionWindow.Mode.defaultLast24h = "default-24h"` and the test uses string comparisons — fine — but the rawValue leaks `default-` prefix to JSON. Consumers will see `"mode": "default-24h"`. That's fine for now; flag it for future schema review.
+- `telemetryAmbiguityFooter` says "events shipped on last launch and cleared the cache." This is the kind of multi-clause sentence a tired operator at 3am will misread. Two short sentences would be friendlier.
+- Help text says "30m, 2h, 24h, 3d" — gives no upper bound. `c11 health --since 99999d` is parsed and yields a `since` of 273 years ago. That's not wrong but could be capped at 30d with a friendly error.
+- The four-events golden has `2026-05-03 15:28 | sentinel  | unclean_exit |...` — note the **two spaces after `sentinel`**. The padding is right, but `sentinel` is 8 chars and the pad is 9 chars. Visually `metrickit` (9 chars) has zero trailing space, `sentinel` has one, `ips` has six. Aesthetic.
+- `parseUncleanExitFile`'s commit fallback `"????????"` is also 8 chars by design but becomes silently load-bearing because the table doesn't measure column widths from data — only fixed pads. If the commit ever expands to 12 chars and a `?` row coexists, alignment breaks.
+- `CLIError(message: error.description)` — `CLIError` definition outside the diff; verify it doesn't double-print.
+
+---
+
+## Numbered List
+
+### Blockers (will cause production incidents or operator trust loss)
+
+1. **`telemetryAmbiguityFooter` ignores `com.stage11.c11.debug.*` bundles.** On a debug-build dev machine the footer is permanently silent. (file: `Sources/HealthCommandCore.swift:567–588`)
+2. **`mostRecentSentinelMarker` cross-bundle picking can lock onto a stale `active.json`** from a different bundle and fire a misleading `MetricKit baseline still establishing` warning. (file: `Sources/HealthCommandCore.swift:471–540`)
+3. **Sentry recursive walk has no symlink defense.** A symlink under `~/Library/Caches/com.stage11.c11.*/io.sentry/` can lead the enumerator into the wider filesystem; on a hostile or buggy environment this is a hang vector. Add `.isSymbolicLinkKey` filter or `.skipsPackageDescendants`. (file: `Sources/HealthCommandCore.swift:206–229`, `567–588`, `99–109`)
+4. **Empty-result line lies about which rails were checked when `--rail` is set.** The line says "across ips, sentry, metrickit, sentinel" regardless of filter. (file: `Sources/HealthCommandCore.swift:679`, `renderHealthTable`)
+
+### Important (will cause bugs or poor UX)
+
+5. **IPS mtime is not the incident time.** The summary should show the IPS internal `timestamp` (or label the column as "REPORTED" not "TIME"). Today the operator can't trust the times they see. (file: `Sources/HealthCommandCore.swift:124–144`)
+6. **`--rail` repeats silently dedupe to last value.** Reject duplicates explicitly. (file: `Sources/HealthCommandCore.swift:391–414`)
+7. **`bootTime()` failure silently downgrades `--since-boot` to 24h.** Print a stderr diagnostic when sysctl fails. (file: `Sources/HealthCommandCore.swift:373–384`)
+8. **JSON `warnings` are opaque strings.** Make them `{code, message}` from day one. (file: `Sources/HealthCommandCore.swift:730`)
+9. **`parseSinceFlag` accepts floats / scientific notation.** Either tighten regex or document. (file: `Sources/HealthCommandCore.swift:354–366`)
+10. **`runHealth` prints to stderr **and** throws CLIError with the same message.** Likely double-printed. Verify against `CLIError` printing path. (file: `CLI/HealthCommand.swift:8–13`)
+11. **No real `.ips` fixture.** Hand-rolled fixtures pass; production-shaped IPS may not. Pull a sanitized real fixture from `~/Library/Logs/DiagnosticReports/`. (file: `c11Tests/Fixtures/health/ips/`)
+
+### Potential (smells, missing tests, future-bite)
+
+12. **`HealthEvent.Severity.unclean_exit` rawValue with underscore** leaks to user-facing table. (`Sources/HealthCommandCore.swift:33`)
+13. **MetricKit kind grammar accepts out-of-order tokens and zero-padded counts** — relaxed parser vs. tight docstring. (`Sources/HealthCommandCore.swift:260–275`)
+14. **No JSON byte-level snapshot test.** Future `JSONEncoder` migration could change key ordering. (`c11Tests/CLIHealthRuntimeTests.swift`)
+15. **`parseFilenameSafeISO` only accepts 3-digit fractional seconds.** Add a `000Z` test. (`Sources/HealthCommandCore.swift:330–344`)
+16. **`parseUncleanExitFile` returns a row even with corrupt JSON** producing `"? (?) ????????"`. Document the intent. (`Sources/HealthCommandCore.swift:644–662`)
+17. **IPS incident-id 8-char prefix can collide.** Print more, or include filename. (`Sources/HealthCommandCore.swift:131`)
+18. **Help text shows no upper bound on `--since`.** Reasonable to cap at 30d. (`Sources/HealthCommandCore.swift:354–366`)
+19. **`metricKitBaselineWarning` copy overstates confidence.** Reword. (`Sources/HealthCommandCore.swift:559`)
+20. **No symlink-loop test on any scanner.** (`c11Tests/`)
+21. **No test for `mostRecentSentinelMarker` cross-bundle behavior.** (`c11Tests/HealthFlagsTests.swift`)
+22. **Table padding looks irregular when rail names span 3..9 chars.** Aesthetic only. (`Sources/HealthCommandCore.swift:687–693`)
+
+---
+
+## Phase 5: Validation Pass
+
+Re-checking each Blocker / Important inline:
+
+- (1) Confirmed. ✅ `telemetryAmbiguityFooter` line 569 hardcodes `com.stage11.c11/io.sentry`. No `.debug` variant probed. The function will return `nil` for all debug-build users 100% of the time. **The plan-note original intent was likely "treat the user's *running* bundle as the probe target." Pull the running bundle id from `Bundle.main.bundleIdentifier` instead.**
+- (2) Confirmed. ✅ `mostRecentSentinelMarker` walks all `com.stage11.c11*` bundle dirs and picks the entry with the largest timestamp regardless of which bundle id it came from. The test `testMetricKitBaselineWarningFiresOnRecentVersionBump` passes because there's only one bundle dir. Adversarial scenario (two bundles) is not tested.
+- (3) Confirmed. ✅ `FileManager.enumerator(at:..., options:[.skipsHiddenFiles])` does follow symlinks unless `.skipsPackageDescendants` is added. Documented in Apple's docs and confirmed by reading the symbol. Mitigation is simple.
+- (4) Confirmed. ✅ The constant `healthEmptyResultLine` is hardcoded with all four rail names. `renderHealthTable` doesn't know what was filtered.
+- (5) ❓ Likely but hard to verify without running on a real machine. Apple's documentation on IPS file mtime lag is sparse but anecdotally well-known.
+- (6) Confirmed. ✅ `parseHealthCLIArgs` re-assigns `rail` on each `--rail` arg with no check.
+- (7) Confirmed. ✅ `bootTime()` line 384 returns `Date(timeIntervalSinceNow: -24 * 3600)` on failure — no log, no throw, no marker.
+- (8) ⬇️ Real but lower priority. Today's `[String]` works. Future-proofing.
+- (9) Confirmed. ✅ `Double("1.5h")` — `Double("1.5") = 1.5`, returns `1.5 * 3600 = 5400`. `Double("1e3")` returns 1000.
+- (10) ❓ Depends on `CLIError` print path. The diff for `CLI/c11.swift` doesn't show how `throw CLIError` is rendered, so I can't fully verify without the rest of `CLI/c11.swift`. Likely double-print.
+- (11) ⬇️ Real but lower priority. Hand-rolled fixture covers happy path. Real .ips is a hardening test.
+
+---
+
+## Closing
+
+**Would I mass deploy this to 100k users?** No, not as-is, but only because of (1)/(4): a debug-build dev sees a permanently-broken telemetry footer and a lying "no events" line. Both are 5-minute fixes. (2) is medium-risk: misleading warnings on multi-bundle machines. (3) is "we'd never see it but if we did, we'd never live it down."
+
+**To 100 internal users?** Yes, with (1)/(4) patched today and (2)/(3)/(5) on the post-merge issue list.
+
+**The structural call:** the four-rail design is correct. The dual-target pbxproj layout is correct. The "no `SentrySDK.capture*`, no AppDelegate touches, no LaunchSentinel mods" contract is honored cleanly. The tests are real runtime tests with sandboxed `home` paths, not source-grep theater. That's the win. The losses are at the seams: cross-bundle assumptions, mtime confusion, footer hardcoding, and the symlink-walk attack surface.
+
+**One specific compliment:** the choice to make `home` a parameter on every scanner and `timeZone` a parameter on the renderer is the kind of small, deliberate testability investment that pays off forever. Don't let it rot.
+
+**One specific warning:** the moment a second consumer (sidebar widget, web dashboard, bot) ingests the JSON output, the `warnings: [String]` shape is a problem. Promote to structured warnings before that happens, not after.
+
+— Claude Opus 4.7 (1M context)

--- a/notes/trident-review-C11-24-pack-20260503-1749/critical-codex.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/critical-codex.md
@@ -1,0 +1,61 @@
+## Critical Code Review
+- **Date:** 2026-05-03T21:58:08Z
+- **Model:** Codex (GPT-5)
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Linear Story:** C11-24
+- **Review Type:** Critical/Adversarial
+---
+
+## The Ugly Truth
+
+The core scanner design is mostly sane: it is passive, local, socket-free, and it does not parse or upload Sentry envelope contents. The parser tests are behavioral fixture tests, not grep tests, and the launch sentinel producer was left alone.
+
+The weak spot is the diagnostic-warning layer. The new `c11 health` command ships a MetricKit-baseline warning that looks useful in tests but is unlikely to fire in the real CLI path. There is also a privacy footgun in JSON mode: it serializes full local paths for every health event.
+
+I did not run local tests. Project policy says never run tests locally for this repo; the prompt's npm test commands do not apply to this Swift/Xcode project.
+
+## What Will Break
+
+1. When a newly version-bumped c11 has zero MetricKit diagnostics, `c11 health` will usually omit the intended baseline warning. `runHealth` reads the current version from `Bundle.main.infoDictionary?["CFBundleShortVersionString"]` in [CLI/HealthCommand.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/CLI/HealthCommand.swift:37), but the `c11-cli` target build settings do not define a generated Info.plist or marketing version for that command-line target in [GhosttyTabs.xcodeproj/project.pbxproj](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/GhosttyTabs.xcodeproj/project.pbxproj:1498). Even if that is fixed, `mostRecentSentinelMarker` considers `active.json` a candidate in [Sources/HealthCommandCore.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/Sources/HealthCommandCore.swift:502), so the current launch marker can mask the previous-version marker and make [Sources/HealthCommandCore.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/Sources/HealthCommandCore.swift:555) return nil.
+
+2. When an operator runs `c11 health --json` and shares the output, it includes full absolute paths from `ev.path` in [Sources/HealthCommandCore.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/Sources/HealthCommandCore.swift:719). That leaks the macOS username and exact local cache/report layout. The table output avoids paths; JSON should not silently become the privacy-regressing mode.
+
+## What's Missing
+
+- A runtime test that simulates the real post-upgrade sentinel state: an old `unclean-exit-*.json` plus a newer current-version `active.json`, with zero MetricKit diagnostics, should still produce the baseline warning if the product wants a "prior session marker" comparison.
+- A CLI-version-source test or seam. The current test injects `bundleVersion` directly, so it never exercises `runHealth`'s real version lookup.
+- A JSON privacy contract test. The JSON shape test asserts keys exist but does not assert that paths are redacted, relative, or intentionally present behind an explicit flag.
+
+## The Nits
+
+- `telemetryAmbiguityFooter` probes only `~/Library/Caches/com.stage11.c11/io.sentry` while `scanSentryQueued` scans every `com.stage11.c11*` bundle. That may be intentional for production-only wording, but it means debug or suffixed bundles get different ambiguity behavior than the scanner itself.
+- `parseMetricKitFilename` accepts kind token order that the comment says the producer will not emit. Low risk, but the grammar and tests disagree on whether order is fixed.
+
+## Findings
+
+### Blockers
+
+None found.
+
+### Important
+
+1. ✅ Confirmed: MetricKit baseline warning is effectively dead in realistic CLI use.
+
+   The changed CLI code depends on `Bundle.main.infoDictionary` for `CFBundleShortVersionString`, but the command-line target configuration shown around [GhosttyTabs.xcodeproj/project.pbxproj](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/GhosttyTabs.xcodeproj/project.pbxproj:1498) does not provide the app target's Info.plist/version settings to `c11-cli`. The warning guard at [Sources/HealthCommandCore.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/Sources/HealthCommandCore.swift:550) exits on nil or empty current version.
+
+   Execution path: `c11 health` dispatches before socket connection in [CLI/c11.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/CLI/c11.swift:1560), `runHealth` passes `bundleVersion` from the CLI bundle, `metricKitBaselineWarning` exits before comparing markers. If a version is supplied, `mostRecentSentinelMarker` still picks the newest marker including `active.json`, so the current active marker can suppress the old-version archive the warning is meant to compare against.
+
+2. ✅ Confirmed: JSON output leaks absolute local filesystem paths.
+
+   `renderHealthJSON` writes `"path": ev.path` for every event at [Sources/HealthCommandCore.swift](/Users/atin/Projects/Stage11/code/c11-worktrees/c11-24-health-cli/Sources/HealthCommandCore.swift:725). Those paths include locations under `/Users/<operator>/Library/...`. This is a direct privacy issue for support/debug output. Either redact the home prefix, make paths opt-in, or replace with a stable local-relative location such as `~/Library/...`.
+
+### Potential
+
+1. ⬇️ Real but lower priority: Sentry ambiguity warning checks a narrower bundle path than Sentry scanning.
+
+   `scanSentryQueued` accepts all cache directories with `com.stage11.c11` prefix, but `telemetryAmbiguityFooter` probes only the exact production path. If a suffixed debug/beta bundle has an empty Sentry cache, `c11 health --rail sentry` can report zero queued events with no ambiguity warning. This is only a production incident if suffixed bundle IDs are expected in operator support flows.
+
+## Closing
+
+I would not call this ready to mass deploy unchanged. The scanners themselves are acceptable for v1, but the MetricKit warning needs to be made real in the actual CLI path, and JSON path exposure needs an explicit privacy decision before operators are encouraged to share machine-local diagnostic output.

--- a/notes/trident-review-C11-24-pack-20260503-1749/critical-gemini.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/critical-gemini.md
@@ -1,0 +1,56 @@
+## Critical Code Review
+- **Date:** 2026-05-03T16:00:00Z
+- **Model:** Gemini 1.5 Pro
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Linear Story:** C11-24
+- **Review Type:** Critical/Adversarial
+---
+
+### The Ugly Truth
+The code correctly gathers data across the specified rails and provides a neat interface, but it fails on privacy and stability—two areas essential for a diagnostic tool. Emitting the user's OS home directory in raw JSON output is a blatant privacy leak, and the lack of deterministic sorting means automated pipelines consuming the JSON will experience flapping. Moreover, the launch sentinel parser is a ticking time bomb for performance due to unbounded O(N) file parsing and expensive formatter instantiations.
+
+### What Will Break
+- **Automated ingestion**: The JSON event array will flap when timestamps tie because `sorted` is unstable for ties. 
+- **Privacy compliance**: Users copy-pasting the JSON output to GitHub or internal tickets will inadvertently leak their macOS username.
+- **Performance**: On machines with a long history of crashes, `c11 health` will lag significantly while it parses JSON and instantiates date formatters for hundreds of old session files just to find the most recent version bump.
+- **IPS Parsing**: Truncating the `.ips` read to 8192 bytes will slice multi-byte UTF-8 sequences in half on certain payloads, causing the strict `String(data:encoding:.utf8)` to return `nil` and drop the header entirely.
+
+### What's Missing
+- Path sanitization to replace `NSHomeDirectory()` with `~` in the output paths.
+- Secondary and tertiary sort keys for `HealthEvent`.
+- Caching or hoisting of `ISO8601DateFormatter` in loops.
+- Targeted scanning of `io.sentry/envelopes` instead of all of `io.sentry`.
+
+### The Nits
+- `c11 health --since-boot` silently falls back to 24h ago if `sysctlbyname` fails, with no indication to the user that the scope changed.
+
+### Blockers
+1. **Privacy Leak in JSON Paths** ✅ Confirmed
+   - `renderHealthJSON` maps `ev.path` directly into the JSON output. Since `path` is an absolute URL containing `NSHomeDirectory()`, it leaks the user's OS username.
+   - *Fix:* Redact the home directory prefix (replace with `~`) before assigning it to `path` or serializing the JSON.
+
+2. **Unstable JSON Output** ✅ Confirmed
+   - In `collectHealthEvents`, `events.sorted { $0.timestamp > $1.timestamp }` only compares timestamps. If two files have the identical modification date (e.g. batch writes), the array order is non-deterministic.
+   - *Fix:* Sort by timestamp DESC, then by `rail.rawValue` ASC, then by `path` ASC.
+
+### Important
+3. **Fragile UTF-8 Decoding in IPS** ✅ Confirmed
+   - In `readFirstLine(of:)`, `(try? handle.read(upToCount: 8192))` can split a multi-byte character. `String(data: data, encoding: .utf8)` strictly validates and will return `nil` for the entire 8192-byte chunk if it's truncated mid-character.
+   - *Fix:* Use `String(decoding: data, as: UTF8.self)` which is lossy and resilient, gracefully replacing malformed bytes.
+
+4. **O(N) Performance Trap in Sentinel Marker** ✅ Confirmed
+   - `mostRecentSentinelMarker(home:)` iterates every session file, synchronously reading `Data(contentsOf:)` and creating a new `ISO8601DateFormatter()` for each one.
+   - *Fix:* Hoist the `ISO8601DateFormatter` instantiation outside the loop. Even better, parse the timestamp from the filename *before* opening the file, and only parse the JSON if the timestamp is newer than the current `best`.
+
+5. **False Positive Queued Sentry Events** ✅ Confirmed
+   - `scanSentryQueued` invokes `walkSentryDir` on the root `io.sentry` directory. Sentry SDK writes other internal files here (e.g., config, lockfiles) which will incorrectly be counted as queued events. Similarly, `telemetryAmbiguityFooter` checks `io.sentry`, suppressing the warning if state files exist.
+   - *Fix:* Both should only walk/check `io.sentry/envelopes`.
+
+### Potential
+6. **Cross-Bundle Version Warning False Positives** ✅ Confirmed
+   - `mostRecentSentinelMarker` checks all `com.stage11.c11*` directories (including debug builds) but compares the result to `Bundle.main`'s version. Running a debug build could falsely trigger the "version bump" warning for the production CLI.
+   - *Fix:* Scope the sentinel check to the current bundle ID instead of prefix-matching all bundles, or match the bundle ID explicitly in the loop.
+
+### Closing
+This code is NOT ready for production. The privacy leak of the macOS username in the JSON output is a showstopper for a tool meant to generate shareable diagnostic information, and the JSON output instability will cause CI/CD headaches. Fix the blockers and hoist the date formatter to prevent CLI lag before merging.

--- a/notes/trident-review-C11-24-pack-20260503-1749/evolutionary-claude.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/evolutionary-claude.md
@@ -1,0 +1,234 @@
+## Evolutionary Code Review
+
+- **Date:** 2026-05-03T17:49:00Z
+- **Model:** Claude Opus (claude-opus-4-7[1m])
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Base:** origin/crash-visibility/launch-sentinel (5402d3fcd69c3ecb54ff440664fad51abf59f0e7)
+- **Linear Story:** C11-24
+- **Review Type:** Evolutionary / Exploratory
+
+---
+
+## What's Really Being Built
+
+The stated feature is a CLI: `c11 health` reads four directories on disk, prints a table or JSON. Useful, narrow, ships clean.
+
+What's actually being built is bigger and worth naming because nobody has yet:
+
+**A passive observer of c11's own visible-from-disk crash surface.** Sentry, Apple, MetricKit, and c11's own sentinel each leave a different kind of breadcrumb. This branch is the first time c11 has a reader that *unifies* those breadcrumbs into a single timeline keyed only on filesystem state. The producers (Sentry SDK, ReportCrash, MXMetricManager, `LaunchSentinel.recordLaunchAndArchivePrevious`) all run independently and have no idea this reader exists. They never will. That's the design.
+
+That separation — producers don't know about readers; readers are read-only of artifacts the producers happened to leave — is the real primitive. Everything in `Sources/HealthCommandCore.swift` is one instance of a pattern I'll call **Disk-Coupled Telemetry Aggregation (DCTA)**: producers write artifacts to well-known paths during their normal lifecycle; one or more readers walk those paths later, decoupled in time, decoupled in process, decoupled in trust. The producer can crash, the reader still works. The reader can never run, the producer is unaffected. The artifact format is the only contract.
+
+This pattern matters beyond crashes. Once the operator gets used to `c11 health` answering "what happened to c11 lately?", they will want the same shape for "what's happening across my fleet of agents", "did this build run cleanly across the last 12 c11 launches", "what's the diff in crash-rate between my last two release tags". Those are the same query against the same disk surface, with different filters. The branch ships the engine for all of them.
+
+**It's also the first deliberately offline-capable c11 CLI subcommand.** Most `c11 *` commands assume the c11 daemon is running and reachable via socket. `c11 health` does not. It works on a machine where c11 has never run, where the socket is dead, where the daemon crashed five minutes ago. That changes c11's deployment story — there's now a c11 surface that survives c11 itself. For an app whose value proposition is "the room for the operator:agent pair", being able to ask the room about itself even when the room can't answer through its own door is a quiet but real capability shift.
+
+**For future-D11**: this branch defines a small portable substrate (rail enum, scan-with-since, filename grammar, JSON shape) that almost-but-not-quite is the right shape for D11 to inherit unchanged. The seams are mostly right. A few are wrong in ways small enough to fix now and large enough to matter later. Those are the leverage points below.
+
+---
+
+## Emerging Patterns
+
+### Forming, should formalize
+
+1. **Scanner-as-pure-function-of-(home, since).** All four `scanXxx(home:since:) -> [HealthEvent]` have the same signature. They're swappable. They produce the same output type. They can be parallelized, mocked, fuzzed, golden-tested against a tmp dir. This shape is good. It just isn't *named* yet — there's no `protocol Rail` or `struct ScannerSpec` — so the uniformity is by convention. Convention rots. Formalize it before the fifth rail makes the cracks visible.
+2. **Filename-as-source-of-truth, body-as-best-effort.** `parseUncleanExitFile` and `parseMetricKitFilename` both encode this rule explicitly: timestamp comes from the filename grammar, the body is *additional metadata* that may be missing without invalidating the row. This is exactly right for crash-survival reasoning — a corrupted body must not be able to hide a crash. Make this an explicit doc comment on both producer and reader so nobody "fixes" it later.
+3. **Bundle-id family iteration.** `scanSentryQueued` and `scanLaunchSentinel` both walk `Library/Caches/com.stage11.c11*` for "any sibling bundle". This is load-bearing for legacy `com.stage11.c11mux` data and dev/debug variants. The pattern is: enumerate top-level Caches, filter by prefix, descend. It's duplicated. It's also the *correct* boundary. Hoist it into a `forEachC11Bundle(home:)` helper and you've shaved 40 lines and made "what counts as a c11 bundle" a single edit.
+4. **Read-only-of-someone-else's-format.** None of the four scanners parses the full payload. IPS reads the first JSON line. Sentry treats envelopes as opaque files. MetricKit reads the filename only. Sentinel reads filename plus a tiny header. This is intentional and correct: c11 is not a crash analyzer, it is a presence detector. The contract is "did the artifact exist", not "what's in it". Make this explicit in the file header — it's the principle that lets the rails shrink instead of grow.
+
+### Anti-patterns forming, catch early
+
+1. **The HealthEvent.Severity enum is a junk drawer.** It mixes orthogonal axes: `crash`/`hang`/`resource`/`mixed` are MetricKit categories; `queued` is a Sentry lifecycle state; `unclean_exit` is a sentinel finding; `diagnostic` is a fallback. `mixed` exists because MetricKit can combine categories in one filename. Adding a fifth rail means adding a sixth severity bucket that probably doesn't fit anyone's mental model. Today this works because the table column is wide and the JSON consumer does whatever. It will not survive contact with the next two rails.
+2. **String-typed CLI errors meet stringly-typed JSON output.** `HealthCLIError` is a typed enum with `description` strings; rendering uses raw enum `rawValue`. The shape on the JSON wire (`"rail": "ips"`, `"severity": "crash"`) is implicit — there's no schema, no version field, no negotiated contract. Pin it now (just a `"schema_version": 1` key) and JSON consumers can be written without fear.
+3. **`telemetryAmbiguityFooter` and `metricKitBaselineWarning` are sibling helpers with very different shapes.** One takes `(home, bundleVersion, metricKitCount, now)` and decides off disk + version compare. The other takes `(home, sentryCount)` and decides off disk + count. They read different paths, they do different filesystem walks, they use different early-return styles. Both fire from the same place in `runHealth`. Both will multiply. Without a uniform `Warning` type, the third one will look different again.
+4. **Two-target source file via dual pbxproj entries.** `HealthCommandCore.swift` is added to both `c11` and `cmux-cli` build files (`DH001BF0...0718` and `DH001BF0...0719`). It works. It's also the second time in the codebase a file is dual-targeted (the first being `c11.swift` itself), and it's a quiet hint that the CLI/main split would be cleaner with a small shared "c11core" target the cmux-cli and the main app both link. Not urgent. But every dual-target file makes the case stronger.
+
+---
+
+## How This Could Evolve
+
+### 1. Promote scanners to a `HealthRail` protocol
+
+Today the four scanners are `func scanXxx(home:since:) -> [HealthEvent]`. The dispatcher `collectHealthEvents` is a four-arm `if rails.contains(.ips) { ... }` ladder. Adding a fifth rail means: edit the enum, edit the helper text, edit the dispatcher, edit the empty-result line, edit `renderHealthJSON`'s `railCounts`, edit help text, edit the warning footer wiring (if applicable), edit the help string `--rail <name>` enumeration, edit the `--rail` parser's diagnostic message. Eight edits in three files for one new rail.
+
+```swift
+protocol HealthRail {
+    static var id: HealthEvent.Rail { get }
+    static var displayName: String { get }
+    func scan(home: String, since: Date) -> [HealthEvent]
+    func warning(home: String, events: [HealthEvent], context: HealthWarningContext) -> String?
+}
+```
+
+Register them in a static array. The dispatcher becomes a one-liner over the registry. The help text reads from the registry. The unknown-rail diagnostic enumerates the registry. Adding a fifth rail becomes: write one struct, append to the array. The error messages stay correct automatically.
+
+This is the **single highest-leverage change** for v1.1, and it costs maybe 80 lines of refactor with no behavior change. The existing tests cover the surface; the refactor is mechanical.
+
+### 2. Push `HealthEvent.Severity` to a per-rail enum
+
+Each rail knows its own severity space. Sentry has `queued` (and someday `failed`, `retrying`). IPS has `crash`/`hang`. MetricKit has the category combinations. Sentinel has `unclean_exit` (and someday `clean`/`force_quit`/`sigkill` if it gets smarter).
+
+Two reasonable evolutions:
+
+- **Per-rail severity types**, exposed in JSON as `{"rail": "metrickit", "severity": "crash-hang-mixed"}`. Render layer flattens to one column for the table.
+- **Severity-as-tags**, dropping the single-column model entirely: `{"tags": ["crash", "hang"]}` for the multi-category MetricKit case. This naturally handles "mixed" without a special bucket. The table can show the first tag and a `+N` indicator; the JSON gets richer.
+
+The second is more honest to what's actually happening. It also subsumes a future "annotate this event with a build/commit" axis without another schema migration.
+
+### 3. The fifth-rail seam: make adding one a 30-minute job
+
+Concrete fifth rails the operator will plausibly want:
+
+- **Console.app `log show --predicate 'subsystem CONTAINS "c11"'`** for the last hour. Reads from the unified log. No disk artifact unless you snapshot it. Different shape, but the filename-as-truth principle still holds — the line timestamp is the truth.
+- **Spindump artifacts from `/Library/Logs/DiagnosticReports/Spin*.ips`** — Apple's "your app froze" record, separate from crash IPS. Probably 30 lines if `scanIPS` is generalized to a glob+predicate scanner.
+- **Workspace snapshot lifecycle events.** c11's own workspace-snapshot writes/restores have a separate failure mode; reading `~/Library/Application Support/c11/workspace-snapshots/` for missing-or-corrupt files is a c11-specific health signal nobody else can produce.
+- **Sentry envelope retention age.** Not "how many" but "how stale" — the oldest queued envelope. A queue that's been stuck for 7 days is a different problem from a queue with one fresh envelope.
+
+Build the rail protocol with these in mind and the abstraction stays honest. Build it abstractly and you'll reinvent it when the second non-disk rail (log show) shows up.
+
+### 4. JSON schema evolution and `schema_version`
+
+The current JSON output has no version key. The first downstream consumer (`c11 health --json | jq`, a CI gate, a fleet-aggregator script) will lock in this shape. Add `"schema_version": 1` now, document the contract, and you have a clean lever to evolve later. Cost: one line. Value: every future change to the JSON shape stays backwards-compatible-by-choice rather than backwards-compatible-by-accident.
+
+### 5. The fleet-mode latent in `home: String`
+
+`collectHealthEvents(window:rails:home:)` already takes `home` as a parameter. The runtime test exercises that. What this means in practice:
+
+```bash
+c11 health --home ~atin/sshfs/laptop2 --since 24h
+c11 health --home /Volumes/c11-fleet-archive/atin-imac/2026-05-03 --since-boot
+```
+
+is one CLI flag away. The Swift function is already pure-of-disk. Surface the flag, document it as "for fleet aggregation and post-mortem replay", and you've extended the use case from "one machine" to "any rsynced snapshot of one or more machines". The same rendering. The same JSON shape. Suddenly `c11 health` is a fleet inspector when you want it to be.
+
+This is in the spirit of v1.1's deferred items but is *not* one of them — it's a smaller flag landing on top of an already-pure function.
+
+---
+
+## Mutations and Wild Ideas
+
+### A. `c11 health --watch` — the live tail
+
+A long-running variant: scan every N seconds, print only deltas, exit on Ctrl-C. Implementation: same scanner pure functions, a run-loop wrapper, a "previously seen paths" set keyed on `path` field. A different surface for the same engine. It would let an operator leave one pane running during a long agent session and *see* a crash the moment its artifact lands.
+
+### B. Sentinel-as-fingerprint, not just timestamp
+
+Right now sentinel events are `{version, build, commit}`. Add a sibling field `fingerprint = sha256(version + build + commit + bundle_id)` — ten bytes — and you can group/dedup unclean-exits across rails: "this sentinel event correlates to this Sentry envelope you queued under that exact build". You don't have to parse the envelope to do the correlation; you just need the fingerprint to be in both places.
+
+The producer side is one line in `LaunchSentinel.recordLaunchAndArchivePrevious`. The reader can correlate without depending on it (best-effort, like the rest of the body parsing).
+
+### C. `c11 health --producer-trace`
+
+Inverts the read direction: instead of reading artifacts, dump where each rail *would* read from on this specific machine right now and whether the directory exists, the count of files, the most-recent mtime. Use case: setup debugging. "Why does my health command say zero metrickit?" → `--producer-trace` shows `~/Library/Logs/c11/metrickit: directory does not exist (MetricKit subscription has not yet fired on this machine)`.
+
+This mutation costs almost nothing and turns the command into a self-diagnosing tool. The exact same scanners can be invoked in "describe-only" mode by passing a flag through to a producer-trace closure.
+
+### D. The events-as-stream variant
+
+`collectHealthEvents` returns `[HealthEvent]` — an array, eagerly built. For a v1 with hundreds of events that's fine. For "show me everything across the last 90 days on this machine and also the rsynced laptop2 snapshot" it's not. Yield events as they're scanned (`AsyncStream<HealthEvent>` or a callback-based scanner). The render layer can then emit incrementally. Useful for `--watch` (D above) and for the fleet-mode (#5 in evolution). Not needed for v1, worth keeping in mind so the v1 internals don't make it harder.
+
+### E. The dual `c11 health` and `c11 reportz`
+
+A whimsical one. `c11 health` is the sober timeline. `c11 reportz` (or `c11 ¬health`) takes the same data and generates a report in narrative form: "On May 1st, c11 unclean-exited twice during version 0.43.0. The next version, 0.44.0, ran clean for 36 hours before its first MetricKit hang at 14:30 on May 3." Same engine, different render. Operator-facing storytelling on top of disk artifacts. Probably not v1.1, but the engine you're building easily supports it.
+
+### F. Replace the ad-hoc `parseFilenameSafeISO` with an `ISO8601FilenameStamp` helper
+
+This 24-character grammar (`YYYY-MM-DDTHH-MM-SS.fffZ`) is used by *both* MetricKit producer/reader *and* sentinel producer/reader. Right now it's ad-hoc string surgery in `parseFilenameSafeISO`. Promote it to a struct with `init(_:Date)` and `init?(stamp: String)` and a `static let length = 24`. Producer and reader share the same source of truth. Add a fuzz test on it. This is the kind of small primitive that pays compound interest.
+
+---
+
+## Leverage Points
+
+Where small changes create disproportionate value:
+
+1. **Rail registry** (#1 above). 80 lines, no behavior change, fifth-rail cost drops by ~80%.
+2. **`schema_version` in JSON**. One line, locks the contract, makes downstream consumers safe to write.
+3. **`forEachC11Bundle(home:)` helper**. ~25 lines saved across `scanSentryQueued`, `scanLaunchSentinel`, `mostRecentSentinelMarker`, and `telemetryAmbiguityFooter`. Single source of truth for "what counts as a c11 bundle dir". Fixes the "what about com.stage11.c11.beta?" question once.
+4. **Promote `parseFilenameSafeISO` and `filenameSafeISO` to a paired primitive shared with `LaunchSentinel`/`CrashDiagnostics`**. Producer and reader stop having two copies of the same 24-char rule. Today both halves are correct; tomorrow somebody changes one and not the other. Bind them now.
+5. **`HealthEvent` gets a `bundleID` and `build` field (both optional)**. Three of the four rails already know this information. IPS knows `bundleID` from the first-line parse. Sentry encodes it in the path. Sentinel encodes it in the JSON body. MetricKit doesn't (yet) but the producer easily could. Once `HealthEvent` carries it, the JSON can group by build, the table can show a column, and the warning helpers stop having to re-walk the disk to find the version.
+6. **A `HealthArtifact` (the file you scanned) vs `HealthEvent` (the row you emit) split**. Some artifacts produce multiple events (think: future MetricKit JSON parser). Some events come from multiple artifacts (think: dedup via fingerprint). Splitting the type now is cheap; splitting it later is migration.
+
+---
+
+## The Flywheel
+
+The flywheel that wants to spin:
+
+1. **More producers leave artifacts** → more rails to read → richer health surface. Each c11 subsystem (workspace snapshots, agent restarts, daemon lifecycle) can become a rail by writing well-known files. The skill teaches subsystem authors that "if it can fail, write a tiny artifact when it does, and `c11 health` will surface it." Subsystem authors don't need to know about `c11 health` to participate — they just need to write the artifact.
+
+2. **More health visibility** → more confidence → more aggressive iteration. The operator can ship a release-candidate, watch `c11 health` over 24 hours, and decide whether to promote based on disk artifacts rather than vibes. This compounds with the version-bump baseline warning that's already in v1: that warning *itself* is a small engine for "did you just ship something risky and is it behaving."
+
+3. **Fleet aggregation falls out** (#5 in evolution). `c11 health --home /path/to/snapshot` is one flag, and now the same skill works for "what happened on the CI runner last night" and "what's my dev laptop done since I left it." The engine doesn't care.
+
+4. **Cross-rail correlation gets easier with each rail added** (mutation B, the fingerprint). Once two rails agree on a fingerprint shape, the third rail joins for free, and `c11 health --correlated` becomes a useful filter.
+
+The thing that *would* break the flywheel: letting `HealthEvent.Severity` keep growing as a single junk-drawer enum. Every new rail will fight to add a case, the enum will accumulate special meanings, and at some point the table column gets wider than the user's terminal. That's why per-rail severity (or tags, my preference) before the fifth rail is the right call.
+
+---
+
+## Concrete Suggestions
+
+### High Value (significant improvement, worth doing now or in v1.1)
+
+1. **Add `schema_version: 1` to `renderHealthJSON` payload** (`Sources/HealthCommandCore.swift:1158-1167`). One line, locks the contract for downstream tools. ✅ Confirmed — the JSON is built as a `[String: Any]` dict; adding a key is trivial and the existing `testJSONShapeContainsTopLevelKeys` covers the structural check.
+
+2. **Hoist the `Library/Caches/com.stage11.c11*` walk** into a private helper. Three call sites today: `scanSentryQueued` (line 609), `scanLaunchSentinel` (line 1023), `mostRecentSentinelMarker` (line 910), plus a fourth implicit call inside `telemetryAmbiguityFooter` (line 994) which hardcodes `com.stage11.c11` instead of iterating the family. This hardcoding is a latent bug: if someone runs the debug build only and the production cache never appears, the footer never fires. Fix the bug *and* deduplicate by extracting one helper. ✅ Confirmed — file structure supports it; existing tests cover all four call sites and would catch a regression.
+
+3. **Promote scanners to a registry pattern** (the `HealthRail` protocol idea). Today: ~30 lines of dispatcher in `collectHealthEvents` + `runHealth` + `renderHealthJSON` + help text + error message that all enumerate the four rails. Tomorrow: a single registry array. Adding a fifth rail goes from eight edits to one. ❓ Needs exploration — a clean Swift implementation needs to handle the per-rail warning helper as a peer concept (some rails have warnings, some don't), so the protocol is `HealthRail + (optionally) HealthRailWarning`. Worth prototyping in a v1.1 follow-up branch.
+
+4. **Pin the filename-safe ISO grammar as a shared primitive** (`Sources/HealthCommandCore.swift:705` and the matching producer in `Sources/SentryHelper.swift`). The current setup has two copies of the same 24-character rule, one in the reader and one in the producer. Make a `FilenameSafeISO8601` type that exposes both `format(_: Date) -> String` and `parse(_: String) -> Date?`. Use it from `LaunchSentinel.recordLaunchAndArchivePrevious`, `CrashDiagnostics.persist`, and the four reader sites. Add a round-trip property test. ✅ Confirmed — the producers and reader are clearly mirroring each other today; binding them at the type level removes an entire class of "we changed the producer and forgot the reader" bug.
+
+5. **Fix `telemetryAmbiguityFooter`'s hardcoded bundle path** (`Sources/HealthCommandCore.swift:996`). The probe path is `\(home)/Library/Caches/com.stage11.c11/io.sentry`. On a machine where only the debug build (`com.stage11.c11.debug`) ever ran, this footer never fires, even though the operator is in the exact ambiguous state the footer is designed for. Fix: walk the bundle family the same way `scanSentryQueued` does, and fire the footer if *any* bundle has an empty `io.sentry/` and overall sentry count is zero. ✅ Confirmed — the bug is real in v1; there's a test (`testTelemetryAmbiguityFooterFiresWhenCacheExistsAndIsEmpty`) that uses `com.stage11.c11` exactly, which masks the issue. Add a test using `com.stage11.c11.debug` to lock the fix.
+
+### Strategic (sets up future advantages)
+
+6. **Add `bundleID` and `build` (optional) fields to `HealthEvent`**. Three rails know these already. JSON consumers want them. The "group by build, show me what 0.44.1 broke" story is one schema field away. ✅ Confirmed — additive change, the JSON test only asserts presence of a fixed key set so it won't break.
+
+7. **Surface `home` as a CLI flag (`--home <path>`)**, with a short doc-comment describing fleet/snapshot use cases. The plumbing is already done — the function takes the parameter; the runtime test proves it works. ❓ Needs exploration — there's a privacy/safety dimension (running against an arbitrary path is fine, but document that nothing is *sent* anywhere, the read is purely local). Worth a mini design pass before shipping.
+
+8. **Replace `HealthEvent.Severity` with per-rail severity tags**. Mutation #2 above. Most natural to do *with* the rail-registry refactor (#3) since each rail can declare its own severity space. ❓ Needs exploration — table rendering becomes more interesting, and downstream JSON consumers may have already locked the current shape; bundle this with `schema_version` bump (1 → 2).
+
+9. **Add a `HealthArtifact` type distinct from `HealthEvent`**. Today they're 1:1, but only by coincidence; future MetricKit JSON parsing or correlation features want N:M. Cheap to split now, painful to split later. ⬇️ Lower priority than initially thought — without a concrete consumer of the split (e.g., correlation feature, MetricKit body parsing), this risks being a YAGNI abstraction. Reconsider when the second non-1:1 rail appears.
+
+### Experimental (worth exploring, uncertain payoff)
+
+10. **`c11 health --producer-trace`** (mutation C). Self-diagnosing setup tool. Cheap to build, very high "operator walks away knowing why" value the first time something is misconfigured.
+
+11. **`c11 health --watch`** (mutation A). Tail-mode for live observation. Likely most valuable during release candidate testing or during a multi-hour agent run.
+
+12. **Fingerprint correlation across rails** (mutation B). Useful only after two rails agree on the format, but trivial once they do. Producer-side cost is one line per rail.
+
+13. **AsyncStream-based scanners** (mutation D). Only worth it once `--watch` or fleet-mode lands; until then, the array shape is fine. Note it as a known seam for v1.2.
+
+14. **`c11 reportz`** (mutation E, the narrative renderer). Pure speculation, but the engine you have can produce it. Might be a fun day's work for an LLM-rendered report once there's enough data to narrate over.
+
+---
+
+## Validation Pass — Verified Suggestions
+
+| # | Status | Note |
+|---|--------|------|
+| 1 | ✅ Confirmed | `renderHealthJSON` builds a `[String: Any]` payload at lines 1158-1167; one extra key added before serialization. Existing `testJSONShapeContainsTopLevelKeys` will not regress. |
+| 2 | ✅ Confirmed | Three explicit call sites + one implicit one (in `telemetryAmbiguityFooter`); helper signature would be `func forEachC11Bundle(home:body:(URL, String) -> Void)` returning early on the standard "non-c11 prefix → continue" filter. |
+| 3 | ❓ Needs exploration | The protocol abstraction is sound, but `metricKitBaselineWarning` and `telemetryAmbiguityFooter` have heterogeneous shapes; the protocol may need a `HealthRailWithWarning` extension or a parallel `HealthWarning` registry. Prototype before committing to a final shape. |
+| 4 | ✅ Confirmed | The grammar is mirrored 1:1 between `LaunchSentinel.recordLaunchAndArchivePrevious` (producer) and `parseFilenameSafeISO` (reader). A shared type binding both is risk-reducing. |
+| 5 | ✅ Confirmed | The hardcoded path at `Sources/HealthCommandCore.swift:996` does not match the bundle-family walk used elsewhere; this is a v1 footgun, not just an evolutionary nit. The test at `c11Tests/HealthFlagsTests.swift:1676-1689` happens to use `com.stage11.c11` and so doesn't expose it. |
+| 6 | ✅ Confirmed | `HealthEvent` is a struct with named fields; adding optional fields is fully additive. `renderHealthJSON` and `renderHealthTable` would simply ignore them until updated. |
+| 7 | ❓ Needs exploration | Trivial wiring; the work is in choosing the flag name, deciding interaction with `--since-boot` (which needs the *target machine's* boot time, which can't be read from a snapshot), and documenting the safety story. |
+| 8 | ❓ Needs exploration | Bundle with `schema_version` bump; needs care for the table-rendering width. |
+| 9 | ⬇️ Lower priority | Worth keeping in the back pocket but not pulling in until a concrete consumer demands it. |
+
+---
+
+## Most Exciting Opportunities
+
+If I had to pick the three that would most change what `c11 health` becomes:
+
+1. **The rail registry** turns a four-rail CLI into an extensible health platform. Every c11 subsystem becomes a potential rail with no central coordination. This is the pattern that lets future-D11 inherit the substrate cleanly.
+
+2. **The shared filename-safe ISO primitive** is the small engineering move that prevents a production bug. Producer and reader stop drifting. It's the kind of work that doesn't show up in any release note but saves someone a 90-minute debug session in 2027.
+
+3. **The fleet seam (`--home <path>`)** is already 90% there. Surfacing it makes `c11 health` work for a use case the branch wasn't designed for, with no architectural change. That's the cleanest possible signal that the abstraction is right.
+
+The branch ships solidly as v1. These suggestions are how it grows — and the registry refactor is the one I'd reach for first in a v1.1.

--- a/notes/trident-review-C11-24-pack-20260503-1749/evolutionary-codex.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/evolutionary-codex.md
@@ -1,0 +1,174 @@
+## Evolutionary Code Review
+- **Date:** 2026-05-03T21:57:12Z
+- **Model:** Codex (GPT-5)
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Linear Story:** C11-24
+- **Review Type:** Evolutionary/Exploratory
+---
+
+Setup note: I reviewed HEAD against `origin/crash-visibility/launch-sentinel` as requested. Local `origin/dev` is not present, and I did not run `git fetch` / `git pull` because the wrapper instruction for this pass says the only allowed write is this review file. The local branch is seven commits ahead of the specified base.
+
+## What's Really Being Built
+
+This is not just a `c11 health` command. It is the first version of a **local evidence plane** for c11: a passive, file-system-backed way to turn the operator's machine into its own crash forensics index.
+
+The important move is the shape of `Sources/HealthCommandCore.swift`: four independent rails collapse into one `HealthEvent` stream at `collectHealthEvents` (`Sources/HealthCommandCore.swift:50`). That is the primitive. Once c11 can normalize Apple IPS files, Sentry queue residue, MetricKit payload filenames, and launch-sentinel archives into one sorted stream, the next capability is not "more health output." It is **local incident reconstruction without trusting any one producer**.
+
+That matters for future D11 because D11 should inherit the model, not the UI: local producers leave passive evidence, and a reader composes those crumbs into an operator-facing diagnosis. This branch starts that architecture in a small enough form to keep it honest.
+
+## Emerging Patterns
+
+The strong pattern is **producer contract by filename and path**. MetricKit already encodes its event type in the filename written by `CrashDiagnostics.persist` (`Sources/SentryHelper.swift:55`), launch sentinel encodes unclean exits in `unclean-exit-<stamp>.json` (`Sources/SentryHelper.swift:133`), and Sentry/IPS are discovered by product-scoped directories or names (`Sources/HealthCommandCore.swift:92`, `Sources/HealthCommandCore.swift:180`). That is an emerging convention: producers do not need a database if their disk layout is deliberate and parseable.
+
+The second pattern is **pure core, thin CLI**. `CLI/HealthCommand.swift` only chooses the window, home, rail filter, and output format, then delegates to core functions (`CLI/HealthCommand.swift:7`). Tests exercise the runtime behavior through a temp home and rendered JSON/table output (`c11Tests/CLIHealthRuntimeTests.swift:21`, `c11Tests/CLIHealthRuntimeTests.swift:52`). This is the right direction.
+
+The anti-pattern to catch early is **implicit context leaking into renderers and warnings**. The collector knows which rails were scanned, the CLI knows the requested window, JSON reports rail counts, but the table renderer receives only `[HealthEvent]` and warnings (`Sources/HealthCommandCore.swift:672`). That means the empty table line is fixed to "last 24h across ips, sentry, metrickit, sentinel" (`Sources/HealthCommandCore.swift:667`) even when the user ran `--rail sentinel` or `--since 30m`. That is a small v1 wrinkle, but architecturally it is the sign that a `HealthReport` object wants to exist.
+
+## How This Could Evolve
+
+### 1. Promote the output boundary from events to `HealthReport`
+
+Right now the core returns raw events (`Sources/HealthCommandCore.swift:50`) and the CLI separately computes warnings (`CLI/HealthCommand.swift:35`). A more durable primitive would be:
+
+```swift
+struct HealthReport {
+    let window: HealthCollectionWindow
+    let rails: [HealthRailSnapshot]
+    let events: [HealthEvent]
+    let warnings: [HealthWarning]
+}
+
+struct HealthRailSnapshot {
+    let rail: HealthEvent.Rail
+    let count: Int
+    let status: HealthRailStatus
+    let scannedPaths: [String]
+}
+```
+
+This is not polish. It changes the command from "print events" to "return an evidence snapshot." The table, JSON, and tests then render the same object. It also fixes the empty-result drift because the renderer can include the actual window and rail filter.
+
+✅ Confirmed: `renderHealthJSON` already builds a report-like payload from `events`, `window`, `rails`, and `warnings` (`Sources/HealthCommandCore.swift:705`). The compatibility path is straightforward: create `HealthReport`, teach JSON/table renderers to accept it, then keep thin adapters if needed for existing tests.
+
+### 2. Turn rails into data, not four conditionals
+
+The four scanner functions are intentionally small and uniform, but the registry is still spread across:
+
+- `HealthEvent.Rail.allCases` (`Sources/HealthCommandCore.swift:7`)
+- `collectHealthEvents` conditionals (`Sources/HealthCommandCore.swift:56`)
+- `parseHealthCLIArgs` rail parsing (`Sources/HealthCommandCore.swift:433`)
+- help text (`CLI/c11.swift:7735`)
+- warning wiring (`CLI/HealthCommand.swift:39`)
+
+The next rail should not require touching five places. A minimal, non-bloated registry could live near the enum:
+
+```swift
+struct HealthRailDefinition {
+    let rail: HealthEvent.Rail
+    let scan: (HealthScanContext) -> [HealthEvent]
+    let warnings: (HealthReportDraft) -> [HealthWarning]
+}
+```
+
+The important choice is that this should be a table of functions, not a protocol hierarchy. Keep the ergonomic advantage of plain functions while making the set of rails composable.
+
+✅ Confirmed: every current scanner already has the same effective shape: `home + since -> [HealthEvent]` (`Sources/HealthCommandCore.swift:92`, `Sources/HealthCommandCore.swift:180`, `Sources/HealthCommandCore.swift:322`, `Sources/HealthCommandCore.swift:594`). The only extra input needed is bundle version for MetricKit warning logic, which belongs in a context object rather than a scanner parameter.
+
+### 3. Name the producer contracts
+
+This branch relies on load-bearing disk contracts, but those contracts are currently embedded in comments and parser assumptions. Examples:
+
+- MetricKit filename grammar is documented in `Sources/HealthCommandCore.swift:235` and produced by `Sources/SentryHelper.swift:55`.
+- Launch sentinel archive shape is documented in `Sources/HealthCommandCore.swift:590` and produced by `Sources/SentryHelper.swift:126`.
+- Sentry deliberately treats regular files as opaque evidence (`Sources/HealthCommandCore.swift:175`).
+
+Future D11 wants these contracts as first-class concepts: "this producer emits passive local evidence at this path, with this retention and this parser." That could be a small internal `HealthEvidenceContract` struct used only for JSON `rail` metadata and developer docs. The payoff is that adding a fifth rail becomes a contract addition, not tribal memory.
+
+✅ Confirmed: the producer and consumer are already close enough to link without changing `Sources/SentryHelper.swift`, which this review intentionally does not propose modifying. A consumer-side contract table can cite the existing producer paths and grammar.
+
+## Mutations and Wild Ideas
+
+**Health as black-box flight recorder.** Keep the CLI passive, but let the evidence model become a local "flight recorder" abstraction: all c11 subsystems that can leave passive forensic residue get one rail definition. The operator asks one question: "What happened recently?" The implementation remains boring files and parsers.
+
+**Evidence confidence.** Add a field like `confidence: confirmed | inferred | ambiguous`. Sentinel `unclean_exit` is confirmed evidence of prior non-clean shutdown; Sentry queued files are inferred queued telemetry; an empty Sentry cache warning is ambiguous. This would make the JSON more useful to agents without changing the human table much.
+
+**Ritual mode.** The operator's daily command could eventually be `c11 health --brief`, returning one stable, scannable paragraph: window, counts, newest event, warnings. Not a notification, not sidebar reporting, just a better terminal rhythm for repeated checks.
+
+**Forensics recipes.** A future `--explain <event-id>` could render a rail-specific explanation from the contract table: where the evidence came from, what it proves, and what it does not prove. This is especially useful for Sentry and MetricKit, where "no rows" can mean several different things.
+
+## Leverage Points
+
+The highest leverage point is the renderer boundary. Once table and JSON consume one `HealthReport`, every future rail gets counts, warnings, and empty-state semantics for free. The current JSON function is already doing half of this work (`Sources/HealthCommandCore.swift:705`), while the table path is still event-only (`Sources/HealthCommandCore.swift:672`).
+
+The second leverage point is scanner uniformity. All four rails already follow the same mental contract: enumerate candidate files, parse minimal metadata, filter by `since`, emit `HealthEvent`. Formalizing that as a tiny registry makes the next rail boring.
+
+The third leverage point is test fixture generation. `CLIHealthRuntimeTests.scaffoldAllRails` (`c11Tests/CLIHealthRuntimeTests.swift:176`) is already an implicit synthetic evidence factory. If it becomes a small helper type, future rail tests can be added without copying temp-home scaffolding across test files.
+
+## The Flywheel
+
+There is a good flywheel here:
+
+1. Producers leave small, passive, local evidence.
+2. `c11 health` normalizes it into one report.
+3. Tests encode each producer contract with fixtures and temp homes.
+4. New incidents teach c11 a new passive rail or warning.
+5. The next incident is easier to reconstruct.
+
+The compounding effect depends on not overfitting to today's four rails. The branch is close: it has the right pure functions and tests. The next evolution should make the "rail" abstraction just explicit enough that future evidence sources inherit the same path.
+
+## Concrete Suggestions
+
+1. **High Value: Introduce `HealthReport` and render both table and JSON from it.**
+   - Move window, selected rails, per-rail counts, events, and warnings into one value.
+   - Change `renderHealthTable` so empty output reflects the actual requested window and rail filter, instead of always using the default line at `Sources/HealthCommandCore.swift:667`.
+   - Keep `renderHealthJSON`'s shape stable by serializing the same report fields it already emits at `Sources/HealthCommandCore.swift:729`.
+   - ✅ Confirmed: compatible with current architecture. The CLI already constructs `window`, `rails`, `events`, and `warnings` before printing (`CLI/HealthCommand.swift:27`, `CLI/HealthCommand.swift:53`).
+
+2. **High Value: Add a tiny rail definition table.**
+   - Keep the scanners as free functions.
+   - Add a table mapping each `HealthEvent.Rail` to its scanner and warning contributors.
+   - Use the table for collection, CLI rail validation, JSON counts, and possibly help text generation.
+   - ✅ Confirmed: scanner signatures are already uniform enough to adapt without broad changes. Risk: do not let this turn into a large protocol framework; a table is enough.
+
+3. **Strategic: Add `HealthScanContext`.**
+   - Include `home`, `now`, `bundleVersion`, and maybe `fileManager`.
+   - Use it in `runHealth`, scanners, and warning helpers so all time and environment decisions come from one place.
+   - This improves deterministic tests and prepares for future D11 runners that may scan alternate homes or mounted bundles.
+   - ✅ Confirmed: current call sites already pass `home` and `since` explicitly (`Sources/HealthCommandCore.swift:50`), while `runHealth` owns `now` and bundle version (`CLI/HealthCommand.swift:17`, `CLI/HealthCommand.swift:37`). The migration is mechanical.
+
+4. **Strategic: Track rail status, not just event count.**
+   - Add statuses like `missing`, `empty`, `scanned`, `permissionDenied`, and `parseSkipped`.
+   - Surface them primarily in JSON; table can stay compact.
+   - This preserves passive behavior while making "0 events" more interpretable.
+   - ✅ Confirmed: current scanners intentionally swallow missing directories and parse failures (`Sources/HealthCommandCore.swift:97`, `Sources/HealthCommandCore.swift:326`, `Sources/HealthCommandCore.swift:598`). That behavior is correct for v1, but the status can be recorded without turning it into a fatal error. Risk: keep status coarse to avoid recreating the deferred debug-log gap work.
+
+5. **Strategic: Promote test scaffolding into a reusable synthetic evidence builder.**
+   - Extract the temp-home file creation currently inside `CLIHealthRuntimeTests.scaffoldAllRails` (`c11Tests/CLIHealthRuntimeTests.swift:176`) into a test helper.
+   - Give each rail a helper like `writeIPS`, `writeSentryEnvelope`, `writeMetricKit`, `writeSentinelArchive`.
+   - This makes the fifth rail cheaper to test and keeps fixture behavior consistent.
+   - ✅ Confirmed: every parser test currently repeats temp-home creation (`c11Tests/HealthIPSParserTests.swift:132`, `c11Tests/HealthSentryParserTests.swift:100`, `c11Tests/HealthMetricKitParserTests.swift:103`, `c11Tests/HealthSentinelParserTests.swift:105`). This can be centralized without touching production code.
+
+6. **Experimental: Add evidence confidence to JSON.**
+   - Example: sentinel `unclean_exit` = `confirmed`, Sentry queued file = `inferred`, telemetry empty warning = `ambiguous`.
+   - Helps agents reason over output without brittle string parsing.
+   - ❓ Needs exploration: the current `HealthEvent` is intentionally small (`Sources/HealthCommandCore.swift:6`). This is worth trying only after `HealthReport` exists.
+
+7. **Experimental: Add `--brief` for the daily operator rhythm.**
+   - Output one compact summary line from `HealthReport`: window, counts, newest event, warnings.
+   - This is still passive CLI behavior, not active reporting.
+   - ❓ Needs exploration: probably best deferred until the table/report boundary is cleaner.
+
+## Validation Pass
+
+- ✅ Confirmed: `HealthReport` fits the existing data flow. `runHealth` already gathers all needed report inputs before rendering (`CLI/HealthCommand.swift:27`, `CLI/HealthCommand.swift:33`, `CLI/HealthCommand.swift:39`).
+- ✅ Confirmed: a rail definition table is compatible with the four current scanner functions because they share the same minimal input and output shape.
+- ✅ Confirmed: `HealthScanContext` would reduce implicit dependencies without changing passive semantics. It does not require touching `LaunchSentinel` or `CrashDiagnostics`.
+- ✅ Confirmed: rail status can be implemented as observability of scanner outcomes, not as new side effects. It remains read-only and socket-free.
+- ✅ Confirmed: test helper extraction is compatible with the project's test-quality policy because tests would still exercise runtime behavior through temp-home files, not grep project metadata.
+- ❓ Needs exploration: evidence confidence and `--brief` should wait until the report model exists, otherwise they add surface area before the core abstraction is ready.
+
+## Bottom Line
+
+The branch is building a passive local evidence plane. The next best move is not to add more warnings or a flashier command. It is to make the report object explicit, make rails data-driven, and let every future diagnostic source plug into the same small contract.
+

--- a/notes/trident-review-C11-24-pack-20260503-1749/evolutionary-gemini.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/evolutionary-gemini.md
@@ -1,0 +1,42 @@
+## Evolutionary Code Review
+- **Date:** 2026-05-03T17:49:00Z
+- **Model:** Gemini 1.5 Pro
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Linear Story:** C11-24
+- **Review Type:** Evolutionary/Exploratory
+---
+
+**What's Really Being Built**:
+You aren't just building a CLI diagnostic tool for a human operator; you are building an "Immune System API" or an "Observability Seam" for the operator:agent pair. By normalizing crash logs, MetricKit payloads, Sentry envelopes, and launch sentinels into a single, queryable `HealthEvent` timeline (especially via the `--json` flag), you give agents self-awareness of the host environment's stability. It transitions application crashes from being "opaque host failures" to "queryable context" that an agent can parse and act upon.
+
+**Emerging Patterns**:
+1. **The Universal Timeline Pattern**: Mapping four wildly different OS and SDK data models (Sentry cache paths, IPS formats, JSON diagnostics) into a unified `(timestamp, rail, severity, summary, path)` abstraction. 
+2. **Graceful Host-Tolerant Parsing**: Using extensive `try?` and skipping missing files/directories gracefully. This pattern assumes the host file system might be fundamentally broken or pristine and still yields a valid payload without aborting.
+3. **Core/Shell Segregation**: `HealthCommandCore.swift` is pure logic decoupled from the CLI argument parsing and decoupled from the Sentry SDK. It perfectly positions this logic to be consumed directly by the socket/daemon in the future.
+
+**How This Could Evolve**:
+- **Socket Streaming (Live Immune System)**: Right now it is point-in-time polling via CLI (`c11 health`). As the core is already dual-targeted, the daemon could continuously monitor these rails and broadcast `system.health_events` over the socket, allowing agents to instantly react to OOMs or hangs without needing to poll.
+- **The 5th Rail (Agent Telemetry)**: If `c11` is the orchestrator, it should also track agent health. Adding an "Agent Rail" where agents drop their own crash/panic JSONs into a known directory would make `c11 health` the ultimate timeline for both host and tenant failures.
+
+**Mutations and Wild Ideas**:
+- **Agent-Driven Auto-Triage**: Instead of the operator manually running `c11 health` when things act weird, agents could automatically execute `c11 health --since 5m --json` upon detecting an unexpected shell exit or pane failure, attaching the result to their context window before deciding to retry or report the failure to the user.
+- **Cross-Machine Health / Fleet View**: The architecture allows passing a `home` parameter. This implies we could mount or sync the `Library` folder of a remote machine and use the local `c11` CLI to diagnose remote agents. It opens the door to a `c11 health --remote <ssh-target>` variant.
+
+**Leverage Points**:
+- **The `--json` flag**: This single addition turns a human-readable table into an API. It is the highest-leverage decision in the PR because it directly enables agent-driven consumption.
+- **The `home` parameter injection**: Makes testing trivial, but strategically opens the door for offline or remote diagnostics snapshots.
+
+**The Flywheel**:
+- **Self-Healing Loop**: If agents are taught (via the c11 SKILL) to read `c11 health` on failure, they generate better, highly-contextual failure reports for the operator or the orchestrator. This leads to quicker fixes to the environment, allowing agents to run longer without dying. The observability compound success.
+
+**Concrete Suggestions**:
+
+1. **High Value**: Update the `SKILL.md` (Agent operating skill) to explicitly teach agents to invoke `c11 health --json --since 15m` when a sub-process crashes or a pane exits unexpectedly.
+   - ✅ Confirmed — The `--json` output makes this perfectly parseable by agents today. No code changes needed, just a documentation/prompting update in `skills/c11/SKILL.md`.
+
+2. **Strategic**: Add an `agent` rail (the 5th rail). Introduce a designated folder like `~/Library/Logs/c11/agents/` where agents can drop standard crash/failure payload JSONs. `scanAgent()` would pick these up just like MetricKit.
+   - ✅ Confirmed — `HealthEvent.Rail` can easily be expanded, and the file-parsing pattern established for MetricKit/Sentinel fits this perfectly. This makes the four scanner functions more uniform by setting up a template for the 5th.
+
+3. **Experimental**: Expose the `HealthCommandCore` logic through a v2 Socket Method (e.g., `system.health`).
+   - ❓ Needs exploration — Since `Sources/HealthCommandCore.swift` is dual-target, the main c11 app can call it directly and serve it to socket clients without shelling out to the `c11 health` CLI command. It's a quick win for programmatic access but needs to ensure it doesn't block the main thread during heavy I/O sweeps.

--- a/notes/trident-review-C11-24-pack-20260503-1749/standard-claude.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/standard-claude.md
@@ -1,0 +1,324 @@
+## Code Review
+
+- **Date:** 2026-05-03T17:49:00Z
+- **Model:** Claude (claude-opus-4-7[1m])
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Base:** origin/crash-visibility/launch-sentinel @ 5402d3fcd69c3ecb54ff440664fad51abf59f0e7
+- **Linear Story:** C11-24
+- **Lens:** Standard (code quality, correctness, design, tests, style)
+
+---
+
+## What this branch does
+
+Adds a new read-only CLI subcommand `c11 health` that summarises crash and reliability evidence on the local machine across four independent rails:
+
+1. **IPS** — Apple `.ips` reports under `~/Library/Logs/DiagnosticReports`, scoped to entries owned by the c11 family of bundle IDs.
+2. **Sentry queued** — file count under `~/Library/Caches/com.stage11.c11*/io.sentry/` (no envelope parsing; just "something is queued").
+3. **MetricKit** — JSON files under `~/Library/Logs/c11/metrickit` whose filename grammar is `<filename-safe-ISO>-<kind>.json` (where `<kind>` is `metric` / `diagnostic` / one or more of `crash<n>`, `hang<n>`, `cpu<n>`, `disk<n>`). `metric` rows are skipped (telemetry baselines, not diagnostics).
+4. **Sentinel** — `unclean-exit-*.json` archives written by `LaunchSentinel.recordLaunchAndArchivePrevious()` from PR #109, which catches Force-Quit / SIGKILL where Sentry and `.ips` cannot.
+
+The design is clean: a single core (`Sources/HealthCommandCore.swift`) with no UI, socket, or `SentrySDK` calls, plus a thin shim (`CLI/HealthCommand.swift`) for argument plumbing. Output supports both a fixed-width table and a structured JSON form (`renderHealthJSON`). Two diagnostic warnings (MetricKit baseline still establishing after a recent version bump; Sentry cache empty/ambiguous) are appended as footer lines.
+
+The work also adds two compile-time configurations of the same source file: it lives in both the main `c11` target and the `CLI` build, exposed under `@testable import c11_DEV` / `@testable import c11`.
+
+### Logic trace (default invocation)
+
+```
+c11 health
+  -> CLI/c11.swift dispatch:
+     `--json` global flag is stripped to `jsonOutput`,
+     `commandArgs = []`,
+     command == "health" routes to runHealth().
+  -> runHealth() (CLI/HealthCommand.swift)
+     parseHealthCLIArgs([]) -> mode=.defaultLast24h, rail=nil, json=false
+     since = now - 24h
+     home  = NSHomeDirectory()
+     events = collectHealthEvents(window, allRails, home)
+       -> scanIPS / scanSentryQueued / scanMetricKit / scanLaunchSentinel
+       -> sorted by timestamp descending
+     warnings = [metricKitBaselineWarning?, telemetryAmbiguityFooter?]
+     renderHealthTable(events, warnings) -> stdout
+```
+
+### Architectural shape
+
+- The split between core (pure, testable) and shim (I/O, dispatch) is the right structure for a non-trivial CLI surface and matches the project's existing patterns. The dual-target Swift file is unusual but justified by the constraint that the standalone `c11` CLI binary is a separate Mach-O target from the app, and the shared logic is genuinely useful in both.
+- The contract with the upstream sentinel producer is correct: the consumer treats the **filename** as the source of truth for the timestamp and the body as best-effort metadata. This is the right side of the bargain to be on, since the producer always writes a filename-safe ISO stamp and the body might be partially written or fail to parse.
+- Privacy-by-default and read-only-by-default are honoured: the CLI never calls `SentrySDK.capture*`, never posts notifications, never touches the c11 socket, and never reaches into tenant config. It strictly reads files c11 itself produced, plus Apple's own crash reports.
+
+Overall the work is solid. The headline issues below are mostly tactical, with one architectural concern around the `metricKitBaselineWarning` data source.
+
+---
+
+## General feedback
+
+**Strengths**
+
+- The four-rail core is clearly factored. Each `scan*` function is independently testable, gracefully handles missing directories, and respects the `since` window.
+- `HealthCLIError` is a `CustomStringConvertible` enum with meaningful messages — much better than throwing generic strings.
+- Tests are runtime-behavioural: tmp-home scaffolds + real file I/O + assertions on returned `HealthEvent` arrays. Zero `grep-the-source` smell. The CLAUDE.md test policy is well respected.
+- Golden snapshots use a `timeZone:` injection seam rather than mocking `Date()`, which is a clean way to make wall-clock-sensitive output deterministic.
+- The "list of footers" approach (`warnings: [String]`) is straightforward and renders identically in table and JSON output.
+
+**Weaknesses**
+
+- Several places duplicate the same `ISO8601DateFormatter()` configuration (5 instances). Minor but worth a small helper.
+- The `metricKitBaselineWarning` reads `active.json` and `unclean-exit-*.json` written by `LaunchSentinel`, but only treats `version` (not `build`) as the change signal. A build-only bump (e.g. nightly with same `0.44.1` MarketingVersion) won't trigger the warning even though MetricKit's baseline does reset on each Mach-O bundle change. This is a Potential, not a Blocker — see #6.
+- A few rendering-correctness edge cases around overlong content (#3, #4 below) that golden tests miss because the fixture data is short.
+- Help-text content has a small fidelity issue with the `--rail` filter description (#5).
+
+---
+
+## Numbered findings
+
+> Severity legend: **Blocker** must fix before merge; **Important** should fix, not blocking; **Potential** nice-to-have or uncertain.
+
+### Blockers
+
+_None._ The code is correct on the happy paths, the tests exercise real behaviour, and nothing here looks like it would fail review on a serious project.
+
+### Important
+
+**1. ✅ `--rail` accepts only one value; multiple `--rail` flags silently overwrite the previous one. (Sources/HealthCommandCore.swift:574, CLI/c11.swift:7735)**
+
+`HealthCLIOptions.railFilter` is `HealthEvent.Rail?` (a single optional), and `parseHealthCLIArgs` overwrites `rail` on every `--rail` occurrence. Help text (`Filter to one rail: ips, sentry, metrickit, sentinel`) implicitly suggests one rail at a time, but the natural operator instinct given four rails is `c11 health --rail ips --rail sentinel`. Today that silently keeps only the last one with no error.
+
+Two acceptable fixes:
+- Tighten: throw `HealthCLIError.unknownFlag` (or a new `.duplicateFlag`) on a second `--rail` so the operator gets an error rather than silent loss.
+- Loosen: change `railFilter` to `Set<HealthEvent.Rail>?` and accumulate. Help text and `runHealth` both compose cleanly with this since the call-site already does `Set<HealthEvent.Rail> = opts.railFilter.map { [$0] } ?? allRails`.
+
+Tightening is the smaller change and keeps the v1 contract honest. Recommend tighten now, loosen later if real usage demands it.
+
+**2. ✅ `bootTime()` falls back to "24h ago" on `sysctlbyname` failure, but `--since-boot` then becomes a synonym for the default 24h window. (Sources/HealthCommandCore.swift:402)**
+
+```swift
+func bootTime() -> Date {
+    var tv = timeval()
+    var size = MemoryLayout<timeval>.size
+    let result = sysctlbyname("kern.boottime", &tv, &size, nil, 0)
+    if result == 0 { ... }
+    return Date(timeIntervalSinceNow: -24 * 3600)
+}
+```
+
+The doc comment says "Falls back to 24h ago on failure so callers do not have to handle nil for a value the kernel always exposes on macOS" — the practical realism here is fine, but on a machine where `sysctlbyname` actually does fail, the operator who explicitly asked for "since boot" silently gets a 24h window with no warning. Recommend either:
+
+- Print a single-line warning to stderr in this fallback path (e.g. `c11 health: kern.boottime unavailable, falling back to 24h window`), so the operator can tell their explicit ask was downgraded; or
+- Throw a `HealthCLIError` from this code path and let `runHealth` surface it. (Less attractive — it makes the "harmless degradation" case feel like an error.)
+
+The first is cheaper and matches the read-only ethos.
+
+**3. ⬇️ Lower priority: `renderHealthTable` does not truncate long `summary` values, which will visually break the fixed-width table on long bundle/envelope names. (Sources/HealthCommandCore.swift:644-672)**
+
+The table format uses `padding(toLength:withPad:startingAt:)` for the rail and severity columns, but the summary is unbounded and gets concatenated as-is. A long sentry envelope name like `com.stage11.c11.debug.runtime/legacy-envelope-with-a-really-really-long-suffix` will produce a wrapping line on standard 100-col terminals and visually break alignment of subsequent rows. The IPS path also can produce summaries that include UUID-like incident IDs.
+
+Recommend truncating `summary` to ~80 chars with a `…` ellipsis (or to terminal width minus the prefix length) for the table form. JSON output should keep full strings.
+
+Marking this as ⬇️ because it doesn't break correctness; it's a polish issue and the v1 demo paths produce short summaries. Worth a follow-up.
+
+**4. ⬇️ Lower priority: `renderHealthTable` always emits a trailing newline even when both events and warnings are empty. (Sources/HealthCommandCore.swift:670-672)**
+
+```swift
+return lines.joined(separator: "\n") + "\n"
+```
+
+That is fine, but the `runHealth` shim also calls `print(...)` with `terminator: ""`, which combined with the always-appended `\n` is correct. The only nit: the empty-results path becomes a single-line message followed by a newline. The "four-events" golden expects a trailing newline too. It is consistent, just worth a comment that the rendered string is **already terminated** so callers can use `terminator: ""`. A one-line comment above `return` would prevent future "let's just print it normally" regressions.
+
+Not blocking. ⬇️ for follow-up.
+
+**5. ✅ `--rail <name>` help text omits the "all rails by default" note. (CLI/c11.swift:7741)**
+
+```
+--rail <name>          Filter to one rail: ips, sentry, metrickit, sentinel.
+```
+
+A reader of `--help` cannot tell from this whether omitting `--rail` defaults to all rails or to a specific rail. It does default to all four (correctly), so add "Default: all rails." or "Omit to query all four rails."
+
+Trivial wording fix.
+
+### Potential
+
+**6. ❓ `metricKitBaselineWarning` reads `version` only, ignoring `build`. (Sources/HealthCommandCore.swift:558)**
+
+```swift
+guard marker.version != curr else { return nil }
+```
+
+`LaunchSentinel.recordLaunchAndArchivePrevious()` records both `CFBundleShortVersionString` (version) and `CFBundleVersion` (build) in the JSON body. The current consumer compares only `version` against `bundleVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"]`. In practice MetricKit's baseline reset is keyed on the bundle's signed Mach-O (so build bumps with the same MarketingVersion can also reset the baseline). For nightly builds where the version stays at e.g. `0.44.1` but the build increments per-build, an operator could see "0 MetricKit events" after a fresh build and not get the warning even though the explanation is exactly the same.
+
+This is a behaviour question, not a defect. Two reasonable answers:
+- v1 scope is "version bump = warn"; build-only bumps are out of scope. State this in a code comment so a future maintainer doesn't mistakenly think it's a bug.
+- v1 should also detect `build` mismatches. Then change the consumer to read both fields and trigger if either differs.
+
+Flagging for operator/PM judgement, not a blocker.
+
+**7. ❓ `metricKitBaselineWarning` will misbehave if the most-recent marker on disk has a clock skew (system clock turned back). (Sources/HealthCommandCore.swift:567)**
+
+```swift
+let age = now.timeIntervalSince(marker.timestamp)
+guard age >= 0, age <= 24 * 3600 else { return nil }
+```
+
+The `age >= 0` guard silently suppresses the warning if `marker.timestamp` is in the future relative to `now`. That is a defensive choice and probably the right one (don't show a warning we can't justify), but it does mean an operator who ran with a future-dated clock and bumped the version will lose this signal forever for that marker. Probably fine — clock skew is exotic — but worth a code comment.
+
+**8. ✅ `mostRecentSentinelMarker` reads every `unclean-exit-*.json` and `active.json` under every c11 bundle, doing one JSON parse per file. (Sources/HealthCommandCore.swift:486)**
+
+This is O(n) where n is the count of marker files across all bundle dirs (debug, debug.runtime, prod, …). For a typical operator that's small (single digits), but if `unclean-exit-*.json` accumulate (no GC mentioned in the producer), this could grow to hundreds and noticeably slow `c11 health` to compute the warning. Two cheap mitigations:
+
+- Sort by filename (the filename's ISO stamp is a total ordering) and read only the newest one; fall back to body parsing only if that file's `version` field is missing.
+- Limit to the N most recent (e.g. last 10) per bundle directory.
+
+The current code's `best == nil || best!.timestamp < timestamp` does pick the right answer, just with O(n) reads. Probably fine for v1; revisit when sentinel housekeeping ships.
+
+**9. ✅ Five duplicate `ISO8601DateFormatter` configurations. (Sources/HealthCommandCore.swift:288, 291, 502, 515, 711, 712)**
+
+Same five-line dance is repeated. Extract a small helper:
+
+```swift
+private func isoFormatter() -> ISO8601DateFormatter {
+    let f = ISO8601DateFormatter()
+    f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return f
+}
+```
+
+Cosmetic, but reduces drift risk. Note that `LaunchSentinel` already has an identical private `isoFormatter()` helper in `Sources/SentryHelper.swift` — could even hoist this to a shared `Sources/IsoTime.swift` or similar, since both files use the same format. That said, sharing across files has its own cost; one-file extraction is the safer move.
+
+**10. ✅ `parseFilenameSafeISO` accepts but doesn't validate fractional-seconds format strictness. (Sources/HealthCommandCore.swift:275-291)**
+
+```swift
+guard stamp.count == 24, stamp.last == "Z" else { return nil }
+var chars = Array(stamp)
+guard chars[10] == "T",
+      chars[13] == "-",
+      chars[16] == "-",
+      chars[19] == "."
+else { return nil }
+```
+
+The structural checks are correct for the `YYYY-MM-DDTHH-MM-SS.fffZ` shape. However, this accepts non-numeric characters in the digit positions (e.g. `20XX-05-03T15-19-00.123Z` will be replaced to `20XX-05-03T15:19:00.123Z` and then tossed to `ISO8601DateFormatter`, which will reject it; so the failure surfaces, just one layer late). That's defensible because `ISO8601DateFormatter` is the source of truth for date validity. Worth a one-line comment that says exactly this so a maintainer doesn't add redundant validation.
+
+**11. ✅ `scanSentryQueued` walks `io.sentry/` recursively and emits one event per regular file, including any non-envelope side files Sentry-Cocoa might write. (Sources/HealthCommandCore.swift:411-428)**
+
+The doc comment acknowledges this: "any regular file inside `io.sentry/` is treated as a queued event." That is conservative and matches v1 scope (file count, not envelope semantics). The risk is over-counting if Sentry-Cocoa writes `installation.id` or similar metadata files inside `io.sentry/`. In a sample install I'd expect one or two such files at most, so the ambiguity is small.
+
+Recommend adding to the doc comment: "Sentry-Cocoa may write small bookkeeping files (e.g. `installation.id`) under `io.sentry/`; v1 over-counts these by ≤2 per bundle. Acceptable for the count-only signal." Then `telemetryAmbiguityFooter`'s "0 events" check will still be the more meaningful one in practice.
+
+**12. ✅ `parseUncleanExitFile` defaults to `commit = "????????"` when missing. (Sources/HealthCommandCore.swift:643)**
+
+The string `"????????"` is rendered into the table summary, which is accurate when the marker JSON lacks a commit field. However, on a machine where every marker lacks the field (e.g. local dev builds without `C11Commit` set in Info.plist), every sentinel row will end with `????????` which reads as eight visually-identical question marks. Suggest using `"unknown"` or similar so the rendered output is more legible, and so operators can search for "unknown" rather than a glob-active sequence of `?`. Cosmetic; not blocking.
+
+**13. ❓ `HealthEvent.Severity` is a flat enum with values `crash`, `queued`, `metrickit`, `hang`, `resource`, `mixed`, `diagnostic`, `unclean_exit`. The `.metrickit` case is defined but never produced. (Sources/HealthCommandCore.swift:18-25)**
+
+`metricKitSeverity` returns one of `.crash`, `.hang`, `.resource`, `.mixed`, `.diagnostic`. The `.metrickit` raw case is dead. Either remove it (preferred — it confuses future maintainers about what valid severity values are) or document why it's reserved for a future case. Cosmetic.
+
+**14. ✅ `HealthEvent.Severity.unclean_exit` uses a snake_case raw value, while every other severity uses lowercase single-word values. (Sources/HealthCommandCore.swift:24)**
+
+This is also the value emitted in JSON (`"severity": "unclean_exit"`) and in the table summary. Mixing snake_case with lowercase tokens in the same enum's raw values is inconsistent for downstream JSON consumers. Two equally good options:
+- Rename to `.uncleanExit` and rawValue `"unclean-exit"` (kebab-case to mirror the filename convention).
+- Or keep `unclean_exit` but document the inconsistency once in a comment.
+
+Not blocking; downstream consumers are presumably c11-internal for v1.
+
+**15. ❓ `parseHealthCLIArgs` accepts `--help`/`-h` mid-args but does nothing with them. (Sources/HealthCommandCore.swift:430-434)**
+
+```swift
+case "-h", "--help":
+    // Help is dispatched upstream via dispatchSubcommandHelp; tolerate here.
+    i += 1
+```
+
+In practice the upstream dispatch (`dispatchSubcommandHelp` in CLI/c11.swift line 1553) intercepts these before `runHealth` is ever called. The "tolerate here" branch is defensive code for a path that can't be reached. Not wrong; just dead in the integrated CLI. Fine to keep for direct unit-testing of `parseHealthCLIArgs`. The comment is accurate.
+
+### Test coverage
+
+Coverage is good. Specifically:
+
+- Each rail has its own parser-test file that exercises happy paths, malformed inputs, missing directories, and the `since` window. ✓
+- `CLIHealthRuntimeTests` scaffolds a tmp HOME containing one event per rail, asserts the count and ordering, asserts JSON shape, and asserts golden table rendering. ✓
+- `HealthFlagsTests` exercises the full grid of `--since` / `--since-boot` / `--rail` / `--json` combinations, including mutual exclusion and unknown values. ✓
+- The MetricKit `metric` skip and the IPS top-level vs subdir rules are explicitly tested. ✓
+- Both warnings (`metricKitBaselineWarning` and `telemetryAmbiguityFooter`) have positive and negative tests. ✓
+
+Coverage gaps that would be worth follow-ups (not blockers):
+
+- No test for `metricKitSeverity` mapping a multi-category kind (e.g. `crash1-hang2` → `.mixed`) — the production path is hit indirectly via filename parsing, but a focused unit test on `metricKitSeverity` would lock the contract.
+- No test for the JSON-output's `rails` map when `--rail` filters to a single rail (does the JSON still include zero-count entries for the others, or only the queried one?). Looking at `renderHealthJSON` line 715: it iterates `HealthEvent.Rail.allCases where rails.contains(rail)`, so filtered rails are omitted from the JSON output. That's a behavioural choice worth pinning with a test so it doesn't silently regress.
+- No test for the ordering tie-break when two events share the same timestamp. Probably fine to accept "stable sort by inputs" semantics; just be aware it's not tested.
+
+### Style / project-conventions
+
+- ✓ No em-dashes in user-facing strings (`"(prev to curr)"`, `"telemetry may be off, or events shipped on last launch and cleared the cache."`).
+- ✓ No grep-the-source tests; everything is runtime-behavioural per CLAUDE.md.
+- ✓ No `SentrySDK.capture*`, no socket access, no notification posting in the health code paths.
+- ✓ `LaunchSentinel` and `AppDelegate` lines 2347 / 2795 are not modified — verified by `git diff origin/crash-visibility/launch-sentinel..HEAD -- Sources/SentryHelper.swift`. `Sources/SentryHelper.swift` is only added to the `CLI` build target via pbxproj if needed; check below confirms it isn't.
+- ✓ The Sources/HealthCommandCore.swift dual-target wiring in `project.pbxproj` (DH001BF0…0718 and DH001BF0…0719) is the correct shape: the file is added to both target's Sources build phases via the same fileRef.
+
+Ran a quick re-check of all 7 commits and confirmed:
+
+- No edit to `LaunchSentinel`, `applicationDidFinishLaunching`, `applicationWillTerminate`, or any sentinel call site in `Sources/SentryHelper.swift`.
+- No new socket commands, no new sidebar telemetry, no new `report_*` calls.
+- No edit to typing-latency-sensitive paths (`WindowTerminalHostView.hitTest`, `TabItemView`, `TerminalSurface.forceRefresh`).
+
+The Impl deviation list is reasonable:
+1. `.lattice/*` — correct, scratch belongs to the delegator.
+2. Dual-target file — correct, the CLI binary needs the core; main-only-with-shim was never going to compile.
+3. `(prev to curr)` instead of `(prev → curr)` — correct per CLAUDE.md no-em-dash policy. (Note: `→` is technically not an em-dash, it's a rightwards arrow; the substitution is still fine because the policy is "default to colons/commas/periods" and the AI-tells reading favours plain text. No issue.)
+4. Optional `timeZone:` parameter — correct, harmless seam, nil in production.
+5. Tests not run locally — correct per CLAUDE.md.
+
+---
+
+## Validation pass
+
+Re-read each Important and Potential item against the actual diff and project state:
+
+- #1 `--rail` overwrite — confirmed by reading `parseHealthCLIArgs`. ✅ Confirmed.
+- #2 `bootTime()` silent fallback — confirmed by reading `bootTime()` at HealthCommandCore.swift:402. ✅ Confirmed.
+- #3 Long summary truncation — confirmed by reading `renderHealthTable`. The padding is only on rail/severity columns; summary is unbounded. ⬇️ Lower priority, but valid.
+- #4 Trailing newline contract — verified `print(renderHealthTable(...), terminator: "")` in CLI/HealthCommand.swift. ⬇️ Lower priority, valid as a comment-only follow-up.
+- #5 `--rail` help omits default — confirmed in CLI/c11.swift:7735-7748. ✅ Confirmed.
+- #6 `version`-only baseline check — confirmed by reading `metricKitBaselineWarning` and `LaunchSentinel.recordLaunchAndArchivePrevious()`. The producer writes both; the consumer reads only `version`. ❓ Behaviour question — not a defect.
+- #7 Future-dated clock — confirmed by reading the `age >= 0` guard. Defensive, fine, just worth a comment. ❓
+- #8 O(n) marker reads — confirmed; no early-exit on filename ordering. ✅ Confirmed (acceptable for v1).
+- #9 Duplicate ISO formatters — confirmed via `grep` (5 hits). ✅ Confirmed (cosmetic).
+- #10 Loose digit-position validation — confirmed; `ISO8601DateFormatter` does the real check downstream. ✅ Confirmed (acceptable; comment helps).
+- #11 Sentry walker over-counts side files — confirmed; doc comment already acknowledges. ✅ Confirmed (acceptable; expand comment).
+- #12 `"????????"` placeholder — confirmed at HealthCommandCore.swift:625. ✅ Confirmed (cosmetic).
+- #13 `.metrickit` severity case is dead — confirmed by reading `metricKitSeverity`. ✅ Confirmed (cosmetic).
+- #14 `unclean_exit` rawValue style — confirmed; rest of the enum is single-token lowercase. ✅ Confirmed (cosmetic).
+- #15 Defensive `--help` in `parseHealthCLIArgs` — confirmed; upstream dispatch intercepts first. ❓ Acceptable as written.
+
+No findings flipped to ❌ false-positive on the validation pass.
+
+---
+
+## Summary
+
+**Blockers:** none.
+
+**Important:** four — and only #1 and #2 are functional issues that should be addressed before merge. #3 and #4 are flagged as ⬇️ (lower priority). #5 is a one-line help-text wording fix.
+
+**Potential:** ten items, mostly cosmetic / minor / questions for the operator. None block merge.
+
+The branch is in good shape. The architecture is sound, the rails are independently testable, the producer/consumer boundary with `LaunchSentinel` is respected, and the test coverage is appropriately runtime-behavioural. The two functional fixes worth doing pre-merge are: (1) decide what `--rail X --rail Y` means and either error or accumulate; (2) emit a stderr note when `bootTime()` falls back. Everything else is fine to land and address in follow-ups.
+
+### Quick-scan list
+
+- [Important] **#1** `--rail` silent overwrite on multi-flag — error or accumulate.
+- [Important] **#2** `bootTime()` silent 24h fallback when sysctl fails — log to stderr.
+- [Important] **#5** `--rail` help text omits "default: all rails."
+- [Important ⬇️] **#3** `summary` not truncated; long values break table alignment.
+- [Important ⬇️] **#4** `renderHealthTable` always trailing-newlines; add a contract comment.
+- [Potential] **#6** baseline warning checks `version` only, ignores `build` (intentional?).
+- [Potential] **#7** `age >= 0` clock-skew guard suppresses warning silently.
+- [Potential] **#8** O(n) `unclean-exit-*.json` parses; could short-circuit on newest filename.
+- [Potential] **#9** Five duplicated `ISO8601DateFormatter` configs; extract helper.
+- [Potential] **#10** `parseFilenameSafeISO` defers digit validation to `ISO8601DateFormatter`.
+- [Potential] **#11** Sentry walker counts non-envelope side files.
+- [Potential] **#12** `commit = "????????"` placeholder reads as visual noise.
+- [Potential] **#13** `HealthEvent.Severity.metrickit` is a dead case.
+- [Potential] **#14** `unclean_exit` rawValue is the only snake_case in the severity enum.
+- [Potential] **#15** Defensive `--help` branch in `parseHealthCLIArgs` is dead in integrated CLI.

--- a/notes/trident-review-C11-24-pack-20260503-1749/standard-codex.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/standard-codex.md
@@ -1,0 +1,33 @@
+## Code Review
+- **Date:** 2026-05-03T21:58:41Z
+- **Model:** Codex (GPT-5)
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Linear Story:** C11-24
+---
+
+General assessment: the branch is well scoped for the `c11 health` MVP. The four evidence rails are implemented as passive filesystem scanners, the CLI dispatch is placed after subcommand help so `c11 health --help` should work, and the tests exercise parser behavior and a sandboxed all-rails collection path rather than source-text checks. I did not run local tests per project policy, and I did not fetch/pull because this review was explicitly read-only and pulling could mutate the worktree.
+
+The main concern is in one of the two required diagnostic warnings. The MetricKit baseline warning exists and is unit-tested in isolation, but the real CLI path has two runtime-state mismatches that can prevent it from firing when the operator needs it.
+
+### Blockers
+
+1. ✅ Confirmed: MetricKit baseline warning can be suppressed by the current session marker and by CLI bundle-version lookup.
+   - Files: `Sources/HealthCommandCore.swift:502`, `Sources/HealthCommandCore.swift:531`, `Sources/HealthCommandCore.swift:550`, `CLI/HealthCommand.swift:37`, `GhosttyTabs.xcodeproj/project.pbxproj:1498`
+   - `mostRecentSentinelMarker` treats both `unclean-exit-*.json` and `active.json` as comparable markers, then picks the newest timestamp. In the real producer, `active.json` is the current app launch marker, not a prior-session marker. When c11 is running after a version bump, the current `active.json` is newer than any archived prior marker and usually has the same version as the CLI/app, so `metricKitBaselineWarning` exits at `marker.version != curr` and hides the baseline warning.
+   - The CLI also derives `bundleVersion` from `Bundle.main.infoDictionary` in `CLI/HealthCommand.swift:37`. The CLI target config shown at `GhosttyTabs.xcodeproj/project.pbxproj:1498-1534` does not define an Info.plist, `MARKETING_VERSION`, or `CURRENT_PROJECT_VERSION` for the command-line binary. Existing CLI Sentry code already has a custom app-bundle discovery helper for this reason. If `Bundle.main` is the standalone CLI bundle, `bundleVersion` is nil and the warning never evaluates.
+   - This is branch-introduced and affects the C11-24 contract because the MVP explicitly includes the MetricKit baseline diagnostic warning. The fix should compare against a prior marker, not the current active marker, and resolve the version from the containing app bundle or another established CLI version source.
+
+### Important
+
+None found.
+
+### Potential
+
+2. ✅ Confirmed: Sentry ambiguity warning only checks the exact production cache path.
+   - File: `Sources/HealthCommandCore.swift:565`
+   - The Sentry scanner covers every `com.stage11.c11*` cache directory, including tagged debug and legacy `c11mux` bundles, but `telemetryAmbiguityFooter` only probes `~/Library/Caches/com.stage11.c11/io.sentry`. That matches the current warning copy ("Production Sentry cache empty") and the plan's live-machine baseline, so I am not treating this as a defect. If the operator expects `c11 health` from tagged debug builds to warn on empty debug Sentry caches too, this helper should use the same bundle-directory iteration as `scanSentryQueued`.
+
+### Validation Notes
+
+Reviewed branch diff against `origin/crash-visibility/launch-sentinel` as requested. Verified the changed files are limited to the new health CLI/core, dispatch/help wiring, project target wiring, fixtures, and health tests. I did not run `npm`, XCTest, or local build/test commands; the project instructions say tests run in CI, and the handoff explicitly described this as a read-only review.

--- a/notes/trident-review-C11-24-pack-20260503-1749/standard-gemini.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/standard-gemini.md
@@ -1,0 +1,25 @@
+## Code Review
+- **Date:** 2026-05-03T17:49:00Z
+- **Model:** Gemini 1.5 Pro
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Linear Story:** C11-24
+---
+
+Overall, the `c11 health` implementation is excellently scoped. The architectural choice to isolate `HealthCommandCore` to be completely pure, testable, and separate from UI and network dependencies fulfills the read-only, passive requirements beautifully. The testing strategy successfully avoids grepping source code and establishes a robust sandboxed E2E baseline.
+
+### Architectural
+
+The decision to split the command into a thin CLI shim (`HealthCommand.swift`) and a pure core (`HealthCommandCore.swift`) as a dual-target file is pragmatically correct. It successfully enables full test coverage within `c11Tests` while maintaining the needed boundary for the CLI execution context. There are no architectural concerns to flag; the pattern is sound and future-proof.
+
+### Tactical
+
+**Blockers**
+None. The code adheres strictly to the privacy and passivity requirements detailed in `CLAUDE.md`. Tests run correctly within the constraints.
+
+**Important**
+1. ✅ **Confirmed:** In `CLI/HealthCommand.swift` (line 37), `Bundle.main.infoDictionary` is read directly to determine the app version for the `metricKitBaselineWarning`. If the CLI is invoked via a symlink outside the app bundle (e.g., from `/usr/local/bin/c11`), this will be `nil`, causing the warning to silently fail. Upstream cmux has `CLISocketSentryTelemetry.currentBundleVersionValue(forKey:)` in `c11.swift` to resolve the actual app bundle; adopting a similar strategy here will ensure the warning fires consistently.
+2. ✅ **Confirmed:** In `Sources/HealthCommandCore.swift` (line 560), `telemetryAmbiguityFooter` hardcodes the production bundle path `"\(home)/Library/Caches/com.stage11.c11/io.sentry"`. While the text specifies "Production Sentry cache", this will skip the ambiguity footer for `.debug` or `.staging` builds. Using the same prefix-matching logic (`hasPrefix("com.stage11.c11")`) as `scanSentryQueued` would make this warning resilient across build variants.
+
+**Potential**
+1. ⬇️ **Lower priority:** In `mostRecentSentinelMarker(home:)`, the loop parses the JSON payload for *every* `unclean-exit-*.json` file to extract the version and timestamp. While fast enough for a small number of crashes, as the cache grows, this could become unnecessarily expensive. A potential optimization is to sort the directory contents by filename or `modificationDate` first, and only decode the most recent JSON file to extract the version.

--- a/notes/trident-review-C11-24-pack-20260503-1749/synthesis-action.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/synthesis-action.md
@@ -1,0 +1,148 @@
+# Action-Ready Synthesis: C11-24
+
+## Verdict
+fix-then-merge
+
+The architecture is sound (passive, read-only, four-rail core + CLI shim, dual-target file, sandboxed runtime tests). LaunchSentinel and AppDelegate hooks were not modified, em-dash policy is honored, no `SentrySDK.capture*` / no socket / no notifications. There are, however, four reviewer-consensus blockers in the diagnostic-warning layer and the JSON output that should be patched before merge: the MetricKit baseline warning is effectively dead in the real CLI path, the sentinel marker selection masks the very signal it is meant to compare against, the Sentry ambiguity footer ignores debug builds entirely, and JSON output leaks absolute home paths. None require redesign; all are localized fixes inside `Sources/HealthCommandCore.swift` or `CLI/HealthCommand.swift`.
+
+## Apply by default
+
+### Blockers (merge-blocking)
+
+- **B1: MetricKit baseline warning is effectively dead in the real CLI path (CLI version lookup returns nil).**
+  - Location: `CLI/HealthCommand.swift:37`, `Sources/HealthCommandCore.swift:550`, `GhosttyTabs.xcodeproj/project.pbxproj:1498-1534`
+  - Problem: `runHealth` reads `Bundle.main.infoDictionary?["CFBundleShortVersionString"]`, but the `c11-cli` target's build configuration defines no Info.plist, no `MARKETING_VERSION`, and no `CURRENT_PROJECT_VERSION`. When the user runs `c11 health`, `bundleVersion` resolves to nil and `metricKitBaselineWarning` exits at the `let curr = bundleVersion, !curr.isEmpty` guard before doing any work. The warning that the MVP explicitly ships will never fire from the CLI binary in production.
+  - Fix: Resolve the running c11 app bundle's version from a stable source instead of relying on the CLI's own `Bundle.main`. The codebase already has a precedent: `CLISocketSentryTelemetry` in `CLI/c11.swift` walks to find the c11 app bundle for Sentry init. Reuse that pattern (or extract a small helper) so `runHealth` passes the *app* version, not the CLI binary's nil version. As a stopgap, threading a non-empty version is non-negotiable for the warning to fire.
+  - Sources: standard-codex (Blocker #1), critical-codex (Important #1), standard-gemini (Important #1).
+
+- **B2: `mostRecentSentinelMarker` treats the current launch's `active.json` as a candidate, which masks the prior-version marker the warning compares against.**
+  - Location: `Sources/HealthCommandCore.swift:486-540` (`mostRecentSentinelMarker`), `Sources/HealthCommandCore.swift:550-561` (`metricKitBaselineWarning`)
+  - Problem: The producer at `Sources/SentryHelper.swift:131` writes `active.json` for the *current* launch. The reader picks the marker with the maximum timestamp from both `unclean-exit-*.json` and `active.json`. After a version bump, the current `active.json` has the *new* version and the newest timestamp, so the warning's `marker.version != curr` guard returns nil. The warning is meant to compare current version against the *prior* session's version, but the helper picks the current session itself.
+  - Fix: Exclude `active.json` from the candidate set in `mostRecentSentinelMarker` (the function only needs prior markers). Alternatively, treat `active.json` as "current" and only consider it a "prior" marker when its `version` differs from the running bundle version. The simpler correct behavior is: only enumerate `unclean-exit-*.json` files; `active.json` is by definition the current session and not a baseline. While here, also restrict the bundle-dir walk to the running bundle id (or document why cross-bundle comparison is desired) so a stale `active.json` from a sibling bundle cannot poison the result.
+  - Sources: standard-codex (Blocker #1, paired sub-finding), critical-codex (Important #1, paired sub-finding), critical-claude (#2), critical-gemini (Potential #6 cross-bundle variant).
+
+- **B3: `telemetryAmbiguityFooter` hardcodes the production bundle path; debug builds (the dev-machine population) never see this footer.**
+  - Location: `Sources/HealthCommandCore.swift:567-588`
+  - Problem: The probe path is hardcoded `"\(home)/Library/Caches/com.stage11.c11/io.sentry"`. On a machine where only `c11_DEV` (`com.stage11.c11.debug.*`) ever ran, the probe returns false, the function exits early, and the operator who is in the exact ambiguous state the footer is designed for sees nothing. `scanSentryQueued` uses `hasPrefix("com.stage11.c11")` family iteration; this helper diverged.
+  - Fix: Reuse the same family-iteration shape `scanSentryQueued` uses. Walk all `~/Library/Caches/com.stage11.c11*` bundle directories, and fire the footer when *every* sibling's `io.sentry/` directory exists and is empty (or no sibling has any envelopes). At minimum, prefer probing the running bundle's id (`Bundle.main.bundleIdentifier`) instead of the hardcoded production string.
+  - Sources: critical-claude (Blocker #1), standard-gemini (Important #2), standard-codex (Potential #2), critical-codex (Potential #1), evolutionary-claude (Concrete suggestion #5).
+
+- **B4: JSON output leaks absolute local filesystem paths (operator macOS username and cache layout).**
+  - Location: `Sources/HealthCommandCore.swift:725` (`renderHealthJSON`, `"path": ev.path`)
+  - Problem: Every event in `--json` output includes `ev.path`, which is an absolute filesystem path like `/Users/<operator>/Library/Caches/com.stage11.c11.debug.runtime/io.sentry/envelopes/<uuid>`. The diagnostic story for `c11 health` is that operators paste this output into tickets, Zulip threads, GitHub issues, or share with agents. The table form intentionally omits the path; the JSON form should not silently regress that privacy posture.
+  - Fix: Redact the home prefix before emitting. Replace `NSHomeDirectory()` (or the `home` parameter threaded through scanners) with the literal `~` in the `path` field of each event prior to serialization. This is a one-line transform at the renderer boundary and does not require changing scanner signatures.
+  - Sources: critical-codex (Important #2), critical-gemini (Blocker #1).
+
+### Important (land in same PR)
+
+- **I1: `--rail` repeats are silently coalesced to the last value, contradicting the help text.**
+  - Location: `Sources/HealthCommandCore.swift:430-455` (`parseHealthCLIArgs`, the `--rail` arm at line 444)
+  - Problem: `c11 health --rail ips --rail sentinel` parses to `railFilter = .sentinel`, no error, no diagnostic. The help text says "Filter to one rail" but the natural operator instinct, given four rails, is that repeating the flag accumulates. Today's behavior silently drops the first rail.
+  - Fix: Either (a) reject duplicate `--rail` with a clear error (smaller change, keeps the v1 contract honest) or (b) widen `railFilter` to `Set<HealthEvent.Rail>?` and accumulate. Recommend (a) for v1: throw a new `HealthCLIError.duplicateFlag(String)` (or reuse `unknownFlag`) when `rail != nil` on the second occurrence. Update help text to mention "Specify at most once" if you go with (a).
+  - Sources: standard-claude (#1), critical-claude (#6).
+
+- **I2: `bootTime()` silently downgrades `--since-boot` to a 24h window when sysctl fails.**
+  - Location: `Sources/HealthCommandCore.swift:402-414` (`bootTime`)
+  - Problem: On `sysctlbyname("kern.boottime", ...)` failure, the function returns `Date(timeIntervalSinceNow: -24 * 3600)` with no log, no throw, no marker. `--since-boot` becomes a synonym for the default 24h window without telling the operator. `kern.boottime` is bulletproof on macOS in practice, but when it does fail, the silent lie is worse than a clear diagnostic.
+  - Fix: When the sysctl call fails, write a single line to stderr (e.g., `c11 health: kern.boottime unavailable, falling back to 24h window`) before returning the fallback Date. Keep the fallback so the command still produces output; just stop hiding the downgrade.
+  - Sources: standard-claude (#2), critical-claude (#7), critical-gemini (Nit).
+
+- **I3: Empty-result line lies about which rails were checked when `--rail` is set.**
+  - Location: `Sources/HealthCommandCore.swift:679` (`healthEmptyResultLine`), `Sources/HealthCommandCore.swift:644-672` (`renderHealthTable`)
+  - Problem: The constant `healthEmptyResultLine` is hardcoded to `"c11 health: nothing in the last 24h across ips, sentry, metrickit, sentinel."`. When the operator runs `c11 health --rail sentinel` with no sentinel events, the output claims all four rails were checked. Misleading.
+  - Fix: Build the empty line dynamically. Add a `rails: Set<HealthEvent.Rail>` parameter to `renderHealthTable` (or pass through a small `HealthRenderContext`) and join the actual rail names from `rails`. Also reflect the actual window mode rather than always saying "last 24h" (e.g., for `--since 30m`, say "last 30m"; for `--since-boot`, say "since boot"). Update the existing CLI shim and tests to thread the new parameter.
+  - Sources: critical-claude (Blocker #4), evolutionary-codex (#1 noted indirectly).
+
+- **I4: JSON output is non-deterministic when two events share a timestamp (no tiebreak).**
+  - Location: `Sources/HealthCommandCore.swift:74` (`collectHealthEvents` final sort)
+  - Problem: `events.sorted { $0.timestamp > $1.timestamp }` only compares timestamps. Swift's `sorted` is not stable, so two events with the same timestamp (entirely possible for batch-written sentinel/MetricKit files at sub-millisecond resolution) produce non-deterministic order. Downstream JSON consumers (`jq` filters, fleet aggregators, future CI gates) will see flapping output even when the underlying disk state is unchanged.
+  - Fix: Add secondary and tertiary sort keys. Sort by `timestamp` desc, then `rail.rawValue` asc, then `path` asc. One line change in the sort closure. Add a small unit test that creates two events with identical timestamps across rails and asserts the resulting order.
+  - Sources: critical-gemini (Blocker #2).
+
+- **I5: `readFirstLine` strict UTF-8 decoding can drop entire IPS reports on multi-byte boundary truncation.**
+  - Location: `Sources/HealthCommandCore.swift` `readFirstLine(of:)` (around lines 196-205 in the diff)
+  - Problem: `(try? handle.read(upToCount: 8192))` reads at most 8192 bytes, then `String(data: data, encoding: .utf8)` is strict. If the 8192nd byte sits in the middle of a multi-byte UTF-8 sequence (any `.ips` payload with non-ASCII bundle metadata, app names, localized strings, or unicode in the JSON header), the entire decode returns nil and the IPS row falls back to filename-only summary, dropping the parsed bundle/bug-type/incident-id signal.
+  - Fix: Replace `String(data: data, encoding: .utf8)` with `String(decoding: data, as: UTF8.self)`. The latter is lossy and resilient: it inserts replacement characters for malformed bytes rather than returning nil. The first-line parse path doesn't care about the trailing replacement character; it cuts at the first `\n`.
+  - Sources: critical-gemini (Important #3).
+
+### Straightforward mediums
+
+- **M1: `--rail <name>` help text omits the "all rails by default" note.**
+  - Location: `CLI/c11.swift:7741`
+  - Problem: A reader of `--help` cannot tell from the current line whether omitting `--rail` defaults to all rails or to nothing.
+  - Fix: Append `Default: all rails.` (or `Omit to query all four rails.`) to the `--rail <name>` line. One word of help text.
+  - Sources: standard-claude (#5).
+
+- **M2: Hoist `ISO8601DateFormatter` instantiation out of the per-marker loop in `mostRecentSentinelMarker`.**
+  - Location: `Sources/HealthCommandCore.swift:502, 515` and the surrounding loop body in `mostRecentSentinelMarker`
+  - Problem: A new `ISO8601DateFormatter` is instantiated per file inside the marker loop, and a separate copy of the same five-line setup is duplicated five times across the file (lines 288, 291, 502, 515, 711, 712 per standard-claude). On a machine with many archived `unclean-exit-*.json` files this becomes measurably slow during health command invocation.
+  - Fix: Extract a small private helper `private func isoFormatter() -> ISO8601DateFormatter` with the standard `[.withInternetDateTime, .withFractionalSeconds]` setup, and reuse a single instance per call site. Even better, in `mostRecentSentinelMarker` specifically, parse the timestamp from the filename first (cheap) and only `Data(contentsOf:)` + decode the JSON when the filename's timestamp beats the current best candidate. This drops the function from O(n) full reads to O(1) full reads in the common case.
+  - Sources: standard-claude (#9, #8), standard-gemini (Potential #1), critical-gemini (Important #4).
+
+- **M3: Remove the dead `HealthEvent.Severity.metrickit` enum case.**
+  - Location: `Sources/HealthCommandCore.swift:18-25` (`HealthEvent.Severity` definition)
+  - Problem: `metricKitSeverity(forKind:)` returns one of `.crash`, `.hang`, `.resource`, `.mixed`, `.diagnostic`. The `.metrickit` case is defined but never produced. Confuses future maintainers about what valid severity values can appear in the wire format.
+  - Fix: Delete the `case metrickit` line. Re-run tests; nothing should depend on it.
+  - Sources: standard-claude (#13).
+
+### Evolutionary clear wins
+
+- **EW1: Add `"schema_version": 1` to the JSON output.**
+  - Location: `Sources/HealthCommandCore.swift:707-743` (`renderHealthJSON`'s `payload` dictionary)
+  - Problem: The JSON shape has no version key. The first downstream consumer (a `jq` filter, a CI gate, a fleet aggregator, an agent that auto-runs `c11 health --json` on crash) will lock in this shape. Changing the schema later becomes a breaking change with no clean signal for consumers to detect.
+  - Fix: Add one key to the `payload` dictionary: `"schema_version": 1`. The existing `testJSONShapeContainsTopLevelKeys` test will need to add this key to its expected set. Cost: one production line, one test line. Locks the contract for every future JSON change to be explicitly versioned.
+  - Sources: evolutionary-claude (Concrete suggestion #1), evolutionary-codex (#1 supports a `HealthReport` shape that subsumes this).
+
+## Surface to user (do not apply silently)
+
+- **S1: Sentry walker counts non-envelope side files (only walks `io.sentry/`, not `io.sentry/envelopes/`).**
+  - Why deferred: disagreement on the fix direction.
+  - Summary: critical-gemini wants both `scanSentryQueued` and `telemetryAmbiguityFooter` scoped to `io.sentry/envelopes/` only, treating any non-envelope file as "false positive queued event." standard-claude and the existing doc comment treat the over-count as an acknowledged trade-off ("any regular file inside `io.sentry/` is treated as a queued event") and suggest only documenting it. The two positions imply different file layouts in production. Sentry-Cocoa's actual on-disk layout (envelopes vs. installation.id vs. metadata files) needs a verification pass before locking the fix. The under-count risk if envelopes ever land outside the `envelopes/` subdir is non-zero.
+  - Sources: critical-gemini (Important #5), standard-claude (Potential #11), standard-codex (Potential #2).
+
+- **S2: IPS rail uses file mtime instead of the IPS internal `timestamp`, so "since" filtering is "since CrashReporter finished writing," not "since the crash."**
+  - Why deferred: design-needed; this is a documented limitation, not a clear bug.
+  - Summary: critical-claude flags that mtime can lag the actual crash timestamp by minutes (or longer on a heavily loaded system), and operators who run `c11 health --since 30m` after a recent crash may miss it. The fix requires parsing the IPS first-line JSON's `timestamp` field instead of (or in addition to) mtime, and choosing what to render in the table column header ("REPORTED" vs "TIME"). Worth deciding before promoting `c11 health` as a precise incident finder, but acceptable for v1 if labelled.
+  - Sources: critical-claude (Important #5).
+
+- **S3: Symlink defense in scanners (`scanSentryQueued`, `walkSentryDir`, `telemetryAmbiguityFooter`, `scanIPS` subdir walk).**
+  - Why deferred: subjective threat model; single reviewer.
+  - Summary: critical-claude flags that `FileManager.enumerator(at:..., options:[.skipsHiddenFiles])` follows symlinks by default. A malicious or buggy symlink under `~/Library/Caches/com.stage11.c11.*/io.sentry/` could lead enumeration into the wider filesystem (or hang). No other reviewer raised this. The blast radius is limited because the operator's own user directory is the trust root and a `c11 health` run is bounded by `since`. Worth a follow-up discussion on whether the read-only sweep should add `.isSymbolicLinkKey` filtering, but not consensus-blocking.
+  - Sources: critical-claude (Blocker #3).
+
+- **S4: `runHealth` may double-print error messages (writes to stderr AND throws CLIError with the same message).**
+  - Why deferred: ambiguous; reviewer could not verify the CLIError print path inside `CLI/c11.swift` without reading more of that file.
+  - Summary: critical-claude notes that `runHealth` writes the error to stderr and then throws `CLIError(message: error.description)`. If the upstream dispatcher prints the thrown CLIError too, the operator sees the same line twice. Needs a 5-minute trace through `CLI/c11.swift`'s top-level error handling to confirm or deny. If confirmed, fix is to drop one of the two emissions.
+  - Sources: critical-claude (Important #10).
+
+- **S5: `parseSinceFlag` accepts decimal and scientific-notation values (`1.5h`, `1e3h`).**
+  - Why deferred: subjective; the function uses `Double(head)` which permissively accepts these. Could be a feature or a footgun.
+  - Summary: critical-claude flags that the parser accepts `1.5h`, `0.5d`, `1e3h`, etc., even though help shows only integer suffixes. Argues for a tighter regex or capping to e.g. 30d. Counter-argument: permissive parsing is the standard CLI behavior for most duration parsers, and an unrealistically long window is harmless because the disk artifacts cap the actual count. Worth surfacing because it's an explicit policy choice.
+  - Sources: critical-claude (Important #9).
+
+- **S6: `HealthEvent.Severity.unclean_exit` raw value is the only snake_case in the enum (rest are single-word lowercase).**
+  - Why deferred: subjective, downstream-consumer impact unknown.
+  - Summary: standard-claude and critical-claude both flag the inconsistency. The rawValue leaks to JSON (`"severity": "unclean_exit"`) and the table column. Renaming to `"unclean-exit"` (kebab-case mirroring filename convention) or `"uncleanExit"` would normalize, but it's a wire-format change that any future consumer would have to cope with. Bundle with the `schema_version` key (EW1) if you want to make a clean v2 cut.
+  - Sources: standard-claude (#14), critical-claude (Nit / Potential #12).
+
+- **S7: `parseUncleanExitFile` returns a `HealthEvent` row with `"? (?) ????????"` summary when JSON body is unparseable.**
+  - Why deferred: design choice (intentionally surfaces presence of corrupt files).
+  - Summary: standard-claude (#12) and critical-claude (Potential #16) note the placeholder. The current behavior is "filename is source of truth for timestamp; corrupt body is intentionally surfaced rather than swallowed." This is correct for crash-survival reasoning, but the rendered output is ugly. Two options: (a) document the intent in a code comment so a future maintainer doesn't "fix" it; (b) replace `"????????"` with `"unknown"` to make the row more legible. Either is fine; needs a call.
+  - Sources: standard-claude (#12), critical-claude (Potential #16).
+
+## Evolutionary worth considering (do not apply silently)
+
+- **E1: Promote scanners to a `HealthRail` registry.**
+  - Summary: All four scanners share the same `(home, since) -> [HealthEvent]` shape; the dispatcher, help text, JSON `railCounts`, error messages, and warning wiring all enumerate the four rails by name across multiple files. Adding a fifth rail today is ~8 edits in 3 files. A small registry (a struct or a function table mapping `HealthEvent.Rail` to its scanner and optional warning contributor) collapses this to "write one struct, register it." 80-line refactor, no behavior change, dramatically reduces the cost of every future rail.
+  - Why worth a look: the value of `c11 health` compounds with every additional rail (workspace snapshot lifecycle, agent crash JSONs, spindump artifacts, log-show queries). The registry investment pays back the first time a fifth rail lands.
+  - Sources: evolutionary-claude (Concrete suggestion #3, Leverage point #1), evolutionary-codex (Concrete suggestion #2).
+
+- **E2: Introduce a `HealthReport` value (`window`, `rails`, `events`, `warnings`) consumed by both renderers.**
+  - Summary: Today `runHealth` separately constructs the window, rails, events, and warnings, then passes only `events` and `warnings` to `renderHealthTable` while passing all four to `renderHealthJSON`. This is the structural reason behind I3 (the empty-result line lies about rails) and the asymmetry between the two renderers. Promoting a `HealthReport` value with `window`, `rails`, `events`, `warnings` and rendering both table and JSON from it gives both surfaces the same context, lets the table render an honest empty-state line for free, and prepares for a future `--brief` mode or correlation features.
+  - Why worth a look: this is the cleanest fix for I3, but doing it as a refactor instead of a point-fix is a v1.1 design pass that the user should sign off on before it lands as part of this PR.
+  - Sources: evolutionary-codex (Concrete suggestion #1, Leverage point #1), evolutionary-claude (Mutation list, indirect).
+
+- **E3: Surface `home` as a `--home <path>` CLI flag for fleet/snapshot use cases.**
+  - Summary: `collectHealthEvents` already takes `home` as a parameter (the runtime test exercises it). Surfacing a `--home <path>` flag turns `c11 health` into a fleet-mode tool: `c11 health --home /Volumes/c11-fleet/atin-imac/2026-05-03 --since-boot` works on rsynced snapshots without code change. There is a privacy/safety dimension (clearly document that nothing is sent anywhere, the read is purely local), and `--since-boot` semantics need a call (target machine's boot time is not in the snapshot).
+  - Why worth a look: high-leverage, low-cost feature that extends the use case from "one machine" to "any disk image of one or more machines" with no architectural change. Aligned with the deferred v1.1 list.
+  - Sources: evolutionary-claude (Evolution #5, Concrete suggestion #7), evolutionary-gemini (Wild ideas).

--- a/notes/trident-review-C11-24-pack-20260503-1749/synthesis-critical.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/synthesis-critical.md
@@ -1,0 +1,192 @@
+## Critical Review Synthesis: C11-24 Health CLI
+
+- **Date:** 2026-05-03
+- **Branch:** `c11-24/health-cli`
+- **Latest Commit:** `cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92`
+- **Lattice Story:** C11-24
+- **Sources:** critical-claude.md, critical-codex.md, critical-gemini.md
+- **Synthesis Type:** Critical / Adversarial
+
+---
+
+## Executive Summary
+
+All three reviewers agree the structural design of `c11 health` is sound: the four-rail scanner approach is correct, the "passive only" contract is honored (no SentrySDK.capture, no socket touches, no AppDelegate or LaunchSentinel modifications), and the dual-target pbxproj registration is clean. The unit tests are real runtime tests with sandboxed home paths rather than source-grep theater.
+
+The failure modes cluster at the seams: the diagnostic-warning layer is unreliable in realistic CLI use, JSON output leaks user paths, scanners over-trust filesystem inputs, cross-bundle assumptions break on debug machines, and several output behaviors are non-deterministic or misleading.
+
+**Production-Readiness Verdict: NOT READY for mass deployment.** Two of three reviewers explicitly call this out (Codex: "would not call this ready to mass deploy unchanged"; Gemini: "this code is NOT ready for production"; Claude: "no, not as-is"). Internal/operator deployment is acceptable after the consensus blockers below are patched. The consensus minimum bar before merge is: fix the JSON path leak, fix the empty-result-line lie, fix the cross-bundle/debug-bundle telemetry probes, and at minimum confirm the MetricKit baseline warning actually fires on a real CLI invocation.
+
+---
+
+## 1. Consensus Risks (Multiple Models Agreed)
+
+These are the highest-priority issues; each was independently flagged by two or three of the reviewers.
+
+1. **JSON output leaks absolute filesystem paths including the macOS username.** (Codex Important #2, Gemini Blocker #1)
+   - `renderHealthJSON` writes `ev.path` directly. Paths contain `/Users/<operator>/Library/...`. This is a privacy leak in a tool whose output is explicitly intended to be shared in tickets, GitHub issues, and chat. Both reviewers rate this a blocker.
+   - File: `Sources/HealthCommandCore.swift:719–725`
+   - Fix: redact `NSHomeDirectory()` prefix to `~`, or make full paths opt-in behind an explicit flag.
+
+2. **`mostRecentSentinelMarker` cross-bundle picking corrupts the MetricKit baseline warning.** (Claude Blocker #2, Codex Important #1, Gemini Potential #6)
+   - The function walks all `com.stage11.c11*` bundle dirs and picks the entry with the largest timestamp regardless of which bundle id produced it. A stale `active.json` from a different bundle (e.g., production after using debug daily) is selected as "the previous version," firing a misleading "MetricKit baseline still establishing after version bump" warning.
+   - Codex notes that `active.json` itself can mask the previous-version marker because it counts as the newest candidate.
+   - File: `Sources/HealthCommandCore.swift:471–540` (notably 502, 555)
+   - Fix: scope to the running `Bundle.main.bundleIdentifier`, or exclude `active.json` for the current bundle when looking for prior-version markers.
+
+3. **`telemetryAmbiguityFooter` and Sentry probes hardcode the production bundle id and ignore debug builds.** (Claude Blocker #1, Codex Nit/Potential, Gemini implicit via cross-bundle concern)
+   - The footer probes only `~/Library/Caches/com.stage11.c11/io.sentry`. On developer machines running `c11_DEV` (`com.stage11.c11.debug.*`), this path may not even exist; the footer is silently always `nil`. The same population is the most likely to invoke `c11 health`.
+   - File: `Sources/HealthCommandCore.swift:567–588`
+   - Fix: probe the running bundle id, or fold the check into the same per-bundle walk that `scanSentryQueued` already performs.
+
+4. **MetricKit baseline warning is effectively dead in realistic CLI usage.** (Claude Blocker #2 implied, Codex Important #1)
+   - Even after fixing the cross-bundle issue (#2), `runHealth` reads version via `Bundle.main.infoDictionary["CFBundleShortVersionString"]`, but the `c11-cli` target's pbxproj does not appear to define a generated Info.plist or marketing version. The `metricKitBaselineWarning` guard exits early on nil/empty version. Net effect: the warning never fires in production CLI invocations, even though tests pass because they inject `bundleVersion` directly.
+   - Files: `CLI/HealthCommand.swift:37`, `GhosttyTabs.xcodeproj/project.pbxproj:1498`, `Sources/HealthCommandCore.swift:550`
+   - Fix: either give the CLI target a proper Info.plist with the version, or provide a build-time constant. Add a runtime test that exercises the real lookup path, not the injected seam.
+
+5. **Sentry scan over-counts because it walks the entire `io.sentry` directory.** (Claude Blocker #3 implied via symlink concern, Gemini Important #5)
+   - `scanSentryQueued` walks `io.sentry/` root, but Sentry SDK writes config and lockfiles there as well. These get counted as queued events. Same applies to `telemetryAmbiguityFooter`'s presence check, which can be falsely satisfied by state files.
+   - File: `Sources/HealthCommandCore.swift:206–229`
+   - Fix: scope both to `io.sentry/envelopes`.
+
+6. **`--rail` filter behavior is misleading or wrong.** (Claude Blocker #4 + Important #6)
+   - Two distinct bugs in the same area:
+     - The empty-result line is hardcoded with all four rail names, lying about which rails were actually checked when `--rail` is set.
+     - `--rail` specified multiple times is silently coalesced to the last value rather than rejected or unioned.
+   - File: `Sources/HealthCommandCore.swift:391–414`, `679`
+   - Fix: build the empty line dynamically from the `rails` parameter; explicitly reject duplicate `--rail` flags or document set semantics.
+
+7. **`bootTime()` failure silently downgrades `--since-boot` to 24h.** (Claude Important #7, Gemini Nit)
+   - `sysctlbyname` failure falls back to `Date(timeIntervalSinceNow: -24 * 3600)` with no log, no throw, no marker. The user invoked `--since-boot` specifically and gets 24h-windowed results presented as since-boot. Both reviewers flag this as user-trust-degrading.
+   - File: `Sources/HealthCommandCore.swift:373–384`
+   - Fix: emit a stderr diagnostic and either keep behavior or thread the failure to the caller.
+
+---
+
+## 2. Unique Concerns (Single-Model)
+
+Each of these was raised by only one reviewer but is worth investigating.
+
+### Claude-only
+
+8. **IPS mtime is not the incident time.** Apple's `ReportCrash` daemon writes the `.ips` file after the crash, sometimes with significant lag. The summary uses mtime but presents it as "when the crash happened." The fix is to surface the IPS-internal `timestamp` field or rename the column to "REPORTED."
+   - File: `Sources/HealthCommandCore.swift:124–144`
+
+9. **Sentry recursive walk has no symlink defense.** `FileManager.enumerator` follows symlinks by default. A symlink under `io.sentry/` pointing at `/` would let the enumerator wander the filesystem (or hang). Low real-world likelihood, high embarrassment cost if it happens.
+   - File: `Sources/HealthCommandCore.swift:206–229`
+
+10. **JSON `warnings` is `[String]` rather than structured `{code, message, details}`.** This is a forever-landmine the moment a second consumer (sidebar widget, dashboard, bot) tries to programmatically interpret warnings. Cheap to fix today; breaking change later.
+    - File: `Sources/HealthCommandCore.swift:730`
+
+11. **`parseSinceFlag` accepts decimals, scientific notation, and potentially `inf`/`nan` strings.** `Double("1.5h")` → 5400s; `Double("1e3h")` → 3600000s. The help text shows only integers. Tighten or document.
+    - File: `Sources/HealthCommandCore.swift:354–366`
+
+12. **`runHealth` prints to stderr AND throws CLIError with the same message.** Probably double-printed to the user; needs verification against `CLIError`'s rendering path.
+    - File: `CLI/HealthCommand.swift:8–13`
+
+13. **MetricKit kind grammar is over-permissive.** Parser accepts out-of-order tokens (`disk1-crash1`) and zero-padded counts (`crash01`) despite docstring claiming a fixed canonical order. Producer writes canonical order today, but the contract is loose.
+    - File: `Sources/HealthCommandCore.swift:267–275`
+
+14. **IPS 8-char incident-ID prefix can collide.** 32-bit collision space; rare but the operator looking at duplicates in a list won't know.
+    - File: `Sources/HealthCommandCore.swift:131`
+
+15. **`HealthEvent.Severity.unclean_exit` snake_case rawValue leaks to user-facing table.** Inconsistent with single-word severities elsewhere.
+    - File: `Sources/HealthCommandCore.swift:33`
+
+16. **No real (sanitized) Apple `.ips` fixture in the test suite.** Hand-rolled fixtures cover only the keys the parser cares about; production .ips files have many more keys and sometimes nested objects on the first line.
+
+17. **`parseFilenameSafeISO` only accepts exactly 3-digit fractional seconds.** Brittle to any producer change to 6-digit microseconds or `.000Z` truncation. Add explicit `.000Z` test.
+    - File: `Sources/HealthCommandCore.swift:330–344`
+
+18. **`parseUncleanExitFile` returns a row with `"? (?) ????????"` for unparseable JSON.** Intentional sentinel surfacing rather than swallowing, but worth a comment to document the design choice.
+    - File: `Sources/HealthCommandCore.swift:644–662`
+
+19. **`metricKitBaselineWarning` copy overstates confidence.** "May not deliver for ~24h" presumes the Sentry rail ran on the prior boot, which we don't know.
+
+20. **No upper bound on `--since`.** `--since 99999d` parses to 273 years ago. Reasonable to cap at 30d.
+
+### Codex-only
+
+21. **No CLI-version-source seam in tests.** Current tests inject `bundleVersion` and never exercise `runHealth`'s real `Bundle.main` lookup, hiding the dead-warning bug from #4.
+
+22. **No JSON privacy contract test.** The JSON shape test asserts keys exist but does not assert paths are redacted, relative, or intentionally present behind a flag.
+
+### Gemini-only
+
+23. **JSON event ordering is non-deterministic on timestamp ties.** `events.sorted { $0.timestamp > $1.timestamp }` has no secondary sort key; batch-written files with identical mtimes will flap in CI/CD pipelines consuming the JSON.
+    - Fix: secondary sort by `rail.rawValue`, tertiary by `path`.
+    - File: `collectHealthEvents`
+
+24. **O(N) performance trap in `mostRecentSentinelMarker`.** Synchronously reads `Data(contentsOf:)` and constructs a fresh `ISO8601DateFormatter` per file. On long-history machines, `c11 health` will lag.
+    - Fix: hoist the formatter; parse the timestamp from the filename first and only open the JSON if the timestamp beats current best.
+    - File: `Sources/HealthCommandCore.swift` (sentinel walk)
+
+25. **Fragile UTF-8 decoding in IPS first-line read.** `String(data: data, encoding: .utf8)` is strict; a 8192-byte truncation that splits a multi-byte character returns `nil` and drops the entire header.
+    - Fix: use `String(decoding: data, as: UTF8.self)` (lossy).
+    - File: `readFirstLine(of:)`
+
+---
+
+## 3. The Ugly Truths (Recurring Hard Messages)
+
+Themes that surfaced across multiple reviews, distilled.
+
+1. **The diagnostic warning layer is the weakest part of the change.** All three reviewers independently land on the MetricKit / sentinel marker / telemetry footer pipeline as the soft underbelly. Tests pass because they inject the values that production code can't actually obtain (Codex) or because they use single-bundle scenarios that don't reflect dev machines (Claude). The warning that's supposed to be the operator's "you might be missing data" hint is the warning least likely to fire when needed and most likely to fire when not.
+
+2. **JSON mode silently became the privacy-regressing mode.** The table output is careful with what it shows; the JSON mode dumps everything raw, including absolute paths. Two reviewers flag this as a blocker. The instinct to make JSON "complete" beat the contract that JSON is what gets pasted into shared channels.
+
+3. **The scanners over-trust their inputs.** Symlink walks, unbounded directory enumeration, mtime-as-incident-time, full `io.sentry` directory inclusion of internal SDK files: the four scanners are doing real I/O against real user data with thin assumptions about how clean the inputs will be. None of these failure modes are exercised by tests.
+
+4. **Cross-bundle assumptions are wrong on the population most likely to use the tool.** Developers run debug builds. The telemetry footer ignores them entirely. The sentinel marker conflates them with production. The user who notices these bugs will be a c11 maintainer, which is the worst possible discovery channel.
+
+5. **Tests are real runtime tests but field-thin.** Claude is explicit: "The unit/runtime tests are fine. They aren't field tests. Don't mistake them." All three reviewers note missing tests in adjacent areas (real `.ips` fixtures, JSON byte-level snapshots, version-source seams, privacy contracts, cross-bundle scenarios).
+
+6. **Output determinism is shakier than it looks.** Gemini surfaces the timestamp-tie sort instability; Claude flags the JSONEncoder migration footgun and the inner-event-dict ordering reliance on `.sortedKeys` propagation. The JSON contract is "diffable across runs" but isn't yet locked down with a byte-level snapshot.
+
+---
+
+## 4. Consolidated Blockers and Production-Readiness Assessment
+
+### Consensus Blockers (must fix before any merge)
+
+1. **Redact home directory from JSON `path` fields.** (Codex, Gemini blocker; Claude implicit via "don't ship forever landmine" framing) — Privacy leak in shareable output.
+2. **Fix `mostRecentSentinelMarker` cross-bundle and `active.json` selection.** (Claude, Codex, Gemini) — Misleading MetricKit baseline warning on common dev/multi-bundle setups.
+3. **Probe the running bundle id (or all matching bundles) in `telemetryAmbiguityFooter`.** (Claude, Codex) — Footer permanently silent on debug builds.
+4. **Fix the empty-result line to reflect actual rails checked.** (Claude) — Tool lies about its scope when `--rail` is set.
+5. **Make MetricKit baseline warning actually obtainable in CLI runtime.** (Codex) — Provide CLI-target version source; add a test that exercises the real lookup path, not the injected seam.
+
+### Important (fix before mass deployment, acceptable for internal pre-merge)
+
+6. **Scope Sentry scanning and ambiguity check to `io.sentry/envelopes`.** (Gemini) — Prevents over-counting and false suppression from SDK state files.
+7. **Add deterministic secondary/tertiary sort keys to `HealthEvent` ordering.** (Gemini) — JSON pipeline stability.
+8. **Use lossy UTF-8 decoding in `readFirstLine`.** (Gemini) — Prevents silent header drop on truncation boundary.
+9. **Hoist `ISO8601DateFormatter` and gate JSON parse on filename timestamp in `mostRecentSentinelMarker`.** (Gemini) — Avoids CLI lag on long-history machines.
+10. **Reject duplicate `--rail` flags or document last-wins semantics.** (Claude) — Surprise UX.
+11. **`bootTime()` should emit stderr diagnostic on sysctl failure.** (Claude, Gemini) — Don't lie about `--since-boot` scope.
+12. **Verify and de-duplicate the stderr-print + CLIError-throw double-print in `runHealth`.** (Claude) — Likely visible duplication.
+13. **Add symlink defense to all directory enumerators.** (Claude) — Hang/escape vector.
+14. **Promote JSON `warnings` from `[String]` to structured records before any second consumer ingests the format.** (Claude) — Future breaking-change avoidance.
+15. **Tighten or document `parseSinceFlag` numeric acceptance.** (Claude) — Decimals, scientific notation, infinity sneak through.
+
+### Potential (defer to post-merge issues unless trivial)
+
+16. Add a real sanitized `.ips` fixture. (Claude)
+17. Add JSON byte-level snapshot test. (Claude)
+18. Tighten MetricKit kind grammar (ordering, zero-padding). (Claude)
+19. Address IPS mtime-vs-incident-time labeling. (Claude)
+20. IPS incident-ID prefix collision: print 12 chars or include filename. (Claude)
+21. Rename `unclean_exit` rawValue to single-word for table readability. (Claude)
+22. Cap `--since` upper bound at 30d. (Claude)
+23. Soften `metricKitBaselineWarning` copy. (Claude)
+24. Document `parseUncleanExitFile`'s sentinel-row behavior. (Claude)
+25. Add CLI-version-source test seam. (Codex)
+26. Add JSON privacy contract test. (Codex)
+
+### Production-Readiness Verdict
+
+**Status: NOT READY for mass deployment. ACCEPTABLE for internal users after consensus blockers patched.**
+
+- **For 100k users:** No. The privacy leak, the cross-bundle warning misfires, the dead MetricKit warning on real CLI invocations, and the empty-result-line lie collectively undermine operator trust in a tool whose entire purpose is to build trust in diagnostic data.
+- **For 100 internal users:** Yes, with the five consensus blockers patched today and the Important list scheduled as a follow-up batch.
+- **The structural call:** Three reviewers agree the architecture (four rails, passive contract, dual-target pbxproj, sandboxed-home test design) is right. The contract with the rest of the codebase (no SentrySDK.capture, no AppDelegate or LaunchSentinel changes, no socket touches) is honored. The losses are at the seams: cross-bundle handling, output privacy, scanner over-trust, and warning reliability. None of the Important items requires architectural change; they are localized patches.
+- **Common deployment-blocking thread:** Two of three reviewers concentrate their concern on the same surface — the diagnostic-warning layer being unreliable in production CLI runtime, despite passing tests. Any fix list that doesn't address the version-source path, the cross-bundle scoping, and the JSON path leak is not a serious production fix list.

--- a/notes/trident-review-C11-24-pack-20260503-1749/synthesis-evolutionary.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/synthesis-evolutionary.md
@@ -1,0 +1,183 @@
+## Evolutionary Synthesis — C11-24 (`c11 health`)
+
+- **Date:** 2026-05-03
+- **Branch:** c11-24/health-cli
+- **HEAD:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Sources:** evolutionary-claude.md (Opus 4.7), evolutionary-codex.md (GPT-5), evolutionary-gemini.md (Gemini 1.5 Pro)
+- **Scope:** Read-only synthesis of three evolutionary reviews. No code/Lattice changes.
+
+---
+
+## Executive Summary — Biggest Opportunities
+
+All three reviews independently arrive at the same thesis with different vocabulary:
+
+- **Claude (Opus):** "Disk-Coupled Telemetry Aggregation" — producers write artifacts to well-known paths, decoupled readers walk them later.
+- **Codex (GPT-5):** "Local evidence plane" / "passive flight recorder" — local incident reconstruction without trusting any one producer.
+- **Gemini:** "Immune System API / Observability Seam" — agent-readable timeline turning opaque host failures into queryable context.
+
+The shared insight: **the four-rail unifier is not the feature, it is the platform.** What ships as a CLI is actually the engine for fleet aggregation, agent self-triage, live tailing, narrative reporting, and (eventually) D11's evidence substrate.
+
+The three biggest opportunities, in priority order:
+
+1. **Formalize the rail abstraction (registry/table) before the fifth rail arrives.** Unanimous across all three reviews. Highest-leverage, mechanical refactor, ~80 lines, no behavior change. Drops the per-rail addition cost from ~8 edits across 5 files to ~1 struct + 1 append.
+2. **Promote the renderer boundary from `[HealthEvent]` to a `HealthReport` value object.** Codex names it explicitly; Claude names the same need via the "schema_version + bundleID/build fields" cluster; Gemini implies it through the "JSON-as-API" framing. Fixes the empty-state-text drift bug *and* gives every future surface (table, JSON, brief, watch, narrative) one input shape.
+3. **Surface the latent fleet/agent dimensions already in the architecture.** `home: String` is already a parameter. Three reviews independently flag `--home <path>` as a flag-away win that turns the engine into a fleet inspector with zero architectural change. Gemini extends to `--remote <ssh-target>`. Combined with a new "agent rail" (Gemini), `c11 health` becomes the operator-and-tenant timeline rather than just the host timeline.
+
+The unanimous warning: **`HealthEvent.Severity` is a junk drawer that will not survive the fifth rail.** Address it (per-rail severity, or tags) before the schema locks in via downstream JSON consumers.
+
+---
+
+## 1. Consensus Direction — Evolution Paths Multiple Models Identified
+
+Patterns where two or three reviews independently converged:
+
+1. **Rail registry / data-driven scanner table** (Claude #1, Codex #2, Gemini implicitly via "5th rail"). All three see the four scanners as already-uniform pure functions waiting for a registry. Claude proposes a `HealthRail` protocol; Codex argues for a plain function table over a protocol hierarchy ("keep the ergonomic advantage of plain functions"). Gemini doesn't propose the structure but treats "the next rail" as the natural extension. **Synthesis:** start with Codex's lighter table-of-functions; promote to a protocol only if/when warning helpers need polymorphism (Claude's `HealthRailWithWarning` extension). The protocol-vs-table debate is real; the table is the cheaper opening move.
+
+2. **`HealthReport` / report-shaped output boundary** (Codex #1, Claude #4 + leverage point #6 implicitly, Gemini via the "JSON as API" framing). Codex names the value object directly; Claude reaches the same idea through `schema_version`, `bundleID`/`build` fields, and the `HealthArtifact` vs `HealthEvent` split; Gemini emphasizes that the `--json` flag has *already* turned the command into an API, so the schema needs to be a deliberate object. **Synthesis:** introduce `HealthReport { window, rails, events, warnings, schema_version }` as the unified renderer input. This single move unblocks four downstream items (empty-state fix, schema versioning, `--brief`, evidence confidence).
+
+3. **`schema_version` / explicit JSON contract** (Claude #1 + #4, Codex via `HealthReport` framing, Gemini via "JSON as API"). All three agree the JSON shape is now load-bearing because agents and CI gates will lock onto it. Add the version key now while it is one line.
+
+4. **Fleet seam via `home`** (Claude #5 + leverage point #3, Codex via `HealthScanContext`, Gemini explicitly as `--remote <ssh-target>`). The plumbing exists; only the flag is missing. All three see this as the cleanest signal that the abstraction is right — the same engine works for "this machine", "rsynced snapshot", and (Gemini) "remote SSH target".
+
+5. **Producer/reader contract formalization** (Claude #4 — paired `FilenameSafeISO8601` primitive; Codex #3 — `HealthEvidenceContract` consumer-side table; Gemini implicit in the universal-timeline pattern). The two reviews approach the same risk from opposite ends: Claude binds producer and reader at the type level; Codex documents the contract on the reader side without touching producers. **Synthesis:** Codex's approach is non-invasive (does not modify `SentryHelper.swift` or `LaunchSentinel`) and is the right v1.1 move; Claude's typed primitive is the right v1.2+ move once a producer change is otherwise needed.
+
+6. **Test scaffolding consolidation** (Codex #5 explicitly, Claude implicitly via "fuzz test on the ISO primitive", Gemini implicitly via "fixture per rail"). All three see `scaffoldAllRails` and the duplicated temp-home setup as the seed of a synthetic-evidence builder. Cheap, prevents fifth-rail test sprawl.
+
+7. **The "next rails" list converges on roughly the same candidates.** Claude lists Console.app log show, spindump IPS, workspace-snapshot lifecycle, Sentry envelope age. Gemini lists "agent rail" (drop-zone for agent-emitted JSONs). Codex stays abstract but defends the shape. **Synthesis:** the agent rail is the highest-value next rail because it closes the operator-vs-tenant gap that none of the current four rails fills, and it is the rail the c11 SKILL can teach agents to populate themselves.
+
+---
+
+## 2. Best Concrete Suggestions — Most Actionable Across All Three
+
+Ranked by leverage-per-effort, with cross-references to which reviews support each:
+
+1. **Add `schema_version: 1` to `renderHealthJSON`.** (Claude #1, implied by Codex/Gemini.) One line. Locks the JSON contract before downstream consumers exist. Existing `testJSONShapeContainsTopLevelKeys` won't regress. Path: `Sources/HealthCommandCore.swift:1158-1167`.
+
+2. **Hoist `Library/Caches/com.stage11.c11*` walk into `forEachC11Bundle(home:)`.** (Claude #2 + #5.) Three explicit call sites + one *hardcoded* implicit one. The hardcoding in `telemetryAmbiguityFooter` (`Sources/HealthCommandCore.swift:996`) is a real v1 footgun: it never fires on machines that only ran the debug build. Fix the bug while deduplicating; add a test using `com.stage11.c11.debug` to lock the fix.
+
+3. **Introduce `HealthReport`.** (Codex #1, Claude implicitly through #6/#9, Gemini implicitly.) The single move that fixes the empty-state-text drift (the table currently always says "last 24h across ips, sentry, metrickit, sentinel" regardless of `--rail` or `--since`) *and* unblocks every future surface. Both renderers consume the same value. Compatible with current data flow — `runHealth` already gathers all the inputs.
+
+4. **Add `HealthScanContext { home, now, bundleVersion, fileManager }`.** (Codex #3.) Mechanical migration; concentrates time and environment decisions in one place; preparation for fleet/snapshot mode. Does not require touching `LaunchSentinel` or `CrashDiagnostics`.
+
+5. **Promote scanners to a rail definition table.** (Claude #1 as protocol, Codex #2 as table, both validated.) Start with Codex's table-of-functions form. Adding a fifth rail becomes one struct + one append. Bundle this with `HealthScanContext` (#4) so scanner signature is `(HealthScanContext) -> [HealthEvent]`.
+
+6. **Pin filename-safe ISO grammar as a paired primitive.** (Claude #4.) Producer (`SentryHelper.swift`/`LaunchSentinel`) and reader (`HealthCommandCore.parseFilenameSafeISO`) currently maintain independent copies of the same 24-character rule. Type-level binding plus a round-trip property test eliminates a future drift bug. Note: this is the one item Codex explicitly chose *not* to touch (its review intentionally avoided producer-side changes); land it in a follow-up that consciously crosses the producer/reader boundary.
+
+7. **Add `bundleID` and `build` (optional) fields to `HealthEvent`.** (Claude #6, supports Gemini's "agent rail".) Three of four rails already know this. Additive — no test breakage. Unblocks "group by build, what did 0.44.1 break" queries.
+
+8. **Surface `--home <path>` as a CLI flag.** (Claude #7, Codex via `HealthScanContext`, Gemini as `--remote`.) The function is already pure-of-disk. Document as fleet/snapshot/post-mortem use case. Caveat (Claude): `--since-boot` is meaningless against a remote snapshot — needs a defensive error or a documented restriction.
+
+9. **Track rail status per scan (`missing | empty | scanned | permissionDenied | parseSkipped`).** (Codex #4.) Surfaced in JSON, not table. Makes "0 events" interpretable without changing passive semantics. Coarse-grained on purpose.
+
+10. **Add "agent rail" — fifth rail at `~/Library/Logs/c11/agents/`.** (Gemini #2.) Drop-zone for agent-emitted JSON crash payloads. Validates the rail-registry abstraction and closes the operator-vs-tenant observability gap. Pairs with a SKILL update teaching agents to drop these.
+
+11. **Update `skills/c11/SKILL.md` to teach agents `c11 health --json --since 15m` on failure.** (Gemini #1.) Zero code change. Activates the flywheel today. The single most leveraged *non-code* change in the synthesis.
+
+12. **Consolidate test scaffolding into `SyntheticEvidenceBuilder`.** (Codex #5.) Extract `scaffoldAllRails` into helpers per rail (`writeIPS`, `writeSentryEnvelope`, etc.). Compatible with the test-quality policy because tests still exercise runtime behavior through temp-home files.
+
+---
+
+## 3. Wildest Mutations — Creative / Ambitious Ideas Worth Exploring
+
+Ranked by ambition × payoff, not by feasibility:
+
+1. **`c11 health --watch` (live tail).** (Claude mutation A.) Long-running variant; scan every N seconds; print only deltas; exit on Ctrl-C. Operator leaves it running during a multi-hour agent session and *sees* a crash the moment its artifact lands. Naturally pairs with the AsyncStream-based scanners (Claude mutation D).
+
+2. **Agent-driven auto-triage.** (Gemini wild idea #1.) Agents detecting unexpected shell exit / pane failure automatically run `c11 health --since 5m --json` and attach the result to their context window before retrying or escalating. The flywheel kicks in immediately because the SKILL is the only delivery vehicle needed. This is the highest-payoff mutation across all three reviews — it changes c11 from "operator runs a tool" to "agents observe their own ground truth."
+
+3. **Sentinel-as-fingerprint cross-rail correlation.** (Claude mutation B.) Add `fingerprint = sha256(version + build + commit + bundle_id)` — ten bytes — to sentinel events. Other rails inherit the field from filename/path context. `c11 health --correlated` clusters multi-rail evidence of the same incident without parsing payloads.
+
+4. **Cross-machine fleet view via `--remote <ssh-target>`.** (Gemini wild idea #2, builds on Claude #5.) Mount or sync a remote `Library` folder; run local `c11 health` against it. With agent rail (#2) added, this becomes "what happened on the CI runner / dev laptop / remote agent host last night."
+
+5. **`c11 health --producer-trace`.** (Claude mutation C.) Inverts the read direction: dumps where each rail *would* read from on this machine, whether the directory exists, file count, most-recent mtime. Self-diagnosing setup tool. "Why does my health command say zero metrickit?" → trace shows the directory doesn't exist because MetricKit hasn't fired yet on this machine. Cheap to build, very high "operator walks away knowing why" value.
+
+6. **Health as a v2 socket method (`system.health`).** (Gemini experimental #3.) Daemon continuously monitors rails and broadcasts `system.health_events`; agents react instantly to OOMs/hangs without polling. Caveat: must be careful not to block the main thread on heavy I/O sweeps. The pure-function scanners and the `HealthScanContext` abstraction make this a small wrapper.
+
+7. **Evidence confidence axis (`confirmed | inferred | ambiguous`).** (Codex experimental #6.) Sentinel `unclean_exit` = confirmed; Sentry queued = inferred; empty-cache warning = ambiguous. JSON-only initially. Lets agents reason over output without brittle string parsing. Bundles naturally with `HealthReport`.
+
+8. **`c11 reportz` — narrative renderer.** (Claude mutation E.) Same engine, different render. LLM-rendered story over the disk evidence: "On May 1st, c11 unclean-exited twice during 0.43.0. The next version, 0.44.0, ran clean for 36 hours before its first MetricKit hang at 14:30 on May 3." Pure speculation; the engine you have can produce it.
+
+9. **`c11 health --brief` ritual mode.** (Codex experimental #7.) One-line scannable summary for daily operator rhythm: window, counts, newest event, warnings. Better terminal cadence for repeated checks. Wait until `HealthReport` exists.
+
+10. **`--explain <event-id>` forensics recipes.** (Codex.) Rail-specific explanation from a contract table: where the evidence came from, what it proves, what it does *not* prove. Especially useful where "no rows" can mean several different things (Sentry, MetricKit).
+
+---
+
+## 4. Leverage Points and Flywheel Opportunities
+
+### Highest-leverage points (small change, disproportionate value)
+
+1. **The renderer boundary.** (Codex.) Once table and JSON consume one `HealthReport`, every future rail gets counts, warnings, and empty-state semantics for free. This is the single architectural seam that, if gotten right, makes the next ~5 features additive.
+
+2. **Scanner uniformity → registry.** (Claude #1 leverage, Codex #2.) Four scanners already share the contract; promoting that to data drops fifth-rail cost ~80%.
+
+3. **`schema_version` in JSON.** (Claude leverage #2.) One line. Locks the contract before downstream consumers exist. Every future schema change becomes backwards-compatible-by-choice rather than backwards-compatible-by-accident.
+
+4. **`forEachC11Bundle(home:)` helper.** (Claude leverage #3.) ~25 lines saved. Single source of truth for "what counts as a c11 bundle dir." Fixes the latent debug-bundle bug in `telemetryAmbiguityFooter`.
+
+5. **Paired `FilenameSafeISO8601` primitive.** (Claude leverage #4.) Producer and reader stop drifting. Doesn't show up in any release note; saves a future debug session.
+
+6. **`HealthEvent` carrying `bundleID` and `build`.** (Claude leverage #5.) Three rails already know these. Once the event carries them, every downstream surface (group-by-build, version-compare warnings, fleet aggregation) gets them for free.
+
+7. **`HealthArtifact` vs `HealthEvent` split.** (Claude leverage #6.) Cheap now, painful later. One review (Claude) downgrades this without a concrete consumer; the synthesis agrees — defer until the second non-1:1 rail (e.g., MetricKit body parsing, fingerprint correlation) makes the case.
+
+8. **Test scaffolding helpers.** (Codex leverage #3.) `scaffoldAllRails` becoming `SyntheticEvidenceBuilder` shrinks the cost of every future rail's tests.
+
+### The flywheel(s)
+
+All three reviews independently identify the same compounding loop, with different starting points. Combined, the flywheel reads:
+
+1. **Producers leave passive, local, well-named artifacts** during their normal lifecycle. They never know about the reader.
+2. **`c11 health` normalizes those artifacts into one report** — same shape, same JSON, same renderer.
+3. **The SKILL teaches agents to read the report on failure** (Gemini's contribution). Agents now have ground-truth context about their host environment without polling, asking the operator, or hallucinating.
+4. **Agent failure reports become highly-contextual** — the operator (and the orchestrator) gets specific diagnoses instead of "something broke."
+5. **Faster fixes to the environment** → agents run longer without dying → more confidence → more aggressive iteration.
+6. **New incidents teach c11 a new rail** (Codex's framing). The rail-registry abstraction makes adding it boring. The new rail is immediately consumable by every existing surface (table, JSON, agent SKILL, fleet view).
+7. **Cross-rail correlation gets easier with each rail added** (Claude mutation B, the fingerprint). Once two rails agree on a fingerprint, the third joins for free.
+8. **Fleet aggregation falls out** (Claude #5, Gemini #2). `--home <path>` is one flag away. The same skill works for "what happened on the CI runner last night" and "what's my dev laptop done since I left it." The engine doesn't care.
+
+### What would break the flywheel
+
+Unanimous warning: **letting `HealthEvent.Severity` keep growing as a single junk-drawer enum.** Every new rail will fight to add a case; the enum will accumulate special meanings; the table column gets wider than the user's terminal; the JSON consumers lock in a schema that doesn't compose. Per-rail severity (or severity-as-tags, Claude's preference) before the fifth rail is the right call. Bundle with `schema_version` bump (1 → 2).
+
+### What lights the flywheel today (no code changes)
+
+The single highest-leverage *non-code* move (Gemini #1): **update `skills/c11/SKILL.md` to teach agents `c11 health --json --since 15m` on unexpected shell exit / pane failure.** Zero engineering. Activates the agent-driven-auto-triage mutation (#2 in wildest) immediately. Validates the JSON-as-API framing in production. Generates real signal about which rails matter most to agents, which feeds back into rail-registry priorities.
+
+---
+
+## 5. Recommended Sequencing
+
+Distilled from the priority orderings across all three reviews:
+
+### v1.1 — "Make the seams right before the fifth rail"
+1. `schema_version: 1` in JSON (one line, no debate).
+2. Fix `telemetryAmbiguityFooter` hardcoded bundle path + extract `forEachC11Bundle(home:)` helper. (Real bug; deduplicates four call sites.)
+3. Introduce `HealthReport` and `HealthScanContext`; refactor renderers to consume them.
+4. Promote scanners to a rail definition table (start with Codex's lighter table form).
+5. Update `skills/c11/SKILL.md` with the agent auto-triage pattern. (Independent; can ship anytime.)
+
+### v1.2 — "Activate the agent and fleet dimensions"
+6. Add `bundleID` and `build` fields to `HealthEvent`.
+7. Add `--home <path>` flag with documented snapshot/fleet semantics.
+8. Add the agent rail (`~/Library/Logs/c11/agents/`) as the first proof of the registry.
+9. Per-rail severity / severity-as-tags + `schema_version` bump 1→2.
+10. Rail status field (`missing | empty | scanned | permissionDenied`).
+
+### v1.3+ — "Let the platform breathe"
+11. `--watch` (live tail) + AsyncStream-based scanners.
+12. Paired `FilenameSafeISO8601` primitive (touches producers; bundle with another producer-side change).
+13. `--producer-trace` (self-diagnosing setup tool).
+14. Cross-rail fingerprint correlation.
+15. Socket method `system.health` (when daemon-side polling becomes valuable).
+16. `--brief`, `--explain <event-id>`, `c11 reportz` (operator-rhythm and narrative surfaces).
+
+### Speculative / D11
+17. The whole substrate (rail enum, scan-with-since, filename grammar, JSON shape) is the right shape for D11 to inherit largely unchanged. The seams above are the ones to lock in *now* so that inheritance is clean.
+
+---
+
+## Bottom Line
+
+The three reviews agree on a single architectural read: the branch ships a four-rail CLI but builds the substrate for a passive local evidence plane that agents and operators will both consume. The single most important v1.1 investment is making the rail abstraction and the report value-object explicit — every later mutation (watch mode, agent rail, fleet view, narrative renderer, socket API) is additive on top of that foundation. The single most important *non-code* move is teaching agents in the SKILL to read their own ground truth via `c11 health --json`, which lights the flywheel today with zero engineering.

--- a/notes/trident-review-C11-24-pack-20260503-1749/synthesis-standard.md
+++ b/notes/trident-review-C11-24-pack-20260503-1749/synthesis-standard.md
@@ -1,0 +1,141 @@
+# Synthesis: Standard Code Reviews for C11-24
+
+- **Date:** 2026-05-03
+- **Branch:** c11-24/health-cli
+- **Latest Commit:** cdc51c278ddf7bd31ac0c0c540b614d4ee5c1e92
+- **Base:** origin/crash-visibility/launch-sentinel @ 5402d3fcd69c3ecb54ff440664fad51abf59f0e7
+- **Lens:** Standard (code quality, correctness, design, tests, style)
+- **Reviewers merged:** Claude (claude-opus-4-7[1m]), Codex (GPT-5), Gemini 1.5 Pro
+
+---
+
+## Executive Summary
+
+All three reviewers agree the branch is well-scoped, architecturally sound, and respects the read-only / privacy-by-default contract for `c11 health`. The split between a pure `HealthCommandCore` and a thin CLI shim is praised by all three; tests are runtime-behavioural rather than grep-the-source; the four evidence rails (IPS, Sentry queued, MetricKit, Sentinel) are independently testable; and nothing in the diff touches typing-latency hot paths, the socket, the sidebar, or `LaunchSentinel` itself.
+
+Where the reviewers diverge is on severity grading of the same defects in the MetricKit baseline warning path. Codex grades two runtime-state mismatches as a **Blocker** (the warning likely never fires in production for the cases it was designed to catch). Gemini grades the same family of issues as **Important**. Claude flagged the version-vs-build half of the question as a **Potential** behaviour question and did not catch the `Bundle.main` issue at all. Resolving this disagreement is the single most important call for the merge decision.
+
+### Merge verdict
+
+**Conditional merge** — fix the MetricKit baseline warning before merging, then land. Specifically:
+
+1. Resolve the CLI bundle-version lookup so `metricKitBaselineWarning` actually has a `curr` to compare against when the binary runs outside the app bundle.
+2. Stop treating the current-session `active.json` as a prior-session marker (or filter markers to the prior session only).
+3. Decide whether `--rail` should error or accumulate on multi-flag, and apply Claude's recommended stderr note for the `bootTime()` fallback.
+
+The remainder is polish and follow-up work, none of which blocks merge.
+
+---
+
+## 1. Consensus Issues (2+ Models Agree)
+
+1. **MetricKit baseline warning fails to fire in real production paths.** Both Codex (Blocker) and Gemini (Important) independently identify that `CLI/HealthCommand.swift:37` reads `Bundle.main.infoDictionary` to obtain the app version, but the standalone CLI binary does not have an Info.plist with `CFBundleShortVersionString`. Codex confirms via `GhosttyTabs.xcodeproj/project.pbxproj:1498-1534` that the CLI target defines no Info.plist, no `MARKETING_VERSION`, no `CURRENT_PROJECT_VERSION`. Gemini notes that upstream cmux already solved this with `CLISocketSentryTelemetry.currentBundleVersionValue(forKey:)` in `c11.swift`. The fix is to resolve the version from the containing app bundle (or another established CLI version source), not from `Bundle.main` of the CLI binary itself.
+
+2. **`telemetryAmbiguityFooter` only checks the production cache path, not all c11 bundle variants.** Both Codex (Potential) and Gemini (Important) flag that `Sources/HealthCommandCore.swift:560/565` hardcodes `~/Library/Caches/com.stage11.c11/io.sentry`, while `scanSentryQueued` walks every `com.stage11.c11*` bundle. Result: tagged debug builds (`com.stage11.c11.debug`, `com.stage11.c11.debug.runtime`) and legacy `c11mux` bundles get no ambiguity warning even when their Sentry caches are empty. Codex defers to the warning copy ("Production Sentry cache empty") and treats this as acceptable; Gemini wants prefix-match parity with the scanner. Recommend prefix-match to make the diagnostic resilient across build variants.
+
+3. **`mostRecentSentinelMarker` is O(n) over all `unclean-exit-*.json` files.** Both Claude (#8, Potential) and Gemini (Potential) flag that the loop decodes every JSON file rather than sorting by filename (which carries a total ISO timestamp ordering) and reading only the newest. Both agree this is fine for v1 with a small number of markers and worth a follow-up if sentinel housekeeping doesn't ship.
+
+4. **Architectural praise: pure-core / thin-shim split is the right shape.** All three reviewers explicitly endorse the dual-target Swift file (`HealthCommandCore.swift` in both `c11` and `CLI` targets). Claude calls the wiring in `project.pbxproj` (DH001BF0…0718 / 0719) the correct shape; Gemini calls it pragmatically correct and future-proof; Codex implicitly endorses by treating the structure as well-scoped MVP work.
+
+5. **Tests respect the CLAUDE.md "no grep-the-source" policy.** Claude and Gemini explicitly call this out; Codex implies it by approving the parser-test and sandboxed all-rails approach. Tests scaffold tmp HOMEs with real file I/O and assert on returned `HealthEvent` arrays.
+
+6. **Read-only / privacy contract is honoured.** All three reviewers verify that the health code paths do not call `SentrySDK.capture*`, do not touch the c11 socket, do not post notifications, and do not modify tenant config or `LaunchSentinel`.
+
+---
+
+## 2. Divergent Views (Models Disagree)
+
+1. **Severity of the MetricKit baseline warning issues.**
+   - **Codex: Blocker.** Two combined runtime-state mismatches (current-session marker treated as prior, plus CLI `Bundle.main` lookup returning nil) mean the MVP-required diagnostic warning likely never fires in production. Codex argues this breaks the C11-24 contract.
+   - **Gemini: Important (one item).** Same `Bundle.main` issue called out, framed as "silently fails" rather than "never fires." Does not separately call out the `active.json` confusion.
+   - **Claude: Potential (different angle).** Did not catch either the `Bundle.main` or the `active.json` issues. Instead flagged that the warning compares `version` only and ignores `build`, framed as a behaviour question rather than a defect.
+   - **Resolution recommendation:** Side with Codex's diagnosis. The combination of "current `active.json` shadows prior markers" and "CLI Bundle.main has no version" plausibly silences the warning end-to-end in real CLI invocations. Either fix is needed independently, but together they justify Codex's Blocker grade. The `version` vs `build` question Claude raised remains valid as a follow-up.
+
+2. **Whether to widen `telemetryAmbiguityFooter` to cover non-production bundles.**
+   - **Codex:** Acceptable as written — the warning copy says "Production Sentry cache empty" and matches the live-machine baseline. Not a defect.
+   - **Gemini:** Should be widened — debug/staging operators would want the ambiguity warning too.
+   - **Resolution recommendation:** Operator-facing call. Gemini's framing better serves agents and operators running tagged builds during development; Codex's framing is closer to the literal current copy. Default to Gemini's: widen the helper to use the same prefix-match as `scanSentryQueued`, and update the warning copy to say "Sentry cache empty" without the "Production" qualifier.
+
+3. **Claude found 13 additional Important / Potential items the other two reviewers did not surface** (covered in Section 3). Codex and Gemini wrote much shorter reviews and concentrated on the MetricKit warning path. There is no contradiction here, just a different bar for what makes it into the writeup.
+
+---
+
+## 3. Unique Findings (Single-Model)
+
+### Claude only
+
+1. **`--rail` accepts only one value; multiple `--rail` flags silently overwrite.** (Important) `parseHealthCLIArgs` overwrites `rail` on every `--rail` occurrence. Either error on duplicate or change to `Set<HealthEvent.Rail>?` and accumulate. Recommend tightening for v1.
+2. **`bootTime()` silent fallback to "24h ago" when `sysctlbyname` fails.** (Important) An operator who explicitly asks for `--since-boot` gets a 24h window with no signal. Recommend a single-line stderr warning on the fallback path.
+3. **`renderHealthTable` does not truncate long `summary` values.** (Important, lower priority) Long bundle/envelope names break fixed-width table alignment. Truncate to ~80 chars with ellipsis for table form; keep full strings in JSON.
+4. **`renderHealthTable` always emits a trailing newline.** (Important, lower priority) Consistent and currently correct, but a one-line contract comment would prevent future "let's just print it normally" regressions.
+5. **`--rail <name>` help text omits the "all rails by default" note.** (Important) Trivial wording fix in `CLI/c11.swift:7741`.
+6. **`metricKitBaselineWarning` checks `version` only, ignores `build`.** (Potential) Build-only bumps with the same MarketingVersion will not trigger the warning even though MetricKit's baseline does reset.
+7. **`age >= 0` clock-skew guard silently suppresses the warning.** (Potential) Defensive but worth a comment.
+8. **Five duplicate `ISO8601DateFormatter` configurations.** (Potential) Extract a small helper. `Sources/SentryHelper.swift` has an identical private helper that could be shared.
+9. **`parseFilenameSafeISO` defers digit validation to `ISO8601DateFormatter`.** (Potential) Acceptable; comment helps.
+10. **`scanSentryQueued` may over-count by including non-envelope side files** (e.g. `installation.id`). Doc comment already acknowledges; expand it.
+11. **`parseUncleanExitFile` defaults `commit = "????????"` when missing.** (Potential) Eight visually identical question marks read as noise; use `"unknown"` instead.
+12. **`HealthEvent.Severity.metrickit` is a dead case** — defined but never produced. Remove or document as reserved.
+13. **`HealthEvent.Severity.unclean_exit` rawValue is the only snake_case in the enum.** (Potential) Inconsistent with the other lowercase single-token values for downstream JSON consumers.
+14. **Defensive `--help` branch in `parseHealthCLIArgs` is dead** in the integrated CLI (intercepted upstream). Acceptable as written.
+15. **Test coverage gaps worth follow-ups (not blockers):** no test for `metricKitSeverity` mapping a multi-category kind, no test for whether the JSON output omits filtered rails, no test for ordering tie-break on equal timestamps.
+
+### Codex only
+
+1. **Specific diagnosis that `mostRecentSentinelMarker` treats `active.json` as a prior-session marker.** This is the second half of the MetricKit blocker that Gemini and Claude did not surface in this form. The fix should compare against a prior marker, not the current active marker.
+
+### Gemini only
+
+1. **Direct pointer to upstream cmux's `CLISocketSentryTelemetry.currentBundleVersionValue(forKey:)`** as the reference solution for resolving the app bundle version from the CLI. Useful concrete pointer.
+
+---
+
+## 4. Consolidated Action List
+
+### Blockers (fix before merge)
+
+1. **Repair the MetricKit baseline warning so it actually fires.** Two coupled fixes:
+   1. Resolve the app bundle version from outside the standalone CLI binary's `Bundle.main` (mirror upstream cmux's `CLISocketSentryTelemetry.currentBundleVersionValue(forKey:)`).
+   2. Make `mostRecentSentinelMarker` compare against a prior-session marker, not the current `active.json` (or filter `active.json` out of the candidate set when looking for prior-session evidence).
+   - References: `Sources/HealthCommandCore.swift:486`, `:502`, `:531`, `:550`; `CLI/HealthCommand.swift:37`; `GhosttyTabs.xcodeproj/project.pbxproj:1498-1534`.
+
+### Important (should fix; not strictly blocking)
+
+1. **`--rail` multi-flag silent overwrite.** Either error on duplicate `--rail` or accumulate into a `Set<HealthEvent.Rail>?`. Recommend tightening (error) for v1.
+2. **`bootTime()` silent 24h fallback when `sysctlbyname` fails.** Emit a single-line stderr warning so operators know their `--since-boot` ask was downgraded.
+3. **`telemetryAmbiguityFooter` only checks the production cache path.** Use the same `com.stage11.c11*` prefix iteration as `scanSentryQueued`, and update the warning copy to drop the "Production" qualifier.
+4. **`--rail <name>` help text omits the default.** Add "Default: all rails." to `CLI/c11.swift:7741`.
+
+### Important (lower priority polish)
+
+5. **Truncate `summary` in `renderHealthTable` to ~80 chars** with ellipsis to prevent long bundle/envelope names from breaking table alignment. JSON output should keep full strings.
+6. **Add a contract comment above `renderHealthTable`'s return** noting that the rendered string is already terminated, so callers must use `terminator: ""`.
+
+### Potential (follow-ups, none block merge)
+
+7. **Decide whether `metricKitBaselineWarning` should detect `build` mismatches** in addition to `version`. Either way, document the choice in a code comment so a future maintainer doesn't read it as a bug.
+8. **Add a code comment to the `age >= 0` clock-skew guard** explaining that future-dated markers are intentionally suppressed.
+9. **Optimise `mostRecentSentinelMarker`** by sorting filenames first (filenames carry a total ISO timestamp ordering) and decoding only the newest. Defer until sentinel housekeeping ships.
+10. **Extract the duplicated `ISO8601DateFormatter` configuration** (5 sites) into a small helper. Consider hoisting to a shared file with `Sources/SentryHelper.swift`'s identical helper, weighing the cost of cross-file sharing.
+11. **Add a one-line comment to `parseFilenameSafeISO`** noting that digit validation is deferred to `ISO8601DateFormatter` by design.
+12. **Expand the `scanSentryQueued` doc comment** to explicitly call out that Sentry-Cocoa bookkeeping files (e.g. `installation.id`) inflate the count by ≤2 per bundle.
+13. **Replace `commit = "????????"` placeholder with `"unknown"`** for legibility.
+14. **Remove `HealthEvent.Severity.metrickit`** (dead case) or document it as reserved for a future use.
+15. **Decide on `unclean_exit` rawValue style** — either rename to `.uncleanExit` with `"unclean-exit"` rawValue (matching the filename kebab-case convention) or document the snake_case as intentional.
+16. **Keep or remove the defensive `--help` / `-h` branch in `parseHealthCLIArgs`.** Currently dead in the integrated CLI but useful for direct unit testing. Acceptable as written.
+
+### Test coverage follow-ups
+
+17. **Add a focused unit test for `metricKitSeverity`** mapping a multi-category kind (e.g. `crash1-hang2` → `.mixed`).
+18. **Add a test pinning the JSON-output behaviour when `--rail` filters to a single rail** (filtered rails are currently omitted entirely from the `rails` map; pin this so it can't silently regress).
+19. **Add a test for the ordering tie-break** when two events share the same timestamp.
+
+---
+
+## 5. Notes on Reviewer Coverage
+
+- **Claude** wrote by far the most thorough review (15 numbered findings plus a validation pass plus quick-scan list). Useful breadth; risk of drowning the operator in cosmetic items. Claude missed the two runtime-state issues Codex caught.
+- **Codex** wrote a tightly focused review centered on the single most important defect (the MetricKit warning path). High signal-to-noise; only two findings total, but the Blocker call is well-supported with file/line references.
+- **Gemini** sat between the two — short review, hit the architectural verdict, called out the two warning issues at Important severity. Provided the most actionable concrete pointer (upstream cmux's `currentBundleVersionValue` helper).
+
+The three reviews complement each other well. Codex's Blocker call should be respected; Claude's `--rail` and `bootTime()` items are real Important fixes; Gemini's pointer to the upstream helper accelerates the Blocker fix.


### PR DESCRIPTION
## Summary

New `c11 health` command: a passive, socket-free aggregator across four crash-evidence rails on the local machine. Collapses a 30-minute cross-rail forensic sweep into a 2-second CLI answer.

Rails:
- **IPS** (`~/Library/Logs/DiagnosticReports/c11*.ips`) — Apple's CrashReporter output. Parses first-line JSON for incident_id, bundleID, bug_type, and the OS-reported `timestamp`. Falls back to file mtime when the JSON timestamp is missing.
- **Sentry queued** (`~/Library/Caches/com.stage11.c11*/io.sentry/`) — Pre-death cache, ships next launch. Counts envelope files, no parsing.
- **MetricKit** (`~/Library/Logs/c11/metrickit/*.json`) — OS-level terminations Sentry can't see. Parses the filename grammar produced by `CrashDiagnostics.persist`.
- **Launch sentinel** (`~/Library/Caches/com.stage11.c11*/sessions/unclean-exit-*.json`) — Telemetry-independent Force-Quit / SIGKILL detection. Consumes the artifacts written by PR #109.

Flags: `--since <30m|2h|24h|3d>`, `--since-boot`, `--rail <ips|sentry|metrickit|sentinel>`, `--json`. Default 24h window. Two diagnostic warnings: `metrickit_baseline_recent_version_bump` and `telemetry_state_ambiguous`.

**Passive only.** No Sentry posts, no sidebar nudges, no notifications. CLI surface only. Read-only — no signal handlers, no exception catchers. Does not modify the launch sentinel from PR #109.

JSON output is wire-versioned (`schema_version: 1`).

## Scope

This PR ships **Part B only** of the original [C11-24 plan](https://github.com/Stage-11-Agentics/c11/blob/c11-24/health-cli/.lattice/plans/task_01KQQM2D3V8VJ421RV2Y9XYPQC.md). Per the 2026-05-03 expert prompt:

- Part A (`c11 log --surface <id>`, per-surface debug-log filter) is split out into Lattice ticket **C11-25**.
- Debug-log gap detection is deferred to v1.1 (today's incident proved this is inconclusive without a labeled corpus).
- Trident review surfaced 7 surface-to-user items + 3 evolutionary items. The 4 truly small ones got absorbed into this PR; the other 6 are bundled into Lattice ticket **C11-26** for v1.1 hardening.

## What's in this PR

19 commits, 4135 insertions, 0 deletions. Logical grouping:

- **7 implementation commits** (Impl phase): scaffold + dispatch wiring, then four rails one-per-commit, then flags+JSON+warnings, then a sandboxed end-to-end runtime test.
- **9 review-fix commits** (Review phase): 4 blockers (B1-B4: MetricKit version resolution from c11.app, sentinel marker excluding active.json, telemetry footer walking the family, JSON path redaction), 5 importants (I1-I5: --rail duplicate detection, bootTime fallback diagnostic, empty-result line reflecting actual rail/window, stable sort tiebreak, lossy UTF-8 first-line read), 3 mediums (M1-M3: --rail help text, ISO formatter helper hoist, dead enum case removal), 1 evolutionary clear win (EW1: schema_version added to JSON).
- **3 fix-from-escalation commits** (Fix phase): S4 (collapsed duplicate stderr emission), S7 (corrupt unclean-exit rows render "unknown" instead of "?" with a code comment explaining why we keep the row), S2 (IPS rail uses internal JSON timestamp with mtime fallback so `--since 30m` after a recent crash doesn't miss it).
- **1 artifact commit**: validation report + raw c11 health outputs + the 13-file trident review pack.

## Validation

Performed against tagged build `c11-24-health` (commit `bbb8fa89`) on the live machine. Verdict: **PASS**.

Full report: [`notes/c11-24/validation-report.md`](https://github.com/Stage-11-Agentics/c11/blob/c11-24/health-cli/notes/c11-24/validation-report.md). Raw outputs: [`notes/c11-24/raw/`](https://github.com/Stage-11-Agentics/c11/tree/c11-24/health-cli/notes/c11-24/raw) (18 captured runs).

Highlights:

- All flag paths smoked: `c11 health`, `--json`, `--since 30m`, `--since-boot`, `--rail sentinel`, `--rail bogus` (single-line stderr), `--since 30m --since-boot` (mutual exclusion error), `--rail ips --rail sentry` (duplicate detection), `--help` (routes through `dispatchSubcommandHelp`).
- Sentinel synthesis confirmed: SIGKILL the tagged build, relaunch, `c11 health --rail sentinel` shows one `unclean_exit` row referencing `com.stage11.c11.debug.c11.24.health` at the synthesized timestamp.
- MetricKit synthesis confirmed: fake `~/Library/Logs/c11/metrickit/2026-05-03T22-19-00.000Z-hang3.json` produces one `hang` row with the parsed kind.
- Diagnostic warnings observed on this host:
  - `telemetry_state_ambiguous`: **fires** (empty `~/Library/Caches/com.stage11.c11/io.sentry/`).
  - `metrickit_baseline_recent_version_bump`: correctly **does not fire** on a fresh tag with no prior session marker.

## Test plan

- [x] Build green via `xcodebuild -project GhosttyTabs.xcodeproj -scheme c11 -configuration Debug` at every commit.
- [x] All flag paths exercised manually on the tagged build.
- [x] Sentinel rail confirmed end-to-end (Force-Quit → relaunch → row appears).
- [x] MetricKit rail confirmed via synthetic JSON.
- [x] Both diagnostic warnings exercised (one fires, one correctly silent).
- [ ] CI: unit tests under `c11Tests/Health*Tests.swift` and `c11Tests/CLIHealthRuntimeTests.swift` (per CLAUDE.md "Testing policy", not run locally; will run in CI on this PR).
- [ ] CI: e2e tests via `gh workflow run test-e2e.yml --ref c11-24/health-cli`.

## Anomaly worth flagging (not blocking this PR)

The Validate phase noticed that the launch sentinel's `active.json` shows `commit: ""` after an incremental rebuild via `reload.sh`, while the same field carried `bbb8fa899` before the force-quit/relaunch. The c11 `Info.plist` `C11Commit` injection appears to run once per DerivedData path rather than per incremental rebuild. The C11-24 consumer surfaces whatever was captured (correct behavior); the gap is upstream in PR #109's sentinel-write path. Worth a separate ticket against the launch sentinel feature owner.

## Connection to PR #109

This PR's base branch is `crash-visibility/launch-sentinel` (PR #109), which adds the telemetry-independent launch sentinel that this work consumes as the fourth rail. **#109 must merge first.** When #109 retargets to `main`, this PR's base should be retargeted to `main` automatically (or manually via `gh pr edit --base main`).

## Lattice ticket

C11-24 — full plan, validation, and trident review trail at `lattice show C11-24 --full`. Status: `review` (will move to `done` after merge per project convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)