### PR TITLE
ci(release): make Sentry dSYM upload non-fatal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,6 +298,7 @@ jobs:
 
       - name: Upload dSYMs to Sentry
         if: steps.guard_release_assets.outputs.skip_all != 'true'
+        continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: stage-11-kl


### PR DESCRIPTION
## Summary

The v0.45.0 release run (#25337136080) failed at the **Upload dSYMs to Sentry** step (`Project not found` for `stage-11-kl/stage11-c11`), which short-circuited the rest of the job — Sparkle appcast generation and the actual GitHub release-asset upload never ran. Build, sign, and notarize all succeeded; only post-build observability tooling failed.

This adds `continue-on-error: true` to that step so an unreachable Sentry project can't block shipping. The Sentry config (org/project/token) can be diagnosed independently.

## Test plan

- [x] One-line YAML change, no behavioral risk to the build pipeline
- [ ] Merge → delete + re-push `v0.45.0` tag → confirm release workflow publishes the GitHub Release with the .dmg, appcast.xml, and remote-daemon assets