### PR TITLE
restart-registry: capture session project_dir for worktree-safe resume

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -13342,9 +13342,25 @@ struct CMUXCLI {
                     // `Sources/WorkspaceMetadataKeys.swift` is linked into
                     // both the c11 app target and the c11-cli target, so the
                     // reserved-key constant has one spelling in one place.
-                    let metadata: [String: Any] = [
+                    var metadata: [String: Any] = [
                         SurfaceMetadataKeyName.claudeSessionId: trimmedSessionId
                     ]
+                    // Pair the session id with the project directory it was
+                    // created in. `claude --resume` resolves the session JSONL
+                    // relative to the shell's cwd, so a session captured in a
+                    // worktree subdir cannot be resumed from its parent.
+                    // Recording the project_dir lets the restart registry `cd`
+                    // there before issuing the resume command. Re-validate
+                    // here: the store rejects malformed values, but skipping
+                    // the write entirely on an invalid path keeps the
+                    // session_id capture intact rather than failing the
+                    // whole metadata-merge call.
+                    if let cwd = parsedInput.cwd?
+                        .trimmingCharacters(in: .whitespacesAndNewlines),
+                       !cwd.isEmpty,
+                       isValidClaudeSessionProjectDir(cwd) {
+                        metadata[SurfaceMetadataKeyName.claudeSessionProjectDir] = cwd
+                    }
                     var params: [String: Any] = [
                         "surface_id": surfaceId,
                         "metadata": metadata,
@@ -13514,14 +13530,20 @@ struct CMUXCLI {
                 _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
                 // C11-24: clear `claude.session_id` from the surface metadata
                 // so a subsequent c11 restart doesn't auto-resume an
-                // already-ended session. `terminal_type` stays — it's a
-                // per-surface configuration ("this surface is a claude
-                // terminal"), not a per-session pointer.
+                // already-ended session. The paired `claude.session_project_dir`
+                // is cleared in the same call — they're written atomically
+                // at SessionStart and only meaningful as a pair.
+                // `terminal_type` stays — it's a per-surface configuration
+                // ("this surface is a claude terminal"), not a per-session
+                // pointer.
                 let surfaceId = consumedSession.surfaceId
                 if !surfaceId.isEmpty {
                     var params: [String: Any] = [
                         "surface_id": surfaceId,
-                        "keys": [SurfaceMetadataKeyName.claudeSessionId],
+                        "keys": [
+                            SurfaceMetadataKeyName.claudeSessionId,
+                            SurfaceMetadataKeyName.claudeSessionProjectDir
+                        ],
                         "source": "explicit"
                     ]
                     if !workspaceId.isEmpty {

--- a/Sources/AgentRestartRegistry.swift
+++ b/Sources/AgentRestartRegistry.swift
@@ -29,6 +29,15 @@ func isValidClaudeSessionId(_ candidate: String) -> Bool {
     return claudeSessionIdUUIDPattern.firstMatch(in: candidate, options: [], range: range) != nil
 }
 
+/// Wrap a path in single quotes for safe interpolation into a shell
+/// command. `isValidClaudeSessionProjectDir` already rejects single
+/// quotes; this helper still escapes them defensively so a bypass of the
+/// validator (direct in-process writer, future regression) cannot become
+/// a command-injection vector.
+nonisolated func shellSingleQuote(_ value: String) -> String {
+    "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+}
+
 /// Pure-value lookup table mapping a known terminal type + session hint to
 /// the shell command that resumes it. Phase 1 ships a single row for
 /// `claude-code`; rows for `codex`, `opencode`, `kimi` land in Phase 5
@@ -132,11 +141,26 @@ struct AgentRestartRegistry: Sendable {
     /// globally. Opencode and kimi have no verified resume flag and launch
     /// fresh — best-effort is preferable to a broken flag.
     static let phase1: AgentRestartRegistry = .init(name: "phase1", rows: [
-        Row(terminalType: "claude-code") { sessionId, _ in
+        Row(terminalType: "claude-code") { sessionId, metadata in
             guard let raw = sessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
                   !raw.isEmpty,
                   isValidClaudeSessionId(raw) else { return nil }
-            return "claude --dangerously-skip-permissions --resume \(raw)\n"
+            let resume = "claude --dangerously-skip-permissions --resume \(raw)"
+            // `claude --resume <id>` resolves the session JSONL relative to
+            // the current shell's cwd encoding (`~/.claude/projects/<encoded-cwd>/<id>.jsonl`).
+            // A session captured in a worktree subdir cannot be resumed
+            // from its parent. When the hook recorded a project_dir, `cd`
+            // there first — re-validating defensively in case a future
+            // bypass slipped a malformed value past the store. The
+            // single-quote escape is belt-and-braces: the validator
+            // already rejects single quotes.
+            if let raw = metadata[SurfaceMetadataKeyName.claudeSessionProjectDir]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !raw.isEmpty,
+               isValidClaudeSessionProjectDir(raw) {
+                return "cd \(shellSingleQuote(raw)) && \(resume)\n"
+            }
+            return "\(resume)\n"
         },
         Row(terminalType: "codex") { _, _ in
             // codex resume --last resumes the most recent codex session globally.

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -154,7 +154,8 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         "terminal_type",
         "title",
         "description",
-        "claude.session_id"
+        "claude.session_id",
+        "claude.session_project_dir"
     ]
 
     static func validateReservedKey(_ key: String, _ value: Any) -> WriteError? {
@@ -194,6 +195,24 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 return .reservedKeyInvalidType(
                     key,
                     "must match UUIDv4 shape 8-4-4-4-12 hex"
+                )
+            }
+            return nil
+        case "claude.session_project_dir":
+            // Project directory the claude session was created in;
+            // interpolated into `cd '<path>' && …` at restore time. The
+            // registry single-quote-escapes it, but we still reject
+            // values that could break that escape (single-quote, NUL,
+            // newlines) or yield a non-absolute path. PATH_MAX on Darwin
+            // is 1024 — cap at 4096 for headroom on synthetic / encoded
+            // paths.
+            guard let s = value as? String else {
+                return .reservedKeyInvalidType(key, "expected string")
+            }
+            if !isValidClaudeSessionProjectDir(s) {
+                return .reservedKeyInvalidType(
+                    key,
+                    "must be an absolute POSIX path (≤4096 chars, no NUL/newline/single-quote)"
                 )
             }
             return nil

--- a/Sources/WorkspaceMetadataKeys.swift
+++ b/Sources/WorkspaceMetadataKeys.swift
@@ -28,6 +28,16 @@ public enum SurfaceMetadataKeyName {
     /// the C11-13 `mailbox.*` (pane-scoped) namespace.
     public static let claudeSessionId = "claude.session_id"
 
+    /// Surface-scoped project directory the Claude session was created in
+    /// (its current-working-directory at `SessionStart`). Written alongside
+    /// `claude.session_id` by the same hook. The pair is atomic: claude's
+    /// session JSONL files are stored under `~/.claude/projects/<encoded-cwd>/<id>.jsonl`
+    /// and `claude --resume <id>` looks them up by the *current* shell's
+    /// cwd, so a session captured in a worktree subdir cannot be resumed
+    /// from its parent directory. The registry uses this value to `cd`
+    /// into the recorded directory before issuing `claude --resume`.
+    public static let claudeSessionProjectDir = "claude.session_project_dir"
+
     /// Canonical `terminal_type` key (same literal as
     /// `SurfaceMetadataStore.reservedKeys`). Named here for executor
     /// readability; validation still flows through the store's reserved
@@ -38,6 +48,31 @@ public enum SurfaceMetadataKeyName {
     /// what `c11 set-agent --type claude-code` writes and what the
     /// Phase 1 restart registry keys against.
     public static let terminalTypeClaudeCode = "claude-code"
+}
+
+/// Project-dir grammar for `claude.session_project_dir`. Must be an
+/// absolute POSIX path with no NUL, newline, carriage return, or single
+/// quote. The single-quote ban is what lets the registry's single-quote
+/// shell escape stay a no-op even under defense-in-depth. Length cap is
+/// 4096 — well above Darwin's 1024 PATH_MAX, with headroom for synthetic
+/// or encoded paths.
+///
+/// File-scoped so both `SurfaceMetadataStore.validateReservedKey` (in the
+/// app target) and the `c11 claude-hook session-start` handler (in the
+/// CLI target) can share one definition. `WorkspaceMetadataKeys.swift` is
+/// the only file linked into both targets that the schema layer naturally
+/// reaches for.
+public let claudeSessionProjectDirMaxLen = 4096
+nonisolated public func isValidClaudeSessionProjectDir(_ candidate: String) -> Bool {
+    guard candidate.first == "/" else { return false }
+    if candidate.count > claudeSessionProjectDirMaxLen { return false }
+    for scalar in candidate.unicodeScalars {
+        switch scalar.value {
+        case 0x00, 0x0A, 0x0D, 0x27: return false  // NUL, LF, CR, '
+        default: continue
+        }
+    }
+    return true
 }
 
 /// Validation for workspace metadata writes.

--- a/c11Tests/SurfaceMetadataStoreValidationTests.swift
+++ b/c11Tests/SurfaceMetadataStoreValidationTests.swift
@@ -145,4 +145,91 @@ final class SurfaceMetadataStoreValidationTests: XCTestCase {
         XCTAssertNil(metadata["claude.session_id"])
         XCTAssertNil(sources["claude.session_id"])
     }
+
+    // MARK: - claude.session_project_dir
+
+    func testStoreAcceptsAbsolutePosixProjectDir() throws {
+        let workspace = UUID()
+        let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        let result = try store.setMetadata(
+            workspaceId: workspace,
+            surfaceId: surface,
+            partial: ["claude.session_project_dir": "/Users/op/repo/c11-worktrees/feat"],
+            mode: .merge,
+            source: .explicit
+        )
+        XCTAssertEqual(result.applied["claude.session_project_dir"], true)
+    }
+
+    func testStoreRejectsRelativeProjectDir() {
+        let workspace = UUID()
+        let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        XCTAssertThrowsError(
+            try store.setMetadata(
+                workspaceId: workspace,
+                surfaceId: surface,
+                partial: ["claude.session_project_dir": "relative/path"],
+                mode: .merge,
+                source: .explicit
+            )
+        ) { error in
+            guard let writeError = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(writeError.code, "reserved_key_invalid_type")
+        }
+    }
+
+    func testStoreRejectsProjectDirWithSingleQuoteOrNewline() {
+        let workspace = UUID()
+        let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        // A single quote would break the registry's single-quote shell
+        // escape; a newline would let an attacker append a second command
+        // after the synthesized `cd ... && claude --resume`.
+        let payloads = [
+            "/path/with'quote",
+            "/path/with\nnewline",
+            "/path/with\rcr",
+            "/path/with\u{0000}nul"
+        ]
+        for payload in payloads {
+            XCTAssertThrowsError(
+                try store.setMetadata(
+                    workspaceId: workspace,
+                    surfaceId: surface,
+                    partial: ["claude.session_project_dir": payload],
+                    mode: .merge,
+                    source: .explicit
+                ),
+                "store must reject project_dir containing dangerous bytes"
+            )
+        }
+    }
+
+    func testStoreRejectsNonStringProjectDir() {
+        let workspace = UUID()
+        let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        XCTAssertThrowsError(
+            try store.setMetadata(
+                workspaceId: workspace,
+                surfaceId: surface,
+                partial: ["claude.session_project_dir": 42],
+                mode: .merge,
+                source: .explicit
+            )
+        ) { error in
+            guard let writeError = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(writeError.code, "reserved_key_invalid_type")
+        }
+    }
 }

--- a/c11Tests/WorkspaceRestartCommandsTests.swift
+++ b/c11Tests/WorkspaceRestartCommandsTests.swift
@@ -186,6 +186,109 @@ final class WorkspaceRestartCommandsTests: XCTestCase {
         XCTAssertTrue(workspace.pendingRestartCommands(from: snapshot, registry: .phase1).isEmpty)
     }
 
+    // MARK: - claude.session_project_dir
+
+    func testPrependsCdWhenProjectDirRecorded() {
+        let workspace = Workspace()
+        let panelId = UUID()
+        let projectDir = "/Users/test/repo/c11-worktrees/feature-branch"
+        let snapshot = makeSnapshot(panels: [
+            makePanelSnapshot(
+                id: panelId,
+                type: .terminal,
+                metadata: [
+                    SurfaceMetadataKeyName.terminalType: .string(SurfaceMetadataKeyName.terminalTypeClaudeCode),
+                    SurfaceMetadataKeyName.claudeSessionId: .string(claudeSessionId),
+                    SurfaceMetadataKeyName.claudeSessionProjectDir: .string(projectDir)
+                ]
+            )
+        ])
+
+        let pending = workspace.pendingRestartCommands(from: snapshot, registry: .phase1)
+
+        XCTAssertEqual(pending.count, 1)
+        XCTAssertEqual(
+            pending.first?.command,
+            "cd '\(projectDir)' && claude --dangerously-skip-permissions --resume \(claudeSessionId)\n"
+        )
+    }
+
+    func testFallsBackToBareResumeWhenProjectDirAbsent() {
+        // Existing surfaces captured before the project_dir field shipped
+        // must keep working — bare `claude --resume` is the right behavior.
+        let workspace = Workspace()
+        let snapshot = makeSnapshot(panels: [
+            makePanelSnapshot(
+                id: UUID(),
+                type: .terminal,
+                metadata: [
+                    SurfaceMetadataKeyName.terminalType: .string(SurfaceMetadataKeyName.terminalTypeClaudeCode),
+                    SurfaceMetadataKeyName.claudeSessionId: .string(claudeSessionId)
+                ]
+            )
+        ])
+
+        let pending = workspace.pendingRestartCommands(from: snapshot, registry: .phase1)
+
+        XCTAssertEqual(
+            pending.first?.command,
+            "claude --dangerously-skip-permissions --resume \(claudeSessionId)\n"
+        )
+    }
+
+    func testFallsBackToBareResumeWhenProjectDirMalformed() {
+        // The store rejects malformed paths at write time, but registry
+        // re-validation must still drop a bypass. Defense-in-depth: a
+        // relative path or one with shell metacharacters cannot become
+        // part of the synthesized command.
+        let workspace = Workspace()
+        let snapshot = makeSnapshot(panels: [
+            makePanelSnapshot(
+                id: UUID(),
+                type: .terminal,
+                metadata: [
+                    SurfaceMetadataKeyName.terminalType: .string(SurfaceMetadataKeyName.terminalTypeClaudeCode),
+                    SurfaceMetadataKeyName.claudeSessionId: .string(claudeSessionId),
+                    // Relative path → registry rejects, falls back to bare.
+                    SurfaceMetadataKeyName.claudeSessionProjectDir: .string("relative/path")
+                ]
+            )
+        ])
+
+        let pending = workspace.pendingRestartCommands(from: snapshot, registry: .phase1)
+
+        XCTAssertEqual(
+            pending.first?.command,
+            "claude --dangerously-skip-permissions --resume \(claudeSessionId)\n",
+            "registry must drop a malformed project_dir rather than emit it"
+        )
+    }
+
+    func testProjectDirWithSpacesIsSingleQuoted() {
+        // Real-world paths can have spaces. The single-quote escape must
+        // wrap the whole path so `cd` receives one argument.
+        let workspace = Workspace()
+        let projectDir = "/Users/test/My Projects/repo"
+        let snapshot = makeSnapshot(panels: [
+            makePanelSnapshot(
+                id: UUID(),
+                type: .terminal,
+                metadata: [
+                    SurfaceMetadataKeyName.terminalType: .string(SurfaceMetadataKeyName.terminalTypeClaudeCode),
+                    SurfaceMetadataKeyName.claudeSessionId: .string(claudeSessionId),
+                    SurfaceMetadataKeyName.claudeSessionProjectDir: .string(projectDir)
+                ]
+            )
+        ])
+
+        let pending = workspace.pendingRestartCommands(from: snapshot, registry: .phase1)
+
+        XCTAssertEqual(
+            pending.first?.command,
+            "cd '\(projectDir)' && claude --dangerously-skip-permissions --resume \(claudeSessionId)\n"
+        )
+    }
+
     // MARK: - stringValues helper
 
     func testStringValuesKeepsOnlyStringEntries() {


### PR DESCRIPTION
## Summary

Recovery audit on three c11 crashes today (21:57 / 22:04 / 22:08, same `v2MainSync` deadlock signature C11-26 just fixed) found that surfaces with a recorded `claude.session_id` were emitting `claude --dangerously-skip-permissions --resume <id>` on restart but failing with **"No conversation found with session ID"** when the surface's working directory didn't match where the session was originally created.

Root cause: Claude Code stores session JSONLs at `~/.claude/projects/<encoded-cwd>/<id>.jsonl`. `claude --resume <id>` resolves them by the *current* shell's cwd encoding. A session captured inside a worktree subdir (e.g. `code/c11-worktrees/c11-6-app-chrome-scale/`) cannot be resumed from its parent (`code/`).

This change captures the session's cwd at SessionStart alongside the session id (atomic pair) and uses it at restore time to `cd` into the recorded directory before issuing the resume command.

## What changed

- **New canonical key:** `claude.session_project_dir` (paired with `claude.session_id`).
- **`claude-hook session-start`** writes both keys in one merge call from `parsedInput.cwd`. SessionStart fires once per session per the [Claude Code Hooks reference](https://code.claude.com/docs/en/hooks) — at start *and* on resume — passing `session_id` and `cwd` in JSON; one write is idempotent and complete.
- **`claude-hook session-end`** clears both keys (atomic pair).
- **`AgentRestartRegistry.phase1`** claude row reads `claude.session_project_dir` from metadata and emits `cd '<path>' && claude --dangerously-skip-permissions --resume <id>\n` when present and valid; falls back to the bare resume command otherwise. Existing surfaces with id-only metadata keep working unchanged.
- **Defense-in-depth** mirrors the `claude.session_id` pattern: store rejects malformed paths at write time (absolute path, no NUL/newline/CR/single-quote, ≤4096 chars); registry re-validates at synthesis time and single-quote-escapes before interpolating.

## Files

- `Sources/WorkspaceMetadataKeys.swift` — `claudeSessionProjectDir` constant + `isValidClaudeSessionProjectDir(_:)` (file-scoped here so both the app target and CLI target reach the same definition).
- `Sources/SurfaceMetadataStore.swift` — reserved-key entry + validator branch.
- `Sources/AgentRestartRegistry.swift` — `shellSingleQuote(_:)` helper; claude-code row consults metadata.
- `CLI/c11.swift` — session-start writes the pair; session-end clears the pair.
- `c11Tests/SurfaceMetadataStoreValidationTests.swift` — 4 new tests (accept absolute, reject relative, reject single-quote/newline/CR/NUL, reject non-string).
- `c11Tests/WorkspaceRestartCommandsTests.swift` — 4 new tests (cd-prefixed shape, fallback when absent, fallback when malformed, single-quoting handles paths with spaces).

## Failure mode this fixes

Observed today on `surface:15` ("plan-review", C11-6 Delegator):

\`\`\`
~/…/Projects/Stage11/code ➜ claude --dangerously-skip-permissions --resume df1799da-ca89-4454-9d13-9ed8fb47db61
No conversation found with session ID: df1799da-ca89-4454-9d13-9ed8fb47db61
\`\`\`

The session JSONL existed at `~/.claude/projects/-Users-atin-Projects-Stage11-code-c11-worktrees-c11-6-app-chrome-scale/df1799da-...jsonl` but the surface's cwd was `code/`, not the worktree. Three sequential restart cycles all failed identically.

After this change, the `cd` prefix puts the shell in the recorded project dir before resume, so the JSONL lookup succeeds.

## Out of scope

- Surfaces captured *before* this change have only `claude.session_id` recorded (no project_dir) and continue to fall back to the bare resume command — same behavior as today, no regression. They self-heal on the next SessionStart that fires under the new build.
- The "self-capture gap" (orchestrators / delegators that never wrote `claude.session_id` to their own surface) is unchanged here. The wrapper-level capture this change relies on (the existing `claude-hook session-start` path) closes that gap going forward for any claude that runs through the c11 wrapper.
- Codex / opencode / kimi rows in the registry are untouched.

## Test plan

- [x] Build: `xcodebuild -scheme c11-unit` green
- [ ] CI runs the 8 new unit tests (per `CLAUDE.md`, never run locally)
- [ ] Operator smoke: tag-build the change, start a fresh claude in a worktree subdir, capture a snapshot, force-restart c11, verify the surface comes back with the resumed session and history intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)