### PR TITLE
tests: fix String→TabID mismatch in WorkspaceLayoutExecutorAcceptanceTests

### DIFF
--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -476,8 +476,14 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
         let panelUUIDToPlanId = Dictionary(
             uniqueKeysWithValues: planSurfaceIdToPanelUUID.map { ($0.value, $0.key) }
         )
+        // `ExternalTab.id` is a stringified UUID (bonsplit's external view),
+        // but `Workspace.panelIdFromSurfaceId(_:)` is typed on the opaque
+        // `TabID` wrapper. Parse the string back to UUID and wrap before
+        // looking up — same conversion `WorkspacePlanCapture.panelID(forTabIDString:)`
+        // does at the v2 socket boundary.
         let livePlanIds: [String] = livePane.tabs.map { tab in
-            guard let panelId = workspace.panelIdFromSurfaceId(tab.id),
+            guard let tabUUID = UUID(uuidString: tab.id),
+                  let panelId = workspace.panelIdFromSurfaceId(TabID(uuid: tabUUID)),
                   let planId = panelUUIDToPlanId[panelId] else {
                 return "unknown(\(tab.id))"
             }
@@ -497,9 +503,13 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
                 XCTFail("[\(fixtureName) @ \(path)] could not resolve expected selected surface \(expectedSurfaceId)")
                 return
             }
+            // `livePane.selectedTabId` is `String?` (bonsplit's external
+            // view); `expectedTabId` is `TabID`. Project the wrapper to
+            // its canonical UUID-string form so the comparison stays in
+            // the same value space.
             XCTAssertEqual(
                 livePane.selectedTabId,
-                expectedTabId,
+                expectedTabId.uuid.uuidString,
                 "[\(fixtureName) @ \(path)] selectedTabId mismatch (expected surface \(expectedSurfaceId))"
             )
         }


### PR DESCRIPTION
## Summary

Unblocks \`mailbox-unit\` (\`mailbox-parity.yml\`) on every PR/push that triggers it. The compile error was already there but masked by SentryHelper.swift's MetricKit issue; #114 cleared that and this surfaced as the next layer.

## What's broken on \`origin/main\`

\`\`\`
c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift:480:68: error:
    cannot convert value of type 'String' to expected argument type 'TabID'
c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift:500:13: error:
    conflicting arguments to generic parameter 'T' ('String?' vs. 'TabID')
\`\`\`

\`ExternalTab.id\` is a stringified UUID (bonsplit's external view) but \`Workspace.panelIdFromSurfaceId(_:)\` and \`surfaceIdFromPanelId(_:)\` are typed on the opaque \`TabID\` wrapper. The \`comparePane\` helper:

- passes \`tab.id\` (String) where \`TabID\` is expected, and
- compares \`livePane.selectedTabId\` (String?) against \`expectedTabId\` (TabID) inside \`XCTAssertEqual\`.

## Fix

Apply the same conversion \`WorkspacePlanCapture.panelID(forTabIDString:)\` uses at the v2 socket boundary: parse the UUID string and wrap with \`TabID(uuid:)\`. For the equality assertion, project the TabID wrapper to its canonical UUID-string form so both sides of \`XCTAssertEqual\` are in the same value space.

## Why this didn't catch locally before

Two reasons: (1) \`xcodebuild build\` on the \`c11-unit\` scheme only builds the host app target — \`build-for-testing\` (or \`test\`) is what compiles the test target; (2) Local Xcode 26 / Swift 6.2 happens to accept the old code through some inference path that Xcode 16.4 / Swift 6.1 in CI does not. The fix compiles cleanly on both.

## Why no one else has hit this

\`mailbox-parity.yml\` only triggers when \`Sources/Mailbox/**\`, \`CLI/c11.swift\`, etc. change. Most main pushes don't touch those paths so the workflow doesn't run, so this regression has been quietly sitting on main since the TabID wrapper was introduced.

## Test plan

- [x] Local build clean (the file now compiles without error on Swift 6.2)
- [ ] CI \`mailbox-unit\` job goes green for the first time since the breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)