### PR TITLE
C11-10: Per-surface tab colors inside panes

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -10194,13 +10194,18 @@ struct CMUXCLI {
 
         let response = try client.sendV2(method: "surface.list", params: ["workspace_id": resolvedWorkspaceId])
         let items = (response["surfaces"] as? [[String: Any]]) ?? []
-        let match = items.first { ($0["id"] as? String) == surfaceId }
+        guard let match = items.first(where: { ($0["id"] as? String) == surfaceId }) else {
+            // Match the v2 server's not_found semantics. resolveSurfaceId short-circuits
+            // any UUID-shaped string without validating membership, so a stale or wrong
+            // UUID would otherwise print 'color: (none)' and exit 0 — silently lying.
+            throw CLIError(message: "Surface not found: \(surfaceRef ?? surfaceId)")
+        }
 
         if jsonOutput {
-            print(jsonString(match ?? [:]))
+            print(jsonString(match))
             return
         }
-        if let color = match?["custom_color"] as? String {
+        if let color = match["custom_color"] as? String {
             print("color: \(color)")
         } else {
             print("color: (none)")

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -10084,6 +10084,13 @@ struct CMUXCLI {
         }
     }
 
+    private func resolveCurrentWorkspaceId(client: SocketClient) throws -> String {
+        if let id = try normalizeWorkspaceHandle(nil, client: client, allowCurrent: true) {
+            return id
+        }
+        throw CLIError(message: "No current workspace available")
+    }
+
     private func resolveWorkspaceColorTarget(_ raw: String?, client: SocketClient) throws -> String? {
         let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
         if value == "@current" || value == "@focused" {

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -10195,7 +10195,7 @@ struct CMUXCLI {
         let (workspaceOpt, rest1) = parseOption(args, name: "--workspace")
         let (surfaceOpt, _) = parseOption(rest1, name: "--surface")
         let workspaceHandle = try resolveWorkspaceColorTarget(workspaceOpt, client: client)
-        let resolvedWorkspaceId = workspaceHandle ?? (try resolveCurrentWorkspaceId(client: client))
+        let resolvedWorkspaceId = try workspaceHandle ?? resolveCurrentWorkspaceId(client: client)
         let surfaceRef = surfaceOpt ?? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
         let surfaceId = try resolveSurfaceId(
             surfaceRef,

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2834,6 +2834,9 @@ struct CMUXCLI {
         case "workspace-color":
             try runWorkspaceColor(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
 
+        case "surface-color":
+            try runSurfaceColor(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
+
         // C11-13 Stage 2: inter-agent mailbox (send/recv/trace/tail + helpers).
         case "mailbox":
             try runMailboxCommand(
@@ -10087,6 +10090,108 @@ struct CMUXCLI {
             return try normalizeWorkspaceHandle(nil, client: client, allowCurrent: true)
         }
         return try normalizeWorkspaceHandle(value, client: client)
+    }
+
+    // MARK: - `c11 surface-color` (C11-10)
+    //
+    // Per-surface tab color: identifies a single surface tab in a pane,
+    // distinct from the workspace-level chrome accent. Help text says
+    // "surface tab in a pane" to disambiguate from workspace tabs.
+
+    private func runSurfaceColor(commandArgs: [String], client: SocketClient, jsonOutput: Bool) throws {
+        guard let first = commandArgs.first else {
+            throw CLIError(message: "surface-color requires a subcommand. Try: c11 surface-color get (operates on the surface tab in a pane)")
+        }
+        let sub = first.lowercased()
+        let rest = Array(commandArgs.dropFirst())
+        switch sub {
+        case "set":
+            try runSurfaceColorSet(args: rest, client: client, jsonOutput: jsonOutput)
+        case "clear":
+            try runSurfaceColorClear(args: rest, client: client, jsonOutput: jsonOutput)
+        case "get":
+            try runSurfaceColorGet(args: rest, client: client, jsonOutput: jsonOutput)
+        case "list-palette":
+            // Shares the workspace-color palette — same list, same names.
+            try runWorkspaceColorListPalette(client: client, jsonOutput: jsonOutput)
+        default:
+            throw CLIError(message: "Unknown surface-color subcommand: \(first)")
+        }
+    }
+
+    private func runSurfaceColorSet(args: [String], client: SocketClient, jsonOutput: Bool) throws {
+        let (workspaceOpt, rest1) = parseOption(args, name: "--workspace")
+        let (surfaceOpt, rest2) = parseOption(rest1, name: "--surface")
+        let positional = rest2.filter { !$0.hasPrefix("-") }
+        guard let hex = positional.first else {
+            throw CLIError(message: "surface-color set <hex> [--workspace <ref>] [--surface <ref>]")
+        }
+
+        let workspaceHandle = try resolveWorkspaceColorTarget(workspaceOpt, client: client)
+        let surfaceRef = surfaceOpt ?? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+        let surfaceId = try resolveSurfaceId(
+            surfaceRef,
+            workspaceId: workspaceHandle ?? (try resolveCurrentWorkspaceId(client: client)),
+            client: client
+        )
+
+        var params: [String: Any] = ["hex": hex, "surface_id": surfaceId]
+        if let workspaceHandle { params["workspace_id"] = workspaceHandle }
+        let response = try client.sendV2(method: "surface.set_custom_color", params: params)
+        if jsonOutput {
+            print(jsonString(response))
+        } else {
+            let applied = response["custom_color"] as? String ?? hex
+            print("OK surface_color=\(applied)")
+        }
+    }
+
+    private func runSurfaceColorClear(args: [String], client: SocketClient, jsonOutput: Bool) throws {
+        let (workspaceOpt, rest1) = parseOption(args, name: "--workspace")
+        let (surfaceOpt, _) = parseOption(rest1, name: "--surface")
+        let workspaceHandle = try resolveWorkspaceColorTarget(workspaceOpt, client: client)
+        let surfaceRef = surfaceOpt ?? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+        let surfaceId = try resolveSurfaceId(
+            surfaceRef,
+            workspaceId: workspaceHandle ?? (try resolveCurrentWorkspaceId(client: client)),
+            client: client
+        )
+
+        var params: [String: Any] = ["clear": true, "surface_id": surfaceId]
+        if let workspaceHandle { params["workspace_id"] = workspaceHandle }
+        let response = try client.sendV2(method: "surface.set_custom_color", params: params)
+        if jsonOutput {
+            print(jsonString(response))
+        } else {
+            print("OK surface color cleared")
+        }
+    }
+
+    private func runSurfaceColorGet(args: [String], client: SocketClient, jsonOutput: Bool) throws {
+        let (workspaceOpt, rest1) = parseOption(args, name: "--workspace")
+        let (surfaceOpt, _) = parseOption(rest1, name: "--surface")
+        let workspaceHandle = try resolveWorkspaceColorTarget(workspaceOpt, client: client)
+        let resolvedWorkspaceId = workspaceHandle ?? (try resolveCurrentWorkspaceId(client: client))
+        let surfaceRef = surfaceOpt ?? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
+        let surfaceId = try resolveSurfaceId(
+            surfaceRef,
+            workspaceId: resolvedWorkspaceId,
+            client: client
+        )
+
+        let response = try client.sendV2(method: "surface.list", params: ["workspace_id": resolvedWorkspaceId])
+        let items = (response["surfaces"] as? [[String: Any]]) ?? []
+        let match = items.first { ($0["id"] as? String) == surfaceId }
+
+        if jsonOutput {
+            print(jsonString(match ?? [:]))
+            return
+        }
+        if let color = match?["custom_color"] as? String {
+            print("color: \(color)")
+        } else {
+            print("color: (none)")
+        }
     }
 
     private func availableThemeNames() -> [String] {

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -10137,7 +10137,7 @@ struct CMUXCLI {
         let (surfaceOpt, rest2) = parseOption(rest1, name: "--surface")
         let positional = rest2.filter { !$0.hasPrefix("-") }
         guard let hex = positional.first else {
-            throw CLIError(message: "surface-color set <hex> [--workspace <ref>] [--surface <ref>]")
+            throw CLIError(message: "surface-color set <hex> [--workspace <ref>] [--surface <ref>] (quote hex starting with '#': c11 surface-color set \"#RRGGBB\")")
         }
 
         let workspaceHandle = try resolveWorkspaceColorTarget(workspaceOpt, client: client)
@@ -10161,7 +10161,11 @@ struct CMUXCLI {
 
     private func runSurfaceColorClear(args: [String], client: SocketClient, jsonOutput: Bool) throws {
         let (workspaceOpt, rest1) = parseOption(args, name: "--workspace")
-        let (surfaceOpt, _) = parseOption(rest1, name: "--surface")
+        let (surfaceOpt, rest2) = parseOption(rest1, name: "--surface")
+        let extras = rest2.filter { !$0.hasPrefix("-") }
+        if !extras.isEmpty {
+            throw CLIError(message: "surface-color clear takes no positional arguments. Use 'surface-color set <hex>' to set a color.")
+        }
         let workspaceHandle = try resolveWorkspaceColorTarget(workspaceOpt, client: client)
         let surfaceRef = surfaceOpt ?? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"]
         let surfaceId = try resolveSurfaceId(

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -10086,7 +10086,20 @@ struct CMUXCLI {
 
     private func resolveWorkspaceColorTarget(_ raw: String?, client: SocketClient) throws -> String? {
         let value = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
-        if value == nil || value?.isEmpty == true || value == "@current" || value == "@focused" {
+        if value == "@current" || value == "@focused" {
+            return try normalizeWorkspaceHandle(nil, client: client, allowCurrent: true)
+        }
+        if value == nil || value?.isEmpty == true {
+            // No --workspace flag: prefer caller's env workspace so commands launched
+            // from an unfocused surface still target the caller's own workspace
+            // (matches the env-first pattern used at CLI/c11.swift:1762 'identify').
+            let env = ProcessInfo.processInfo.environment
+            if let envWs = env["CMUX_WORKSPACE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines), !envWs.isEmpty {
+                return try normalizeWorkspaceHandle(envWs, client: client)
+            }
+            if let envWs = env["C11_WORKSPACE_ID"]?.trimmingCharacters(in: .whitespacesAndNewlines), !envWs.isEmpty {
+                return try normalizeWorkspaceHandle(envWs, client: client)
+            }
             return try normalizeWorkspaceHandle(nil, client: client, allowCurrent: true)
         }
         return try normalizeWorkspaceHandle(value, client: client)

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4254,6 +4254,50 @@
         }
       }
     },
+    "alert.tabColor.apply": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply"
+          }
+        }
+      }
+    },
+    "alert.tabColor.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
+          }
+        }
+      }
+    },
+    "alert.tabColor.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a hex color in the format #RRGGBB."
+          }
+        }
+      }
+    },
+    "alert.tabColor.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom Tab Color"
+          }
+        }
+      }
+    },
     "alert.renameWorkspace.cancel": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4262,6 +4262,42 @@
             "state": "translated",
             "value": "Apply"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "套用"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "적용"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Применить"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Застосувати"
+          }
         }
       }
     },
@@ -4272,6 +4308,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cancel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャンセル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "취소"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отменить"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скасувати"
           }
         }
       }
@@ -4284,6 +4356,42 @@
             "state": "translated",
             "value": "Enter a hex color in the format #RRGGBB."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#RRGGBB形式で16進カラーコードを入力してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入 #RRGGBB 格式的十六进制颜色。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請輸入 #RRGGBB 格式的十六進位色碼。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "#RRGGBB 형식으로 16진수 색상을 입력하세요."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введите цвет в формате #RRGGBB."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Введіть hex-колір у форматі #RRGGBB."
+          }
         }
       }
     },
@@ -4294,6 +4402,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Custom Tab Color"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタムタブカラー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义标签页颜色"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自訂標籤頁顏色"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용자 지정 탭 색상"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пользовательский цвет вкладки"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Власний колір вкладки"
           }
         }
       }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -341,6 +341,10 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var type: PanelType
     var title: String?
     var customTitle: String?
+    /// Per-surface tab color, normalized as `#RRGGBB`. Optional for
+    /// backwards compatibility with pre-C11-10 snapshots; old snapshots
+    /// decode with `customColor == nil` via `decodeIfPresent`.
+    var customColor: String? = nil
     var directory: String?
     var isPinned: Bool
     var isManuallyUnread: Bool

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2291,6 +2291,8 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceList(params: params))
         case "surface.current":
             return v2Result(id: id, self.v2SurfaceCurrent(params: params))
+        case "surface.set_custom_color":
+            return v2Result(id: id, self.v2SurfaceSetCustomColor(params: params))
         case "surface.focus":
             return v2Result(id: id, self.v2SurfaceFocus(params: params))
         case "surface.split":
@@ -6056,7 +6058,8 @@ class TerminalController {
                     "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
                     "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id]),
                     "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id]),
-                    "tty": v2OrNull(ws.surfaceTTYNames[panel.id])
+                    "tty": v2OrNull(ws.surfaceTTYNames[panel.id]),
+                    "custom_color": v2OrNull(ws.panelCustomColor(panelId: panel.id))
                 ]
                 if let browserPanel = panel as? BrowserPanel {
                     item["developer_tools_visible"] = browserPanel.isDeveloperToolsVisible()
@@ -6108,7 +6111,8 @@ class TerminalController {
                 "pane_ref": v2Ref(kind: .pane, uuid: paneId),
                 "surface_id": v2OrNull(surfaceId?.uuidString),
                 "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
-                "surface_type": v2OrNull(surfaceId.flatMap { ws.panels[$0]?.panelType.rawValue })
+                "surface_type": v2OrNull(surfaceId.flatMap { ws.panels[$0]?.panelType.rawValue }),
+                "custom_color": v2OrNull(surfaceId.flatMap { ws.panelCustomColor(panelId: $0) })
             ]
         }
 
@@ -6116,6 +6120,58 @@ class TerminalController {
             return .err(code: "not_found", message: "Workspace not found", data: nil)
         }
         return .ok(payload)
+    }
+
+    private func v2SurfaceSetCustomColor(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let surfaceId = v2UUID(params, "surface_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
+        }
+
+        let clear = (params["clear"] as? Bool) ?? false
+        let hex = params["hex"] as? String
+
+        if !clear && hex == nil {
+            return .err(code: "invalid_params", message: "Provide either 'hex' or 'clear=true'", data: nil)
+        }
+        if !clear, let hex, WorkspaceTabColorSettings.normalizedHex(hex) == nil {
+            return .err(code: "invalid_params", message: "Invalid hex color (use #RRGGBB)", data: ["hex": hex])
+        }
+
+        var applied: String? = nil
+        var workspaceUUID: UUID? = nil
+        var found = false
+        v2MainSync {
+            guard let workspace = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
+            guard workspace.panels[surfaceId] != nil else { return }
+            workspaceUUID = workspace.id
+            found = true
+            if clear {
+                workspace.setPanelCustomColor(panelId: surfaceId, color: nil)
+                applied = nil
+            } else if let hex {
+                workspace.setPanelCustomColor(panelId: surfaceId, color: hex)
+                applied = workspace.panelCustomColor(panelId: surfaceId)
+            }
+        }
+
+        guard found else {
+            return .err(code: "not_found", message: "Surface not found", data: [
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId)
+            ])
+        }
+
+        return .ok([
+            "workspace_id": v2OrNull(workspaceUUID?.uuidString),
+            "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceUUID),
+            "surface_id": surfaceId.uuidString,
+            "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+            "custom_color": v2OrNull(applied),
+            "cleared": clear
+        ])
     }
 
     private func v2SurfaceFocus(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6136,6 +6136,9 @@ class TerminalController {
         if !clear && hex == nil {
             return .err(code: "invalid_params", message: "Provide either 'hex' or 'clear=true'", data: nil)
         }
+        if clear && hex != nil {
+            return .err(code: "invalid_params", message: "'clear' and 'hex' are mutually exclusive", data: nil)
+        }
         if !clear, let hex, WorkspaceTabColorSettings.normalizedHex(hex) == nil {
             return .err(code: "invalid_params", message: "Invalid hex color (use #RRGGBB)", data: ["hex": hex])
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -625,6 +625,7 @@ extension Workspace {
             type: panel.panelType,
             title: panelTitle,
             customTitle: customTitle,
+            customColor: panelCustomColors[panelId],
             directory: directory,
             isPinned: isPinned,
             isManuallyUnread: isManuallyUnread,
@@ -830,6 +831,7 @@ extension Workspace {
         }
 
         setPanelCustomTitle(panelId: panelId, title: snapshot.customTitle)
+        setPanelCustomColor(panelId: panelId, color: snapshot.customColor)
         setPanelPinned(panelId: panelId, pinned: snapshot.isPinned)
 
         if snapshot.isManuallyUnread {
@@ -5187,6 +5189,10 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var panelDirectories: [UUID: String] = [:]
     @Published var panelTitles: [UUID: String] = [:]
     @Published private(set) var panelCustomTitles: [UUID: String] = [:]
+    /// Per-surface custom color, normalized as `#RRGGBB`. Identity marker for
+    /// individual pane tabs; distinct from workspace-level `customColor` which
+    /// drives sidebar/theme chrome. See ticket C11-10.
+    @Published private(set) var panelCustomColors: [UUID: String] = [:]
     /// M7 per-surface title-bar collapse state (in-memory, session-scoped).
     @Published var titleBarCollapsed: [UUID: Bool] = [:]
     /// M7 per-surface flag: user explicitly collapsed this surface (suppresses auto-expand).
@@ -5767,6 +5773,7 @@ final class Workspace: Identifiable, ObservableObject {
         let directory: String?
         let cachedTitle: String?
         let customTitle: String?
+        let customColor: String?
         let manuallyUnread: Bool
     }
 
@@ -6092,6 +6099,34 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         syncPanelTitleFromMetadata(panelId: panelId)
+    }
+
+    /// Set or clear the surface tab color for a panel. Pass nil or an empty/whitespace
+    /// string to clear; otherwise the input is normalized to `#RRGGBB` via
+    /// `WorkspaceTabColorSettings.normalizedHex`. Invalid hex inputs are ignored
+    /// (state unchanged) so callers can pass user input directly.
+    func setPanelCustomColor(panelId: UUID, color: String?) {
+        guard panels[panelId] != nil else { return }
+        let next: String?
+        if let raw = color?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
+            guard let normalized = WorkspaceTabColorSettings.normalizedHex(raw) else { return }
+            next = normalized
+        } else {
+            next = nil
+        }
+        let previous = panelCustomColors[panelId]
+        guard previous != next else { return }
+        if let next {
+            panelCustomColors[panelId] = next
+        } else {
+            panelCustomColors.removeValue(forKey: panelId)
+        }
+    }
+
+    /// Returns the current normalized surface tab color for a panel, or nil if
+    /// none is set.
+    func panelCustomColor(panelId: UUID) -> String? {
+        panelCustomColors[panelId]
     }
 
     func isPanelPinned(_ panelId: UUID) -> Bool {
@@ -6820,6 +6855,7 @@ final class Workspace: Identifiable, ObservableObject {
         panelDirectories = panelDirectories.filter { validSurfaceIds.contains($0.key) }
         panelTitles = panelTitles.filter { validSurfaceIds.contains($0.key) }
         panelCustomTitles = panelCustomTitles.filter { validSurfaceIds.contains($0.key) }
+        panelCustomColors = panelCustomColors.filter { validSurfaceIds.contains($0.key) }
         pinnedPanelIds = pinnedPanelIds.filter { validSurfaceIds.contains($0) }
         manualUnreadPanelIds = manualUnreadPanelIds.filter { validSurfaceIds.contains($0) }
         panelGitBranches = panelGitBranches.filter { validSurfaceIds.contains($0.key) }
@@ -8389,6 +8425,11 @@ final class Workspace: Identifiable, ObservableObject {
         if let customTitle = detached.customTitle {
             panelCustomTitles[detached.panelId] = customTitle
         }
+        if let customColor = detached.customColor {
+            panelCustomColors[detached.panelId] = customColor
+        } else {
+            panelCustomColors.removeValue(forKey: detached.panelId)
+        }
         if detached.isPinned {
             pinnedPanelIds.insert(detached.panelId)
         } else {
@@ -8417,6 +8458,7 @@ final class Workspace: Identifiable, ObservableObject {
             panelDirectories.removeValue(forKey: detached.panelId)
             panelTitles.removeValue(forKey: detached.panelId)
             panelCustomTitles.removeValue(forKey: detached.panelId)
+            panelCustomColors.removeValue(forKey: detached.panelId)
             pinnedPanelIds.remove(detached.panelId)
             manualUnreadPanelIds.remove(detached.panelId)
             manualUnreadMarkedAt.removeValue(forKey: detached.panelId)
@@ -10396,6 +10438,7 @@ extension Workspace: BonsplitDelegate {
                 directory: panelDirectories[panelId],
                 cachedTitle: cachedTitle,
                 customTitle: panelCustomTitles[panelId],
+                customColor: panelCustomColors[panelId],
                 manuallyUnread: manualUnreadPanelIds.contains(panelId)
             )
         } else {
@@ -10419,6 +10462,7 @@ extension Workspace: BonsplitDelegate {
         panelPullRequests.removeValue(forKey: panelId)
         panelTitles.removeValue(forKey: panelId)
         panelCustomTitles.removeValue(forKey: panelId)
+        panelCustomColors.removeValue(forKey: panelId)
         pinnedPanelIds.remove(panelId)
         manualUnreadPanelIds.remove(panelId)
         manualUnreadMarkedAt.removeValue(forKey: panelId)
@@ -10582,6 +10626,7 @@ extension Workspace: BonsplitDelegate {
                 panelPullRequests.removeValue(forKey: panelId)
                 panelTitles.removeValue(forKey: panelId)
                 panelCustomTitles.removeValue(forKey: panelId)
+                panelCustomColors.removeValue(forKey: panelId)
                 pinnedPanelIds.remove(panelId)
                 manualUnreadPanelIds.remove(panelId)
                 panelSubscriptions.removeValue(forKey: panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6121,6 +6121,9 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             panelCustomColors.removeValue(forKey: panelId)
         }
+        if let tabId = surfaceIdFromPanelId(panelId) {
+            bonsplitController.updateTab(tabId, customColorHex: .some(next))
+        }
     }
 
     /// Returns the current normalized surface tab color for a panel, or nil if
@@ -8452,6 +8455,7 @@ final class Workspace: Identifiable, ObservableObject {
             isDirty: detached.panel.isDirty,
             isLoading: detached.isLoading,
             isPinned: detached.isPinned,
+            customColorHex: detached.customColor,
             inPane: paneId
         ) else {
             panels.removeValue(forKey: detached.panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5566,6 +5566,7 @@ final class Workspace: Identifiable, ObservableObject {
         )
         self.bonsplitController = BonsplitController(configuration: config)
         bonsplitController.contextMenuShortcuts = Self.buildContextMenuShortcuts()
+        bonsplitController.tabColorPalette = Self.bonsplitTabColorPalette()
 
         // Remove the default "Welcome" tab that bonsplit creates
         let welcomeTabIds = bonsplitController.allTabIds
@@ -8844,6 +8845,21 @@ final class Workspace: Identifiable, ObservableObject {
         return shortcuts
     }
 
+    /// Snapshot of the workspace tab color palette mapped into the Bonsplit
+    /// menu shape. Built once at workspace init; the user-defaults-backed
+    /// palette can grow during a session, but we accept the slight staleness
+    /// here in exchange for not adding a defaults observer in slice 4. A
+    /// follow-up can refresh this on UserDefaults change if needed.
+    static func bonsplitTabColorPalette() -> [BonsplitTabColorMenuItem] {
+        WorkspaceTabColorSettings.palette().map { entry in
+            BonsplitTabColorMenuItem(
+                id: entry.id,
+                label: entry.name,
+                hex: entry.hex
+            )
+        }
+    }
+
     // MARK: - Flash/Notification Support
 
     /// Single fan-out for a focus flash. Drives, in order:
@@ -11113,9 +11129,78 @@ extension Workspace: BonsplitDelegate {
         case .toggleZoom:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             toggleSplitZoom(panelId: panelId)
+        case .clearColor:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            setPanelCustomColor(panelId: panelId, color: nil)
+        case .chooseCustomColor:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            promptCustomTabColor(panelId: panelId)
         @unknown default:
             break
         }
+    }
+
+    func splitTabBar(_ controller: BonsplitController, didSelectTabColorPaletteEntry hex: String, for tab: Bonsplit.Tab, inPane pane: PaneID) {
+        guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+        setPanelCustomColor(panelId: panelId, color: hex)
+    }
+
+    private func promptCustomTabColor(panelId: UUID) {
+        let seed = panelCustomColors[panelId] ?? "#1565C0"
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "alert.tabColor.title",
+            defaultValue: "Custom Tab Color"
+        )
+        alert.informativeText = String(
+            localized: "alert.tabColor.message",
+            defaultValue: "Enter a hex color in the format #RRGGBB."
+        )
+
+        let input = NSTextField(string: seed)
+        input.placeholderString = "#1565C0"
+        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(
+            localized: "alert.tabColor.apply",
+            defaultValue: "Apply"
+        ))
+        alert.addButton(withTitle: String(
+            localized: "alert.tabColor.cancel",
+            defaultValue: "Cancel"
+        ))
+
+        let alertWindow = alert.window
+        alertWindow.initialFirstResponder = input
+        DispatchQueue.main.async {
+            alertWindow.makeFirstResponder(input)
+            input.selectText(nil)
+        }
+
+        let response = alert.runModal()
+        guard response == .alertFirstButtonReturn else { return }
+        let raw = input.stringValue
+        guard let normalized = WorkspaceTabColorSettings.addCustomColor(raw) else {
+            // Reuse the existing invalid-color path; mirror messaging used by
+            // the workspace color flow so users see a consistent explanation.
+            let invalid = NSAlert()
+            invalid.alertStyle = .warning
+            invalid.messageText = String(
+                localized: "alert.invalidColor.title",
+                defaultValue: "Invalid Color"
+            )
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            invalid.informativeText = trimmed.isEmpty
+                ? String(localized: "alert.invalidColor.emptyMessage", defaultValue: "Enter a hex color in the format #RRGGBB.")
+                : String(localized: "alert.invalidColor.invalidMessage", defaultValue: "\"\(trimmed)\" is not a valid hex color. Use #RRGGBB.")
+            invalid.addButton(withTitle: String(localized: "alert.invalidColor.ok", defaultValue: "OK"))
+            _ = invalid.runModal()
+            return
+        }
+        setPanelCustomColor(panelId: panelId, color: normalized)
+        // Refresh the bonsplit palette so newly-added custom colors are
+        // immediately visible in subsequent submenu opens.
+        bonsplitController.tabColorPalette = Self.bonsplitTabColorPalette()
     }
 
     func splitTabBar(_ controller: BonsplitController, didChangeGeometry snapshot: LayoutSnapshot) {

--- a/c11Tests/SessionPersistenceTests.swift
+++ b/c11Tests/SessionPersistenceTests.swift
@@ -108,6 +108,89 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testSessionPanelSnapshotCustomColorRoundTrip() throws {
+        let panelId = UUID()
+        let snapshot = SessionPanelSnapshot(
+            id: panelId,
+            type: .terminal,
+            title: nil,
+            customTitle: nil,
+            customColor: "#C0392B",
+            directory: nil,
+            isPinned: false,
+            isManuallyUnread: false,
+            gitBranch: nil,
+            listeningPorts: [],
+            ttyName: nil,
+            terminal: nil,
+            browser: nil,
+            markdown: nil,
+            metadata: nil,
+            metadataSources: nil
+        )
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertTrue(json.contains("\"customColor\""))
+        XCTAssertTrue(json.contains("#C0392B"))
+
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: encoded)
+        XCTAssertEqual(decoded.customColor, "#C0392B")
+        XCTAssertEqual(decoded.id, panelId)
+    }
+
+    func testSessionPanelSnapshotCustomColorOmittedWhenNil() throws {
+        let snapshot = SessionPanelSnapshot(
+            id: UUID(),
+            type: .terminal,
+            title: nil,
+            customTitle: nil,
+            customColor: nil,
+            directory: nil,
+            isPinned: false,
+            isManuallyUnread: false,
+            gitBranch: nil,
+            listeningPorts: [],
+            ttyName: nil,
+            terminal: nil,
+            browser: nil,
+            markdown: nil,
+            metadata: nil,
+            metadataSources: nil
+        )
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertFalse(
+            json.contains("\"customColor\""),
+            "Nil customColor should not bloat snapshots — JSONEncoder omits the key"
+        )
+
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: encoded)
+        XCTAssertNil(decoded.customColor)
+    }
+
+    func testSessionPanelSnapshotDecodesLegacyJSONWithoutCustomColor() throws {
+        let panelId = UUID()
+        // Hand-rolled legacy JSON without the customColor field; mirrors a
+        // pre-C11-10 snapshot. Must decode with customColor == nil.
+        let legacyJSON = """
+        {
+          "id": "\(panelId.uuidString)",
+          "type": "terminal",
+          "isPinned": false,
+          "isManuallyUnread": false,
+          "listeningPorts": []
+        }
+        """
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: data)
+
+        XCTAssertEqual(decoded.id, panelId)
+        XCTAssertNil(decoded.customColor)
+        XCTAssertNil(decoded.customTitle)
+    }
+
     func testWorkspaceCustomColorDecodeSupportsMissingLegacyField() throws {
         var snapshot = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
         snapshot.windows[0].tabManager.workspaces[0].customColor = nil

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -2070,4 +2070,77 @@ final class WorkspacePanelCustomColorTests: XCTestCase {
             "panelCustomColors must be cleared by teardownAllPanels (via pruneSurfaceMetadata)"
         )
     }
+
+    func testSetPanelCustomColorPropagatesToBonsplitTab() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId,
+              let tabId = workspace.surfaceIdFromPanelId(panelId) else {
+            XCTFail("Expected initial panel and bonsplit tab mapping")
+            return
+        }
+
+        XCTAssertNil(workspace.bonsplitController.tab(tabId)?.customColorHex)
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "#1565C0")
+        XCTAssertEqual(
+            workspace.bonsplitController.tab(tabId)?.customColorHex, "#1565C0",
+            "Setting a panel custom color must mirror through to the bonsplit tab"
+        )
+
+        workspace.setPanelCustomColor(panelId: panelId, color: nil)
+        XCTAssertNil(
+            workspace.bonsplitController.tab(tabId)?.customColorHex,
+            "Clearing a panel custom color must clear the bonsplit tab's value"
+        )
+    }
+
+    func testDetachAttachAcrossWorkspacesPreservesPanelCustomColor() {
+        let source = Workspace()
+        guard let panelId = source.focusedPanelId else {
+            XCTFail("Expected source focused panel")
+            return
+        }
+
+        source.setPanelCustomColor(panelId: panelId, color: "#7B3F00")
+
+        guard let detached = source.detachSurface(panelId: panelId) else {
+            XCTFail("Expected detach to succeed")
+            return
+        }
+
+        XCTAssertEqual(
+            detached.customColor, "#7B3F00",
+            "DetachedSurfaceTransfer must carry the surface tab color"
+        )
+        XCTAssertNil(
+            source.panelCustomColor(panelId: panelId),
+            "Source workspace cleanup paths must drop panelCustomColors entry on detach"
+        )
+
+        let destination = Workspace()
+        guard let destinationPane = destination.bonsplitController.allPaneIds.first else {
+            XCTFail("Expected destination pane")
+            return
+        }
+
+        let attachedPanelId = destination.attachDetachedSurface(
+            detached,
+            inPane: destinationPane,
+            focus: false
+        )
+        XCTAssertEqual(attachedPanelId, panelId)
+        XCTAssertEqual(
+            destination.panelCustomColor(panelId: panelId), "#7B3F00",
+            "Destination workspace must restore the surface tab color from the transfer"
+        )
+
+        guard let attachedTabId = destination.surfaceIdFromPanelId(panelId) else {
+            XCTFail("Expected attached tab mapping")
+            return
+        }
+        XCTAssertEqual(
+            destination.bonsplitController.tab(attachedTabId)?.customColorHex, "#7B3F00",
+            "Bonsplit tab in the destination must render the migrated color"
+        )
+    }
 }

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -1986,3 +1986,88 @@ final class WorkspaceCustomColorDidChangeTests: XCTestCase {
         XCTAssertEqual(fired, fired1, "Setting the same normalized hex must not re-publish")
     }
 }
+
+// MARK: - C11-10 surface tab color (panel-scoped custom color)
+
+@MainActor
+final class WorkspacePanelCustomColorTests: XCTestCase {
+    func testSetPanelCustomColorNormalizesValidHex() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected focused panel in new workspace")
+            return
+        }
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "ff8800")
+        XCTAssertEqual(workspace.panelCustomColor(panelId: panelId), "#FF8800")
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "  #aabbcc  ")
+        XCTAssertEqual(workspace.panelCustomColor(panelId: panelId), "#AABBCC")
+    }
+
+    func testSetPanelCustomColorRejectsInvalidHexLeavesPriorValue() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected focused panel in new workspace")
+            return
+        }
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "#123456")
+        XCTAssertEqual(workspace.panelCustomColor(panelId: panelId), "#123456")
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "not-a-color")
+        XCTAssertEqual(
+            workspace.panelCustomColor(panelId: panelId), "#123456",
+            "Invalid hex must not mutate the existing color"
+        )
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "#GGHHII")
+        XCTAssertEqual(workspace.panelCustomColor(panelId: panelId), "#123456")
+    }
+
+    func testSetPanelCustomColorClearsViaNilOrEmpty() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected focused panel in new workspace")
+            return
+        }
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "#C0392B")
+        XCTAssertEqual(workspace.panelCustomColor(panelId: panelId), "#C0392B")
+
+        workspace.setPanelCustomColor(panelId: panelId, color: nil)
+        XCTAssertNil(workspace.panelCustomColor(panelId: panelId))
+        XCTAssertNil(workspace.panelCustomColors[panelId])
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "#1565C0")
+        workspace.setPanelCustomColor(panelId: panelId, color: "   ")
+        XCTAssertNil(workspace.panelCustomColor(panelId: panelId))
+    }
+
+    func testSetPanelCustomColorIgnoresUnknownPanelId() {
+        let workspace = Workspace()
+        let unknownPanelId = UUID()
+
+        workspace.setPanelCustomColor(panelId: unknownPanelId, color: "#FF0000")
+        XCTAssertNil(workspace.panelCustomColor(panelId: unknownPanelId))
+        XCTAssertTrue(workspace.panelCustomColors.isEmpty)
+    }
+
+    func testTeardownClearsPanelCustomColors() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected focused panel in new workspace")
+            return
+        }
+
+        workspace.setPanelCustomColor(panelId: panelId, color: "#196F3D")
+        XCTAssertFalse(workspace.panelCustomColors.isEmpty)
+
+        workspace.teardownAllPanels()
+
+        XCTAssertTrue(
+            workspace.panelCustomColors.isEmpty,
+            "panelCustomColors must be cleared by teardownAllPanels (via pruneSurfaceMetadata)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Adds nullable per-surface tab color (normalized `#RRGGBB`) that follows the surface across reorder, cross-pane move, detach/reattach, cross-workspace, and session restore. First-class state on `Workspace.panelCustomColors`; mirrored into Bonsplit for rendering; exposed via socket `surface.set_custom_color` and `c11 surface-color {set|clear|get|list-palette}` (non-focus).
- New tab context-menu submenu **Tab Color** with palette / Choose Custom Color… / Clear Color (Bonsplit) wired through `setPanelCustomColor` (c11). All new strings localized for ja/uk/ko/zh-Hans/zh-Hant/ru in both c11 (`Resources/Localizable.xcstrings`) and Bonsplit (`Sources/Bonsplit/Resources/*.lproj`).
- Bonsplit submodule advanced through 5 commits on `Stage-11-Agentics/bonsplit` (`c11-10-surface-tab-color` branch + `c11-10-review-fixes` branch, both fast-forwarded into bonsplit `main`).

## Plan and ticket

- Lattice: **C11-10** — `task_01KPSV8EP543P5RTGRJDQ7DFB6`
- Plan: `.lattice/plans/task_01KPSV8EP543P5RTGRJDQ7DFB6.md` (operator-approved 2026-05-04 with 4 resolved decisions)
- Trident review pack: `notes/trident-review-C11-10-pack-20260504-2224/` (verdict `fix-then-merge`, no Blockers)
- Validation report: comment trail on the Lattice ticket, including a 5-minute operator smoke-test path

## Commits (chronological)

**Impl (6 slices):**
- `11cb128f` slice 1: panel custom color state + session snapshot round-trip
- `5b6e55b9`+`f1c6ee8c` slice 2: TabItem.customColorHex plumbing + c11 wiring
- `b18fd841` slice 3: tab color rendering (rail at `appearance.tabActiveIndicatorHeight`)
- `47e19309`+`ab2f9dae` slice 4: Tab Color submenu + c11 callback handlers + 4 new English strings
- `dc5dd408` slice 5: `surface.set_custom_color` v2 method + `c11 surface-color` CLI
- `f1cb44d6` slice 6: integration tests (Bonsplit mirror + cross-workspace move)

**Translator:**
- `457f7d5b` `alert.tabColor.*` localized for ja/uk/ko/zh-Hans/zh-Hant/ru
- `29ba7316` Bonsplit pointer bump for `command.tabColor.*` translations

**Review (trident applied items):**
- `bdb1dfeb` (I1) surface-color targets caller's env workspace (CMUX_WORKSPACE_ID first)
- `9003896d` (I2) get fails on stale/wrong-workspace UUID
- `9521966f` (I5) server rejects ambiguous clear+hex
- `0ea2c182` (M1+M2) CLI input hygiene
- `885a5209` (I3+I4) Bonsplit pointer bump for rail-height + swatch caching

**Validate (build fixes):**
- `6bae11e1` add missing `resolveCurrentWorkspaceId` helper (slice 5 escape)
- `9ba6853d` lift `try` over `??` in runSurfaceColorGet (slice 5 escape)

## Bonsplit submodule

5 commits land in `Stage-11-Agentics/bonsplit`:
- `e08fc07` Add optional customColorHex to TabItem/Tab and createTab/updateTab
- `c71ff96` Render optional customColorHex as restrained tab accent indicator
- `688e8fb` Add Tab Color submenu (clear/choose custom/palette) with localized strings
- `97b18915` localize command.tabColor.* for ja/uk/ko/zh-Hans/zh-Hant/ru
- `269e85f2` Review fixes (I3, I4): TabItemView appearance + swatch caching

The submodule pointer bump `29ba7316` also incidentally picks up upstream `8db34f0` "Appearance: chrome-scale public knobs + tabBarHeight rewire (#4)" which landed on bonsplit `main` between Impl and Translator. Not C11-10 work; just clean fast-forward of upstream.

## Test plan

- [ ] CI runs the unit + integration test suite (per project policy, no local runs).
- [ ] Run `./scripts/reload.sh --tag c11-10-tabcolor` from the worktree.
- [ ] Right-click any pane tab → **Tab Color** → pick a palette color. Confirm the tab strip shows the color rail (selected: full-height; unselected: 0.85 opacity).
- [ ] **Tab Color** → **Choose Custom Color…** → enter `#BADA55`, **Apply**. Confirm rail repaints.
- [ ] **Tab Color** → **Clear Color**. Confirm rail removed.
- [ ] Quit + relaunch tagged build. Confirm color persists.
- [ ] `C11_SOCKET=/tmp/c11-debug-c11-10-tabcolor.sock c11 surface-color set "#FF6B6B"` (focused tab); `c11 surface-color get` returns the value; `c11 surface-color clear` removes it.
- [ ] Verify pinned tab uses the same indicator (no special-case).
- [ ] Verify newly-created surface starts uncolored.
- [ ] Verify drag-and-drop a colored tab to another pane preserves the color.
- [ ] Verify focused workspace doesn't change when running `c11 surface-color set --workspace <other>` (non-focus).

## Resolved decisions (operator, 2026-05-04)

1. Socket API only; no surface-metadata mirror in this ticket.
2. Newly-created tabs start uncolored (no inheritance).
3. Duplicate-browser-tab capability is out of scope.
4. Pinned tabs render the same indicator (no special-case).

## Documented deviations from plan

1. Slice 4 chose NSAlert (parity with workspace-color flow) over the `presentTextInput` async path. Both already coexist in c11.
2. Slice 4 palette refresh: set once at workspace init + refreshed after a custom color is added; no UserDefaults observer (deferred).
3. Slice 4 c11 + Bonsplit shipped English-only initially; Translator phase filled the other 6 locales in two follow-up commits.

## Known follow-ups (not in this PR)

Trident review escalated 5 Surface-to-user + 3 Evolutionary items as follow-up candidates; full rationale lives in the Lattice ticket's Review-complete comment. Highlights:

- **S1** Bonsplit palette label localization (cross-flow with workspace-color labels).
- **S2** Dark-mode hex adjustment for custom-color rail.
- **S4** `addCustomColor` palette-grow side effect (cross-flow with workspace-color flow).
- **E1** SKILL edit teaching agents to set their own surface tab color when spawning siblings.
- **E2** Generalize `panelCustomTitles` + `panelCustomColors` (and friends) into a `PerSurfaceProperties` seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)