### PR TITLE
C11-6: App Chrome UI Scale (sidebar + tab strip + title bar)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 			C116000300A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */; };
 			C116000500A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */; };
 			C116000700A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */; };
+			C116000900A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -568,6 +569,7 @@
 			C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleSettingsTests.swift; sourceTree = "<group>"; };
 			C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleTokensTests.swift; sourceTree = "<group>"; };
 			C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleObserverTests.swift; sourceTree = "<group>"; };
+			C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyChromeScaleTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -930,6 +932,7 @@
 					C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */,
 					C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */,
 					C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */,
+					C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */,
 					D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */,
 					D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */,
 					D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */,
@@ -1309,6 +1312,7 @@
 					C116000300A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift in Sources */,
 					C116000500A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift in Sources */,
 					C116000700A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift in Sources */,
+					C116000900A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift in Sources */,
 					D7016BF0A1B2C3D4E5F60718 /* TCCPrimerTests.swift in Sources */,
 					D7101BF0A1B2C3D4E5F60718 /* MailboxLayoutTests.swift in Sources */,
 					D7104BF0A1B2C3D4E5F60718 /* MailboxIOTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -259,6 +259,10 @@
 				D7203BF0A1B2C3D4E5F60719 /* MailboxULID.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7103BF1A1B2C3D4E5F60718 /* MailboxULID.swift */; };
 				D7206BF0A1B2C3D4E5F60719 /* MailboxEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7106BF1A1B2C3D4E5F60718 /* MailboxEnvelope.swift */; };
 				D7113BF0A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7113BF1A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift */; };
+			C116000100A1B2C3D4E5F010 /* ChromeScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000200A1B2C3D4E5F010 /* ChromeScale.swift */; };
+			C116000300A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */; };
+			C116000500A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */; };
+			C116000700A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -560,6 +564,10 @@
 			D7111BF1A1B2C3D4E5F60718 /* StdinMailboxHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/StdinMailboxHandler.swift; sourceTree = "<group>"; };
 			D7112BF1A1B2C3D4E5F60718 /* StdinHandlerFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdinHandlerFormattingTests.swift; sourceTree = "<group>"; };
 			D7113BF1A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxDispatcherGCTests.swift; sourceTree = "<group>"; };
+			C116000200A1B2C3D4E5F010 /* ChromeScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chrome/ChromeScale.swift; sourceTree = "<group>"; };
+			C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleSettingsTests.swift; sourceTree = "<group>"; };
+			C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleTokensTests.swift; sourceTree = "<group>"; };
+			C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleObserverTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -733,6 +741,7 @@
 				A5F1002001A1B2C3D4E5F123 /* ThemeCanonicalizer.swift */,
 				A5F1002001A1B2C3D4E5F124 /* ThemeSocketMethods.swift */,
 				A5F1002001A1B2C3D4E5F125 /* ThemeBindingControls.swift */,
+				C116000200A1B2C3D4E5F010 /* ChromeScale.swift */,
 				D7100BF1A1B2C3D4E5F60718 /* MailboxLayout.swift */,
 				D7102BF1A1B2C3D4E5F60718 /* MailboxIO.swift */,
 				D7103BF1A1B2C3D4E5F60718 /* MailboxULID.swift */,
@@ -918,6 +927,9 @@
 					D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */,
 					D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */,
 					D7015BF1A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift */,
+					C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */,
+					C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */,
+					C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */,
 					D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */,
 					D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */,
 					D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */,
@@ -1147,6 +1159,7 @@
 			A5F1001001A1B2C3D4E5F123 /* ThemeCanonicalizer.swift in Sources */,
 			A5F1001001A1B2C3D4E5F124 /* ThemeSocketMethods.swift in Sources */,
 			A5F1001001A1B2C3D4E5F125 /* ThemeBindingControls.swift in Sources */,
+			C116000100A1B2C3D4E5F010 /* ChromeScale.swift in Sources */,
 			D7100BF0A1B2C3D4E5F60718 /* MailboxLayout.swift in Sources */,
 			D7102BF0A1B2C3D4E5F60718 /* MailboxIO.swift in Sources */,
 			D7103BF0A1B2C3D4E5F60718 /* MailboxULID.swift in Sources */,
@@ -1293,6 +1306,9 @@
 					D7011BF0A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift in Sources */,
 					D7012BF0A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift in Sources */,
 					D7015BF0A1B2C3D4E5F60718 /* DefaultGridSettingsTests.swift in Sources */,
+					C116000300A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift in Sources */,
+					C116000500A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift in Sources */,
+					C116000700A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift in Sources */,
 					D7016BF0A1B2C3D4E5F60718 /* TCCPrimerTests.swift in Sources */,
 					D7101BF0A1B2C3D4E5F60718 /* MailboxLayoutTests.swift in Sources */,
 					D7104BF0A1B2C3D4E5F60718 /* MailboxIOTests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53343,6 +53343,83 @@
           }
         }
       }
+    },
+    "settings.chromeScale.preset.compact": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compact"
+          }
+        }
+      }
+    },
+    "settings.chromeScale.preset.standard": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default"
+          }
+        }
+      }
+    },
+    "settings.chromeScale.preset.large": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Large"
+          }
+        }
+      }
+    },
+    "settings.chromeScale.preset.extraLarge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extra Large"
+          }
+        }
+      }
+    },
+    "settings.chromeScale.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scale c11 sidebar text and surface tab strip without changing terminal font size."
+          }
+        }
+      }
+    },
+    "settings.chromeScale.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Chrome UI Scale"
+          }
+        }
+      }
+    },
+    "settings.section.chromeScale": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "App Chrome UI Scale"
+          }
+        }
+      }
     }
   }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53352,6 +53352,42 @@
             "state": "translated",
             "value": "Compact"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コンパクト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "紧凑"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "緊湊"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "컴팩트"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Компактный"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Компактний"
+          }
         }
       }
     },
@@ -53362,6 +53398,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "За замовчуванням"
           }
         }
       }
@@ -53374,6 +53446,42 @@
             "state": "translated",
             "value": "Large"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "大"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "크게"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Большой"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Великий"
+          }
         }
       }
     },
@@ -53384,6 +53492,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Extra Large"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特大"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特大"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "特大"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "매우 크게"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очень большой"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дуже великий"
           }
         }
       }
@@ -53396,6 +53540,42 @@
             "state": "translated",
             "value": "Scale c11 sidebar text and surface tab strip without changing terminal font size."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのフォントサイズを変更せずに、c11サイドバーのテキストとサーフェスのタブストリップをスケーリングします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在不更改终端字体大小的情况下,缩放 c11 侧边栏文本和 surface 标签栏。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在不更改終端字型大小的情況下,縮放 c11 側邊欄文字和 surface 標籤列。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 글꼴 크기를 변경하지 않고 c11 사이드바 텍스트와 surface 탭 스트립을 스케일링합니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштабирует текст боковой панели c11 и полосу вкладок surface без изменения размера шрифта терминала."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштабує текст бічної панелі c11 та смугу вкладок surface без зміни розміру шрифту терміналу."
+          }
         }
       }
     },
@@ -53407,6 +53587,42 @@
             "state": "translated",
             "value": "App Chrome UI Scale"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリクロームUIスケール"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用 Chrome UI 缩放"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "應用 Chrome UI 縮放"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 크롬 UI 스케일"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб UI хрома приложения"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб UI хрому застосунку"
+          }
         }
       }
     },
@@ -53417,6 +53633,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "App Chrome UI Scale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリクロームUIスケール"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用 Chrome UI 缩放"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "應用 Chrome UI 縮放"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱 크롬 UI 스케일"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб UI хрома приложения"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Масштаб UI хрому застосунку"
           }
         }
       }

--- a/Sources/AgentChipBadge.swift
+++ b/Sources/AgentChipBadge.swift
@@ -20,8 +20,8 @@ struct AgentChipBadge: View {
         if let chip {
             HStack(spacing: 4) {
                 iconView(for: chip)
-                    .frame(width: chromeTokens.sidebarWorkspaceDetail * 1.4,
-                           height: chromeTokens.sidebarWorkspaceDetail * 1.4)
+                    .frame(width: chromeTokens.sidebarWorkspaceDetail * 1.5,
+                           height: chromeTokens.sidebarWorkspaceDetail * 1.5)
                 if showsLabel, let label = chip.displayLabel, !label.isEmpty {
                     Text(label)
                         .font(.system(size: chromeTokens.sidebarWorkspaceDetail, weight: .medium))
@@ -49,7 +49,7 @@ struct AgentChipBadge: View {
                 .foregroundColor(foreground)
         } else {
             Image(systemName: sfFallback)
-                .font(.system(size: chromeTokens.sidebarWorkspaceDetail * 1.1, weight: .medium))
+                .font(.system(size: chromeTokens.sidebarWorkspaceDetail * 1.2, weight: .medium))
                 .foregroundColor(foreground)
         }
     }

--- a/Sources/AgentChipBadge.swift
+++ b/Sources/AgentChipBadge.swift
@@ -14,14 +14,17 @@ struct AgentChipBadge: View {
     let foreground: Color
     let secondary: Color
 
+    @Environment(\.chromeScaleTokens) private var chromeTokens
+
     var body: some View {
         if let chip {
             HStack(spacing: 4) {
                 iconView(for: chip)
-                    .frame(width: 14, height: 14)
+                    .frame(width: chromeTokens.sidebarWorkspaceDetail * 1.4,
+                           height: chromeTokens.sidebarWorkspaceDetail * 1.4)
                 if showsLabel, let label = chip.displayLabel, !label.isEmpty {
                     Text(label)
-                        .font(.system(size: 10, weight: .medium))
+                        .font(.system(size: chromeTokens.sidebarWorkspaceDetail, weight: .medium))
                         .foregroundColor(secondary)
                         .lineLimit(1)
                         .fixedSize(horizontal: true, vertical: false)
@@ -46,7 +49,7 @@ struct AgentChipBadge: View {
                 .foregroundColor(foreground)
         } else {
             Image(systemName: sfFallback)
-                .font(.system(size: 11, weight: .medium))
+                .font(.system(size: chromeTokens.sidebarWorkspaceDetail * 1.1, weight: .medium))
                 .foregroundColor(foreground)
         }
     }

--- a/Sources/Chrome/ChromeScale.swift
+++ b/Sources/Chrome/ChromeScale.swift
@@ -12,9 +12,16 @@ import SwiftUI
 /// resolver stays parameter-pure for non-SwiftUI consumers.
 enum ChromeScaleSettings {
     static let presetKey = "chromeScalePreset"
+    static let customMultiplierKey = "chromeScaleCustomMultiplier"
+
+    /// Bounds for the Custom slider. Outside this range layout starts to
+    /// distort (subpixel hairlines below ~0.5; tabs overflow above ~3.0), so
+    /// we clamp on read regardless of what UserDefaults contains.
+    static let customMultiplierRange: ClosedRange<CGFloat> = 0.50...3.00
+    static let defaultCustomMultiplier: CGFloat = 1.00
 
     enum Preset: String, CaseIterable, Identifiable {
-        case compact, standard, large, extraLarge
+        case compact, standard, large, extraLarge, custom
         var id: String { rawValue }
 
         /// Localized display name for the Settings picker.
@@ -40,6 +47,11 @@ enum ChromeScaleSettings {
                     localized: "settings.chromeScale.preset.extraLarge",
                     defaultValue: "Extra Large"
                 )
+            case .custom:
+                return String(
+                    localized: "settings.chromeScale.preset.custom",
+                    defaultValue: "Custom"
+                )
             }
         }
     }
@@ -55,13 +67,50 @@ enum ChromeScaleSettings {
         preset(for: defaults.string(forKey: presetKey))
     }
 
+    /// Built-in multiplier for the four fixed presets. `.custom` returns
+    /// `defaultCustomMultiplier` here — call `multiplier(preset:defaults:)`
+    /// when you need to honor the persisted custom slider value.
     static func multiplier(for preset: Preset) -> CGFloat {
         switch preset {
-        case .compact:    return 0.90
+        case .compact:    return 0.85
         case .standard:   return 1.00
-        case .large:      return 1.12
-        case .extraLarge: return 1.25
+        case .large:      return 1.25
+        case .extraLarge: return 1.55
+        case .custom:     return defaultCustomMultiplier
         }
+    }
+
+    /// Resolves the live multiplier including the Custom slider value when
+    /// preset == `.custom`. Reads `customMultiplierKey` from `defaults` and
+    /// clamps to `customMultiplierRange`.
+    static func multiplier(preset: Preset, defaults: UserDefaults) -> CGFloat {
+        guard preset == .custom else { return multiplier(for: preset) }
+        return clampedCustomMultiplier(from: defaults)
+    }
+
+    /// Reads + clamps the persisted Custom multiplier. If the key is absent or
+    /// stored as 0 (UserDefaults' default for missing Double keys), falls back
+    /// to `defaultCustomMultiplier` rather than collapsing to zero.
+    static func clampedCustomMultiplier(from defaults: UserDefaults) -> CGFloat {
+        let raw = defaults.object(forKey: customMultiplierKey) as? Double
+        return clampCustomMultiplier(raw ?? Double(defaultCustomMultiplier))
+    }
+
+    /// Clamp a raw Double into the custom-multiplier range. Treats 0 as "no
+    /// value persisted yet" and substitutes the default.
+    static func clampCustomMultiplier(_ raw: Double) -> CGFloat {
+        let value = CGFloat(raw == 0 ? Double(defaultCustomMultiplier) : raw)
+        return min(customMultiplierRange.upperBound,
+                   max(customMultiplierRange.lowerBound, value))
+    }
+
+    /// SwiftUI helper. Resolves the live multiplier from raw `@AppStorage`
+    /// values, so reading both bindings in `body` establishes the dependency
+    /// without touching `UserDefaults` directly inside the view.
+    static func multiplier(presetRaw: String, customMultiplier: Double) -> CGFloat {
+        let preset = preset(for: presetRaw)
+        guard preset == .custom else { return multiplier(for: preset) }
+        return clampCustomMultiplier(customMultiplier)
     }
 
     /// Belt-and-suspenders notification for any future non-Workspace listener.
@@ -92,7 +141,8 @@ struct ChromeScaleTokens: Equatable {
     // MARK: Surface tab strip tokens (Bonsplit Appearance values)
 
     var surfaceTabTitle: CGFloat                  { 11.0 * multiplier }
-    var surfaceTabIcon: CGFloat                   { 14.0 * multiplier }
+    /// Bumped from 14 → 15 base so tab icons are easier to press at every preset.
+    var surfaceTabIcon: CGFloat                   { 15.0 * multiplier }
     var surfaceTabBarHeight: CGFloat              { 30.0 * multiplier }
     var surfaceTabItemHeight: CGFloat             { 30.0 * multiplier }
     var surfaceTabHorizontalPadding: CGFloat      {  6.0 * multiplier }
@@ -102,10 +152,19 @@ struct ChromeScaleTokens: Equatable {
     var surfaceTabContentSpacing: CGFloat         {  6.0 * multiplier }
     var surfaceTabDirtyIndicatorSize: CGFloat     {  8.0 * multiplier }
     var surfaceTabNotificationBadgeSize: CGFloat  {  6.0 * multiplier }
-    /// Floor at 2pt so the selected-tab underbar stays visible at 0.66× and below
-    /// in the future Custom-multiplier follow-up. At ship presets (0.90×–1.25×)
-    /// the floor is inert (2.7–3.75).
+    /// Floor at 2pt so the selected-tab underbar stays visible at very small
+    /// Custom multipliers. At ship presets (0.85×–1.55×) the floor is inert.
     var surfaceTabActiveIndicatorHeight: CGFloat  { max(2.0, 3.0 * multiplier) }
+
+    // MARK: Split toolbar tokens (Bonsplit Appearance)
+
+    /// SF Symbol point size inside each trailing-edge split-toolbar button
+    /// (agent A, terminal, browser globe, markdown doc, splits, plus, close).
+    var splitToolbarButtonIcon: CGFloat   { 12.0 * multiplier }
+    /// Square frame side length for each split-toolbar button (hover + click target).
+    var splitToolbarButtonFrame: CGFloat  { 22.0 * multiplier }
+    /// Vertical separator height between toolbar groups.
+    var splitToolbarSeparatorHeight: CGFloat { 18.0 * multiplier }
 
     // MARK: Surface title bar tokens
 
@@ -115,10 +174,9 @@ struct ChromeScaleTokens: Equatable {
     static let standard = ChromeScaleTokens(multiplier: 1.0)
 
     static func resolved(from defaults: UserDefaults = .standard) -> ChromeScaleTokens {
-        ChromeScaleTokens(
-            multiplier: ChromeScaleSettings.multiplier(
-                for: ChromeScaleSettings.preset(defaults: defaults)
-            )
+        let preset = ChromeScaleSettings.preset(defaults: defaults)
+        return ChromeScaleTokens(
+            multiplier: ChromeScaleSettings.multiplier(preset: preset, defaults: defaults)
         )
     }
 }
@@ -146,20 +204,30 @@ extension EnvironmentValues {
 /// KVO callbacks fire on the writer's thread; the observer hops to the main
 /// actor before invoking the callback so the callback can mutate
 /// `BonsplitController.configuration` and other main-actor state safely.
+///
+/// Observes both `presetKey` and `customMultiplierKey` so the live-update path
+/// fires whether the user picks a preset or drags the Custom slider.
 final class ChromeScaleObserver: NSObject {
     private let onChange: () -> Void
-    private static let keyPath = ChromeScaleSettings.presetKey
+    private static let observedKeys = [
+        ChromeScaleSettings.presetKey,
+        ChromeScaleSettings.customMultiplierKey,
+    ]
     private let defaults: UserDefaults
 
     init(defaults: UserDefaults = .standard, onChange: @escaping () -> Void) {
         self.defaults = defaults
         self.onChange = onChange
         super.init()
-        defaults.addObserver(self, forKeyPath: Self.keyPath, options: [.new], context: nil)
+        for key in Self.observedKeys {
+            defaults.addObserver(self, forKeyPath: key, options: [.new], context: nil)
+        }
     }
 
     deinit {
-        defaults.removeObserver(self, forKeyPath: Self.keyPath)
+        for key in Self.observedKeys {
+            defaults.removeObserver(self, forKeyPath: key)
+        }
     }
 
     override func observeValue(
@@ -168,7 +236,7 @@ final class ChromeScaleObserver: NSObject {
         change: [NSKeyValueChangeKey: Any]?,
         context: UnsafeMutableRawPointer?
     ) {
-        guard keyPath == Self.keyPath else { return }
+        guard let keyPath, Self.observedKeys.contains(keyPath) else { return }
         let onChange = self.onChange
         Task { @MainActor in onChange() }
     }

--- a/Sources/Chrome/ChromeScale.swift
+++ b/Sources/Chrome/ChromeScale.swift
@@ -1,0 +1,175 @@
+import Foundation
+import SwiftUI
+
+// MARK: - ChromeScaleSettings
+
+/// Persisted "App Chrome UI Scale" preset (C11-6). Scales c11-owned chrome —
+/// sidebar workspace card text and the surface tab strip — without changing
+/// Ghostty terminal cells or web/markdown content.
+///
+/// Mirrors the `WorkspacePresentationModeSettings` shape (key + Mode enum +
+/// `mode(for:)` + `mode(defaults:)`) so the codebase looks coherent and the
+/// resolver stays parameter-pure for non-SwiftUI consumers.
+enum ChromeScaleSettings {
+    static let presetKey = "chromeScalePreset"
+
+    enum Preset: String, CaseIterable, Identifiable {
+        case compact, standard, large, extraLarge
+        var id: String { rawValue }
+
+        /// Localized display name for the Settings picker.
+        var displayName: String {
+            switch self {
+            case .compact:
+                return String(
+                    localized: "settings.chromeScale.preset.compact",
+                    defaultValue: "Compact"
+                )
+            case .standard:
+                return String(
+                    localized: "settings.chromeScale.preset.standard",
+                    defaultValue: "Default"
+                )
+            case .large:
+                return String(
+                    localized: "settings.chromeScale.preset.large",
+                    defaultValue: "Large"
+                )
+            case .extraLarge:
+                return String(
+                    localized: "settings.chromeScale.preset.extraLarge",
+                    defaultValue: "Extra Large"
+                )
+            }
+        }
+    }
+
+    static let defaultPreset: Preset = .standard
+
+    static func preset(for rawValue: String?) -> Preset {
+        Preset(rawValue: rawValue ?? "") ?? defaultPreset
+    }
+
+    /// Parameter-seam overload for non-SwiftUI consumers (e.g. `Workspace.bonsplitAppearance(...)`).
+    static func preset(defaults: UserDefaults) -> Preset {
+        preset(for: defaults.string(forKey: presetKey))
+    }
+
+    static func multiplier(for preset: Preset) -> CGFloat {
+        switch preset {
+        case .compact:    return 0.90
+        case .standard:   return 1.00
+        case .large:      return 1.12
+        case .extraLarge: return 1.25
+        }
+    }
+
+    /// Belt-and-suspenders notification for any future non-Workspace listener.
+    /// Workspace observes UserDefaults via KVO (`ChromeScaleObserver`), so this
+    /// notification is NOT load-bearing for the live-update path.
+    static let didChangeNotification = Notification.Name("com.stage11.c11.chromeScaleDidChange")
+}
+
+// MARK: - ChromeScaleTokens
+
+/// Single-stored-property + computed-tokens design. The synthesized `Equatable`
+/// reduces to a `multiplier` compare so this type can sit inside `TabItemView`'s
+/// `==` (typing-latency hot path) without growing the comparison surface. If you
+/// add stored properties, audit that hot path before merging.
+struct ChromeScaleTokens: Equatable {
+    let multiplier: CGFloat
+
+    // MARK: Sidebar tokens
+
+    var sidebarWorkspaceTitle: CGFloat         { 12.5 * multiplier }
+    var sidebarWorkspaceDetail: CGFloat        { 10.0 * multiplier }
+    var sidebarWorkspaceMetadata: CGFloat      { 10.0 * multiplier }
+    var sidebarWorkspaceAccessory: CGFloat     {  9.0 * multiplier }
+    var sidebarWorkspaceProgressLabel: CGFloat {  9.0 * multiplier }
+    var sidebarWorkspaceLogIcon: CGFloat       {  8.0 * multiplier }
+    var sidebarWorkspaceBranchDot: CGFloat     {  3.0 * multiplier }
+
+    // MARK: Surface tab strip tokens (Bonsplit Appearance values)
+
+    var surfaceTabTitle: CGFloat                  { 11.0 * multiplier }
+    var surfaceTabIcon: CGFloat                   { 14.0 * multiplier }
+    var surfaceTabBarHeight: CGFloat              { 30.0 * multiplier }
+    var surfaceTabItemHeight: CGFloat             { 30.0 * multiplier }
+    var surfaceTabHorizontalPadding: CGFloat      {  6.0 * multiplier }
+    var surfaceTabMinWidth: CGFloat               { 112.0 * multiplier }
+    var surfaceTabMaxWidth: CGFloat               { 220.0 * multiplier }
+    var surfaceTabCloseIconSize: CGFloat          {  9.0 * multiplier }
+    var surfaceTabContentSpacing: CGFloat         {  6.0 * multiplier }
+    var surfaceTabDirtyIndicatorSize: CGFloat     {  8.0 * multiplier }
+    var surfaceTabNotificationBadgeSize: CGFloat  {  6.0 * multiplier }
+    /// Floor at 2pt so the selected-tab underbar stays visible at 0.66× and below
+    /// in the future Custom-multiplier follow-up. At ship presets (0.90×–1.25×)
+    /// the floor is inert (2.7–3.75).
+    var surfaceTabActiveIndicatorHeight: CGFloat  { max(2.0, 3.0 * multiplier) }
+
+    // MARK: Surface title bar tokens
+
+    var surfaceTitleBarTitle: CGFloat     { 12.0 * multiplier }
+    var surfaceTitleBarAccessory: CGFloat { 10.0 * multiplier }
+
+    static let standard = ChromeScaleTokens(multiplier: 1.0)
+
+    static func resolved(from defaults: UserDefaults = .standard) -> ChromeScaleTokens {
+        ChromeScaleTokens(
+            multiplier: ChromeScaleSettings.multiplier(
+                for: ChromeScaleSettings.preset(defaults: defaults)
+            )
+        )
+    }
+}
+
+// MARK: - Environment
+
+extension EnvironmentValues {
+    private struct ChromeScaleTokensKey: EnvironmentKey {
+        static let defaultValue = ChromeScaleTokens.standard
+    }
+
+    var chromeScaleTokens: ChromeScaleTokens {
+        get { self[ChromeScaleTokensKey.self] }
+        set { self[ChromeScaleTokensKey.self] = newValue }
+    }
+}
+
+// MARK: - ChromeScaleObserver
+
+/// `Workspace` is `@MainActor final class … : ObservableObject` — not an
+/// `NSObject` subclass — so it can't host `UserDefaults.addObserver(...)`
+/// directly. `ChromeScaleObserver` is the small `NSObject` helper each
+/// `Workspace` holds; lifetime is tied to the Workspace via composition.
+///
+/// KVO callbacks fire on the writer's thread; the observer hops to the main
+/// actor before invoking the callback so the callback can mutate
+/// `BonsplitController.configuration` and other main-actor state safely.
+final class ChromeScaleObserver: NSObject {
+    private let onChange: () -> Void
+    private static let keyPath = ChromeScaleSettings.presetKey
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard, onChange: @escaping () -> Void) {
+        self.defaults = defaults
+        self.onChange = onChange
+        super.init()
+        defaults.addObserver(self, forKeyPath: Self.keyPath, options: [.new], context: nil)
+    }
+
+    deinit {
+        defaults.removeObserver(self, forKeyPath: Self.keyPath)
+    }
+
+    override func observeValue(
+        forKeyPath keyPath: String?,
+        of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        guard keyPath == Self.keyPath else { return }
+        let onChange = self.onChange
+        Task { @MainActor in onChange() }
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8336,6 +8336,8 @@ struct VerticalTabsSidebar: View {
     private var m1bSidebarTabItemMigrated = false
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
+    @AppStorage(ChromeScaleSettings.presetKey)
+    private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
 
     /// Space at top of sidebar for traffic light buttons
     private let trafficLightPadding: CGFloat = 28
@@ -8412,6 +8414,14 @@ struct VerticalTabsSidebar: View {
     var body: some View {
         let workspaceCount = tabManager.tabs.count
         let canCloseWorkspace = workspaceCount > 1
+        // Compute chrome-scale tokens once per parent eval. Threaded as a
+        // precomputed `let` to TabItemView so its typing-latency hot-path
+        // == comparison stays a single multiplier compare. (C11-6)
+        let chromeTokens = ChromeScaleTokens(
+            multiplier: ChromeScaleSettings.multiplier(
+                for: ChromeScaleSettings.preset(for: chromeScalePresetRaw)
+            )
+        )
 
         VStack(spacing: 0) {
             GeometryReader { proxy in
@@ -8486,7 +8496,8 @@ struct VerticalTabsSidebar: View {
                                     remoteContextMenuWorkspaceIds: remoteContextMenuTargets.map(\.id),
                                     allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
                                     allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected },
-                                    sidebarFlashToken: tab.sidebarFlashToken
+                                    sidebarFlashToken: tab.sidebarFlashToken,
+                                    chromeTokens: chromeTokens
                                 )
                                 .equatable()
                             }
@@ -10931,7 +10942,8 @@ private struct TabItemView: View, Equatable {
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
-        lhs.sidebarFlashToken == rhs.sidebarFlashToken
+        lhs.sidebarFlashToken == rhs.sidebarFlashToken &&
+        lhs.chromeTokens == rhs.chromeTokens
     }
 
     // Use plain references instead of @EnvironmentObject to avoid subscribing
@@ -10967,6 +10979,9 @@ private struct TabItemView: View, Equatable {
     /// running a single, gentle pulse in the same accent color used for
     /// other workspace affordances. Visual-only; never selects.
     let sidebarFlashToken: Int
+    /// Chrome scale tokens (sidebar+tab strip font/sizing multipliers). Value-typed
+    /// and Equatable so it folds into `==` as a single multiplier compare. (C11-6)
+    let chromeTokens: ChromeScaleTokens
     @State private var isHovering = false
     @State private var rowHeight: CGFloat = 1
     @State private var sidebarFlashOpacity: Double = 0
@@ -11152,7 +11167,7 @@ private struct TabItemView: View, Equatable {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(remoteWorkspaceSidebarText)
-                        .font(.system(size: 10, design: .monospaced))
+                        .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
                         .foregroundColor(activeSecondaryColor(0.8))
                         .lineLimit(1)
                         .truncationMode(.middle)
@@ -11160,7 +11175,7 @@ private struct TabItemView: View, Equatable {
                     Spacer(minLength: 0)
 
                     Text(remoteConnectionStatusText)
-                        .font(.system(size: 9, weight: .medium))
+                        .font(.system(size: chromeTokens.sidebarWorkspaceAccessory, weight: .medium))
                         .foregroundColor(activeSecondaryColor(0.58))
                         .lineLimit(1)
                 }
@@ -11237,7 +11252,7 @@ private struct TabItemView: View, Equatable {
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .top, spacing: 6) {
                 Text(tab.title)
-                    .font(.system(size: 12.5, weight: titleFontWeight))
+                    .font(.system(size: chromeTokens.sidebarWorkspaceTitle, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(2)
                     .truncationMode(.tail)
@@ -11250,7 +11265,7 @@ private struct TabItemView: View, Equatable {
                 HStack(spacing: 5) {
                     if tab.isPinned {
                         Image(systemName: "pin.fill")
-                            .font(.system(size: 9, weight: .semibold))
+                            .font(.system(size: chromeTokens.sidebarWorkspaceAccessory, weight: .semibold))
                             .foregroundColor(activeSecondaryColor(0.8))
                     }
 
@@ -11259,7 +11274,7 @@ private struct TabItemView: View, Equatable {
                             Circle()
                                 .fill(activeUnreadBadgeFillColor)
                             Text("\(unreadCount)")
-                                .font(.system(size: 9, weight: .semibold))
+                                .font(.system(size: chromeTokens.sidebarWorkspaceAccessory, weight: .semibold))
                                 // Badge fill is always gold (`activeUnreadBadgeFillColor`).
                                 // Use black on the gold circle whenever the tab is the
                                 // active selection in .solidFill — including custom-color
@@ -11280,7 +11295,7 @@ private struct TabItemView: View, Equatable {
                         tabManager.closeWorkspaceWithConfirmation(tab)
                     }) {
                         Image(systemName: "xmark")
-                            .font(.system(size: 9, weight: .medium))
+                            .font(.system(size: chromeTokens.sidebarWorkspaceAccessory, weight: .medium))
                             .foregroundColor(activeSecondaryColor(0.7))
                     }
                     .buttonStyle(.plain)
@@ -11293,7 +11308,7 @@ private struct TabItemView: View, Equatable {
                         Text(workspaceShortcutLabel)
                             .lineLimit(1)
                             .fixedSize(horizontal: true, vertical: false)
-                            .font(.system(size: 10, weight: .semibold, design: .rounded))
+                            .font(.system(size: chromeTokens.sidebarWorkspaceDetail, weight: .semibold, design: .rounded))
                             .monospacedDigit()
                             .foregroundColor(activePrimaryTextColor)
                             .padding(.horizontal, 6)
@@ -11325,7 +11340,7 @@ private struct TabItemView: View, Equatable {
 
             if let subtitle = effectiveSubtitle {
                 Text(subtitle)
-                    .font(.system(size: 10))
+                    .font(.system(size: chromeTokens.sidebarWorkspaceDetail))
                     .foregroundColor(activeSecondaryColor(0.8))
                     .lineLimit(2)
                     .truncationMode(.tail)
@@ -11359,10 +11374,10 @@ private struct TabItemView: View, Equatable {
             if detailVisibility.showsLog, let latestLog = tab.logEntries.last {
                 HStack(spacing: 4) {
                     Image(systemName: logLevelIcon(latestLog.level))
-                        .font(.system(size: 8))
+                        .font(.system(size: chromeTokens.sidebarWorkspaceLogIcon))
                         .foregroundColor(logLevelColor(latestLog.level, isActive: usesInvertedActiveForeground))
                     Text(latestLog.message)
-                        .font(.system(size: 10))
+                        .font(.system(size: chromeTokens.sidebarWorkspaceMetadata))
                         .foregroundColor(activeSecondaryColor(0.8))
                         .lineLimit(1)
                         .truncationMode(.tail)
@@ -11386,7 +11401,7 @@ private struct TabItemView: View, Equatable {
 
                     if let label = progress.label {
                         Text(label)
-                            .font(.system(size: 9))
+                            .font(.system(size: chromeTokens.sidebarWorkspaceProgressLabel))
                             .foregroundColor(activeSecondaryColor(0.6))
                             .lineLimit(1)
                     }
@@ -11401,7 +11416,7 @@ private struct TabItemView: View, Equatable {
                         HStack(alignment: .top, spacing: 3) {
                             if sidebarShowGitBranchIcon, branchLinesContainBranch {
                                 Image(systemName: "arrow.triangle.branch")
-                                    .font(.system(size: 9))
+                                    .font(.system(size: chromeTokens.sidebarWorkspaceAccessory))
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
                             VStack(alignment: .leading, spacing: 1) {
@@ -11409,20 +11424,20 @@ private struct TabItemView: View, Equatable {
                                     HStack(spacing: 3) {
                                         if let branch = line.branch {
                                             Text(branch)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
                                         }
                                         if line.branch != nil, line.directory != nil {
                                             Image(systemName: "circle.fill")
-                                                .font(.system(size: 3))
+                                                .font(.system(size: chromeTokens.sidebarWorkspaceBranchDot))
                                                 .foregroundColor(activeSecondaryColor(0.6))
                                                 .padding(.horizontal, 1)
                                         }
                                         if let directory = line.directory {
                                             Text(directory)
-                                                .font(.system(size: 10, design: .monospaced))
+                                                .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
                                                 .foregroundColor(activeSecondaryColor(0.75))
                                                 .lineLimit(1)
                                                 .truncationMode(.tail)
@@ -11436,11 +11451,11 @@ private struct TabItemView: View, Equatable {
                     HStack(spacing: 3) {
                         if sidebarShowGitBranchIcon, compactGitBranchSummaryText != nil {
                             Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: 9))
+                                .font(.system(size: chromeTokens.sidebarWorkspaceAccessory))
                                 .foregroundColor(activeSecondaryColor(0.6))
                         }
                         Text(dirRow)
-                            .font(.system(size: 10, design: .monospaced))
+                            .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
                             .foregroundColor(activeSecondaryColor(0.75))
                             .lineLimit(1)
                             .truncationMode(.tail)
@@ -11468,7 +11483,7 @@ private struct TabItemView: View, Equatable {
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                             }
-                            .font(.system(size: 10, weight: .semibold))
+                            .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, weight: .semibold))
                             .foregroundColor(pullRequestForegroundColor)
                         }
                         .buttonStyle(.plain)
@@ -11480,7 +11495,7 @@ private struct TabItemView: View, Equatable {
             // Ports row
             if detailVisibility.showsPorts, !tab.listeningPorts.isEmpty {
                 Text(tab.listeningPorts.map { ":\($0)" }.joined(separator: ", "))
-                    .font(.system(size: 10, design: .monospaced))
+                    .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
                     .foregroundColor(activeSecondaryColor(0.75))
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -12598,6 +12613,7 @@ private struct SidebarMetadataRows: View {
     let isActive: Bool
     let onFocus: () -> Void
 
+    @Environment(\.chromeScaleTokens) private var chromeTokens
     @State private var isExpanded: Bool = false
     private let collapsedEntryLimit = 3
 
@@ -12615,7 +12631,7 @@ private struct SidebarMetadataRows: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, weight: .semibold))
                 .foregroundColor(isActive ? activeSecondaryTextColor : .secondary.opacity(0.9))
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -12650,6 +12666,8 @@ private struct SidebarMetadataEntryRow: View {
     let isActive: Bool
     let onFocus: () -> Void
 
+    @Environment(\.chromeScaleTokens) private var chromeTokens
+
     var body: some View {
         Group {
             if let url = entry.url {
@@ -12682,8 +12700,8 @@ private struct SidebarMetadataEntryRow: View {
             Spacer(minLength: 0)
         }
         .font(entry.staleFromRestart
-            ? .system(size: 10, weight: .regular).italic()
-            : .system(size: 10, weight: .regular))
+            ? .system(size: chromeTokens.sidebarWorkspaceMetadata, weight: .regular).italic()
+            : .system(size: chromeTokens.sidebarWorkspaceMetadata, weight: .regular))
         .opacity(entry.staleFromRestart ? 0.55 : 1.0)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -12708,12 +12726,12 @@ private struct SidebarMetadataEntryRow: View {
         if iconRaw.hasPrefix("emoji:") {
             let value = String(iconRaw.dropFirst("emoji:".count))
             guard !value.isEmpty else { return nil }
-            return AnyView(Text(value).font(.system(size: 9)))
+            return AnyView(Text(value).font(.system(size: chromeTokens.sidebarWorkspaceAccessory)))
         }
         if iconRaw.hasPrefix("text:") {
             let value = String(iconRaw.dropFirst("text:".count))
             guard !value.isEmpty else { return nil }
-            return AnyView(Text(value).font(.system(size: 8, weight: .semibold)))
+            return AnyView(Text(value).font(.system(size: chromeTokens.sidebarWorkspaceLogIcon, weight: .semibold)))
         }
         let symbolName: String
         if iconRaw.hasPrefix("sf:") {
@@ -12722,7 +12740,7 @@ private struct SidebarMetadataEntryRow: View {
             symbolName = iconRaw
         }
         guard !symbolName.isEmpty else { return nil }
-        return AnyView(Image(systemName: symbolName).font(.system(size: 8, weight: .medium)))
+        return AnyView(Image(systemName: symbolName).font(.system(size: chromeTokens.sidebarWorkspaceLogIcon, weight: .medium)))
     }
 
     @ViewBuilder
@@ -12750,6 +12768,7 @@ private struct SidebarMetadataMarkdownBlocks: View {
     let isActive: Bool
     let onFocus: () -> Void
 
+    @Environment(\.chromeScaleTokens) private var chromeTokens
     @State private var isExpanded: Bool = false
     private let collapsedBlockLimit = 1
 
@@ -12771,7 +12790,7 @@ private struct SidebarMetadataMarkdownBlocks: View {
                     }
                 }
                 .buttonStyle(.plain)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, weight: .semibold))
                 .foregroundColor(isActive ? .white.opacity(0.65) : .secondary.opacity(0.9))
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -12793,6 +12812,7 @@ private struct SidebarMetadataMarkdownBlockRow: View {
     let isActive: Bool
     let onFocus: () -> Void
 
+    @Environment(\.chromeScaleTokens) private var chromeTokens
     @State private var renderedMarkdown: AttributedString?
 
     var body: some View {
@@ -12805,7 +12825,7 @@ private struct SidebarMetadataMarkdownBlockRow: View {
                     .foregroundColor(foregroundColor)
             }
         }
-        .font(.system(size: 10))
+        .font(.system(size: chromeTokens.sidebarWorkspaceMetadata))
         .multilineTextAlignment(.leading)
         .fixedSize(horizontal: false, vertical: true)
         .contentShape(Rectangle())

--- a/Sources/SurfaceTitleBarView.swift
+++ b/Sources/SurfaceTitleBarView.swift
@@ -32,6 +32,7 @@ struct SurfaceTitleBarView: View {
 
     @ObservedObject private var themeManager = ThemeManager.shared
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.chromeScaleTokens) private var chromeTokens
     @AppStorage(ThemeAppStorage.Keys.m1bSurfaceTitleBarMigrated, store: ThemeAppStorage.defaults)
     private var m1bSurfaceTitleBarMigrated = false
 
@@ -136,7 +137,7 @@ struct SurfaceTitleBarView: View {
         HStack(spacing: 6) {
             Text(state.title ?? String(localized: "titlebar.empty_title",
                                        defaultValue: "Untitled"))
-                .font(.system(size: 12, weight: .semibold))
+                .font(.system(size: chromeTokens.surfaceTitleBarTitle, weight: .semibold))
                 .foregroundColor(resolvedForegroundColor)
                 .lineLimit(effectiveCollapsed ? 1 : nil)
                 .truncationMode(.tail)
@@ -144,7 +145,7 @@ struct SurfaceTitleBarView: View {
             Spacer(minLength: 0)
             Button(action: onToggleCollapsed) {
                 Image(systemName: effectiveCollapsed ? "chevron.right" : "chevron.down")
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: chromeTokens.surfaceTitleBarAccessory, weight: .semibold))
                     .foregroundColor(resolvedSecondaryForegroundColor)
                     .frame(width: 14, height: 14)
                     .contentShape(Rectangle())

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5477,6 +5477,9 @@ final class Workspace: Identifiable, ObservableObject {
         appearance.tabDirtyIndicatorSize     = tokens.surfaceTabDirtyIndicatorSize
         appearance.tabNotificationBadgeSize  = tokens.surfaceTabNotificationBadgeSize
         appearance.tabActiveIndicatorHeight  = tokens.surfaceTabActiveIndicatorHeight
+        appearance.splitToolbarButtonIconSize  = tokens.splitToolbarButtonIcon
+        appearance.splitToolbarButtonFrameSize = tokens.splitToolbarButtonFrame
+        appearance.splitToolbarSeparatorHeight = tokens.splitToolbarSeparatorHeight
     }
 
     func setTabBarVisible(_ visible: Bool) {
@@ -5507,7 +5510,10 @@ final class Workspace: Identifiable, ObservableObject {
             current.tabContentSpacing         == next.tabContentSpacing &&
             current.tabDirtyIndicatorSize     == next.tabDirtyIndicatorSize &&
             current.tabNotificationBadgeSize  == next.tabNotificationBadgeSize &&
-            current.tabActiveIndicatorHeight  == next.tabActiveIndicatorHeight
+            current.tabActiveIndicatorHeight  == next.tabActiveIndicatorHeight &&
+            current.splitToolbarButtonIconSize  == next.splitToolbarButtonIconSize &&
+            current.splitToolbarButtonFrameSize == next.splitToolbarButtonFrameSize &&
+            current.splitToolbarSeparatorHeight == next.splitToolbarSeparatorHeight
         guard !unchanged else { return }
         var nextConfiguration = bonsplitController.configuration
         nextConfiguration.appearance = next

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5083,6 +5083,13 @@ final class Workspace: Identifiable, ObservableObject {
     /// already runs a no-op guard, so rapid changes are safe.
     let customColorDidChange = PassthroughSubject<String?, Never>()
 
+    /// KVO observer on `UserDefaults.standard.chromeScalePreset`. Keeps the
+    /// Bonsplit configuration in sync with the persisted App Chrome UI Scale
+    /// preset for any writer (Settings UI, `defaults write`, future migrations).
+    /// Workspace itself is `@MainActor final class : ObservableObject`, not an
+    /// NSObject subclass, so KVO has to live on this composed helper. (C11-6)
+    private var chromeScaleObserver: ChromeScaleObserver?
+
     /// Operator-authored workspace metadata (e.g. "description", "icon").
     /// Workspace-scoped; not to be confused with surface-scoped
     /// `SurfaceMetadataStore`. Persisted across restart via
@@ -5327,7 +5334,8 @@ final class Workspace: Identifiable, ObservableObject {
         bonsplitAppearance(
             from: config.backgroundColor,
             backgroundOpacity: config.backgroundOpacity,
-            context: nil
+            context: nil,
+            tokens: ChromeScaleTokens.resolved(from: .standard)
         )
     }
 
@@ -5382,11 +5390,12 @@ final class Workspace: Identifiable, ObservableObject {
     private static func bonsplitAppearance(
         from backgroundColor: NSColor,
         backgroundOpacity: Double,
-        context: ThemeContext?
+        context: ThemeContext?,
+        tokens: ChromeScaleTokens = .standard
     ) -> BonsplitConfiguration.Appearance {
         let divider = resolvedDividerPresentation(context: context)
         let activeIndicatorHex = resolvedActiveIndicatorHex(context: context)
-        return BonsplitConfiguration.Appearance(
+        var appearance = BonsplitConfiguration.Appearance(
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
             enableAnimations: false,
             chromeColors: .init(
@@ -5399,6 +5408,30 @@ final class Workspace: Identifiable, ObservableObject {
             ),
             dividerStyle: .init(thicknessPt: divider.thicknessPt)
         )
+        Self.applyChromeScale(tokens, to: &appearance)
+        return appearance
+    }
+
+    /// Pure helper. No `GhosttyApp.shared`, no `UserDefaults`, no
+    /// `NotificationCenter` — just in/out value-type mutation. Both the static
+    /// factory and the live-update path call this so behavior is identical and
+    /// testable in isolation. (C11-6)
+    static func applyChromeScale(
+        _ tokens: ChromeScaleTokens,
+        to appearance: inout BonsplitConfiguration.Appearance
+    ) {
+        appearance.tabBarHeight              = tokens.surfaceTabBarHeight
+        appearance.tabTitleFontSize          = tokens.surfaceTabTitle
+        appearance.tabMinWidth               = tokens.surfaceTabMinWidth
+        appearance.tabMaxWidth               = tokens.surfaceTabMaxWidth
+        appearance.tabIconSize               = tokens.surfaceTabIcon
+        appearance.tabItemHeight             = tokens.surfaceTabItemHeight
+        appearance.tabHorizontalPadding      = tokens.surfaceTabHorizontalPadding
+        appearance.tabCloseIconSize          = tokens.surfaceTabCloseIconSize
+        appearance.tabContentSpacing         = tokens.surfaceTabContentSpacing
+        appearance.tabDirtyIndicatorSize     = tokens.surfaceTabDirtyIndicatorSize
+        appearance.tabNotificationBadgeSize  = tokens.surfaceTabNotificationBadgeSize
+        appearance.tabActiveIndicatorHeight  = tokens.surfaceTabActiveIndicatorHeight
     }
 
     func setTabBarVisible(_ visible: Bool) {
@@ -5406,6 +5439,34 @@ final class Workspace: Identifiable, ObservableObject {
         var next = bonsplitController.configuration
         next.appearance.showsTabBar = visible
         bonsplitController.configuration = next
+    }
+
+    /// Live-update path for chrome-scale changes. Mirrors `applyGhosttyChrome`'s
+    /// shape: pull current appearance, mutate via the pure helper, no-op guard
+    /// across every routed knob, then assign back. Called by the KVO observer
+    /// on `UserDefaults.standard.chromeScalePreset`. (C11-6)
+    func applyChromeScale(reason: String = "unspecified") {
+        let tokens = ChromeScaleTokens.resolved(from: .standard)
+        var next = bonsplitController.configuration.appearance
+        Workspace.applyChromeScale(tokens, to: &next)
+        let current = bonsplitController.configuration.appearance
+        let unchanged =
+            current.tabBarHeight              == next.tabBarHeight &&
+            current.tabTitleFontSize          == next.tabTitleFontSize &&
+            current.tabMinWidth               == next.tabMinWidth &&
+            current.tabMaxWidth               == next.tabMaxWidth &&
+            current.tabIconSize               == next.tabIconSize &&
+            current.tabItemHeight             == next.tabItemHeight &&
+            current.tabHorizontalPadding      == next.tabHorizontalPadding &&
+            current.tabCloseIconSize          == next.tabCloseIconSize &&
+            current.tabContentSpacing         == next.tabContentSpacing &&
+            current.tabDirtyIndicatorSize     == next.tabDirtyIndicatorSize &&
+            current.tabNotificationBadgeSize  == next.tabNotificationBadgeSize &&
+            current.tabActiveIndicatorHeight  == next.tabActiveIndicatorHeight
+        guard !unchanged else { return }
+        var nextConfiguration = bonsplitController.configuration
+        nextConfiguration.appearance = next
+        bonsplitController.configuration = nextConfiguration
     }
 
     func applyGhosttyChrome(from config: GhosttyConfig, reason: String = "unspecified") {
@@ -5536,7 +5597,8 @@ final class Workspace: Identifiable, ObservableObject {
         var appearance = Self.bonsplitAppearance(
             from: GhosttyApp.shared.defaultBackgroundColor,
             backgroundOpacity: GhosttyApp.shared.defaultBackgroundOpacity,
-            context: nil
+            context: nil,
+            tokens: ChromeScaleTokens.resolved(from: .standard)
         )
         let initialChromeState = TabBarChromeSettings.state(
             for: UserDefaults.standard.string(forKey: TabBarChromeSettings.stateKey)
@@ -5560,6 +5622,15 @@ final class Workspace: Identifiable, ObservableObject {
         )
         self.bonsplitController = BonsplitController(configuration: config)
         bonsplitController.contextMenuShortcuts = Self.buildContextMenuShortcuts()
+
+        // Subscribe to UserDefaults.standard.chromeScalePreset so chrome scale
+        // changes from any writer (Settings UI, `defaults write`, future
+        // migrations) propagate to this Workspace's Bonsplit configuration.
+        // The observer is constructed AFTER bonsplitController so its callback
+        // can safely read/write `bonsplitController.configuration`. (C11-6)
+        self.chromeScaleObserver = ChromeScaleObserver { [weak self] in
+            self?.applyChromeScale(reason: "userdefaults-change")
+        }
 
         // Remove the default "Welcome" tab that bonsplit creates
         let welcomeTabIds = bonsplitController.allTabIds

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -192,6 +192,7 @@ struct cmuxApp: App {
     @AppStorage(TabBarChromeSettings.stateKey) private var tabBarChromeStateRaw = TabBarChromeState.full.rawValue
     @AppStorage(KeyboardShortcutSettings.Action.toggleTabBarChrome.defaultsKey) private var toggleTabBarChromeShortcutData = Data()
     @AppStorage(ChromeScaleSettings.presetKey) private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
+    @AppStorage(ChromeScaleSettings.customMultiplierKey) private var chromeScaleCustomMultiplier: Double = Double(ChromeScaleSettings.defaultCustomMultiplier)
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     private var browserToolbarAccessorySpacing: Int {
@@ -363,7 +364,12 @@ struct cmuxApp: App {
                 .environmentObject(notificationStore)
                 .environmentObject(sidebarState)
                 .environmentObject(sidebarSelectionState)
-                .environment(\.chromeScaleTokens, ChromeScaleTokens(multiplier: ChromeScaleSettings.multiplier(for: ChromeScaleSettings.preset(for: chromeScalePresetRaw))))
+                .environment(\.chromeScaleTokens, ChromeScaleTokens(
+                    multiplier: ChromeScaleSettings.multiplier(
+                        presetRaw: chromeScalePresetRaw,
+                        customMultiplier: chromeScaleCustomMultiplier
+                    )
+                ))
                 .onAppear {
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
@@ -4402,6 +4408,8 @@ struct SettingsView: View {
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
     @AppStorage(ChromeScaleSettings.presetKey)
     private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
+    @AppStorage(ChromeScaleSettings.customMultiplierKey)
+    private var chromeScaleCustomMultiplier: Double = Double(ChromeScaleSettings.defaultCustomMultiplier)
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = true
     @AppStorage("sidebarShowPullRequest") private var sidebarShowPullRequest = true
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
@@ -5079,6 +5087,31 @@ struct SettingsView: View {
             ) {
                 ForEach(ChromeScaleSettings.Preset.allCases) { preset in
                     Text(preset.displayName).tag(preset.rawValue)
+                }
+            }
+
+            if ChromeScaleSettings.preset(for: chromeScalePresetRaw) == .custom {
+                SettingsCardDivider()
+                SettingsCardRow(
+                    String(localized: "settings.chromeScale.custom.label", defaultValue: "Custom Multiplier"),
+                    subtitle: String(
+                        localized: "settings.chromeScale.custom.subtitle",
+                        defaultValue: "Drag to fine-tune scale. Range 0.50× to 3.00×."
+                    )
+                ) {
+                    HStack(spacing: 8) {
+                        Slider(
+                            value: $chromeScaleCustomMultiplier,
+                            in: Double(ChromeScaleSettings.customMultiplierRange.lowerBound)
+                                ... Double(ChromeScaleSettings.customMultiplierRange.upperBound),
+                            step: 0.05
+                        )
+                        Text(String(format: "%.2f×", chromeScaleCustomMultiplier))
+                            .font(.caption)
+                            .monospacedDigit()
+                            .frame(width: 56, alignment: .trailing)
+                    }
+                    .frame(width: pickerColumnWidth)
                 }
             }
         }

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -191,6 +191,7 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.closeWorkspace.defaultsKey) private var closeWorkspaceShortcutData = Data()
     @AppStorage(TabBarChromeSettings.stateKey) private var tabBarChromeStateRaw = TabBarChromeState.full.rawValue
     @AppStorage(KeyboardShortcutSettings.Action.toggleTabBarChrome.defaultsKey) private var toggleTabBarChromeShortcutData = Data()
+    @AppStorage(ChromeScaleSettings.presetKey) private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
 
     private var browserToolbarAccessorySpacing: Int {
@@ -362,6 +363,7 @@ struct cmuxApp: App {
                 .environmentObject(notificationStore)
                 .environmentObject(sidebarState)
                 .environmentObject(sidebarSelectionState)
+                .environment(\.chromeScaleTokens, ChromeScaleTokens(multiplier: ChromeScaleSettings.multiplier(for: ChromeScaleSettings.preset(for: chromeScalePresetRaw))))
                 .onAppear {
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
@@ -4375,6 +4377,8 @@ struct SettingsView: View {
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+    @AppStorage(ChromeScaleSettings.presetKey)
+    private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = true
     @AppStorage("sidebarShowPullRequest") private var sidebarShowPullRequest = true
     @AppStorage(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey)
@@ -5037,6 +5041,23 @@ struct SettingsView: View {
             SettingsCardDivider()
 
             SettingsCardNote(String(localized: "settings.appearance.c11Theme.note", defaultValue: "c11 theme changes app chrome only; Ghostty terminal themes stay untouched."))
+        }
+
+        SettingsSectionHeader(title: String(localized: "settings.section.chromeScale", defaultValue: "App Chrome UI Scale"))
+        SettingsCard {
+            SettingsPickerRow(
+                String(localized: "settings.chromeScale.title", defaultValue: "App Chrome UI Scale"),
+                subtitle: String(
+                    localized: "settings.chromeScale.subtitle",
+                    defaultValue: "Scale c11 sidebar text and surface tab strip without changing terminal font size."
+                ),
+                controlWidth: pickerColumnWidth,
+                selection: $chromeScalePresetRaw
+            ) {
+                ForEach(ChromeScaleSettings.Preset.allCases) { preset in
+                    Text(preset.displayName).tag(preset.rawValue)
+                }
+            }
         }
 
         SettingsSectionHeader(title: String(localized: "settings.section.workspaceColors", defaultValue: "Workspace Colors"))

--- a/c11Tests/ChromeScaleObserverTests.swift
+++ b/c11Tests/ChromeScaleObserverTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Unit tests for `ChromeScaleObserver` — the small NSObject KVO helper each
+/// `Workspace` holds. KVO callbacks fire on the writer's thread; the observer
+/// hops to MainActor before invoking the closure. (C11-6 / MAJOR #4)
+final class ChromeScaleObserverTests: XCTestCase {
+
+    func testObserverFiresOnUserDefaultsChange() {
+        let suite = "ChromeScaleObserverTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let expectation = expectation(description: "onChange fires")
+        expectation.expectedFulfillmentCount = 1
+        expectation.assertForOverFulfill = false
+
+        let observer = ChromeScaleObserver(defaults: defaults) {
+            expectation.fulfill()
+        }
+        defer { _ = observer } // keep alive until end of test scope
+
+        defaults.set("large", forKey: ChromeScaleSettings.presetKey)
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testObserverFiresMultipleTimesOnRepeatedWrites() {
+        let suite = "ChromeScaleObserverTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let expectation = expectation(description: "onChange fires multiple times")
+        expectation.expectedFulfillmentCount = 3
+        expectation.assertForOverFulfill = false
+
+        let observer = ChromeScaleObserver(defaults: defaults) {
+            expectation.fulfill()
+        }
+        defer { _ = observer }
+
+        defaults.set("compact",    forKey: ChromeScaleSettings.presetKey)
+        defaults.set("large",      forKey: ChromeScaleSettings.presetKey)
+        defaults.set("extraLarge", forKey: ChromeScaleSettings.presetKey)
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
+    func testObserverDeinitDoesNotCrashOnSubsequentMutation() {
+        // After the observer is released, KVO is removed in deinit. Subsequent
+        // mutations to the same defaults must not crash (which they would if the
+        // observer had not removed itself and was sent observeValue after dealloc).
+        let suite = "ChromeScaleObserverTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        autoreleasepool {
+            let observer = ChromeScaleObserver(defaults: defaults) { /* discarded */ }
+            _ = observer // suppress unused warning
+        }
+
+        // Observer is now deallocated. This should not crash.
+        defaults.set("large", forKey: ChromeScaleSettings.presetKey)
+    }
+}

--- a/c11Tests/ChromeScaleObserverTests.swift
+++ b/c11Tests/ChromeScaleObserverTests.swift
@@ -51,6 +51,25 @@ final class ChromeScaleObserverTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
     }
 
+    func testObserverFiresOnCustomMultiplierChange() {
+        let suite = "ChromeScaleObserverTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let expectation = expectation(description: "onChange fires for custom multiplier")
+        expectation.expectedFulfillmentCount = 1
+        expectation.assertForOverFulfill = false
+
+        let observer = ChromeScaleObserver(defaults: defaults) {
+            expectation.fulfill()
+        }
+        defer { _ = observer }
+
+        defaults.set(1.75, forKey: ChromeScaleSettings.customMultiplierKey)
+
+        wait(for: [expectation], timeout: 2.0)
+    }
+
     func testObserverDeinitDoesNotCrashOnSubsequentMutation() {
         // After the observer is released, KVO is removed in deinit. Subsequent
         // mutations to the same defaults must not crash (which they would if the

--- a/c11Tests/ChromeScaleSettingsTests.swift
+++ b/c11Tests/ChromeScaleSettingsTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Unit tests for `ChromeScaleSettings` — preset enum, multiplier table, and
+/// the parameter-seam `preset(defaults:)` resolver. (C11-6)
+final class ChromeScaleSettingsTests: XCTestCase {
+
+    // MARK: - preset(for:)
+
+    func testPresetForNilFallsBackToDefault() {
+        XCTAssertEqual(ChromeScaleSettings.preset(for: nil), .standard)
+    }
+
+    func testPresetForEmptyStringFallsBackToDefault() {
+        XCTAssertEqual(ChromeScaleSettings.preset(for: ""), .standard)
+    }
+
+    func testPresetForUnknownStringFallsBackToDefault() {
+        XCTAssertEqual(ChromeScaleSettings.preset(for: "tiny"), .standard)
+    }
+
+    func testPresetForKnownStringsResolves() {
+        XCTAssertEqual(ChromeScaleSettings.preset(for: "compact"), .compact)
+        XCTAssertEqual(ChromeScaleSettings.preset(for: "standard"), .standard)
+        XCTAssertEqual(ChromeScaleSettings.preset(for: "large"), .large)
+        XCTAssertEqual(ChromeScaleSettings.preset(for: "extraLarge"), .extraLarge)
+    }
+
+    // MARK: - preset(defaults:)
+
+    func testPresetDefaultsRoundtripsThroughUserDefaults() {
+        let suite = "ChromeScaleSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(ChromeScaleSettings.preset(defaults: defaults), .standard)
+
+        defaults.set("large", forKey: ChromeScaleSettings.presetKey)
+        XCTAssertEqual(ChromeScaleSettings.preset(defaults: defaults), .large)
+
+        defaults.set("extraLarge", forKey: ChromeScaleSettings.presetKey)
+        XCTAssertEqual(ChromeScaleSettings.preset(defaults: defaults), .extraLarge)
+    }
+
+    func testPresetDefaultsFallsBackOnGarbage() {
+        let suite = "ChromeScaleSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set("not-a-preset", forKey: ChromeScaleSettings.presetKey)
+        XCTAssertEqual(ChromeScaleSettings.preset(defaults: defaults), .standard)
+    }
+
+    // MARK: - multiplier(for:)
+
+    func testMultiplierTable() {
+        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .compact),    0.90, accuracy: 0.0001)
+        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .standard),   1.00, accuracy: 0.0001)
+        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .large),      1.12, accuracy: 0.0001)
+        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .extraLarge), 1.25, accuracy: 0.0001)
+    }
+
+    // MARK: - Preset.displayName
+
+    func testEveryPresetHasNonEmptyDisplayName() {
+        for preset in ChromeScaleSettings.Preset.allCases {
+            XCTAssertFalse(preset.displayName.isEmpty, "Empty displayName for preset \(preset.rawValue)")
+        }
+    }
+
+    // MARK: - Preset basics
+
+    func testAllCasesContainsFour() {
+        XCTAssertEqual(ChromeScaleSettings.Preset.allCases.count, 4)
+    }
+
+    func testIdMatchesRawValue() {
+        for preset in ChromeScaleSettings.Preset.allCases {
+            XCTAssertEqual(preset.id, preset.rawValue)
+        }
+    }
+}

--- a/c11Tests/ChromeScaleSettingsTests.swift
+++ b/c11Tests/ChromeScaleSettingsTests.swift
@@ -29,6 +29,7 @@ final class ChromeScaleSettingsTests: XCTestCase {
         XCTAssertEqual(ChromeScaleSettings.preset(for: "standard"), .standard)
         XCTAssertEqual(ChromeScaleSettings.preset(for: "large"), .large)
         XCTAssertEqual(ChromeScaleSettings.preset(for: "extraLarge"), .extraLarge)
+        XCTAssertEqual(ChromeScaleSettings.preset(for: "custom"), .custom)
     }
 
     // MARK: - preset(defaults:)
@@ -45,6 +46,9 @@ final class ChromeScaleSettingsTests: XCTestCase {
 
         defaults.set("extraLarge", forKey: ChromeScaleSettings.presetKey)
         XCTAssertEqual(ChromeScaleSettings.preset(defaults: defaults), .extraLarge)
+
+        defaults.set("custom", forKey: ChromeScaleSettings.presetKey)
+        XCTAssertEqual(ChromeScaleSettings.preset(defaults: defaults), .custom)
     }
 
     func testPresetDefaultsFallsBackOnGarbage() {
@@ -59,10 +63,110 @@ final class ChromeScaleSettingsTests: XCTestCase {
     // MARK: - multiplier(for:)
 
     func testMultiplierTable() {
-        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .compact),    0.90, accuracy: 0.0001)
+        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .compact),    0.85, accuracy: 0.0001)
         XCTAssertEqual(ChromeScaleSettings.multiplier(for: .standard),   1.00, accuracy: 0.0001)
-        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .large),      1.12, accuracy: 0.0001)
-        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .extraLarge), 1.25, accuracy: 0.0001)
+        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .large),      1.25, accuracy: 0.0001)
+        XCTAssertEqual(ChromeScaleSettings.multiplier(for: .extraLarge), 1.55, accuracy: 0.0001)
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(for: .custom),
+            ChromeScaleSettings.defaultCustomMultiplier,
+            accuracy: 0.0001
+        )
+    }
+
+    // MARK: - multiplier(preset:defaults:) — Custom slider
+
+    func testCustomMultiplierReadsFromDefaults() {
+        let suite = "ChromeScaleSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set(1.75, forKey: ChromeScaleSettings.customMultiplierKey)
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(preset: .custom, defaults: defaults),
+            1.75,
+            accuracy: 0.0001
+        )
+    }
+
+    func testCustomMultiplierClampsAboveMax() {
+        let suite = "ChromeScaleSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set(99.0, forKey: ChromeScaleSettings.customMultiplierKey)
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(preset: .custom, defaults: defaults),
+            ChromeScaleSettings.customMultiplierRange.upperBound,
+            accuracy: 0.0001
+        )
+    }
+
+    func testCustomMultiplierClampsBelowMin() {
+        let suite = "ChromeScaleSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set(0.10, forKey: ChromeScaleSettings.customMultiplierKey)
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(preset: .custom, defaults: defaults),
+            ChromeScaleSettings.customMultiplierRange.lowerBound,
+            accuracy: 0.0001
+        )
+    }
+
+    func testCustomMultiplierFallsBackOnMissingKey() {
+        let suite = "ChromeScaleSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // No custom value persisted — should not collapse to 0.
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(preset: .custom, defaults: defaults),
+            ChromeScaleSettings.defaultCustomMultiplier,
+            accuracy: 0.0001
+        )
+    }
+
+    func testNonCustomPresetIgnoresCustomKey() {
+        let suite = "ChromeScaleSettingsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        defaults.set(2.5, forKey: ChromeScaleSettings.customMultiplierKey)
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(preset: .large, defaults: defaults),
+            1.25,
+            accuracy: 0.0001
+        )
+    }
+
+    // MARK: - multiplier(presetRaw:customMultiplier:) — SwiftUI helper
+
+    func testMultiplierFromRawHonorsCustomValue() {
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(presetRaw: "custom", customMultiplier: 2.0),
+            2.0,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(presetRaw: "compact", customMultiplier: 2.0),
+            0.85,
+            accuracy: 0.0001
+        )
+    }
+
+    func testMultiplierFromRawClampsCustomValue() {
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(presetRaw: "custom", customMultiplier: 99.0),
+            ChromeScaleSettings.customMultiplierRange.upperBound,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            ChromeScaleSettings.multiplier(presetRaw: "custom", customMultiplier: 0.0),
+            ChromeScaleSettings.defaultCustomMultiplier,
+            accuracy: 0.0001
+        )
     }
 
     // MARK: - Preset.displayName
@@ -75,8 +179,8 @@ final class ChromeScaleSettingsTests: XCTestCase {
 
     // MARK: - Preset basics
 
-    func testAllCasesContainsFour() {
-        XCTAssertEqual(ChromeScaleSettings.Preset.allCases.count, 4)
+    func testAllCasesContainsFive() {
+        XCTAssertEqual(ChromeScaleSettings.Preset.allCases.count, 5)
     }
 
     func testIdMatchesRawValue() {

--- a/c11Tests/ChromeScaleTokensTests.swift
+++ b/c11Tests/ChromeScaleTokensTests.swift
@@ -23,7 +23,7 @@ final class ChromeScaleTokensTests: XCTestCase {
         XCTAssertEqual(tokens.sidebarWorkspaceBranchDot,      3.0,  accuracy: 0.001)
 
         XCTAssertEqual(tokens.surfaceTabTitle,                  11.0,  accuracy: 0.001)
-        XCTAssertEqual(tokens.surfaceTabIcon,                   14.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabIcon,                   15.0,  accuracy: 0.001)
         XCTAssertEqual(tokens.surfaceTabBarHeight,              30.0,  accuracy: 0.001)
         XCTAssertEqual(tokens.surfaceTabItemHeight,             30.0,  accuracy: 0.001)
         XCTAssertEqual(tokens.surfaceTabHorizontalPadding,       6.0,  accuracy: 0.001)
@@ -35,6 +35,10 @@ final class ChromeScaleTokensTests: XCTestCase {
         XCTAssertEqual(tokens.surfaceTabNotificationBadgeSize,   6.0,  accuracy: 0.001)
         XCTAssertEqual(tokens.surfaceTabActiveIndicatorHeight,   3.0,  accuracy: 0.001)
 
+        XCTAssertEqual(tokens.splitToolbarButtonIcon,           12.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.splitToolbarButtonFrame,          22.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.splitToolbarSeparatorHeight,      18.0,  accuracy: 0.001)
+
         XCTAssertEqual(tokens.surfaceTitleBarTitle,             12.0,  accuracy: 0.001)
         XCTAssertEqual(tokens.surfaceTitleBarAccessory,         10.0,  accuracy: 0.001)
     }
@@ -42,35 +46,36 @@ final class ChromeScaleTokensTests: XCTestCase {
     // MARK: - Multiplier scaling
 
     func testLargeMultipliesEveryToken() {
-        let tokens = ChromeScaleTokens(multiplier: 1.12)
-        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 1.12, accuracy: 0.001)
-        XCTAssertEqual(tokens.sidebarWorkspaceDetail,   10.0 * 1.12, accuracy: 0.001)
-        XCTAssertEqual(tokens.surfaceTabTitle,          11.0 * 1.12, accuracy: 0.001)
-        XCTAssertEqual(tokens.surfaceTabIcon,           14.0 * 1.12, accuracy: 0.001)
-        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 1.12, accuracy: 0.001)
-        XCTAssertEqual(tokens.surfaceTabMinWidth,      112.0 * 1.12, accuracy: 0.001)
-        XCTAssertEqual(tokens.surfaceTabMaxWidth,      220.0 * 1.12, accuracy: 0.001)
-        XCTAssertEqual(tokens.surfaceTabCloseIconSize,   9.0 * 1.12, accuracy: 0.001)
+        let tokens = ChromeScaleTokens(multiplier: 1.25)
+        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceDetail,   10.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabTitle,          11.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabIcon,           15.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabMinWidth,      112.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabMaxWidth,      220.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabCloseIconSize,   9.0 * 1.25, accuracy: 0.001)
     }
 
     func testCompactScalesDown() {
-        let tokens = ChromeScaleTokens(multiplier: 0.90)
-        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 0.90, accuracy: 0.001)
-        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 0.90, accuracy: 0.001)
+        let tokens = ChromeScaleTokens(multiplier: 0.85)
+        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 0.85, accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 0.85, accuracy: 0.001)
     }
 
     func testExtraLargeScalesUp() {
-        let tokens = ChromeScaleTokens(multiplier: 1.25)
-        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 1.25, accuracy: 0.001)
-        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 1.25, accuracy: 0.001)
+        let tokens = ChromeScaleTokens(multiplier: 1.55)
+        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 1.55, accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 1.55, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabIcon,           15.0 * 1.55, accuracy: 0.001)
     }
 
     // MARK: - Active-indicator floor
 
     func testActiveIndicatorFloorAtTwo() {
-        // At the four ship presets the floor is inert (3*0.90 = 2.7 ≥ 2.0).
-        // The floor protects future Custom-multiplier <= 0.66.
-        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.90).surfaceTabActiveIndicatorHeight, 3.0 * 0.90, accuracy: 0.001)
+        // At the four ship presets the floor is inert (3*0.85 = 2.55 ≥ 2.0).
+        // The floor protects Custom-multiplier values ≤ 0.66.
+        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.85).surfaceTabActiveIndicatorHeight, 3.0 * 0.85, accuracy: 0.001)
         XCTAssertEqual(ChromeScaleTokens(multiplier: 0.50).surfaceTabActiveIndicatorHeight, 2.0,        accuracy: 0.001)
         XCTAssertEqual(ChromeScaleTokens(multiplier: 0.66).surfaceTabActiveIndicatorHeight, 2.0,        accuracy: 0.001)
     }
@@ -82,8 +87,8 @@ final class ChromeScaleTokensTests: XCTestCase {
     }
 
     func testTokensEqualWhenMultipliersMatch() {
-        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.90), ChromeScaleTokens(multiplier: 0.90))
-        XCTAssertNotEqual(ChromeScaleTokens(multiplier: 0.90), ChromeScaleTokens(multiplier: 1.0))
+        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.85), ChromeScaleTokens(multiplier: 0.85))
+        XCTAssertNotEqual(ChromeScaleTokens(multiplier: 0.85), ChromeScaleTokens(multiplier: 1.0))
     }
 
     // MARK: - resolved(from:)
@@ -96,9 +101,13 @@ final class ChromeScaleTokensTests: XCTestCase {
         XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 1.0, accuracy: 0.001)
 
         defaults.set("compact", forKey: ChromeScaleSettings.presetKey)
-        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 0.90, accuracy: 0.001)
+        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 0.85, accuracy: 0.001)
 
         defaults.set("extraLarge", forKey: ChromeScaleSettings.presetKey)
-        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 1.25, accuracy: 0.001)
+        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 1.55, accuracy: 0.001)
+
+        defaults.set("custom", forKey: ChromeScaleSettings.presetKey)
+        defaults.set(1.80, forKey: ChromeScaleSettings.customMultiplierKey)
+        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 1.80, accuracy: 0.001)
     }
 }

--- a/c11Tests/ChromeScaleTokensTests.swift
+++ b/c11Tests/ChromeScaleTokensTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Unit tests for `ChromeScaleTokens` — the value-typed bag of computed point
+/// sizes that drives sidebar/surface chrome scaling. (C11-6)
+final class ChromeScaleTokensTests: XCTestCase {
+
+    // MARK: - Default (1.00×) byte-exactness
+
+    func testStandardEqualsLiteralDefaults() {
+        let tokens = ChromeScaleTokens.standard
+        XCTAssertEqual(tokens.sidebarWorkspaceTitle,         12.5,  accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceDetail,        10.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceMetadata,      10.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceAccessory,      9.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceProgressLabel,  9.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceLogIcon,        8.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceBranchDot,      3.0,  accuracy: 0.001)
+
+        XCTAssertEqual(tokens.surfaceTabTitle,                  11.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabIcon,                   14.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabBarHeight,              30.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabItemHeight,             30.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabHorizontalPadding,       6.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabMinWidth,              112.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabMaxWidth,              220.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabCloseIconSize,           9.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabContentSpacing,          6.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabDirtyIndicatorSize,      8.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabNotificationBadgeSize,   6.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabActiveIndicatorHeight,   3.0,  accuracy: 0.001)
+
+        XCTAssertEqual(tokens.surfaceTitleBarTitle,             12.0,  accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTitleBarAccessory,         10.0,  accuracy: 0.001)
+    }
+
+    // MARK: - Multiplier scaling
+
+    func testLargeMultipliesEveryToken() {
+        let tokens = ChromeScaleTokens(multiplier: 1.12)
+        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceDetail,   10.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabTitle,          11.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabIcon,           14.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabMinWidth,      112.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabMaxWidth,      220.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(tokens.surfaceTabCloseIconSize,   9.0 * 1.12, accuracy: 0.001)
+    }
+
+    func testCompactScalesDown() {
+        let tokens = ChromeScaleTokens(multiplier: 0.90)
+        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 0.90, accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 0.90, accuracy: 0.001)
+    }
+
+    func testExtraLargeScalesUp() {
+        let tokens = ChromeScaleTokens(multiplier: 1.25)
+        XCTAssertEqual(tokens.surfaceTabBarHeight,      30.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(tokens.sidebarWorkspaceTitle,    12.5 * 1.25, accuracy: 0.001)
+    }
+
+    // MARK: - Active-indicator floor
+
+    func testActiveIndicatorFloorAtTwo() {
+        // At the four ship presets the floor is inert (3*0.90 = 2.7 ≥ 2.0).
+        // The floor protects future Custom-multiplier <= 0.66.
+        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.90).surfaceTabActiveIndicatorHeight, 3.0 * 0.90, accuracy: 0.001)
+        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.50).surfaceTabActiveIndicatorHeight, 2.0,        accuracy: 0.001)
+        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.66).surfaceTabActiveIndicatorHeight, 2.0,        accuracy: 0.001)
+    }
+
+    // MARK: - Equatable
+
+    func testStandardEqualsExplicitMultiplierOne() {
+        XCTAssertEqual(ChromeScaleTokens.standard, ChromeScaleTokens(multiplier: 1.0))
+    }
+
+    func testTokensEqualWhenMultipliersMatch() {
+        XCTAssertEqual(ChromeScaleTokens(multiplier: 0.90), ChromeScaleTokens(multiplier: 0.90))
+        XCTAssertNotEqual(ChromeScaleTokens(multiplier: 0.90), ChromeScaleTokens(multiplier: 1.0))
+    }
+
+    // MARK: - resolved(from:)
+
+    func testResolvedFromUserDefaults() {
+        let suite = "ChromeScaleTokensTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 1.0, accuracy: 0.001)
+
+        defaults.set("compact", forKey: ChromeScaleSettings.presetKey)
+        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 0.90, accuracy: 0.001)
+
+        defaults.set("extraLarge", forKey: ChromeScaleSettings.presetKey)
+        XCTAssertEqual(ChromeScaleTokens.resolved(from: defaults).multiplier, 1.25, accuracy: 0.001)
+    }
+}

--- a/c11Tests/WorkspaceApplyChromeScaleTests.swift
+++ b/c11Tests/WorkspaceApplyChromeScaleTests.swift
@@ -22,7 +22,7 @@ final class WorkspaceApplyChromeScaleTests: XCTestCase {
         XCTAssertEqual(appearance.tabTitleFontSize,         11.0,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabMinWidth,             112.0,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabMaxWidth,             220.0,  accuracy: 0.001)
-        XCTAssertEqual(appearance.tabIconSize,              14.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabIconSize,              15.0,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabItemHeight,            30.0,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabHorizontalPadding,      6.0,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabCloseIconSize,          9.0,  accuracy: 0.001)
@@ -30,6 +30,9 @@ final class WorkspaceApplyChromeScaleTests: XCTestCase {
         XCTAssertEqual(appearance.tabDirtyIndicatorSize,     8.0,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabNotificationBadgeSize,  6.0,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabActiveIndicatorHeight,  3.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.splitToolbarButtonIconSize,  12.0, accuracy: 0.001)
+        XCTAssertEqual(appearance.splitToolbarButtonFrameSize, 22.0, accuracy: 0.001)
+        XCTAssertEqual(appearance.splitToolbarSeparatorHeight, 18.0, accuracy: 0.001)
     }
 
     func testLargeTokensScaleEveryRoutedField() {
@@ -40,7 +43,7 @@ final class WorkspaceApplyChromeScaleTests: XCTestCase {
         XCTAssertEqual(appearance.tabTitleFontSize,         11.0 * 1.12,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabMinWidth,             112.0 * 1.12,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabMaxWidth,             220.0 * 1.12,  accuracy: 0.001)
-        XCTAssertEqual(appearance.tabIconSize,              14.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabIconSize,              15.0 * 1.12,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabItemHeight,            30.0 * 1.12,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabHorizontalPadding,      6.0 * 1.12,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabCloseIconSize,          9.0 * 1.12,  accuracy: 0.001)
@@ -48,6 +51,9 @@ final class WorkspaceApplyChromeScaleTests: XCTestCase {
         XCTAssertEqual(appearance.tabDirtyIndicatorSize,     8.0 * 1.12,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabNotificationBadgeSize,  6.0 * 1.12,  accuracy: 0.001)
         XCTAssertEqual(appearance.tabActiveIndicatorHeight,  3.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.splitToolbarButtonIconSize,  12.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(appearance.splitToolbarButtonFrameSize, 22.0 * 1.12, accuracy: 0.001)
+        XCTAssertEqual(appearance.splitToolbarSeparatorHeight, 18.0 * 1.12, accuracy: 0.001)
     }
 
     func testCompactScalesDown() {
@@ -61,7 +67,7 @@ final class WorkspaceApplyChromeScaleTests: XCTestCase {
         var appearance = BonsplitConfiguration.Appearance()
         Workspace.applyChromeScale(ChromeScaleTokens(multiplier: 1.25), to: &appearance)
         XCTAssertEqual(appearance.tabBarHeight, 30.0 * 1.25, accuracy: 0.001)
-        XCTAssertEqual(appearance.tabIconSize, 14.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(appearance.tabIconSize, 15.0 * 1.25, accuracy: 0.001)
     }
 
     func testApplyIsIdempotent() {

--- a/c11Tests/WorkspaceApplyChromeScaleTests.swift
+++ b/c11Tests/WorkspaceApplyChromeScaleTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import Bonsplit
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Unit tests for `Workspace.applyChromeScale(_:to:)` — the pure helper that
+/// translates `ChromeScaleTokens` into `BonsplitConfiguration.Appearance`
+/// values. Decoupled from `GhosttyApp.shared` per the v3 plan
+/// (Workspace-Apply-ChromeScale section). (C11-6)
+final class WorkspaceApplyChromeScaleTests: XCTestCase {
+
+    func testStandardTokensProduceDefaultAppearanceFields() {
+        var appearance = BonsplitConfiguration.Appearance()
+        Workspace.applyChromeScale(.standard, to: &appearance)
+
+        // Every routed knob equals its scaled-from-default token at 1.00×.
+        XCTAssertEqual(appearance.tabBarHeight,             30.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabTitleFontSize,         11.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabMinWidth,             112.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabMaxWidth,             220.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabIconSize,              14.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabItemHeight,            30.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabHorizontalPadding,      6.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabCloseIconSize,          9.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabContentSpacing,         6.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabDirtyIndicatorSize,     8.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabNotificationBadgeSize,  6.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabActiveIndicatorHeight,  3.0,  accuracy: 0.001)
+    }
+
+    func testLargeTokensScaleEveryRoutedField() {
+        var appearance = BonsplitConfiguration.Appearance()
+        Workspace.applyChromeScale(ChromeScaleTokens(multiplier: 1.12), to: &appearance)
+
+        XCTAssertEqual(appearance.tabBarHeight,             30.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabTitleFontSize,         11.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabMinWidth,             112.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabMaxWidth,             220.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabIconSize,              14.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabItemHeight,            30.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabHorizontalPadding,      6.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabCloseIconSize,          9.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabContentSpacing,         6.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabDirtyIndicatorSize,     8.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabNotificationBadgeSize,  6.0 * 1.12,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabActiveIndicatorHeight,  3.0 * 1.12,  accuracy: 0.001)
+    }
+
+    func testCompactScalesDown() {
+        var appearance = BonsplitConfiguration.Appearance()
+        Workspace.applyChromeScale(ChromeScaleTokens(multiplier: 0.90), to: &appearance)
+        XCTAssertEqual(appearance.tabBarHeight, 30.0 * 0.90, accuracy: 0.001)
+        XCTAssertEqual(appearance.tabTitleFontSize, 11.0 * 0.90, accuracy: 0.001)
+    }
+
+    func testExtraLargeScalesUp() {
+        var appearance = BonsplitConfiguration.Appearance()
+        Workspace.applyChromeScale(ChromeScaleTokens(multiplier: 1.25), to: &appearance)
+        XCTAssertEqual(appearance.tabBarHeight, 30.0 * 1.25, accuracy: 0.001)
+        XCTAssertEqual(appearance.tabIconSize, 14.0 * 1.25, accuracy: 0.001)
+    }
+
+    func testApplyIsIdempotent() {
+        var appearance = BonsplitConfiguration.Appearance()
+        Workspace.applyChromeScale(.standard, to: &appearance)
+        let snapshot = (
+            appearance.tabBarHeight,
+            appearance.tabTitleFontSize,
+            appearance.tabMinWidth,
+            appearance.tabMaxWidth,
+            appearance.tabIconSize,
+            appearance.tabItemHeight,
+            appearance.tabHorizontalPadding,
+            appearance.tabCloseIconSize,
+            appearance.tabContentSpacing,
+            appearance.tabDirtyIndicatorSize,
+            appearance.tabNotificationBadgeSize,
+            appearance.tabActiveIndicatorHeight
+        )
+        Workspace.applyChromeScale(.standard, to: &appearance)
+        XCTAssertEqual(appearance.tabBarHeight,             snapshot.0,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabTitleFontSize,         snapshot.1,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabMinWidth,              snapshot.2,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabMaxWidth,              snapshot.3,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabIconSize,              snapshot.4,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabItemHeight,            snapshot.5,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabHorizontalPadding,     snapshot.6,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabCloseIconSize,         snapshot.7,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabContentSpacing,        snapshot.8,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabDirtyIndicatorSize,    snapshot.9,  accuracy: 0.001)
+        XCTAssertEqual(appearance.tabNotificationBadgeSize, snapshot.10, accuracy: 0.001)
+        XCTAssertEqual(appearance.tabActiveIndicatorHeight, snapshot.11, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

Closes [C11-6](.lattice/plans/task_01KPS3M21AEJVKD4V1NRFJ173Z.md). Adds a persisted **App Chrome UI Scale** preset that scales c11-owned chrome — sidebar workspace cards, the Bonsplit surface tab strip (titles, icons, accessories, bar shell, item height, padding, close glyph, dirty indicator, notification badge, active-tab underbar), and the surface title bar — without touching Ghostty terminal cells, browser content, or markdown content.

Four presets (Compact 0.90×, Default 1.00×, Large 1.12×, Extra Large 1.25×). Live update on UserDefaults change for any writer (Settings UI, `defaults write`, future migrations) via a per-Workspace KVO observer.

## What's new

- **Settings → Appearance → App Chrome UI Scale** picker (localized en/ja/zh-Hans/zh-Hant/ko/ru/uk).
- `Sources/Chrome/ChromeScale.swift`: `ChromeScaleSettings` (key + Preset enum + multiplier table + `preset(defaults:)`), `ChromeScaleTokens` (Equatable computed-token bag), `EnvironmentValues.chromeScaleTokens`, `ChromeScaleObserver` (NSObject KVO helper held by each Workspace).
- Sidebar workspace card text + agent chip + remote section + metadata rows + markdown blocks all read tokens (TabItemView via precomputed `let chromeTokens` for the typing-latency hot path; nested views via `@Environment`).
- Tab strip wired through new public Bonsplit Appearance knobs from Stage-11-Agentics/bonsplit#4 (now on bonsplit `origin/main`).
- Surface title bar reads tokens from environment.

## Plan v3

The plan went through two cycles of trident plan-review (claude+codex+gemini) with the 4 review packs preserved as Lattice artifacts. v2 came back "one revision away from PASS"; v3 incorporates: CRITICAL #1 (`tabBarHeight` default 33 → 30 byte-exact with rendered shell), CRITICAL #2 (`glyphSize(for:)` rewrite), MAJOR #3 (5 additional public knobs for accessory geometry), MAJOR #4 (`ChromeScaleObserver: NSObject` helper since `Workspace` is not NSObject), MAJOR #5 (`accessorySlotSize` cap via `appearance.tabItemHeight`), MAJOR #6 (token acquisition in `Workspace.init`), MAJOR #7 (socket command deferred), MAJOR #8 (pbxproj target steps), MINORs #9–12.

## Commit grouping

1. **9c8c182f** — ChromeScale resolver, Settings UI picker, env install, 3 unit tests, pbxproj.
2. **fbef8b3c** — Sidebar workspace card token wiring (TabItemView + metadata rows + agent chip).
3. **dbc1927c** — Bump bonsplit submodule (Stage-11-Agentics/bonsplit#4 merge), Workspace `applyChromeScale` helper + KVO observer, SurfaceTitleBarView wiring, `WorkspaceApplyChromeScaleTests`.
4. **6cad0103** — Localizations for ja/zh-Hans/zh-Hant/ko/ru/uk (42 stringUnit entries).

## Test plan

- [x] `xcodebuild -scheme c11-unit build CODE_SIGNING_ALLOWED=NO` clean build (verified across all four commits).
- [ ] CI: c11Tests target runs `ChromeScaleSettingsTests`, `ChromeScaleTokensTests`, `ChromeScaleObserverTests`, `WorkspaceApplyChromeScaleTests`.
- [ ] **Operator validation** — tagged build + visual smoke test:
  - `./scripts/reload.sh --tag c11-6-chrome-scale`.
  - Settings → Appearance → "App Chrome UI Scale" — switch through Compact / Default / Large / Extra Large.
  - Confirm sidebar text scales (workspace title, notification subtitle, agent chip, metadata, log, progress, branch/dir, PR rows, ports).
  - Confirm tab strip scales (title font, bar shell height, item height, icon, close glyph, dirty/notification indicators, active-tab underbar).
  - Default preset = byte-exact with today's tab bar shell height (30pt). Compare screenshots before/after if in doubt.
  - Ghostty terminal cells unchanged.
  - Multi-writer KVO: `defaults write com.stage11.c11 chromeScalePreset large` from a sibling pane — sidebar AND tab strip update without relaunch.
  - Localization: switch app language to `ja` (relaunch) — picker label and four option names render in Japanese.

## Out of scope (deferred)

- `c11 chrome.set-scale <preset>` socket command (MAJOR #7 — file follow-up if a deterministic Validate oracle is needed).
- Custom multiplier slider.
- Per-workspace overrides.
- Markdown document content sizing inside surfaces (only the chrome around the surface scales).
- Comprehensive sweep of every popover/debug/settings string.

## Behavior change for non-default Bonsplit embedders

`BonsplitConfiguration.Appearance.tabBarHeight` default lowered 33 → 30 to match the previously-rendered shell (the property was declared but unused; rendered bar height came from `TabBarMetrics.barHeight = 30`). After this PR the shell actually reads from this knob. `Appearance.compact` and `.spacious` similarly adjusted (28 → 27, 38 → 35) to scale together with `tabItemHeight`. c11's existing default-preset shell is byte-exact with today's behavior; embedders that explicitly relied on the old `33` default will see a 3pt shrink. Documented in Stage-11-Agentics/bonsplit#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)