### PR TITLE
C11-26 followup: route bare main.sync handlers through v2MainSync (fixes EXC_BREAKPOINT crash, 4× today)

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1644,8 +1644,16 @@ class TerminalController {
     // `CFRunLoopRun` reached from inside an outer `DispatchQueue.main.sync` block.
     // Entries in `socketWorkerV2Methods` are dispatched directly on the worker via
     // `socketWorkerV2Response` and short-hop to `@MainActor` only for bounded slices
-    // of work that genuinely need it. Methods absent from the set continue to flow
-    // through the legacy `v2MainSync { self.processCommand(...) }` path unchanged.
+    // of work that genuinely need it.
+    //
+    // Methods absent from `socketWorkerV2Methods` flow through the default-policy
+    // path below, which hops to the main thread *before* invoking `processCommand`.
+    // That hop is a behavior change vs. pre-C11-26 (where `handleClient` called
+    // `processCommand(trimmed)` directly from the worker), and any handler that
+    // internally calls `DispatchQueue.main.sync` would self-deadlock on the main
+    // queue — libdispatch's `__DISPATCH_WAIT_FOR_QUEUE__` traps with EXC_BREAKPOINT.
+    // Handlers reached through this path must use `v2MainSync` (which short-circuits
+    // when already on main) instead of bare `DispatchQueue.main.sync`.
 
     private enum SocketCommandExecutionPolicy: Equatable {
         case mainActor
@@ -8634,7 +8642,7 @@ class TerminalController {
 
     private func v2NotificationList() -> [String: Any] {
         var items: [[String: Any]] = []
-        DispatchQueue.main.sync {
+        v2MainSync {
             items = TerminalNotificationStore.shared.notifications.map { n in
                 return [
                     "id": n.id.uuidString,
@@ -8651,7 +8659,7 @@ class TerminalController {
     }
 
     private func v2NotificationClear() -> V2CallResult {
-        DispatchQueue.main.sync {
+        v2MainSync {
             TerminalNotificationStore.shared.clearAll()
         }
         return .ok([:])
@@ -12684,7 +12692,7 @@ class TerminalController {
         }
 
         var result: V2CallResult = .err(code: "internal_error", message: "No window", data: nil)
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let window = NSApp.keyWindow
                 ?? NSApp.mainWindow
                 ?? NSApp.windows.first(where: { $0.isVisible })
@@ -12717,7 +12725,7 @@ class TerminalController {
     private func v2DebugToggleCommandPalette(params: [String: Any]) -> V2CallResult {
         let requestedWindowId = v2UUID(params, "window_id")
         var result: V2CallResult = .ok([:])
-        DispatchQueue.main.sync {
+        v2MainSync {
             let targetWindow: NSWindow?
             if let requestedWindowId {
                 guard let window = AppDelegate.shared?.mainWindow(for: requestedWindowId) else {
@@ -12740,7 +12748,7 @@ class TerminalController {
     private func v2DebugOpenCommandPaletteRenameTabInput(params: [String: Any]) -> V2CallResult {
         let requestedWindowId = v2UUID(params, "window_id")
         var result: V2CallResult = .ok([:])
-        DispatchQueue.main.sync {
+        v2MainSync {
             let targetWindow: NSWindow?
             if let requestedWindowId {
                 guard let window = AppDelegate.shared?.mainWindow(for: requestedWindowId) else {
@@ -12768,7 +12776,7 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing or invalid window_id", data: nil)
         }
         var visible = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             visible = AppDelegate.shared?.isCommandPaletteVisible(windowId: windowId) ?? false
         }
         return .ok([
@@ -12784,7 +12792,7 @@ class TerminalController {
         }
         var visible = false
         var selectedIndex = 0
-        DispatchQueue.main.sync {
+        v2MainSync {
             visible = AppDelegate.shared?.isCommandPaletteVisible(windowId: windowId) ?? false
             selectedIndex = AppDelegate.shared?.commandPaletteSelectionIndex(windowId: windowId) ?? 0
         }
@@ -12807,7 +12815,7 @@ class TerminalController {
         var selectedIndex = 0
         var snapshot = CommandPaletteDebugSnapshot.empty
 
-        DispatchQueue.main.sync {
+        v2MainSync {
             visible = AppDelegate.shared?.isCommandPaletteVisible(windowId: windowId) ?? false
             selectedIndex = AppDelegate.shared?.commandPaletteSelectionIndex(windowId: windowId) ?? 0
             snapshot = AppDelegate.shared?.commandPaletteSnapshot(windowId: windowId) ?? .empty
@@ -12837,7 +12845,7 @@ class TerminalController {
     private func v2DebugCommandPaletteRenameInputInteraction(params: [String: Any]) -> V2CallResult {
         let requestedWindowId = v2UUID(params, "window_id")
         var result: V2CallResult = .ok([:])
-        DispatchQueue.main.sync {
+        v2MainSync {
             let targetWindow: NSWindow?
             if let requestedWindowId {
                 guard let window = AppDelegate.shared?.mainWindow(for: requestedWindowId) else {
@@ -12863,7 +12871,7 @@ class TerminalController {
     private func v2DebugCommandPaletteRenameInputDeleteBackward(params: [String: Any]) -> V2CallResult {
         let requestedWindowId = v2UUID(params, "window_id")
         var result: V2CallResult = .ok([:])
-        DispatchQueue.main.sync {
+        v2MainSync {
             let targetWindow: NSWindow?
             if let requestedWindowId {
                 guard let window = AppDelegate.shared?.mainWindow(for: requestedWindowId) else {
@@ -12900,7 +12908,7 @@ class TerminalController {
             "text_length": 0
         ])
 
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let window = AppDelegate.shared?.mainWindow(for: windowId) else {
                 result = .err(
                     code: "not_found",
@@ -12936,7 +12944,7 @@ class TerminalController {
                     data: ["enabled": rawEnabled]
                 )
             }
-            DispatchQueue.main.sync {
+            v2MainSync {
                 UserDefaults.standard.set(
                     enabled,
                     forKey: CommandPaletteRenameSelectionSettings.selectAllOnFocusKey
@@ -12945,7 +12953,7 @@ class TerminalController {
         }
 
         var enabled = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
-        DispatchQueue.main.sync {
+        v2MainSync {
             enabled = CommandPaletteRenameSelectionSettings.selectAllOnFocusEnabled()
         }
 
@@ -12957,7 +12965,7 @@ class TerminalController {
     private func v2DebugBrowserAddressBarFocused(params: [String: Any]) -> V2CallResult {
         let requestedSurfaceId = v2UUID(params, "surface_id") ?? v2UUID(params, "panel_id")
         var focusedSurfaceId: UUID?
-        DispatchQueue.main.sync {
+        v2MainSync {
             focusedSurfaceId = AppDelegate.shared?.focusedBrowserAddressBarPanelId()
         }
 
@@ -13000,7 +13008,7 @@ class TerminalController {
             return .err(code: "invalid_params", message: "Missing or invalid window_id", data: nil)
         }
         var visibility: Bool?
-        DispatchQueue.main.sync {
+        v2MainSync {
             visibility = AppDelegate.shared?.sidebarVisibility(windowId: windowId)
         }
         guard let visible = visibility else {
@@ -13285,7 +13293,7 @@ class TerminalController {
 
         let trimmedSurfaceArg = surfaceArg.trimmingCharacters(in: .whitespacesAndNewlines)
         var result = "ERROR: No tab selected"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -13539,7 +13547,7 @@ class TerminalController {
         let requestTimestamp = ProcessInfo.processInfo.systemUptime
 
         var result = "ERROR: Failed to create event"
-        DispatchQueue.main.sync {
+        v2MainSync {
             // Prefer the current active-tab-manager window so shortcut simulation stays
             // scoped to the intended window even when NSApp.keyWindow is stale.
             let targetWindow: NSWindow? = {
@@ -13599,7 +13607,7 @@ class TerminalController {
     }
 
     private func activateApp() -> String {
-        DispatchQueue.main.sync {
+        v2MainSync {
             NSApp.activate(ignoringOtherApps: true)
             NSApp.unhide(nil)
             let hasMainTerminalWindow = NSApp.windows.contains { window in
@@ -13634,7 +13642,7 @@ class TerminalController {
         let text = unescapeSocketText(raw)
 
         var result = "ERROR: No window"
-        DispatchQueue.main.sync {
+        v2MainSync {
             // Like simulate_shortcut, prefer a visible window so debug automation doesn't
             // fail during key window transitions.
             guard let window = NSApp.keyWindow
@@ -13679,7 +13687,7 @@ class TerminalController {
         }
 
         var result = "ERROR: Surface not found"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let panel = resolveTerminalPanel(from: target, tabManager: tabManager) else { return }
             result = panel.hostedView.debugSimulateFileDrop(paths: paths)
                 ? "OK"
@@ -13724,14 +13732,14 @@ class TerminalController {
             }
         }
 
-        DispatchQueue.main.sync {
+        v2MainSync {
             _ = NSPasteboard(name: .drag).declareTypes(types, owner: nil)
         }
         return "OK"
     }
 
     private func clearDragPasteboard() -> String {
-        DispatchQueue.main.sync {
+        v2MainSync {
             _ = NSPasteboard(name: .drag).clearContents()
         }
         return "OK"
@@ -13750,7 +13758,7 @@ class TerminalController {
         let eventType = parsedEvent.eventType
 
         var shouldCapture = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             let pb = NSPasteboard(name: .drag)
             shouldCapture = DragOverlayRoutingPolicy.shouldCaptureFileDropOverlay(
                 pasteboardTypes: pb.types,
@@ -13774,7 +13782,7 @@ class TerminalController {
         }
 
         var shouldCapture = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             let pb = NSPasteboard(name: .drag)
             shouldCapture = DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
                 pasteboardTypes: pb.types,
@@ -13796,7 +13804,7 @@ class TerminalController {
         let eventType = parsedEvent.eventType
 
         var shouldPassThrough = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             let pb = NSPasteboard(name: .drag)
             shouldPassThrough = DragOverlayRoutingPolicy.shouldPassThroughPortalHitTesting(
                 pasteboardTypes: pb.types,
@@ -13819,7 +13827,7 @@ class TerminalController {
         }
 
         var shouldCapture = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             let pb = NSPasteboard(name: .drag)
             shouldCapture = DragOverlayRoutingPolicy.shouldCaptureSidebarExternalOverlay(
                 hasSidebarDragState: hasSidebarDragState,
@@ -13844,7 +13852,7 @@ class TerminalController {
         }
 
         var result = "ERROR: No selected workspace"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let selectedId = tabManager.selectedTabId,
                   let workspace = tabManager.tabs.first(where: { $0.id == selectedId }) else {
                 return
@@ -13952,7 +13960,7 @@ class TerminalController {
         }
 
         var result = "ERROR: No window"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let window = NSApp.mainWindow
                 ?? NSApp.keyWindow
                 ?? NSApp.windows.first(where: { win in
@@ -13993,7 +14001,7 @@ class TerminalController {
         }
 
         var result = "ERROR: No window"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let window = NSApp.mainWindow
                 ?? NSApp.keyWindow
                 ?? NSApp.windows.first(where: { win in
@@ -14095,7 +14103,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: is_terminal_focused <panel_id|idx>" }
 
         var result = "false"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 result = "false"
@@ -14141,7 +14149,7 @@ class TerminalController {
         let panelArg = args.trimmingCharacters(in: .whitespacesAndNewlines)
 
         var result = "ERROR: No tab selected"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -14447,7 +14455,7 @@ class TerminalController {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
         var result: String = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             let tabs = tabManager.tabs.enumerated().map { (index, tab) in
                 let selected = tab.id == tabManager.selectedTabId ? "*" : " "
                 return "\(selected) \(index): \(tab.id.uuidString) \(tab.title)"
@@ -14524,7 +14532,7 @@ class TerminalController {
     private func listSurfaces(_ tabArg: String) -> String {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTab(from: tabArg, tabManager: tabManager) else {
                 result = "ERROR: Tab not found"
                 return
@@ -14546,7 +14554,7 @@ class TerminalController {
         guard !trimmed.isEmpty else { return "ERROR: Missing panel id or index" }
 
         var success = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -14576,7 +14584,7 @@ class TerminalController {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId else {
                 result = "ERROR: No tab selected"
                 return
@@ -14604,7 +14612,7 @@ class TerminalController {
         let payload = parts.count > 1 ? parts[1] : ""
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 result = "ERROR: No tab selected"
@@ -14639,7 +14647,7 @@ class TerminalController {
         let payload = parts.count > 2 ? parts[2] : ""
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             let tab: Tab?
             if let tabId = UUID(uuidString: tabArg) {
                 tab = tabForSidebarMutation(id: tabId)
@@ -14669,7 +14677,7 @@ class TerminalController {
 
     private func listNotifications() -> String {
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             let lines = TerminalNotificationStore.shared.notifications.enumerated().map { index, notification in
                 let surfaceText = notification.surfaceId?.uuidString ?? "none"
                 let readText = notification.isRead ? "read" : "unread"
@@ -14683,7 +14691,7 @@ class TerminalController {
     private func clearNotifications(_ args: String) -> String {
         let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
-            DispatchQueue.main.sync {
+            v2MainSync {
                 TerminalNotificationStore.shared.clearAll()
             }
             return "OK"
@@ -14694,7 +14702,7 @@ class TerminalController {
             return "ERROR: Usage: clear_notifications [--tab=X]"
         }
         var tabId: UUID?
-        DispatchQueue.main.sync {
+        v2MainSync {
             if let tab = resolveTabForReport(trimmed) {
                 tabId = tab.id
             }
@@ -14702,7 +14710,7 @@ class TerminalController {
         guard let tabId else {
             return "ERROR: Tab not found"
         }
-        DispatchQueue.main.sync {
+        v2MainSync {
             TerminalNotificationStore.shared.clearNotifications(forTabId: tabId)
         }
         return "OK"
@@ -14726,7 +14734,7 @@ class TerminalController {
     }
 
     private func simulateAppDidBecomeActive() -> String {
-        DispatchQueue.main.sync {
+        v2MainSync {
             AppDelegate.shared?.applicationDidBecomeActive(
                 Notification(name: NSApplication.didBecomeActiveNotification)
             )
@@ -14743,7 +14751,7 @@ class TerminalController {
         let surfaceArg = parts.count > 1 ? parts[1] : ""
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTab(from: tabArg, tabManager: tabManager) else {
                 result = "ERROR: Tab not found"
                 return
@@ -14766,7 +14774,7 @@ class TerminalController {
         guard !trimmed.isEmpty else { return "ERROR: Missing surface id or index" }
 
         var result = "ERROR: Surface not found"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 result = "ERROR: No tab selected"
@@ -14783,7 +14791,7 @@ class TerminalController {
     }
 
     private func resetFlashCounts() -> String {
-        DispatchQueue.main.sync {
+        v2MainSync {
             GhosttySurfaceScrollView.resetFlashCounts()
         }
         return "OK"
@@ -14808,7 +14816,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: panel_snapshot_reset <panel_id|idx>" }
 
         var result = "ERROR: No tab selected"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -14915,7 +14923,7 @@ class TerminalController {
         let outputPath = outputDir.appendingPathComponent(filename)
 
         var result = "ERROR: No tab selected"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -15006,7 +15014,7 @@ class TerminalController {
         guard let tabManager else { return "ERROR: TabManager not available" }
 
         var result = "ERROR: No tab selected"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -15178,14 +15186,14 @@ class TerminalController {
 
     private func emptyPanelCount() -> String {
         var result = "OK 0"
-        DispatchQueue.main.sync {
+        v2MainSync {
             result = "OK \(DebugUIEventCounters.emptyPanelAppearCount)"
         }
         return result
     }
 
     private func resetEmptyPanelCount() -> String {
-        DispatchQueue.main.sync {
+        v2MainSync {
             DebugUIEventCounters.resetEmptyPanelAppearCount()
         }
         return "OK"
@@ -15193,7 +15201,7 @@ class TerminalController {
 
     private func bonsplitUnderflowCount() -> String {
         var result = "OK 0"
-        DispatchQueue.main.sync {
+        v2MainSync {
 #if DEBUG
             result = "OK \(BonsplitDebugCounters.arrangedSubviewUnderflowCount)"
 #else
@@ -15204,7 +15212,7 @@ class TerminalController {
     }
 
     private func resetBonsplitUnderflowCount() -> String {
-        DispatchQueue.main.sync {
+        v2MainSync {
 #if DEBUG
             BonsplitDebugCounters.reset()
 #endif
@@ -15233,7 +15241,7 @@ class TerminalController {
 
         // Capture the main window on main thread
         var captureError: String?
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let window = NSApp.mainWindow ?? NSApp.windows.first else {
                 captureError = "No window available"
                 return
@@ -15439,7 +15447,7 @@ class TerminalController {
         guard let uuid = UUID(uuidString: tabId) else { return "ERROR: Invalid tab ID" }
 
         var success = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             if let tab = tabManager.tabs.first(where: { $0.id == uuid }) {
                 tabManager.closeTab(tab)
                 success = true
@@ -15452,7 +15460,7 @@ class TerminalController {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
         var success = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             // Try as UUID first
             if let uuid = UUID(uuidString: arg) {
                 if let tab = tabManager.tabs.first(where: { $0.id == uuid }) {
@@ -15473,7 +15481,7 @@ class TerminalController {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
         var result: String = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             if let id = tabManager.selectedTabId {
                 result = id.uuidString
             }
@@ -15643,7 +15651,7 @@ class TerminalController {
 
         var success = false
         var error: String?
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let selectedId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == selectedId }),
                   let terminalPanel = tab.focusedTerminalPanel else {
@@ -15717,7 +15725,7 @@ class TerminalController {
 
         var success = false
         var error: String?
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let targetManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId)
                 ?? (tabManager.tabs.contains(where: { $0.id == workspaceId }) ? tabManager : nil) else {
                 error = "ERROR: Workspace not found"
@@ -15804,7 +15812,7 @@ class TerminalController {
         let text = parts[1]
 
         var success = false
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let surface = resolveSurface(from: target, tabManager: tabManager) else { return }
 
             let unescaped = text
@@ -15831,7 +15839,7 @@ class TerminalController {
 
         var success = false
         var error: String?
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let selectedId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == selectedId }),
                   let terminalPanel = tab.focusedTerminalPanel else {
@@ -15864,7 +15872,7 @@ class TerminalController {
 
         var success = false
         var error: String?
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard resolveTerminalPanel(from: target, tabManager: tabManager) != nil else {
                 error = "ERROR: Surface not found"
                 return
@@ -15890,7 +15898,7 @@ class TerminalController {
 
         var result = "ERROR: Failed to create browser panel"
         let focus = socketCommandAllowsInAppFocusMutations()
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let focusedPanelId = tab.focusedPanelId else {
@@ -15919,7 +15927,7 @@ class TerminalController {
         let urlStr = parts[1]
 
         var result = "ERROR: Panel not found or not a browser"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let panelId = UUID(uuidString: panelArg),
@@ -15940,7 +15948,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: browser_back <panel_id>" }
 
         var result = "ERROR: Panel not found or not a browser"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let panelId = UUID(uuidString: panelArg),
@@ -15961,7 +15969,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: browser_forward <panel_id>" }
 
         var result = "ERROR: Panel not found or not a browser"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let panelId = UUID(uuidString: panelArg),
@@ -15982,7 +15990,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: browser_reload <panel_id>" }
 
         var result = "ERROR: Panel not found or not a browser"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let panelId = UUID(uuidString: panelArg),
@@ -16003,7 +16011,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: get_url <panel_id>" }
 
         var result = "ERROR: Panel not found or not a browser"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let panelId = UUID(uuidString: panelArg),
@@ -16023,7 +16031,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: focus_webview <panel_id>" }
 
         var result = "ERROR: Panel not found or not a browser"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let panelId = UUID(uuidString: panelArg),
@@ -16076,7 +16084,7 @@ class TerminalController {
         guard !panelArg.isEmpty else { return "ERROR: Usage: is_webview_focused <panel_id>" }
 
         var result = "ERROR: Panel not found or not a browser"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let panelId = UUID(uuidString: panelArg),
@@ -16100,7 +16108,7 @@ class TerminalController {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 result = "ERROR: No tab selected"
@@ -16124,7 +16132,7 @@ class TerminalController {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 result = "ERROR: No tab selected"
@@ -16180,7 +16188,7 @@ class TerminalController {
         guard !paneArg.isEmpty else { return "ERROR: Usage: focus_pane <pane_id>" }
 
         var result = "ERROR: Pane not found"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -16208,7 +16216,7 @@ class TerminalController {
         guard !tabArg.isEmpty else { return "ERROR: Usage: focus_surface_by_panel <panel_id>" }
 
         var result = "ERROR: Panel not found"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -16309,7 +16317,7 @@ class TerminalController {
 
         var result = "ERROR: Failed to create pane"
         let focus = socketCommandAllowsInAppFocusMutations()
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }),
                   let focusedPanelId = tab.focusedPanelId else {
@@ -16512,7 +16520,7 @@ class TerminalController {
         options: [String: String]
     ) -> (tabId: UUID?, error: String?) {
         var tabId: UUID?
-        DispatchQueue.main.sync {
+        v2MainSync {
             if let tab = resolveTabForReport(reportArgs) {
                 tabId = tab.id
             }
@@ -16698,7 +16706,7 @@ class TerminalController {
         }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -16762,7 +16770,7 @@ class TerminalController {
 
     private func listSidebarMetadata(_ args: String, emptyMessage: String) -> String {
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = "ERROR: Tab not found"
                 return
@@ -16892,7 +16900,7 @@ class TerminalController {
         }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -16906,7 +16914,7 @@ class TerminalController {
 
     private func listMetaBlocks(_ args: String) -> String {
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = "ERROR: Tab not found"
                 return
@@ -16934,7 +16942,7 @@ class TerminalController {
         let source = parsed.options["source"]
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -16951,7 +16959,7 @@ class TerminalController {
 
     private func clearLog(_ args: String) -> String {
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = "ERROR: Tab not found"
                 return
@@ -16975,7 +16983,7 @@ class TerminalController {
         }
 
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17013,7 +17021,7 @@ class TerminalController {
         let label = parsed.options["label"]
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17025,7 +17033,7 @@ class TerminalController {
 
     private func clearProgress(_ args: String) -> String {
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = "ERROR: Tab not found"
                 return
@@ -17065,7 +17073,7 @@ class TerminalController {
         }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17095,7 +17103,7 @@ class TerminalController {
             return "OK"
         }
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = "ERROR: Tab not found"
                 return
@@ -17202,7 +17210,7 @@ class TerminalController {
         }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17264,7 +17272,7 @@ class TerminalController {
             return "OK"
         }
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17330,7 +17338,7 @@ class TerminalController {
         guard let tabManager else { return "ERROR: TabManager not available" }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17372,7 +17380,7 @@ class TerminalController {
     private func clearPorts(_ args: String) -> String {
         let parsed = parseOptions(args)
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17427,7 +17435,7 @@ class TerminalController {
         }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17482,7 +17490,7 @@ class TerminalController {
         }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17530,7 +17538,7 @@ class TerminalController {
         }
 
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
                 return
@@ -17563,7 +17571,7 @@ class TerminalController {
 
     private func sidebarState(_ args: String) -> String {
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = "ERROR: Tab not found"
                 return
@@ -17660,7 +17668,7 @@ class TerminalController {
 
     private func resetSidebar(_ args: String) -> String {
         var result = "OK"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTabForReport(args) else {
                 result = "ERROR: Tab not found"
                 return
@@ -17692,7 +17700,7 @@ class TerminalController {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
         var refreshedCount = 0
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -17732,7 +17740,7 @@ class TerminalController {
     private func surfaceHealth(_ tabArg: String) -> String {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
         var result = ""
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tab = resolveTab(from: tabArg, tabManager: tabManager) else {
                 result = "ERROR: Tab not found"
                 return
@@ -17764,7 +17772,7 @@ class TerminalController {
         let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
 
         var result = "ERROR: Failed to close surface"
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return
@@ -17820,7 +17828,7 @@ class TerminalController {
 
         var result = "ERROR: Failed to create tab"
         let focus = socketCommandAllowsInAppFocusMutations()
-        DispatchQueue.main.sync {
+        v2MainSync {
             guard let tabId = tabManager.selectedTabId,
                   let tab = tabManager.tabs.first(where: { $0.id == tabId }) else {
                 return

--- a/Sources/Theme/ThemeSocketMethods.swift
+++ b/Sources/Theme/ThemeSocketMethods.swift
@@ -32,9 +32,9 @@ public enum ThemeSocketMethods {
     // MARK: - Read-only
 
     public static func list() -> [String: Any] {
-        let descriptors = DispatchQueue.main.sync { ThemeManager.shared.availableThemes }
-        let lightName = DispatchQueue.main.sync { ThemeManager.shared.activeLightName }
-        let darkName = DispatchQueue.main.sync { ThemeManager.shared.activeDarkName }
+        let descriptors = Self.mainSync { ThemeManager.shared.availableThemes }
+        let lightName = Self.mainSync { ThemeManager.shared.activeLightName }
+        let darkName = Self.mainSync { ThemeManager.shared.activeDarkName }
 
         let items: [[String: Any]] = descriptors.map { descriptor in
             var payload: [String: Any] = [
@@ -64,8 +64,8 @@ public enum ThemeSocketMethods {
     }
 
     public static func get(params: [String: Any]) -> [String: Any] {
-        let lightName = DispatchQueue.main.sync { ThemeManager.shared.activeLightName }
-        let darkName = DispatchQueue.main.sync { ThemeManager.shared.activeDarkName }
+        let lightName = Self.mainSync { ThemeManager.shared.activeLightName }
+        let darkName = Self.mainSync { ThemeManager.shared.activeDarkName }
         let slot = (params["slot"] as? String)?.lowercased()
 
         switch slot {
@@ -97,10 +97,10 @@ public enum ThemeSocketMethods {
         case "dark":
             colorScheme = .dark
         default:
-            colorScheme = DispatchQueue.main.sync { ThemeManager.currentColorScheme() }
+            colorScheme = Self.mainSync { ThemeManager.currentColorScheme() }
         }
 
-        let json = DispatchQueue.main.sync {
+        let json = Self.mainSync {
             let context = ThemeManager.shared.makeContext(colorScheme: colorScheme)
             return ThemeManager.shared.dumpActiveThemeJSON(context: context)
         }
@@ -175,7 +175,7 @@ public enum ThemeSocketMethods {
         }
         let slot = (params["slot"] as? String)?.lowercased() ?? "both"
 
-        let ok: Bool = DispatchQueue.main.sync {
+        let ok: Bool = Self.mainSync {
             switch slot {
             case "light":
                 return ThemeManager.shared.setActiveTheme(name: name, for: .light)
@@ -195,14 +195,14 @@ public enum ThemeSocketMethods {
     }
 
     public static func clearActive() -> [String: Any] {
-        DispatchQueue.main.sync {
+        Self.mainSync {
             ThemeManager.shared.clearActiveOverrides()
         }
         return ["ok": true]
     }
 
     public static func reload() -> [String: Any] {
-        DispatchQueue.main.sync {
+        Self.mainSync {
             ThemeManager.shared.forceReloadUserThemes()
         }
         return ["ok": true]
@@ -214,7 +214,7 @@ public enum ThemeSocketMethods {
             return ["ok": false, "error": "missing required parameters: parent, as"]
         }
 
-        let parentTheme: C11muxTheme? = DispatchQueue.main.sync {
+        let parentTheme: C11muxTheme? = Self.mainSync {
             ThemeManager.shared.theme(named: parent)
         }
         guard let parentTheme else {
@@ -260,6 +260,24 @@ public enum ThemeSocketMethods {
 
     // MARK: - Helpers
 
+    /// Hop to main when needed, run inline when already on main.
+    ///
+    /// Bare `DispatchQueue.main.sync` would self-deadlock if a caller is already on main —
+    /// post-C11-26 the v2 dispatcher routes default-policy commands through main, so any
+    /// theme.* handler reached via `processCommand` is now invoked on the main thread.
+    /// libdispatch detects the self-wait and traps with EXC_BREAKPOINT
+    /// (`__DISPATCH_WAIT_FOR_QUEUE__`). Mirrors `GhosttyTerminalView.performOnMain`
+    /// and `TerminalController.v2MainSync`; ThemeSocketMethods isn't @MainActor itself,
+    /// so the body has to be marked `@MainActor` explicitly.
+    private static func mainSync<T>(_ body: @MainActor () -> T) -> T {
+        if Thread.isMainThread {
+            return MainActor.assumeIsolated { body() }
+        }
+        return DispatchQueue.main.sync {
+            MainActor.assumeIsolated { body() }
+        }
+    }
+
     private static func resolveThemeForDiff(nameOrPath: String) -> C11muxTheme? {
         if nameOrPath.contains("/") || nameOrPath.hasSuffix(".toml") {
             let url = URL(fileURLWithPath: nameOrPath)
@@ -270,6 +288,6 @@ public enum ThemeSocketMethods {
             }
             return theme
         }
-        return DispatchQueue.main.sync { ThemeManager.shared.theme(named: nameOrPath) }
+        return Self.mainSync { ThemeManager.shared.theme(named: nameOrPath) }
     }
 }

--- a/tests_v2/test_v1_handler_main_self_deadlock.py
+++ b/tests_v2/test_v1_handler_main_self_deadlock.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""C11-26 followup regression: v1 socket handlers must not self-deadlock on main.
+
+Why this test exists
+--------------------
+After C11-26 (#112), the new socket dispatcher
+(`processCommandUsingSocketExecutionPolicy`) routes default-policy commands
+through
+
+    DispatchQueue.main.sync { MainActor.assumeIsolated { processCommand(...) } }
+
+from the worker thread. That moves every v1 handler — and every
+default-policy v2 handler — onto the main thread before the switch fires.
+
+About 100 v1 handlers in `TerminalController.swift` (and 12 in
+`ThemeSocketMethods.swift`) were written against the *pre*-C11-26 reality
+where `handleClient` invoked `processCommand(trimmed)` directly on the
+worker. Those handlers hop to main themselves with bare
+`DispatchQueue.main.sync { … }`. Post-C11-26 that hop is reentrant:
+libdispatch's self-deadlock guard (`__DISPATCH_WAIT_FOR_QUEUE__`) traps with
+EXC_BREAKPOINT and Apple's UI never surfaces it — the c11 window vanishes.
+
+The operator hit this 4× on 2026-05-04 (twice on a `c11 DEV main` build,
+twice on shipped 0.45.0/0.45.1). Every Sentry-native breakpad dump in
+`~/.local/state/ghostty/crash/*.ghosttycrash` bottoms out at
+`setProgress(_:) + 924` → `closure #1 in processCommand(_:) + 3856` →
+`__DISPATCH_WAIT_FOR_QUEUE__ + 484`. The earlier 14:26 IPS hang on 0.44.1
+(build 95) is the same class of bug pre-detection: same dispatch path, same
+self-wait, but on an older libdispatch that hung indefinitely instead of
+trapping.
+
+What this test asserts
+----------------------
+- Issuing a v1 `set_progress` command across 30 fresh socket connections does
+  not crash the c11 process. Pre-fix, the first call would trap and the
+  second connect would fail (`ECONNREFUSED`) because the listener was gone.
+  Post-fix, every call returns "OK" and the listener stays up.
+- A spread of other v1 commands that follow the same bare-`main.sync` shape
+  (`set_status`, `clear_status`, `report_pwd`, `clear_progress`,
+  `report_git_branch`, `clear_git_branch`) all complete cleanly. They share
+  the dispatcher path, so a regression on the dispatcher would fail any of
+  them; covering several anchors the fix instead of testing one anchor only.
+
+What this test does NOT do
+--------------------------
+- It does not grep `Sources/TerminalController.swift` for `v2MainSync` or
+  any other implementation token (per c11 CLAUDE.md "Test quality policy" —
+  tests verify observable runtime behavior, not implementation shape).
+- It does not assert on Sentry/breakpad files directly. Whether a regression
+  produces a crash dump or just a hang depends on macOS/libdispatch version;
+  the contract this test enforces is "the call returns OK and the next
+  connection succeeds", which catches both shapes.
+
+How to run
+----------
+This test runs against a tagged debug build of c11. Per c11 CLAUDE.md
+"Testing policy", do NOT `open` an untagged `c11 DEV.app` to run it — use the
+tagged build socket produced by `./scripts/reload.sh --tag <slug>`.
+
+    C11_SOCKET=/tmp/c11-debug-<slug>.sock python3 \\
+        tests_v2/test_v1_handler_main_self_deadlock.py
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+from typing import List
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = (
+    os.environ.get("C11_SOCKET")
+    or os.environ.get("CMUX_SOCKET")
+    or "/tmp/cmux-debug.sock"
+)
+
+# Wall-clock budget per call. The handler does a tiny main-actor write; even
+# under CI variance this should complete well under a second. Pre-fix the
+# call traps inside libdispatch so the socket either drops or hangs.
+PER_CALL_DEADLINE_SECONDS = 2.0
+
+# Repeat count for the focused set_progress probe. The first call is the one
+# that traps pre-fix; we repeat to catch any flakier intermediate state
+# (e.g. accidentally fixed by a stale main-actor pump).
+SET_PROGRESS_REPEAT = 30
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _send_v1(command: str, *, deadline_s: float = PER_CALL_DEADLINE_SECONDS) -> str:
+    """Send one v1 line, return the trimmed response.
+
+    Each call uses a fresh connection, mirroring how the production CLI talks
+    to the daemon. That also means a regression that kills the listener will
+    surface as `ConnectionRefusedError` on the *next* call, which the caller
+    converts into a clear failure message.
+    """
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+        sock.settimeout(deadline_s)
+        sock.connect(SOCKET_PATH)
+        sock.sendall((command + "\n").encode("utf-8"))
+        chunks: List[bytes] = []
+        while True:
+            try:
+                chunk = sock.recv(4096)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+            sock.settimeout(0.1)
+    return b"".join(chunks).decode("utf-8", errors="replace").strip()
+
+
+def _new_workspace(client: cmux) -> str:
+    created = client._call("workspace.create", {}) or {}
+    ws_id = str(created.get("workspace_id") or "")
+    _must(bool(ws_id), f"workspace.create returned no workspace_id: {created}")
+    return ws_id
+
+
+def test_set_progress_does_not_self_deadlock(socket_path: str) -> None:
+    """Repeated v1 set_progress on a fresh workspace returns OK every time.
+
+    This is the focused signature: setProgress's bare DispatchQueue.main.sync
+    is what fired in production today. If the dispatcher path were still
+    self-deadlocking, the first call would trap; after the trap, the listener
+    is gone and the *second* connect raises ConnectionRefusedError.
+    """
+    with cmux(socket_path) as client:
+        ws_id = _new_workspace(client)
+    try:
+        for i in range(SET_PROGRESS_REPEAT):
+            value = round(0.01 + 0.03 * i, 4)  # 0.01..~0.88, all valid
+            start = time.monotonic()
+            try:
+                resp = _send_v1(f"set_progress {value} --label=c11_26 --tab={ws_id}")
+            except (ConnectionRefusedError, OSError) as e:
+                raise cmuxError(
+                    f"set_progress iteration {i} could not reach socket "
+                    f"({e!r}) — listener likely crashed (EXC_BREAKPOINT regression)"
+                )
+            elapsed = time.monotonic() - start
+            _must(
+                resp.startswith("OK"),
+                f"set_progress iteration {i} returned {resp!r}",
+            )
+            _must(
+                elapsed < PER_CALL_DEADLINE_SECONDS,
+                f"set_progress iteration {i} took {elapsed:.2f}s "
+                f"(deadline {PER_CALL_DEADLINE_SECONDS}s) — possible deadlock regression",
+            )
+        print(
+            f"PASS: test_set_progress_does_not_self_deadlock "
+            f"(iterations={SET_PROGRESS_REPEAT})"
+        )
+    finally:
+        with cmux(socket_path) as cleanup:
+            try:
+                cleanup.close_workspace(ws_id)
+            except Exception:
+                pass
+
+
+def test_v1_main_sync_handlers_return_ok(socket_path: str) -> None:
+    """A spread of v1 handlers that share the bare-main.sync shape all return OK.
+
+    Each one routes through processCommand → switch case → bare main.sync
+    (pre-fix). Hitting them in sequence on a single fresh workspace checks
+    the dispatcher path is healthy across more than just setProgress, so a
+    future regression cannot regress a sibling without this catching it.
+    """
+    with cmux(socket_path) as client:
+        ws_id = _new_workspace(client)
+
+    # `command` is the full v1 line; `predicate` decides what counts as success.
+    # Most return "OK"; a few return data lines whose mere presence proves the
+    # handler completed without trapping.
+    probes = [
+        ("set_progress 0.42 --label=probe --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("clear_progress --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("set_status probe-key probe-value --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("clear_status probe-key --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("report_pwd /tmp --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("report_git_branch main --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("clear_git_branch --tab=" + ws_id, lambda r: r.startswith("OK")),
+    ]
+
+    try:
+        for cmd, ok in probes:
+            try:
+                resp = _send_v1(cmd)
+            except (ConnectionRefusedError, OSError) as e:
+                raise cmuxError(
+                    f"{cmd!r} could not reach socket ({e!r}) — listener likely crashed"
+                )
+            _must(ok(resp), f"{cmd!r} returned unexpected response: {resp!r}")
+        print(
+            f"PASS: test_v1_main_sync_handlers_return_ok "
+            f"(probes={len(probes)})"
+        )
+    finally:
+        with cmux(socket_path) as cleanup:
+            try:
+                cleanup.close_workspace(ws_id)
+            except Exception:
+                pass
+
+
+def main() -> int:
+    if not SOCKET_PATH or not os.path.exists(SOCKET_PATH):
+        print(
+            f"SKIP: socket not found at {SOCKET_PATH!r}. "
+            f"Set C11_SOCKET to a tagged build's socket "
+            f"(e.g. /tmp/c11-debug-<slug>.sock).",
+            file=sys.stderr,
+        )
+        return 0
+
+    failures: List[str] = []
+    for fn in (
+        test_set_progress_does_not_self_deadlock,
+        test_v1_main_sync_handlers_return_ok,
+    ):
+        try:
+            fn(SOCKET_PATH)
+        except Exception as e:
+            failures.append(f"{fn.__name__}: {e}")
+            print(f"FAIL: {fn.__name__}: {e}", file=sys.stderr)
+
+    if failures:
+        print(f"\n{len(failures)} test(s) failed", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

After C11-26 (#112), the new socket dispatcher routes default-policy commands through `DispatchQueue.main.sync { MainActor.assumeIsolated { processCommand(...) } }` from the worker thread. That's a behavior change vs. pre-C11-26, where `handleClient` called `processCommand(trimmed)` directly on the worker. About 100 v1 handlers in `TerminalController.swift` (and 12 in `ThemeSocketMethods.swift`) were written for the old assumption — each does its own `DispatchQueue.main.sync { … }` to hop to main. Post-C11-26 that hop is reentrant: libdispatch's self-deadlock guard (`__DISPATCH_WAIT_FOR_QUEUE__`) traps with EXC_BREAKPOINT and the c11 window vanishes silently (Apple's UI never sees it; only the Sentry-native breakpad in `~/.local/state/ghostty/crash/` records it).

Operator hit this **4× on 2026-05-04** on builds 95 / 96 / 97. Every dump bottoms out at:

```
__DISPATCH_WAIT_FOR_QUEUE__ + 484                        ← EXC_BREAKPOINT
_dispatch_sync_f_slow + 148
TerminalController.setProgress(_:) + 924                  ← bare DispatchQueue.main.sync
closure #1 in TerminalController.processCommand(_:) + 3856
specialized TerminalController.withSocketCommandPolicy<A>… + 352
TerminalController.processCommand(_:) + 556
…closure #2 in TerminalController.processCommandUsingSocketExecutionPolicy(_:)
specialized static MainActor.assumeIsolated<A>(_:file:line:) + 128
…libdispatch _dispatch_main_queue_drain (← that's main running the dispatcher's sync block)
main + 64
```

The earlier 14:26 IPS hang on 0.44.1 is the same class of bug pre-detection — same dispatch path, same self-wait, but on an older libdispatch that hung indefinitely instead of trapping (1673 s unresponsive before macOS sampled it).

## Fix

Replace the bare `DispatchQueue.main.sync { … }` calls in socket handlers with the existing `v2MainSync` helper (which short-circuits when already on main), and add a parallel `Self.mainSync` to `ThemeSocketMethods`. Both helpers run inline if the caller is already on main and only hop when called from a worker — so the same handler is correct under either dispatcher path. `ThemeSocketMethods` is not `@MainActor`, so its helper takes a `@MainActor () -> T` body and uses `MainActor.assumeIsolated`, mirroring `GhosttyTerminalView.performOnMain`.

The two intentional bare-`DispatchQueue.main.sync` sites are kept:
- `TerminalController.swift:1734` (the dispatcher itself, which must hop from worker)
- `TerminalController.swift:3366` (inside `v2MainSync`'s own implementation)

Other call sites already gate on `Thread.isMainThread` and are unaffected (`TabManager.swift:586` lives on a CVDisplayLink thread; `Workspace.swift:5656` and `GhosttyTerminalView.swift:1891` already short-circuit).

The dispatcher MARK comment in `TerminalController.swift` (formerly claimed the legacy v2MainSync path was "unchanged") is rewritten to call out the behavior change and the rule for new handlers.

## Files changed

- `Sources/TerminalController.swift` — 99 handler call sites swapped to `v2MainSync`; dispatcher comment updated.
- `Sources/Theme/ThemeSocketMethods.swift` — 12 sites swapped to `Self.mainSync`; helper added with `@MainActor` body + `MainActor.assumeIsolated`.
- `tests_v2/test_v1_handler_main_self_deadlock.py` — new regression test (see below).

## Test plan

- [x] `xcodebuild -scheme c11-unit -configuration Debug build` — succeeds, only pre-existing Swift 6 mode warnings remain (no errors).
- [x] Tagged build via `./scripts/reload.sh --tag c11-26-followup` launches and stays up for the duration of the test run with no entries added to `~/.local/state/ghostty/crash/`.
- [x] `C11_SOCKET=/tmp/c11-debug-c11-26-followup.sock python3 tests_v2/test_v1_handler_main_self_deadlock.py` — both scenarios pass:
  - 30 successive `set_progress` calls, each on a fresh socket, all return `OK`.
  - Spread of 7 v1 handlers (`set_progress`, `clear_progress`, `set_status`, `clear_status`, `report_pwd`, `report_git_branch`, `clear_git_branch`) all return `OK`.
- [x] `C11_SOCKET=/tmp/c11-debug-c11-26-followup.sock python3 tests_v2/test_v2_surface_send_text_no_main_hang.py` — sibling C11-26 regression test still passes (didn't break the original fix).
- [ ] CI: full `tests-v2` and unit suites green.

## Reviewer notes

- The fix is mechanical: 99+12 sed-style swaps. The interesting code is the `Self.mainSync` helper in `ThemeSocketMethods.swift` and the dispatcher comment rewrite. Worth eyeballing those two.
- v2 handlers that already used `v2MainSync` are unchanged. They were always correct under both pre- and post-C11-26 dispatcher paths.
- Open question for follow-up (not in this PR): `v2MainSync` is now used universally for v1 + v2 handlers. The `v2` prefix is misleading. A rename to e.g. `mainSyncSafe` or `withMainActor` would be a clean follow-up, but is invasive across the file and unrelated to the bug fix.

## Crash artifact references

- IPS hang: `/Library/Logs/DiagnosticReports/c11_2026-05-04-142637_Hyperion.hang` (0.44.1)
- Sentry-native breakpad dumps (4× today): `~/.local/state/ghostty/crash/{1dfa4f9f,a8e787d8,1a72b541,ac76b2c0}-*.ghosttycrash`
- LaunchSentinel unclean-exit markers: `~/Library/Caches/com.stage11.c11/sessions/unclean-exit-2026-05-04T*.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)