### PR TITLE
sentry: gate MXMetricPayload override behind Swift 6.2 (unblocks CI)

### DIFF
--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -29,11 +29,20 @@ final class CrashDiagnostics: NSObject, MXMetricManagerSubscriber {
         MXMetricManager.shared.add(self)
     }
 
+    // `MXMetricPayload` is marked unavailable on macOS in the macOS 15.5
+    // SDK (Xcode 16.4 — what `macos-15-xlarge` GitHub runners default to).
+    // Apple made it macOS-available in the macOS 26 SDK (Xcode 26.x), so
+    // gate the override on the Swift toolchain version: 6.2 ships with
+    // Xcode 26 alongside the new SDK, while Xcode 16.4 stays on 6.1. When
+    // CI catches up to Xcode 26 the gate becomes a no-op and the override
+    // re-engages automatically.
+    #if compiler(>=6.2)
     nonisolated func didReceive(_ payloads: [MXMetricPayload]) {
         for payload in payloads {
             persist(payload.jsonRepresentation(), kind: "metric", timestamp: payload.timeStampEnd)
         }
     }
+    #endif
 
     nonisolated func didReceive(_ payloads: [MXDiagnosticPayload]) {
         for payload in payloads {


### PR DESCRIPTION
## Summary

Unblocks `build` (ci.yml) and `mailbox-unit` (mailbox-parity.yml) on every PR/push to main. CI has been red on these jobs since 02d9e4d9 (Apr 29) — last 5 main commits all hit the same compile error.

## What's broken

Both jobs run on `macos-15-xlarge` and pick up the default Xcode 16.4 / macOS 15.5 SDK. In that SDK Apple marks \`MXMetricPayload\` unavailable on macOS:

\`\`\`
Sources/SentryHelper.swift:32:46: error: 'MXMetricPayload' is unavailable in macOS
    nonisolated func didReceive(_ payloads: [MXMetricPayload]) {
                                             ^~~~~~~~~~~~~~~
Sources/SentryHelper.swift:32:22: error: cannot override 'didReceive' which has been marked unavailable
\`\`\`

Apple made \`MXMetricPayload\` macOS-available in the macOS 26 SDK that ships with Xcode 26.x. The \`compat-tests\` workflow pins Xcode 26.3 and compiles fine; the other two workflows are stuck on the 16.4 default and break.

## Fix

Gate the metric-payload \`didReceive\` override on \`compiler(>=6.2)\`. Swift 6.2 ships with Xcode 26 alongside the new SDK; Xcode 16.4 stays on Swift 6.1. The override stays in on Xcode 26+ (where the SDK supports it) and compiles out on Xcode 16.4 (where it doesn't). When CI's stuck workflows catch up to Xcode 26 the gate becomes a no-op automatically — no further code change.

The diagnostic-payload handler (\`MXDiagnosticPayload\`) is unchanged — that type is available on both SDKs.

## Validation

- Local: Xcode 26.3 toolchain (Swift 6.2.3), \`xcodebuild -scheme c11-unit\` green — gate evaluates true, override stays in.
- CI: this PR's \`build\` and \`mailbox-unit\` jobs should go green for the first time since 02d9e4d9 — gate evaluates false, override compiles out.

## Why this isn't deferred to a workflow change

Pinning newer Xcode in \`ci.yml\` / \`mailbox-parity.yml\` (matching what \`compat-tests\` does) would also work but is bigger blast radius — affects every workflow, depends on \`macos-26\` runner image availability, may invalidate caches. The 9-line source gate is local, reversible, and self-resolving when the runner default catches up.

## Related

PR #113 (restart-registry: capture session project_dir) is also red on these same jobs for the same reason. Once this lands, that PR rebases onto main and CI goes green for it too.

## Test plan

- [x] Local Xcode 26 build green
- [ ] CI \`build\` job green
- [ ] CI \`mailbox-unit\` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)