### PR TITLE
C11-25: surface lifecycle perf — webview suspension, terminal throttling, sidebar metrics, Hibernate Workspace

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
 		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
 		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
+		D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */; };
 		D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */; };
 		D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
 		D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */; };
@@ -333,6 +334,7 @@
 		D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
 		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
 		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
+		D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceLifecycle.swift; sourceTree = "<group>"; };
 		D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlan.swift; sourceTree = "<group>"; };
 		D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlanCodableTests.swift; sourceTree = "<group>"; };
 		D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLayoutExecutor.swift; sourceTree = "<group>"; };
@@ -701,6 +703,7 @@
 				D70B3BF1A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift */,
 				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
 				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
+				D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */,
 				D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */,
 				D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */,
 				D8005BF1A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift */,
@@ -1115,6 +1118,7 @@
 				D70B3BF0A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift in Sources */,
 				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
 				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
+				D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */,
 				D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */,
 				D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */,
 				D8005BF0A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
 		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
 		D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */; };
+		D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */; };
 		D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */; };
 		D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
 		D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */; };
@@ -335,6 +336,7 @@
 		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
 		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
 		D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceLifecycle.swift; sourceTree = "<group>"; };
+		D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserSnapshotStore.swift; sourceTree = "<group>"; };
 		D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlan.swift; sourceTree = "<group>"; };
 		D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlanCodableTests.swift; sourceTree = "<group>"; };
 		D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLayoutExecutor.swift; sourceTree = "<group>"; };
@@ -704,6 +706,7 @@
 				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
 				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
 				D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */,
+				D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */,
 				D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */,
 				D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */,
 				D8005BF1A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift */,
@@ -1119,6 +1122,7 @@
 				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
 				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
 				D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */,
+				D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */,
 				D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */,
 				D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */,
 				D8005BF0A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
 		D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */; };
 		D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */; };
+		D7C11254A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */; };
 		D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */; };
 		D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
 		D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */; };
@@ -337,6 +338,7 @@
 		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
 		D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceLifecycle.swift; sourceTree = "<group>"; };
 		D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserSnapshotStore.swift; sourceTree = "<group>"; };
+		D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetricsSampler.swift; sourceTree = "<group>"; };
 		D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlan.swift; sourceTree = "<group>"; };
 		D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlanCodableTests.swift; sourceTree = "<group>"; };
 		D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLayoutExecutor.swift; sourceTree = "<group>"; };
@@ -707,6 +709,7 @@
 				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
 				D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */,
 				D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */,
+				D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */,
 				D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */,
 				D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */,
 				D8005BF1A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift */,
@@ -1123,6 +1126,7 @@
 				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
 				D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */,
 				D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */,
+				D7C11254A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift in Sources */,
 				D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */,
 				D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */,
 				D8005BF0A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */; };
 		D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */; };
 		D7C11254A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */; };
+		D7C11256A1B2C3D4E5F60718 /* TerminalPIDResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11257A1B2C3D4E5F60718 /* TerminalPIDResolver.swift */; };
 		D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */; };
 		D8002BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
 		D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */; };
@@ -340,6 +341,7 @@
 		D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceLifecycle.swift; sourceTree = "<group>"; };
 		D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserSnapshotStore.swift; sourceTree = "<group>"; };
 		D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetricsSampler.swift; sourceTree = "<group>"; };
+		D7C11257A1B2C3D4E5F60718 /* TerminalPIDResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPIDResolver.swift; sourceTree = "<group>"; };
 		D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlan.swift; sourceTree = "<group>"; };
 		D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyPlanCodableTests.swift; sourceTree = "<group>"; };
 		D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceLayoutExecutor.swift; sourceTree = "<group>"; };
@@ -712,6 +714,7 @@
 				D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */,
 				D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */,
 				D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */,
+				D7C11257A1B2C3D4E5F60718 /* TerminalPIDResolver.swift */,
 				D8001BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift */,
 				D8003BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift */,
 				D8005BF1A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift */,
@@ -1130,6 +1133,7 @@
 				D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */,
 				D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */,
 				D7C11254A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift in Sources */,
+				D7C11256A1B2C3D4E5F60718 /* TerminalPIDResolver.swift in Sources */,
 				D8001BF0A1B2C3D4E5F60718 /* WorkspaceApplyPlan.swift in Sources */,
 				D8003BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutor.swift in Sources */,
 				D8005BF0A1B2C3D4E5F60718 /* WorkspaceSnapshot.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */; };
 		D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */; };
 		D800EBF0A1B2C3D4E5F60718 /* SurfaceMetadataStoreValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800EBF1A1B2C3D4E5F60718 /* SurfaceMetadataStoreValidationTests.swift */; };
+		D7C11260A1B2C3D4E5F60718 /* SurfaceLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11261A1B2C3D4E5F60718 /* SurfaceLifecycleTests.swift */; };
 		D800FBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStoreSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800FBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStoreSecurityTests.swift */; };
 		D8010BF0A1B2C3D4E5F60718 /* WorkspacePlanCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8010BF1A1B2C3D4E5F60718 /* WorkspacePlanCapture.swift */; };
 		D8011BF0A1B2C3D4E5F60718 /* WorkspaceBlueprintFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8011BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintFile.swift */; };
@@ -360,6 +361,7 @@
 		D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotCaptureTests.swift; sourceTree = "<group>"; };
 		D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotRoundTripAcceptanceTests.swift; sourceTree = "<group>"; };
 		D800EBF1A1B2C3D4E5F60718 /* SurfaceMetadataStoreValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetadataStoreValidationTests.swift; sourceTree = "<group>"; };
+		D7C11261A1B2C3D4E5F60718 /* SurfaceLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceLifecycleTests.swift; sourceTree = "<group>"; };
 		D800FBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStoreSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotStoreSecurityTests.swift; sourceTree = "<group>"; };
 		D8010BF1A1B2C3D4E5F60718 /* WorkspacePlanCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePlanCapture.swift; sourceTree = "<group>"; };
 		D8011BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceBlueprintFile.swift; sourceTree = "<group>"; };
@@ -942,6 +944,7 @@
 					D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */,
 					D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */,
 					D800EBF1A1B2C3D4E5F60718 /* SurfaceMetadataStoreValidationTests.swift */,
+					D7C11261A1B2C3D4E5F60718 /* SurfaceLifecycleTests.swift */,
 					D800FBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotStoreSecurityTests.swift */,
 				D8014BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintFileCodableTests.swift */,
 				D8015BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintStoreTests.swift */,
@@ -1330,6 +1333,7 @@
 					D800CBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift in Sources */,
 					D800DBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */,
 					D800EBF0A1B2C3D4E5F60718 /* SurfaceMetadataStoreValidationTests.swift in Sources */,
+					D7C11260A1B2C3D4E5F60718 /* SurfaceLifecycleTests.swift in Sources */,
 					D800FBF0A1B2C3D4E5F60718 /* WorkspaceSnapshotStoreSecurityTests.swift in Sources */,
 					D8014BF0A1B2C3D4E5F60718 /* WorkspaceBlueprintFileCodableTests.swift in Sources */,
 					D8015BF0A1B2C3D4E5F60718 /* WorkspaceBlueprintStoreTests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -18940,6 +18940,17 @@
         }
       }
     },
+    "contextMenu.hibernateWorkspaceTooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suspends browser surfaces in this workspace. Terminals stay on auto-throttle (already low-CPU when the workspace isn't focused)."
+          }
+        }
+      }
+    },
     "contextMenu.markWorkspaceRead": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -18893,6 +18893,17 @@
         }
       }
     },
+    "contextMenu.hibernateWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hibernate Workspace"
+          }
+        }
+      }
+    },
     "contextMenu.markWorkspaceRead": {
       "extractionState": "manual",
       "localizations": {
@@ -19641,6 +19652,17 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перейменувати робочий простір…"
+          }
+        }
+      }
+    },
+    "contextMenu.resumeWorkspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resume Workspace"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -18948,6 +18948,42 @@
             "state": "translated",
             "value": "Suspends browser surfaces in this workspace. Terminals stay on auto-throttle (already low-CPU when the workspace isn't focused)."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このワークスペース内のブラウザサーフェスを一時停止します。ターミナルは自動スロットルのまま動作します（ワークスペースが非フォーカス時はすでに低CPU使用率）。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂停此工作区中的浏览器界面。终端保持自动节流（工作区未聚焦时 CPU 占用已较低）。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫停此工作區中的瀏覽器介面。終端機維持自動節流（工作區未聚焦時 CPU 佔用已較低）。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 작업 공간의 브라우저 서피스를 일시 중단합니다. 터미널은 자동 스로틀 상태를 유지합니다(작업 공간에 포커스가 없을 때 이미 CPU 사용량이 낮음)."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приостанавливает поверхности браузера в этом рабочем пространстве. Терминалы остаются на автодросселировании (уже с низким потреблением ЦП, когда рабочее пространство не в фокусе)."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Призупиняє браузерні поверхні в цьому робочому просторі. Термінали залишаються на автодроселюванні (вже з низьким завантаженням ЦП, коли робочий простір не у фокусі)."
+          }
         }
       }
     },

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -18901,6 +18901,42 @@
             "state": "translated",
             "value": "Hibernate Workspace"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを休止"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "休眠工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "休眠工作區"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 절전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Усыпить рабочее пространство"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Призупинити робочий простір"
+          }
         }
       }
     },
@@ -19663,6 +19699,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Resume Workspace"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを再開"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢复工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "恢復工作區"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 다시 시작"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Возобновить рабочее пространство"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відновити робочий простір"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2358,6 +2358,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Register fenced code renderers for the markdown panel content pipeline.
         FencedCodeRendererRegistry.shared.register(MermaidRenderer.shared)
 
+        // C11-25: begin per-surface CPU/RSS sampling. Background timer; the
+        // sidebar reads samples via `SurfaceMetricsSampler.shared.sample(...)`
+        // during body eval. Idempotent — safe across UI tests that
+        // re-init the app delegate.
+        SurfaceMetricsSampler.shared.start()
+
         // Start watching the user themes directory for hot-reload.
         ThemeManager.shared.startWatchingUserThemes()
 

--- a/Sources/BrowserSnapshotStore.swift
+++ b/Sources/BrowserSnapshotStore.swift
@@ -1,0 +1,206 @@
+import AppKit
+import Foundation
+import WebKit
+
+/// Per-surface snapshot of a hibernated browser surface.
+///
+/// Captured before the WebContent process is torn down so the panel can
+/// render a placeholder image (instead of a blank rectangle) until the
+/// operator resumes the workspace.
+///
+/// All fields are best-effort:
+/// - `image` may be nil if `WKWebView.takeSnapshot` returns nil (rare;
+///   typically only when the webview has zero size).
+/// - `url` is the webview's current URL at capture time. Used to refire
+///   `load(URLRequest:)` on resume.
+/// - `scrollY` is read via `evaluateJavaScript("window.scrollY")` and is
+///   replayed via JS on the resumed page's `didFinish` callback.
+struct BrowserSurfaceSnapshot {
+    let image: NSImage?
+    let url: URL?
+    let scrollY: CGFloat?
+    let capturedAt: Date
+}
+
+/// In-memory store of per-surface browser snapshots used by the C11-25
+/// ARC-grade hibernate tier.
+///
+/// Keyed by surface UUID. Populated by `capture(...)` before the
+/// WebContent process is torn down; consumed by the placeholder render
+/// path in `BrowserPanelView` and by the resume path that recreates the
+/// WKWebView with the captured URL + scrollY.
+///
+/// Snapshots are NOT persisted across app launches in C11-25 — a
+/// hibernated workspace restored from disk renders a neutral placeholder
+/// until the operator resumes (C11-25 commit 8 wires the `lifecycle_state`
+/// metadata through the snapshot/restore path so the lifecycle survives;
+/// the IMAGE itself is in-memory-only for this PR — operator accepted
+/// in §0a).
+@MainActor
+final class BrowserSnapshotStore {
+    static let shared = BrowserSnapshotStore()
+
+    private var snapshots: [UUID: BrowserSurfaceSnapshot] = [:]
+
+    private init() {}
+
+    /// Capture the current visible state of `webView` and store it under
+    /// `surfaceId`. Calls `completion` on the main queue once all
+    /// best-effort captures complete.
+    ///
+    /// The image is captured via `WKWebView.takeSnapshot(with:)` (public
+    /// API); URL is read synchronously; scrollY is captured via JS.
+    /// Each leg is independent — a failure in one does not abort the
+    /// others. If the webview is in a degenerate state (zero bounds,
+    /// no URL, JS bridge broken), the snapshot is still stored and the
+    /// placeholder render path falls back to a neutral background.
+    func capture(
+        surfaceId: UUID,
+        webView: WKWebView,
+        completion: @escaping (BrowserSurfaceSnapshot) -> Void
+    ) {
+        let url = webView.url
+        let group = DispatchGroup()
+        var capturedImage: NSImage?
+        var capturedScrollY: CGFloat?
+
+        group.enter()
+        let snapshotConfig = WKSnapshotConfiguration()
+        snapshotConfig.afterScreenUpdates = false
+        webView.takeSnapshot(with: snapshotConfig) { image, _ in
+            capturedImage = image
+            group.leave()
+        }
+
+        group.enter()
+        webView.evaluateJavaScript("window.scrollY") { result, _ in
+            if let n = result as? NSNumber {
+                capturedScrollY = CGFloat(n.doubleValue)
+            }
+            group.leave()
+        }
+
+        group.notify(queue: .main) { [weak self] in
+            let snapshot = BrowserSurfaceSnapshot(
+                image: capturedImage,
+                url: url,
+                scrollY: capturedScrollY,
+                capturedAt: Date()
+            )
+            self?.snapshots[surfaceId] = snapshot
+            completion(snapshot)
+        }
+    }
+
+    /// Direct-set used during snapshot/restore (C11-25 commit 8) when the
+    /// image itself isn't available — the metadata says the surface was
+    /// hibernated but the in-memory image cache is empty after a restart.
+    /// Stores a metadata-only snapshot so the placeholder path renders a
+    /// neutral background instead of the empty webview.
+    func storeMetadataOnly(surfaceId: UUID, url: URL?) {
+        snapshots[surfaceId] = BrowserSurfaceSnapshot(
+            image: nil,
+            url: url,
+            scrollY: nil,
+            capturedAt: Date()
+        )
+    }
+
+    /// Look up a snapshot for a given surface. Returns nil when no
+    /// hibernate has been performed (or when the cache was cleared on
+    /// resume).
+    func snapshot(forSurfaceId id: UUID) -> BrowserSurfaceSnapshot? {
+        return snapshots[id]
+    }
+
+    /// Drop the cached snapshot. Called on resume after the WKWebView
+    /// has been recreated and the placeholder is no longer needed.
+    func clear(forSurfaceId id: UUID) {
+        snapshots.removeValue(forKey: id)
+    }
+}
+
+// MARK: - WebContent process identification (SPI)
+
+/// Access to `_webProcessIdentifier`, the WKWebView SPI returning the pid
+/// of the underlying WebContent process. Used by the ARC-grade hibernate
+/// tier (forceful SIGTERM fallback when graceful release does not reap
+/// the process) and by the per-surface CPU/MEM sampler (C11-25 commit 6).
+///
+/// SPI usage approved for C11-25 by the operator (2026-05-04). The
+/// existing c11 codebase uses similar private-selector access in several
+/// other paths.
+extension WKWebView {
+    /// Returns the pid of the WebContent process backing this webview, or
+    /// nil when the SPI is unavailable (would mean the WebKit framework
+    /// changed shape — log once and degrade gracefully) or when no
+    /// process is currently bound.
+    var c11_webProcessIdentifier: pid_t? {
+        let key = "_webProcessIdentifier"
+        guard responds(to: NSSelectorFromString(key)) else { return nil }
+        guard let raw = value(forKey: key) as? NSNumber else { return nil }
+        let pid = raw.int32Value
+        return pid > 0 ? pid : nil
+    }
+}
+
+// MARK: - WebContent termination helper
+
+/// Tear down a WKWebView's WebContent process. Used by the ARC-grade
+/// hibernate path — captures the snapshot first, then calls this helper
+/// to release the live process.
+@MainActor
+enum BrowserWebContentTerminator {
+    /// Outcome of a teardown attempt — surfaced for logging and DoD
+    /// verification.
+    enum Result {
+        /// Graceful teardown only — `stopLoading + delegates nil` was
+        /// performed; ARC will reap the WebContent process when the last
+        /// strong reference to the WKWebView drops.
+        case graceful
+        /// Forceful — graceful path was performed, AND we sent SIGTERM to
+        /// the WebContent pid because we observed it was still alive.
+        /// Currently unused in C11-25; reserved as a fallback the panel
+        /// can invoke if RSS measurement during validation shows the
+        /// process is not being reaped.
+        case sigterm(pid: pid_t)
+        /// No WebContent process was bound — webview was already inert.
+        case noProcess
+    }
+
+    /// Graceful teardown. Stops loading, nils delegates, removes from
+    /// superview. The caller should release its strong reference to the
+    /// WKWebView immediately after this returns; ARC then reaps the
+    /// WebContent process. C11-25 validation will measure RSS to confirm.
+    @discardableResult
+    static func tearDownGracefully(_ webView: WKWebView) -> Result {
+        let pid = webView.c11_webProcessIdentifier
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        webView.uiDelegate = nil
+        webView.removeFromSuperview()
+        if pid != nil {
+            return .graceful
+        }
+        return .noProcess
+    }
+
+    /// Send SIGTERM to the WebContent process. ONLY for the fallback
+    /// path when the graceful teardown has not reaped the process within
+    /// a measurement window. The pid is read via the
+    /// `_webProcessIdentifier` SPI; if the SPI returns nil (rare), this
+    /// is a no-op. Logs the action for forensic review.
+    @discardableResult
+    static func forceTerminateWebContentProcess(_ webView: WKWebView) -> Result {
+        guard let pid = webView.c11_webProcessIdentifier else {
+            return .noProcess
+        }
+        let rc = kill(pid, SIGTERM)
+        #if DEBUG
+        NSLog("[c11.lifecycle] forceTerminateWebContentProcess pid=\(pid) rc=\(rc)")
+        #else
+        _ = rc
+        #endif
+        return .sigterm(pid: pid)
+    }
+}

--- a/Sources/BrowserSnapshotStore.swift
+++ b/Sources/BrowserSnapshotStore.swift
@@ -54,12 +54,18 @@ final class BrowserSnapshotStore {
     /// others. If the webview is in a degenerate state (zero bounds,
     /// no URL, JS bridge broken), the snapshot is still stored and the
     /// placeholder render path falls back to a neutral background.
+    ///
+    /// `fallbackURL` is used when `webView.url` is nil at capture time
+    /// (e.g. restore-time hibernate fires before the freshly-mounted
+    /// webview has finished its initial navigation). Without it, resume
+    /// would have no URL to navigate back to.
     func capture(
         surfaceId: UUID,
         webView: WKWebView,
+        fallbackURL: URL? = nil,
         completion: @escaping (BrowserSurfaceSnapshot) -> Void
     ) {
-        let url = webView.url
+        let url = webView.url ?? fallbackURL
         let group = DispatchGroup()
         var capturedImage: NSImage?
         var capturedScrollY: CGFloat?

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11892,6 +11892,28 @@ private struct TabItemView: View, Equatable {
 
         Divider()
 
+        // C11-25: hibernate / resume the right-clicked workspace. Mirrors
+        // the App menu bar's Workspace submenu (`c11App.swift:1394`) so
+        // the action is reachable from the sidebar where operators expect
+        // it (DoD #6 placement). Browser surfaces snapshot + terminate
+        // their WebContent processes and render a placeholder until
+        // resume; terminals stay on the auto-throttle path.
+        if tab.isHibernated {
+            Button(String(localized: "contextMenu.resumeWorkspace", defaultValue: "Resume Workspace")) {
+                tab.resume()
+            }
+        } else {
+            Button(String(localized: "contextMenu.hibernateWorkspace", defaultValue: "Hibernate Workspace")) {
+                tab.hibernate()
+            }
+            .help(String(
+                localized: "contextMenu.hibernateWorkspaceTooltip",
+                defaultValue: "Suspends browser surfaces in this workspace. Terminals stay on auto-throttle (already low-CPU when the workspace isn't focused)."
+            ))
+        }
+
+        Divider()
+
         Button(markReadLabel) {
             markTabsRead(targetIds)
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8314,6 +8314,11 @@ private struct SidebarResizerAccessibilityModifier: ViewModifier {
 struct VerticalTabsSidebar: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     @ObservedObject private var themeManager = ThemeManager.shared
+    /// C11-25: subscribe to per-surface CPU/RSS sampler revision bumps so
+    /// the sidebar re-evaluates at the sample cadence (default 2 Hz).
+    /// `TabItemView.==` short-circuits body re-eval when the row's
+    /// metrics value didn't change, so this stays cheap.
+    @ObservedObject private var surfaceMetricsSampler = SurfaceMetricsSampler.shared
     let onSendFeedback: () -> Void
     @EnvironmentObject var tabManager: TabManager
     @EnvironmentObject var notificationStore: TerminalNotificationStore
@@ -8450,6 +8455,15 @@ struct VerticalTabsSidebar: View {
                                         sources: sources
                                     )
                                 }()
+                                // C11-25: read the focused surface's most recent CPU/RSS
+                                // sample as a precomputed `let`. The sampler's revision is
+                                // observed at the struct level so this re-evaluates at the
+                                // sample cadence; equality on the resolved sample (rounded
+                                // for stability) decides whether the row body re-renders.
+                                let surfaceMetricsSample: SurfaceMetricsSampler.Sample? = {
+                                    guard let focusedId = tab.focusedPanelId else { return nil }
+                                    return SurfaceMetricsSampler.shared.sample(forSurfaceId: focusedId)
+                                }()
                                 TabItemView(
                                     tabManager: tabManager,
                                     notificationStore: notificationStore,
@@ -8457,6 +8471,7 @@ struct VerticalTabsSidebar: View {
                                     index: index,
                                     isActive: isActive,
                                     agentChip: agentChip,
+                                    surfaceMetricsSample: surfaceMetricsSample,
                                     workspaceShortcutDigit: WorkspaceShortcutMapper.commandDigitForWorkspace(
                                         at: index,
                                         workspaceCount: workspaceCount
@@ -10919,6 +10934,7 @@ private struct TabItemView: View, Equatable {
         lhs.index == rhs.index &&
         lhs.isActive == rhs.isActive &&
         lhs.agentChip == rhs.agentChip &&
+        TabItemView.surfaceMetricsEqual(lhs.surfaceMetricsSample, rhs.surfaceMetricsSample) &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&
         lhs.accessibilityWorkspaceCount == rhs.accessibilityWorkspaceCount &&
@@ -10934,6 +10950,39 @@ private struct TabItemView: View, Equatable {
         lhs.sidebarFlashToken == rhs.sidebarFlashToken
     }
 
+    /// Equality on metric samples is rounded so sub-percent / sub-MB
+    /// jitter at the 2 Hz sample cadence does not invalidate
+    /// `TabItemView.==` and force body re-eval. We only redraw when the
+    /// rendered text would change.
+    nonisolated static func surfaceMetricsEqual(
+        _ a: SurfaceMetricsSampler.Sample?,
+        _ b: SurfaceMetricsSampler.Sample?
+    ) -> Bool {
+        switch (a, b) {
+        case (nil, nil):
+            return true
+        case let (a?, b?):
+            return Int(a.cpuPct.rounded()) == Int(b.cpuPct.rounded())
+                && Int(a.rssMb.rounded()) == Int(b.rssMb.rounded())
+        default:
+            return false
+        }
+    }
+
+    /// Render a Sample as a compact "<cpu>% <mem>" string.
+    /// CPU is integer percent (0%–800% on multi-core spikes); memory is
+    /// integer MB up to 1024, otherwise 1-decimal GB.
+    nonisolated static func formatSurfaceMetrics(_ sample: SurfaceMetricsSampler.Sample) -> String {
+        let cpu = "\(Int(sample.cpuPct.rounded()))%"
+        let mem: String
+        if sample.rssMb >= 1024 {
+            mem = String(format: "%.1fGB", sample.rssMb / 1024)
+        } else {
+            mem = "\(Int(sample.rssMb.rounded()))MB"
+        }
+        return "\(cpu) \(mem)"
+    }
+
     // Use plain references instead of @EnvironmentObject to avoid subscribing
     // to ALL changes on these objects. Body reads use precomputed parameters;
     // action handlers use the plain references without triggering re-evaluation.
@@ -10944,6 +10993,10 @@ private struct TabItemView: View, Equatable {
     let index: Int
     let isActive: Bool
     let agentChip: AgentChip?
+    /// C11-25: most recent CPU/RSS sample for the workspace's focused
+    /// surface, or nil when no PID is registered (terminals — pending
+    /// the TTY → child PID resolver follow-up).
+    let surfaceMetricsSample: SurfaceMetricsSampler.Sample?
     let workspaceShortcutDigit: Int?
     let canCloseWorkspace: Bool
     let accessibilityWorkspaceCount: Int
@@ -11319,6 +11372,19 @@ private struct TabItemView: View, Equatable {
                         secondary: activeSecondaryColor(0.68)
                     )
                     Spacer(minLength: 0)
+                    // C11-25: per-surface CPU/RSS rendered next to the
+                    // agent chip when a sample is available. Terminal
+                    // PID resolution is a follow-up; terminals show no
+                    // metrics until that lands. Format keeps the row
+                    // narrow: integer percent + integer MB or 1-decimal
+                    // GB. Equality in `==` is rounded for stability.
+                    if let sample = surfaceMetricsSample {
+                        Text(TabItemView.formatSurfaceMetrics(sample))
+                            .font(.system(size: 9, design: .monospaced))
+                            .monospacedDigit()
+                            .foregroundColor(activeSecondaryColor(0.55))
+                            .accessibilityIdentifier("SidebarTabSurfaceMetrics")
+                    }
                 }
                 .padding(.top, 1)
             }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2845,13 +2845,28 @@ final class BrowserPanel: Panel, ObservableObject {
     /// then replaces the WKWebView with a fresh inert one and releases
     /// the prior reference so ARC reaps the WebContent process. The
     /// panel's body branches to placeholder via `lifecycleState`.
+    ///
+    /// `currentURL` is passed as `fallbackURL` so cold-restore
+    /// hibernate (where `webView.url` may still be nil because the
+    /// freshly-mounted webview's initial navigation hasn't completed)
+    /// still records a URL for resume to navigate back to.
     private func performHibernate() {
         let liveWebView = webView
         BrowserSnapshotStore.shared.capture(
             surfaceId: self.id,
-            webView: liveWebView
+            webView: liveWebView,
+            fallbackURL: currentURL
         ) { [weak self] _ in
             guard let self else { return }
+            // Lifecycle-state guard at completion time, not just identity.
+            // If the operator hit Resume between `performHibernate` kicking
+            // off the async capture and the completion firing, the live
+            // webview is still bound and the panel is back to `.active`.
+            // Identity (oldWebView === webView) would still hold, so the
+            // identity-only guard inside `replaceWebViewForHibernate` is
+            // not enough — it would tear down the freshly-resumed browser.
+            // Bail out here when the operator already raced past hibernate.
+            guard self.lifecycle.state == .hibernated else { return }
             self.replaceWebViewForHibernate(oldWebView: liveWebView)
         }
     }
@@ -2860,11 +2875,18 @@ final class BrowserPanel: Panel, ObservableObject {
     /// replaced during hibernate) — refire `navigate(to:)` with the
     /// snapshot's URL so the WebContent process spins back up. Drops
     /// the cached snapshot once the navigation is initiated.
+    ///
+    /// Falls back to `currentURL` when the snapshot's URL is nil
+    /// (cold-restore hibernate captures whatever `webView.url` was at
+    /// capture time, which is nil if the initial navigation hadn't
+    /// landed yet). Without the fallback the resumed panel renders an
+    /// empty page with no recovery short of typing into the omnibar.
     private func performResumeFromHibernate() {
         let snapshot = BrowserSnapshotStore.shared.snapshot(forSurfaceId: self.id)
         BrowserSnapshotStore.shared.clear(forSurfaceId: self.id)
-        if let url = snapshot?.url {
-            shouldRenderWebView = true
+        let resumeURL = snapshot?.url ?? currentURL
+        shouldRenderWebView = true
+        if let url = resumeURL {
             navigate(to: url)
         }
     }
@@ -2875,6 +2897,13 @@ final class BrowserPanel: Panel, ObservableObject {
     /// and installs a fresh inert webview in its place. Unlike the
     /// post-crash variant, the new webview is NOT loaded with the
     /// original URL — the panel renders a placeholder until resume.
+    ///
+    /// The replacement IS bound through `bindWebView` so navigation /
+    /// UI delegates, KVO observers, and context-menu callbacks are in
+    /// place when the operator resumes (resume calls `navigate(to:)`
+    /// against the already-bound webview, and the regular
+    /// `shouldAttachWebView` path handles portal attachment once
+    /// `lifecycleState` flips back to `.active`).
     private func replaceWebViewForHibernate(oldWebView: WKWebView) {
         guard oldWebView === webView else { return }
         webViewObservers.removeAll()
@@ -2890,12 +2919,8 @@ final class BrowserPanel: Panel, ObservableObject {
         )
         webViewInstanceID = UUID()
         webView = replacement
-        // Don't bind the replacement to the portal — the body branches
-        // to placeholder while hibernated, and binding would
-        // unnecessarily reach for portal hosts that the placeholder
-        // doesn't use. Resume calls navigate(to:) which sets up the
-        // attachment via the regular shouldAttachWebView path once
-        // lifecycleState flips back to .active.
+        bindWebView(replacement)
+        applyBrowserThemeModeIfNeeded()
     }
 
     func reattachToWorkspace(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2704,6 +2704,15 @@ final class BrowserPanel: Panel, ObservableObject {
             self.dispatchLifecycleTransition(from: from, to: target)
         }
 
+        // C11-25 commit 6: register with the per-surface CPU/RSS sampler.
+        // The provider reads `_webProcessIdentifier` (KVC SPI; safe to
+        // call off-main) at sample time so it always reflects the
+        // current WebContent process — including after process
+        // termination + auto-relaunch.
+        SurfaceMetricsSampler.shared.register(surfaceId: self.id) { [weak self] in
+            return self?.webView.c11_webProcessIdentifier
+        }
+
         // Navigate to initial URL if provided
         if let url = initialURL {
             shouldRenderWebView = true
@@ -3271,6 +3280,7 @@ final class BrowserPanel: Panel, ObservableObject {
         webViewCancellables.removeAll()
         faviconTask?.cancel()
         faviconTask = nil
+        SurfaceMetricsSampler.shared.unregister(surfaceId: self.id)
     }
 
     // MARK: - Popup window management

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3327,6 +3327,11 @@ final class BrowserPanel: Panel, ObservableObject {
         faviconTask?.cancel()
         faviconTask = nil
         SurfaceMetricsSampler.shared.unregister(surfaceId: self.id)
+        // C11-25 review fix I2: drop any cached hibernate snapshot. Without
+        // this, an operator who closes a hibernated panel without resuming
+        // first leaks the captured NSImage indefinitely (snapshots are 2-8
+        // MB each; the store is unbounded).
+        BrowserSnapshotStore.shared.clear(forSurfaceId: self.id)
     }
 
     // MARK: - Popup window management

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1870,7 +1870,15 @@ final class BrowserPanel: Panel, ObservableObject {
     /// 6087 area) continues to be the implementation path; this
     /// controller adds the metadata seam and is the hook the ARC-grade
     /// hibernate path replaces in C11-25 commit 5.
+    ///
+    /// IUO because it's set at the end of `init` once all other stored
+    /// properties are assigned, so the handler can capture `[weak self]`.
     private(set) var lifecycle: SurfaceLifecycleController!
+
+    /// Published mirror of `lifecycle.state` so SwiftUI can re-render
+    /// (e.g. swap the live WKWebView for a placeholder NSImage when
+    /// hibernated). Updated by the lifecycle controller's handler.
+    @Published private(set) var lifecycleState: SurfaceLifecycleState = .active
 
     @Published private(set) var profileID: UUID
     @Published private(set) var historyStore: BrowserHistoryStore
@@ -2566,21 +2574,6 @@ final class BrowserPanel: Panel, ObservableObject {
     ) {
         self.id = id ?? UUID()
         self.workspaceId = workspaceId
-        let panelId = self.id
-        self.lifecycle = SurfaceLifecycleController(
-            workspaceId: workspaceId,
-            surfaceId: panelId,
-            initial: .active
-        ) { _, _ in
-            // Cheap-tier detach is auto-driven by the existing
-            // `WebViewRepresentable.shouldAttachWebView` gate in
-            // BrowserPanelView (~line 6087). The lifecycle controller
-            // mirrors the canonical `lifecycle_state` metadata key so
-            // the sidebar / `c11 tree --json` / snapshot can observe
-            // the state. C11-25 commit 5 replaces this handler with
-            // snapshot+terminate dispatch when the target is
-            // `.hibernated` (ARC-grade tier).
-        }
         let requestedProfileID = profileID ?? BrowserProfileStore.shared.effectiveLastUsedProfileID
         let resolvedProfileID = BrowserProfileStore.shared.profileDefinition(id: requestedProfileID) != nil
             ? requestedProfileID
@@ -2692,6 +2685,22 @@ final class BrowserPanel: Panel, ObservableObject {
         applyBrowserThemeModeIfNeeded()
         insecureHTTPAlertWindowProvider = { [weak self] in
             self?.webView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+        }
+
+        // Initialize the per-surface lifecycle controller AFTER all stored
+        // properties are set so the handler can capture `self` weakly.
+        // C11-25: cheap-tier detach is auto-driven by the existing
+        // `WebViewRepresentable.shouldAttachWebView` gate in BrowserPanelView
+        // (~line 6087). The controller mirrors the canonical `lifecycle_state`
+        // metadata key and updates `lifecycleState` for SwiftUI re-render.
+        // The C11-25 commit 5 hibernate path extends this handler with
+        // snapshot+terminate dispatch when the target is `.hibernated`.
+        self.lifecycle = SurfaceLifecycleController(
+            workspaceId: workspaceId,
+            surfaceId: self.id,
+            initial: .active
+        ) { [weak self] _, target in
+            self?.lifecycleState = target
         }
 
         // Navigate to initial URL if provided

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2522,6 +2522,24 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate
         setupObservers(for: webView)
+        // C11-25: refresh the cached WebContent pid for the metrics sampler
+        // on the main actor. The pid may still be 0 at bind time (the
+        // WebContent process spins up on first navigation) — `didFinish`
+        // refreshes again to pick it up.
+        refreshCachedWebContentPid()
+    }
+
+    /// Read `webView.c11_webProcessIdentifier` on the main actor and
+    /// push the scalar into `SurfaceMetricsSampler`'s lock-protected
+    /// cache. Called from every webview-binding seam (bindWebView,
+    /// replaceWebViewPreservingState, replaceWebViewForHibernate) and
+    /// from `didFinish` so process-per-origin or post-crash pid changes
+    /// are picked up. The sampler's off-main `tick()` reads the scalar
+    /// without ever touching `WKWebView` itself.
+    @MainActor
+    func refreshCachedWebContentPid() {
+        let pid = webView.c11_webProcessIdentifier
+        SurfaceMetricsSampler.shared.setPid(surfaceId: self.id, pid: pid)
     }
 
     private func configureNavigationDelegateCallbacks() {
@@ -2537,6 +2555,10 @@ final class BrowserPanel: Panel, ObservableObject {
                 self.applyBrowserThemeModeIfNeeded()
                 // Keep find-in-page open through load completion and refresh matches for the new DOM.
                 self.restoreFindStateAfterNavigation(replaySearch: true)
+                // C11-25: refresh the cached WebContent pid for the metrics
+                // sampler. didFinish lands after the WebContent process is
+                // alive, and process-per-origin reloads can change the pid.
+                self.refreshCachedWebContentPid()
             }
         }
         navigationDelegate.didFailNavigation = { [weak self] failedWebView, failedURL in
@@ -2704,14 +2726,13 @@ final class BrowserPanel: Panel, ObservableObject {
             self.dispatchLifecycleTransition(from: from, to: target)
         }
 
-        // C11-25 commit 6: register with the per-surface CPU/RSS sampler.
-        // The provider reads `_webProcessIdentifier` (KVC SPI; safe to
-        // call off-main) at sample time so it always reflects the
-        // current WebContent process — including after process
-        // termination + auto-relaunch.
-        SurfaceMetricsSampler.shared.register(surfaceId: self.id) { [weak self] in
-            return self?.webView.c11_webProcessIdentifier
-        }
+        // C11-25 commit 6 (review fix B4): register with the per-surface
+        // CPU/RSS sampler. WebContent pid is cached on the main actor
+        // (in `bindWebView` and on `didFinish`) and read off-main as a
+        // scalar by the sampler's `tick()`. The sampler never touches
+        // `WKWebView` itself off-main — that would be a `@MainActor`
+        // isolation violation against an AppKit/WebKit object.
+        SurfaceMetricsSampler.shared.register(surfaceId: self.id)
 
         // Navigate to initial URL if provided
         if let url = initialURL {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2692,15 +2692,16 @@ final class BrowserPanel: Panel, ObservableObject {
         // C11-25: cheap-tier detach is auto-driven by the existing
         // `WebViewRepresentable.shouldAttachWebView` gate in BrowserPanelView
         // (~line 6087). The controller mirrors the canonical `lifecycle_state`
-        // metadata key and updates `lifecycleState` for SwiftUI re-render.
-        // The C11-25 commit 5 hibernate path extends this handler with
-        // snapshot+terminate dispatch when the target is `.hibernated`.
+        // metadata key, updates `lifecycleState` for SwiftUI re-render, and
+        // dispatches snapshot+terminate on the ARC-grade hibernate path.
         self.lifecycle = SurfaceLifecycleController(
             workspaceId: workspaceId,
             surfaceId: self.id,
             initial: .active
-        ) { [weak self] _, target in
-            self?.lifecycleState = target
+        ) { [weak self] from, target in
+            guard let self else { return }
+            self.lifecycleState = target
+            self.dispatchLifecycleTransition(from: from, to: target)
         }
 
         // Navigate to initial URL if provided
@@ -2784,6 +2785,108 @@ final class BrowserPanel: Panel, ObservableObject {
     func applyVisibility(_ isVisibleInUI: Bool) {
         if lifecycle.state.isOperatorPinned { return }
         lifecycle.transition(to: isVisibleInUI ? .active : .throttled)
+    }
+
+    /// Operator-driven transition into / out of `.hibernated`. Invoked
+    /// from `TabManager.hibernateWorkspace` / `resumeWorkspace`
+    /// (C11-25 commit 7). Hibernating captures the current snapshot
+    /// and tears down the WebContent process; resuming refires
+    /// `load(URLRequest:)` against the captured URL.
+    func setHibernated(_ on: Bool) {
+        if on {
+            lifecycle.transition(to: .hibernated)
+        } else if lifecycle.state == .hibernated {
+            lifecycle.transition(to: .active)
+        }
+    }
+
+    /// React to a lifecycle transition. Called from the controller's
+    /// handler closure, which already updated `lifecycleState`. Splits
+    /// the work by transition direction:
+    ///
+    /// - `* → .hibernated`: capture snapshot, then release the live
+    ///   WKWebView so ARC reaps the WebContent process. The panel's
+    ///   `webView` is replaced with a fresh, unloaded WKWebView; the
+    ///   body branches to `BrowserHibernatedPlaceholderView` until
+    ///   resume.
+    /// - `.hibernated → .active`: read the captured snapshot's URL
+    ///   and refire `navigate(to:)`. Cookies survive because the
+    ///   `WKHTTPCookieStore` lives at the process-pool level.
+    ///   Best-effort scroll restore is deferred (operator accepted in
+    ///   §0a of the C11-25 plan).
+    /// - `* → .throttled`, `.throttled → .active`: cheap-tier detach
+    ///   is auto-driven by the existing `shouldAttachWebView` gate;
+    ///   no extra dispatch needed here.
+    /// - `* → .suspended`: not entered in C11-25.
+    private func dispatchLifecycleTransition(
+        from: SurfaceLifecycleState,
+        to target: SurfaceLifecycleState
+    ) {
+        switch (from, target) {
+        case (let prior, .hibernated) where prior != .hibernated:
+            performHibernate()
+        case (.hibernated, .active):
+            performResumeFromHibernate()
+        default:
+            break
+        }
+    }
+
+    /// ARC-grade hibernate. Captures a snapshot of the current page,
+    /// then replaces the WKWebView with a fresh inert one and releases
+    /// the prior reference so ARC reaps the WebContent process. The
+    /// panel's body branches to placeholder via `lifecycleState`.
+    private func performHibernate() {
+        let liveWebView = webView
+        BrowserSnapshotStore.shared.capture(
+            surfaceId: self.id,
+            webView: liveWebView
+        ) { [weak self] _ in
+            guard let self else { return }
+            self.replaceWebViewForHibernate(oldWebView: liveWebView)
+        }
+    }
+
+    /// Resume from hibernate. The WKWebView is fresh-and-empty (was
+    /// replaced during hibernate) — refire `navigate(to:)` with the
+    /// snapshot's URL so the WebContent process spins back up. Drops
+    /// the cached snapshot once the navigation is initiated.
+    private func performResumeFromHibernate() {
+        let snapshot = BrowserSnapshotStore.shared.snapshot(forSurfaceId: self.id)
+        BrowserSnapshotStore.shared.clear(forSurfaceId: self.id)
+        if let url = snapshot?.url {
+            shouldRenderWebView = true
+            navigate(to: url)
+        }
+    }
+
+    /// Hibernate-time companion to `replaceWebViewPreservingState`.
+    /// Tears down the live WKWebView (graceful: stopLoading + delegates
+    /// nil + portal detach + ARC release via reference replacement)
+    /// and installs a fresh inert webview in its place. Unlike the
+    /// post-crash variant, the new webview is NOT loaded with the
+    /// original URL — the panel renders a placeholder until resume.
+    private func replaceWebViewForHibernate(oldWebView: WKWebView) {
+        guard oldWebView === webView else { return }
+        webViewObservers.removeAll()
+        webViewCancellables.removeAll()
+        faviconTask?.cancel()
+        faviconTask = nil
+        BrowserWindowPortalRegistry.detach(webView: oldWebView)
+        BrowserWebContentTerminator.tearDownGracefully(oldWebView)
+
+        let replacement = Self.makeWebView(
+            profileID: profileID,
+            websiteDataStore: websiteDataStore
+        )
+        webViewInstanceID = UUID()
+        webView = replacement
+        // Don't bind the replacement to the portal — the body branches
+        // to placeholder while hibernated, and binding would
+        // unnecessarily reach for portal hosts that the placeholder
+        // doesn't use. Resume calls navigate(to:) which sets up the
+        // attachment via the regular shouldAttachWebView path once
+        // lifecycleState flips back to .active.
     }
 
     func reattachToWorkspace(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1862,6 +1862,16 @@ final class BrowserPanel: Panel, ObservableObject {
     /// The workspace ID this panel belongs to
     private(set) var workspaceId: UUID
 
+    /// Per-surface lifecycle controller (C11-25). Owns the canonical
+    /// `lifecycle_state` metadata mirror. Cheap-tier detach (when a
+    /// workspace is deselected, `isVisibleInUI` flips false and the
+    /// existing `WebViewRepresentable.shouldAttachWebView` gate calls
+    /// `BrowserWindowPortalRegistry.hide` — see BrowserPanelView line
+    /// 6087 area) continues to be the implementation path; this
+    /// controller adds the metadata seam and is the hook the ARC-grade
+    /// hibernate path replaces in C11-25 commit 5.
+    private(set) var lifecycle: SurfaceLifecycleController!
+
     @Published private(set) var profileID: UUID
     @Published private(set) var historyStore: BrowserHistoryStore
 
@@ -2556,6 +2566,21 @@ final class BrowserPanel: Panel, ObservableObject {
     ) {
         self.id = id ?? UUID()
         self.workspaceId = workspaceId
+        let panelId = self.id
+        self.lifecycle = SurfaceLifecycleController(
+            workspaceId: workspaceId,
+            surfaceId: panelId,
+            initial: .active
+        ) { _, _ in
+            // Cheap-tier detach is auto-driven by the existing
+            // `WebViewRepresentable.shouldAttachWebView` gate in
+            // BrowserPanelView (~line 6087). The lifecycle controller
+            // mirrors the canonical `lifecycle_state` metadata key so
+            // the sidebar / `c11 tree --json` / snapshot can observe
+            // the state. C11-25 commit 5 replaces this handler with
+            // snapshot+terminate dispatch when the target is
+            // `.hibernated` (ARC-grade tier).
+        }
         let requestedProfileID = profileID ?? BrowserProfileStore.shared.effectiveLastUsedProfileID
         let resolvedProfileID = BrowserProfileStore.shared.profileDefinition(id: requestedProfileID) != nil
             ? requestedProfileID
@@ -2737,6 +2762,19 @@ final class BrowserPanel: Panel, ObservableObject {
 
     func updateWorkspaceId(_ newWorkspaceId: UUID) {
         workspaceId = newWorkspaceId
+        lifecycle.updateWorkspaceId(newWorkspaceId)
+    }
+
+    // MARK: - Lifecycle dispatch
+
+    /// Translate the panel's `isVisibleInUI` from SwiftUI into a lifecycle
+    /// transition. Idempotent; called on workspace-selection edge events
+    /// (`.onChange`) and at panel mount (`.onAppear`). Operator-pinned
+    /// `hibernated` is preserved — only `active ↔ throttled` flips on
+    /// auto-visibility changes.
+    func applyVisibility(_ isVisibleInUI: Bool) {
+        if lifecycle.state.isOperatorPinned { return }
+        lifecycle.transition(to: isVisibleInUI ? .active : .throttled)
     }
 
     func reattachToWorkspace(
@@ -2747,6 +2785,7 @@ final class BrowserPanel: Panel, ObservableObject {
         remoteStatus: BrowserRemoteWorkspaceStatus?
     ) {
         workspaceId = newWorkspaceId
+        lifecycle.updateWorkspaceId(newWorkspaceId)
         usesRemoteWorkspaceProxy = isRemoteWorkspace
         let targetStore = isRemoteWorkspace
             ? WKWebsiteDataStore(forIdentifier: remoteWebsiteDataStoreIdentifier ?? newWorkspaceId)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2584,6 +2584,14 @@ final class BrowserPanel: Panel, ObservableObject {
     /// - Parameter id: Stable panel UUID. Pass `nil` for fresh creation; pass a
     ///   snapshot's panel id during session restore to keep IDs stable across
     ///   app restarts (Tier 1 persistence, Phase 1).
+    /// - Parameter pendingHibernate: C11-25 fix S4+E1. When `true`, the
+    ///   panel comes up natively in `.hibernated` and the initial
+    ///   `WKWebView.load(URLRequest:)` is suppressed — no cookies attach,
+    ///   no pageview is billed against `initialURL` until the operator
+    ///   resumes. Used by `WorkspaceLayoutExecutor` when a `c11 restore`
+    ///   plan declares `lifecycle_state == "hibernated"` for the surface.
+    ///   The `initialURL` is still recorded (in `currentURL` and the
+    ///   snapshot store) so `Resume Workspace` has a destination.
     init(
         id: UUID? = nil,
         workspaceId: UUID,
@@ -2592,7 +2600,8 @@ final class BrowserPanel: Panel, ObservableObject {
         bypassInsecureHTTPHostOnce: String? = nil,
         proxyEndpoint: BrowserProxyEndpoint? = nil,
         isRemoteWorkspace: Bool = false,
-        remoteWebsiteDataStoreIdentifier: UUID? = nil
+        remoteWebsiteDataStoreIdentifier: UUID? = nil,
+        pendingHibernate: Bool = false
     ) {
         self.id = id ?? UUID()
         self.workspaceId = workspaceId
@@ -2716,14 +2725,25 @@ final class BrowserPanel: Panel, ObservableObject {
         // (~line 6087). The controller mirrors the canonical `lifecycle_state`
         // metadata key, updates `lifecycleState` for SwiftUI re-render, and
         // dispatches snapshot+terminate on the ARC-grade hibernate path.
+        //
+        // C11-25 fix S4+E1: when `pendingHibernate` is set the controller
+        // starts at `.hibernated` so the SwiftUI body branches straight to
+        // `BrowserHibernatedPlaceholderView` and the WKWebView is never
+        // attached. `lifecycleState` is set explicitly because the
+        // controller's initial-state assignment does not fire the
+        // transition handler (handler runs on real transitions only).
+        let initialLifecycle: SurfaceLifecycleState = pendingHibernate ? .hibernated : .active
         self.lifecycle = SurfaceLifecycleController(
             workspaceId: workspaceId,
             surfaceId: self.id,
-            initial: .active
+            initial: initialLifecycle
         ) { [weak self] from, target in
             guard let self else { return }
             self.lifecycleState = target
             self.dispatchLifecycleTransition(from: from, to: target)
+        }
+        if pendingHibernate {
+            self.lifecycleState = .hibernated
         }
 
         // C11-25 commit 6 (review fix B4): register with the per-surface
@@ -2734,10 +2754,27 @@ final class BrowserPanel: Panel, ObservableObject {
         // isolation violation against an AppKit/WebKit object.
         SurfaceMetricsSampler.shared.register(surfaceId: self.id)
 
-        // Navigate to initial URL if provided
+        // Navigate to initial URL if provided.
+        //
+        // C11-25 fix S4+E1: when this panel is being constructed in
+        // `.hibernated` (operator restored a hibernated workspace), skip
+        // the initial navigate entirely so no request fires for
+        // `initialURL` — closes the privacy/billing leak where cookies
+        // attach and a billable pageview lands during the brief window
+        // between construction and the legacy re-hibernate dispatch.
+        // Resume reads the URL from `currentURL` (or the snapshot store
+        // entry primed below) when the operator unfreezes the workspace.
         if let url = initialURL {
-            shouldRenderWebView = true
-            navigate(to: url)
+            if pendingHibernate {
+                self.currentURL = url
+                BrowserSnapshotStore.shared.storeMetadataOnly(
+                    surfaceId: self.id,
+                    url: url
+                )
+            } else {
+                shouldRenderWebView = true
+                navigate(to: url)
+            }
         }
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1187,7 +1187,21 @@ struct BrowserPanelView: View {
             isCurrentPaneOwner
 
         return Group {
-            if panel.shouldRenderWebView {
+            if panel.lifecycleState == .hibernated {
+                // C11-25 ARC-grade tier: the WebContent process has been
+                // released for this surface. Render the cached snapshot
+                // (or a neutral background if the snapshot is missing,
+                // e.g. after a c11 restart). The placeholder swaps back
+                // to the live WKWebView when the operator resumes the
+                // workspace and the lifecycle transitions back to
+                // `.active`. The state mirror is `@Published` on
+                // BrowserPanel so SwiftUI re-renders on transition.
+                BrowserHibernatedPlaceholderView(
+                    surfaceId: panel.id,
+                    backgroundColor: Color(nsColor: browserChromeBackgroundColor)
+                )
+                .accessibilityIdentifier("BrowserHibernatedPlaceholder")
+            } else if panel.shouldRenderWebView {
                 WebViewRepresentable(
                     panel: panel,
                     paneId: paneId,
@@ -6471,5 +6485,32 @@ struct WebViewRepresentable: NSViewRepresentable {
             panelId: panel.id,
             paneId: paneId
         )
+    }
+}
+
+// MARK: - C11-25 hibernated browser placeholder
+
+/// SwiftUI placeholder rendered in place of a live WKWebView when a
+/// browser surface is in the `.hibernated` lifecycle state. Pulls the
+/// captured NSImage snapshot from `BrowserSnapshotStore`; if the cache
+/// is empty (e.g. workspace restored from disk before a snapshot was
+/// re-captured), falls back to a neutral background tinted to the
+/// browser's current chrome color.
+private struct BrowserHibernatedPlaceholderView: View {
+    let surfaceId: UUID
+    let backgroundColor: Color
+
+    var body: some View {
+        ZStack {
+            backgroundColor
+            if let snapshot = BrowserSnapshotStore.shared.snapshot(forSurfaceId: surfaceId),
+               let image = snapshot.image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .clipped()
+            }
+        }
+        .contentShape(Rectangle())
     }
 }

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -674,6 +674,9 @@ struct BrowserPanelView: View {
             }
         }
         .onChange(of: isVisibleInUI) { visibleInUI in
+            // C11-25: drive per-surface lifecycle (active ↔ throttled) from
+            // the same flag the rest of the panel reads. Edge-event only.
+            panel.applyVisibility(visibleInUI)
             if visibleInUI {
                 panel.cancelPendingDeveloperToolsVisibilityLossCheck()
                 return
@@ -682,6 +685,12 @@ struct BrowserPanelView: View {
             // final host settles. Only treat a stable hide as a signal to consume
             // an attached-inspector X-close.
             panel.scheduleDeveloperToolsVisibilityLossCheck()
+        }
+        .onAppear {
+            // C11-25: seed the lifecycle state from the initial visibility at
+            // panel mount. Workspaces created in the background mount with
+            // `isVisibleInUI == false` and want to start in `.throttled`.
+            panel.applyVisibility(isVisibleInUI)
         }
         .onChange(of: isFocused) { focused in
 #if DEBUG

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -57,6 +57,12 @@ final class TerminalPanel: Panel, ObservableObject {
     /// `Workspace.toggleTextBoxMode` to detect and move focus.
     weak var inputTextView: InputTextView?
 
+    /// Per-surface lifecycle controller (C11-25). Owns the canonical
+    /// `lifecycle_state` metadata mirror and dispatches occlusion to
+    /// libghostty on state transitions. Visibility is driven from
+    /// `TerminalPanelView` via `applyVisibility(_:)`.
+    let lifecycle: SurfaceLifecycleController
+
     private var cancellables = Set<AnyCancellable>()
 
     var displayTitle: String {
@@ -92,6 +98,17 @@ final class TerminalPanel: Panel, ObservableObject {
         self.id = surface.id
         self.workspaceId = workspaceId
         self.surface = surface
+        self.lifecycle = SurfaceLifecycleController(
+            workspaceId: workspaceId,
+            surfaceId: surface.id,
+            initial: .active
+        ) { [weak surface] _, target in
+            // Pause libghostty's CVDisplayLink wakeups when the surface
+            // leaves `.active`. PTY drains in every state — only the
+            // renderer is throttled. Called on workspace-selection edge
+            // events; never on the typing-latency hot path.
+            surface?.setOcclusion(target == .active)
+        }
 
         // Subscribe to surface's search state changes
         surface.$searchState
@@ -150,6 +167,24 @@ final class TerminalPanel: Panel, ObservableObject {
     func updateWorkspaceId(_ newWorkspaceId: UUID) {
         workspaceId = newWorkspaceId
         surface.updateWorkspaceId(newWorkspaceId)
+        lifecycle.updateWorkspaceId(newWorkspaceId)
+    }
+
+    // MARK: - Lifecycle dispatch
+
+    /// Translate the panel's `isVisibleInUI` from SwiftUI into a
+    /// lifecycle transition. Idempotent: calling with the same value
+    /// twice is a no-op. Called on workspace-selection edge events
+    /// (`.onChange`) and at panel mount (`.onAppear`); never on the
+    /// typing-latency hot path.
+    ///
+    /// Operator-pinned states (`hibernated`) are preserved — only
+    /// `active ↔ throttled` flip on automatic visibility changes. A
+    /// hibernated panel resumes via the operator's "Resume Workspace"
+    /// action, which calls `setHibernated(false)`.
+    func applyVisibility(_ isVisibleInUI: Bool) {
+        if lifecycle.state.isOperatorPinned { return }
+        lifecycle.transition(to: isVisibleInUI ? .active : .throttled)
     }
 
     func focus() {

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -111,11 +111,15 @@ final class TerminalPanel: Panel, ObservableObject {
         }
 
         // C11-25 commit 6: register with the per-surface CPU/RSS sampler.
-        // Terminal child PID resolution is a follow-up (plan §2 row 5
-        // notes the TTY → PID lookup needs a libghostty accessor or an
-        // lsof-style helper). For now we register without a pid so the
-        // surface is known to the sampler; the sidebar renders `—` for
-        // terminal CPU/RSS until the resolver lands.
+        //
+        // C11-25 fix DoD #5: terminal CPU/MEM is now wired via the
+        // Sendable pid-provider rail. The provider is installed in
+        // `TerminalController.reportTTY` once the shell announces its
+        // tty (the only point in time where the tty name is known to
+        // the app side); the sampler invokes `TerminalPIDResolver`
+        // every couple of seconds to track the foreground process.
+        // Until that report lands, the surface is registered without
+        // a pid and the sidebar renders `—`.
         SurfaceMetricsSampler.shared.register(surfaceId: surface.id)
 
         // Subscribe to surface's search state changes

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -113,10 +113,10 @@ final class TerminalPanel: Panel, ObservableObject {
         // C11-25 commit 6: register with the per-surface CPU/RSS sampler.
         // Terminal child PID resolution is a follow-up (plan §2 row 5
         // notes the TTY → PID lookup needs a libghostty accessor or an
-        // lsof-style helper). For now we register a nil-returning
-        // provider so the surface is known to the sampler; the sidebar
-        // renders `—` for terminal CPU/RSS until the resolver lands.
-        SurfaceMetricsSampler.shared.register(surfaceId: surface.id) { nil }
+        // lsof-style helper). For now we register without a pid so the
+        // surface is known to the sampler; the sidebar renders `—` for
+        // terminal CPU/RSS until the resolver lands.
+        SurfaceMetricsSampler.shared.register(surfaceId: surface.id)
 
         // Subscribe to surface's search state changes
         surface.$searchState

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -110,6 +110,14 @@ final class TerminalPanel: Panel, ObservableObject {
             surface?.setOcclusion(target == .active)
         }
 
+        // C11-25 commit 6: register with the per-surface CPU/RSS sampler.
+        // Terminal child PID resolution is a follow-up (plan §2 row 5
+        // notes the TTY → PID lookup needs a libghostty accessor or an
+        // lsof-style helper). For now we register a nil-returning
+        // provider so the surface is known to the sampler; the sidebar
+        // renders `—` for terminal CPU/RSS until the resolver lands.
+        SurfaceMetricsSampler.shared.register(surfaceId: surface.id) { nil }
+
         // Subscribe to surface's search state changes
         surface.$searchState
             .sink { [weak self] state in
@@ -224,6 +232,7 @@ final class TerminalPanel: Panel, ObservableObject {
         unfocus()
         hostedView.setVisibleInUI(false)
         TerminalWindowPortalRegistry.detach(hostedView: hostedView)
+        SurfaceMetricsSampler.shared.unregister(surfaceId: id)
 #if DEBUG
         dlog(
             "surface.panel.close.end panel=\(id.uuidString.prefix(5)) " +

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -142,6 +142,15 @@ struct TerminalPanelView: View {
         // This prevents transient teardown/recreate that can momentarily detach the hosted terminal view.
         .id(panel.id)
         .background(Color.clear)
+        // C11-25: drive the per-surface lifecycle (active ↔ throttled) from
+        // the same `isVisibleInUI` flag the rest of the panel reads. Edge-
+        // event only — onChange/onAppear, never per-keystroke.
+        .onAppear {
+            panel.applyVisibility(isVisibleInUI)
+        }
+        .onChange(of: isVisibleInUI) { newValue in
+            panel.applyVisibility(newValue)
+        }
     }
 }
 

--- a/Sources/SurfaceLifecycle.swift
+++ b/Sources/SurfaceLifecycle.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// Per-surface lifecycle state.
+///
+/// One of four discrete states, mirrored to canonical metadata under
+/// `lifecycle_state` so that the sidebar, `c11 tree --json`, the socket,
+/// and `c11 snapshot` / `restore` can observe it without coupling to
+/// runtime Swift state.
+///
+/// State semantics (per the C11-25 plan):
+///
+/// - `active` — workspace selected, full-rate render, full input.
+/// - `throttled` — workspace deselected. Terminals: libghostty CVDisplayLink
+///   paused via `ghostty_surface_set_occlusion(false)`; PTY drains.
+///   Browsers: WKWebView detached from the host view hierarchy
+///   (cheap-tier suspension).
+/// - `suspended` — reserved. Not entered in C11-25; defined in the enum so
+///   the metadata key has an upgrade path for C11-25b (browser ARC-grade
+///   tier) and future SIGSTOP-tier terminal hibernation.
+/// - `hibernated` — operator-explicit. Browsers: WKWebView snapshot to
+///   NSImage placeholder + WebContent process termination (ARC-grade).
+///   Terminals: same throttle behavior as `throttled` (PTY drains;
+///   SIGSTOP'ing the child is deferred). Survives c11 snapshot/restore;
+///   only resumed by an operator action ("Resume Workspace").
+///
+/// Transition table:
+///
+///     active        → throttled, hibernated
+///     throttled     → active,    hibernated
+///     hibernated    → active
+///     suspended     → (none — reserved in C11-25)
+///     * → suspended → (none — reserved in C11-25)
+///
+/// Self-transitions (X → X) are accepted as a no-op so dispatchers can
+/// idempotently call `transition(to:)` on every workspace-visibility tick
+/// without bouncing the metadata store.
+public enum SurfaceLifecycleState: String, Sendable, CaseIterable {
+    case active
+    case throttled
+    case suspended
+    case hibernated
+
+    /// Canonical metadata key the state is mirrored to.
+    public static let metadataKey = "lifecycle_state"
+
+    /// Maximum length of the metadata string value. The longest case
+    /// (`hibernated`) is 10 chars; the cap is 32 to leave headroom and
+    /// match the `status` key's existing convention.
+    public static let metadataMaxLength = 32
+
+    /// Returns true if transitioning from `self` to `target` is allowed.
+    ///
+    /// Self-transitions are always allowed (idempotent no-op). Transitions
+    /// into or out of `.suspended` are rejected in C11-25; the state is
+    /// reserved for future PRs.
+    public func canTransition(to target: SurfaceLifecycleState) -> Bool {
+        if self == target { return true }
+        switch (self, target) {
+        case (.active, .throttled),
+             (.throttled, .active),
+             (.active, .hibernated),
+             (.throttled, .hibernated),
+             (.hibernated, .active):
+            return true
+        case (_, .suspended), (.suspended, _):
+            return false
+        default:
+            return false
+        }
+    }
+
+    /// True when the surface is operator-pinned to a non-active state and
+    /// must not auto-resume on workspace selection. Only `hibernated`
+    /// satisfies this in C11-25 — `throttled` rehydrates automatically on
+    /// selection, and `suspended` is reserved.
+    public var isOperatorPinned: Bool {
+        switch self {
+        case .hibernated: return true
+        case .active, .throttled, .suspended: return false
+        }
+    }
+}
+
+/// Owns a surface's current `SurfaceLifecycleState`, gates transitions
+/// through the validator, mirrors them to canonical metadata, and fires
+/// a handler so panels can dispatch the AppKit-side work
+/// (detach/bind WebView, set-occlusion, snapshot/terminate, …).
+///
+/// Lives on the panel/controller layer (TerminalPanel, BrowserPanel),
+/// not the surface view, per plan §1.3 — the view is too low-level and
+/// the panel is where workspace-visibility input arrives.
+@MainActor
+final class SurfaceLifecycleController {
+    typealias Handler = (_ from: SurfaceLifecycleState, _ to: SurfaceLifecycleState) -> Void
+
+    let workspaceId: UUID
+    let surfaceId: UUID
+    private(set) var state: SurfaceLifecycleState
+    private let onTransition: Handler
+
+    init(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        initial: SurfaceLifecycleState = .active,
+        onTransition: @escaping Handler
+    ) {
+        self.workspaceId = workspaceId
+        self.surfaceId = surfaceId
+        self.state = initial
+        self.onTransition = onTransition
+    }
+
+    /// Transition to `target`. Returns whether the transition was applied.
+    ///
+    /// Behavior:
+    /// - Rejects (returns `false`) if the validator forbids the transition.
+    /// - Idempotent same-state calls return `true` without firing the handler
+    ///   or writing metadata.
+    /// - On a real transition, writes the new state to
+    ///   `SurfaceMetadataStore` under `lifecycle_state` (default source
+    ///   `.explicit` — operator/agent intent), then invokes the handler.
+    @discardableResult
+    func transition(to target: SurfaceLifecycleState, source: MetadataSource = .explicit) -> Bool {
+        guard state.canTransition(to: target) else { return false }
+        if state == target { return true }
+        let prior = state
+        state = target
+        SurfaceMetadataStore.shared.setInternal(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            key: SurfaceLifecycleState.metadataKey,
+            value: target.rawValue,
+            source: source
+        )
+        onTransition(prior, target)
+        return true
+    }
+
+    /// Seed the controller's state from the metadata mirror without firing
+    /// the handler. Used at restore time (cold path) so a snapshot's
+    /// `hibernated` value carries forward without re-running detach/etc.
+    /// during workspace mount.
+    func seed(from state: SurfaceLifecycleState) {
+        self.state = state
+    }
+}

--- a/Sources/SurfaceLifecycle.swift
+++ b/Sources/SurfaceLifecycle.swift
@@ -93,7 +93,7 @@ public enum SurfaceLifecycleState: String, Sendable, CaseIterable {
 final class SurfaceLifecycleController {
     typealias Handler = (_ from: SurfaceLifecycleState, _ to: SurfaceLifecycleState) -> Void
 
-    let workspaceId: UUID
+    private(set) var workspaceId: UUID
     let surfaceId: UUID
     private(set) var state: SurfaceLifecycleState
     private let onTransition: Handler
@@ -108,6 +108,13 @@ final class SurfaceLifecycleController {
         self.surfaceId = surfaceId
         self.state = initial
         self.onTransition = onTransition
+    }
+
+    /// Reparent the controller to a new workspace. Subsequent metadata
+    /// writes flow to the new workspace; old-workspace metadata is left
+    /// alone (prunes when the surface entry closes).
+    func updateWorkspaceId(_ newWorkspaceId: UUID) {
+        self.workspaceId = newWorkspaceId
     }
 
     /// Transition to `target`. Returns whether the transition was applied.

--- a/Sources/SurfaceLifecycle.swift
+++ b/Sources/SurfaceLifecycle.swift
@@ -9,14 +9,18 @@ import Foundation
 ///
 /// State semantics (per the C11-25 plan):
 ///
-/// - `active` — workspace selected, full-rate render, full input.
-/// - `throttled` — workspace deselected. Terminals: libghostty CVDisplayLink
-///   paused via `ghostty_surface_set_occlusion(false)`; PTY drains.
-///   Browsers: WKWebView detached from the host view hierarchy
-///   (cheap-tier suspension).
-/// - `suspended` — reserved. Not entered in C11-25; defined in the enum so
-///   the metadata key has an upgrade path for C11-25b (browser ARC-grade
-///   tier) and future SIGSTOP-tier terminal hibernation.
+/// - `active` — workspace selected, full-rate render, full input. The
+///   surface is occluded=false / not-visible=false; libghostty drives
+///   CVDisplayLink at full rate.
+/// - `throttled` — workspace deselected. Terminals: surface is marked
+///   occluded (`ghostty_surface_set_occlusion(visible=false)` →
+///   libghostty pauses CVDisplayLink wakeups while the PTY continues
+///   to drain). Browsers: WKWebView detached from the host view
+///   hierarchy (cheap-tier suspension).
+/// - `suspended` — reserved-only metadata value with NO accepting
+///   transitions. The metadata validator rejects writes of this value
+///   (see I4 review fix); kept in the enum so future PRs can wire it
+///   without a schema migration but never enters runtime in C11-25.
 /// - `hibernated` — operator-explicit. Browsers: WKWebView snapshot to
 ///   NSImage placeholder + WebContent process termination (ARC-grade).
 ///   Terminals: same throttle behavior as `throttled` (PTY drains;
@@ -28,8 +32,8 @@ import Foundation
 ///     active        → throttled, hibernated
 ///     throttled     → active,    hibernated
 ///     hibernated    → active
-///     suspended     → (none — reserved in C11-25)
-///     * → suspended → (none — reserved in C11-25)
+///     suspended     → (none — reserved; rejected at validator)
+///     * → suspended → (none — reserved; rejected at validator)
 ///
 /// Self-transitions (X → X) are accepted as a no-op so dispatchers can
 /// idempotently call `transition(to:)` on every workspace-visibility tick
@@ -97,6 +101,11 @@ final class SurfaceLifecycleController {
     let surfaceId: UUID
     private(set) var state: SurfaceLifecycleState
     private let onTransition: Handler
+    /// Reentrancy guard. The current dispatch graph is shallow — handlers
+    /// run synchronously and don't loop back into `transition` — but if a
+    /// future handler does (e.g. a hibernate-fail rollback), recursive
+    /// re-entry would be hard to diagnose. Cheap insurance.
+    private var isTransitioning = false
 
     init(
         workspaceId: UUID,
@@ -126,8 +135,17 @@ final class SurfaceLifecycleController {
     /// - On a real transition, writes the new state to
     ///   `SurfaceMetadataStore` under `lifecycle_state` (default source
     ///   `.explicit` — operator/agent intent), then invokes the handler.
+    /// - Reentrant calls from inside the handler are rejected (returns
+    ///   `false`); a debug `assertionFailure` flags them in DEBUG so they
+    ///   surface in tests.
     @discardableResult
     func transition(to target: SurfaceLifecycleState, source: MetadataSource = .explicit) -> Bool {
+        if isTransitioning {
+            assertionFailure(
+                "SurfaceLifecycleController.transition reentered while a prior transition is in flight"
+            )
+            return false
+        }
         guard state.canTransition(to: target) else { return false }
         if state == target { return true }
         let prior = state
@@ -139,15 +157,9 @@ final class SurfaceLifecycleController {
             value: target.rawValue,
             source: source
         )
+        isTransitioning = true
+        defer { isTransitioning = false }
         onTransition(prior, target)
         return true
-    }
-
-    /// Seed the controller's state from the metadata mirror without firing
-    /// the handler. Used at restore time (cold path) so a snapshot's
-    /// `hibernated` value carries forward without re-running detach/etc.
-    /// during workspace mount.
-    func seed(from state: SurfaceLifecycleState) {
-        self.state = state
     }
 }

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -17,12 +17,13 @@ public enum MetadataKey {
     public static let terminalType = "terminal_type"
     public static let title = "title"
     public static let description = "description"
+    public static let lifecycleState = "lifecycle_state"
 
     /// Non-canonical display hint used by M3's sidebar chip.
     public static let modelLabel = "model_label"
 
     public static let canonical: Set<String> = [
-        role, status, task, model, progress, terminalType, title, description
+        role, status, task, model, progress, terminalType, title, description, lifecycleState
     ]
 
     public static let canonicalTerminalTypes: Set<String> = [
@@ -154,6 +155,7 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         "terminal_type",
         "title",
         "description",
+        "lifecycle_state",
         "claude.session_id",
         "claude.session_project_dir"
     ]
@@ -183,6 +185,28 @@ final class SurfaceMetadataStore: @unchecked Sendable {
             return validateString(key: key, value: value, maxLen: 256)
         case "description":
             return validateString(key: key, value: value, maxLen: 2048)
+        case "lifecycle_state":
+            // Canonical per-surface lifecycle state (C11-25). The set of
+            // legal values is defined by `SurfaceLifecycleState`; reject
+            // anything outside that vocabulary so a stale snapshot or a
+            // typo can't leak into the runtime path. Length cap matches
+            // `SurfaceLifecycleState.metadataMaxLength`.
+            guard let s = value as? String else {
+                return .reservedKeyInvalidType(key, "expected string")
+            }
+            if s.count > SurfaceLifecycleState.metadataMaxLength {
+                return .reservedKeyInvalidType(
+                    key,
+                    "exceeds max length \(SurfaceLifecycleState.metadataMaxLength)"
+                )
+            }
+            if SurfaceLifecycleState(rawValue: s) == nil {
+                return .reservedKeyInvalidType(
+                    key,
+                    "must be one of: active, throttled, suspended, hibernated"
+                )
+            }
+            return nil
         case "claude.session_id":
             // Claude SessionStart's `session_id` is a UUIDv4; reject
             // anything else. The value is interpolated verbatim into

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -191,6 +191,15 @@ final class SurfaceMetadataStore: @unchecked Sendable {
             // anything outside that vocabulary so a stale snapshot or a
             // typo can't leak into the runtime path. Length cap matches
             // `SurfaceLifecycleState.metadataMaxLength`.
+            //
+            // Review fix I4: `.suspended` is reserved-only — the runtime
+            // dispatcher rejects every transition into and out of it
+            // (`SurfaceLifecycleState.canTransition`). Allowing the
+            // metadata write here would let an external writer park a
+            // value the runtime cannot consume, splitting the metadata
+            // mirror from the state machine. Reject at the validator
+            // until a future PR (C11-25c / SIGSTOP terminal hibernate)
+            // lands a real consumer.
             guard let s = value as? String else {
                 return .reservedKeyInvalidType(key, "expected string")
             }
@@ -200,10 +209,16 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                     "exceeds max length \(SurfaceLifecycleState.metadataMaxLength)"
                 )
             }
-            if SurfaceLifecycleState(rawValue: s) == nil {
+            guard let parsed = SurfaceLifecycleState(rawValue: s) else {
                 return .reservedKeyInvalidType(
                     key,
-                    "must be one of: active, throttled, suspended, hibernated"
+                    "must be one of: active, throttled, hibernated"
+                )
+            }
+            if parsed == .suspended {
+                return .reservedKeyInvalidType(
+                    key,
+                    "'suspended' is reserved and not yet a runtime target; use 'hibernated' for operator-pinned surfaces"
                 )
             }
             return nil

--- a/Sources/SurfaceMetricsSampler.swift
+++ b/Sources/SurfaceMetricsSampler.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Combine
+import Darwin
+
+/// Per-surface CPU/RSS sampler. C11-25 commit 6.
+///
+/// Runs on a background `DispatchSourceTimer` at a fixed cadence (default
+/// 2 Hz, tunable to 1 Hz via `UserDefaults` key
+/// `c11.surfaceMetrics.sampleHz`). On each tick it walks every registered
+/// surface, resolves the surface's process identifier via the registered
+/// closure, and samples `proc_pid_rusage(pid, RUSAGE_INFO_V4)` to read
+/// cumulative CPU time + resident-size bytes. CPU% is derived from the
+/// inter-tick CPU-time delta against the inter-tick wall-clock delta.
+///
+/// Threading: the sampler is not `@MainActor` — its state is protected
+/// by an `os_unfair_lock`, and the timer fires off-main. The `@Published
+/// revision` counter is bumped on the main queue after each tick so
+/// SwiftUI re-evaluates the sidebar at the cadence —
+/// `TabItemView.==` catches unchanged metric values and short-circuits
+/// body re-eval, preserving the typing-latency invariant.
+///
+/// PID resolution differs by surface kind:
+///
+/// - Browsers: `webView.c11_webProcessIdentifier` (the
+///   `_webProcessIdentifier` SPI). Cheap, in-process.
+/// - Terminals: NOT YET IMPLEMENTED in C11-25. The TTY → child PID
+///   resolver requires either a libghostty surface accessor patch or a
+///   `lsof`-style process-listing helper. Plan §2 row 5 acknowledges
+///   this is a follow-up; for C11-25 commit 6 the terminal panel
+///   registers a provider that returns `nil`, the sidebar renders `—`
+///   for terminal CPU/RSS.
+final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
+    static let shared = SurfaceMetricsSampler()
+
+    /// Per-surface sample. Stored briefly between ticks; consumers read
+    /// via `sample(forSurfaceId:)`.
+    struct Sample: Equatable {
+        let cpuPct: Double  // percent, may exceed 100 on multi-core spikes
+        let rssMb: Double
+        let sampledAt: Date
+    }
+
+    /// SwiftUI observation hook. Bumped on the main queue after each
+    /// sampling tick. Sidebar reads via `@ObservedObject` to receive
+    /// objectWillChange notifications.
+    @Published private(set) var revision: UInt64 = 0
+
+    private let lock: UnsafeMutablePointer<os_unfair_lock_s>
+    private var samples: [UUID: Sample] = [:]
+    private var pidProviders: [UUID: () -> pid_t?] = [:]
+    private var lastCpuTimes: [pid_t: UInt64] = [:]
+    private var lastSampleAt: Date?
+
+    private let queue = DispatchQueue(
+        label: "com.stage11.c11.surface-metrics",
+        qos: .utility
+    )
+    private var timer: DispatchSourceTimer?
+
+    private init() {
+        lock = .allocate(capacity: 1)
+        lock.initialize(to: os_unfair_lock_s())
+    }
+
+    /// Begin sampling. Idempotent.
+    func start() {
+        // Construct timer off-main; idempotency check is locked.
+        let intervalMs: Int = {
+            let hz = max(1.0, min(10.0, Self.configuredHz()))
+            return Int(1000.0 / hz)
+        }()
+        os_unfair_lock_lock(lock)
+        guard timer == nil else {
+            os_unfair_lock_unlock(lock)
+            return
+        }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(
+            deadline: .now() + .milliseconds(intervalMs),
+            repeating: .milliseconds(intervalMs)
+        )
+        self.timer = timer
+        os_unfair_lock_unlock(lock)
+        timer.setEventHandler { [weak self] in
+            self?.tick()
+        }
+        timer.resume()
+    }
+
+    /// Stop sampling. Used in tests.
+    func stop() {
+        os_unfair_lock_lock(lock)
+        let t = timer
+        timer = nil
+        os_unfair_lock_unlock(lock)
+        t?.cancel()
+    }
+
+    /// Register a surface + PID provider. The provider is invoked off-main
+    /// during sampling; it must be thread-safe (or read state that is).
+    /// Browser panels pass a closure that reads
+    /// `webView.c11_webProcessIdentifier` (KVC, safe off-main); terminal
+    /// panels pass `{ nil }` for C11-25.
+    func register(surfaceId: UUID, pidProvider: @escaping () -> pid_t?) {
+        os_unfair_lock_lock(lock)
+        pidProviders[surfaceId] = pidProvider
+        os_unfair_lock_unlock(lock)
+    }
+
+    /// Drop a surface's registration and any cached sample.
+    func unregister(surfaceId: UUID) {
+        os_unfair_lock_lock(lock)
+        pidProviders.removeValue(forKey: surfaceId)
+        samples.removeValue(forKey: surfaceId)
+        os_unfair_lock_unlock(lock)
+    }
+
+    /// Read the most recent sample for a surface (or nil if none yet /
+    /// PID provider returned nil). Cheap dictionary lookup; safe to call
+    /// from SwiftUI body.
+    func sample(forSurfaceId id: UUID) -> Sample? {
+        os_unfair_lock_lock(lock)
+        defer { os_unfair_lock_unlock(lock) }
+        return samples[id]
+    }
+
+    deinit {
+        timer?.cancel()
+        lock.deinitialize(count: 1)
+        lock.deallocate()
+    }
+
+    // MARK: - Configuration
+
+    private static func configuredHz() -> Double {
+        let raw = UserDefaults.standard.double(forKey: "c11.surfaceMetrics.sampleHz")
+        return raw > 0 ? raw : 2.0
+    }
+
+    // MARK: - Sampling tick
+
+    private func tick() {
+        let now = Date()
+        os_unfair_lock_lock(lock)
+        let providers = pidProviders
+        let priorTimes = lastCpuTimes
+        let prior = lastSampleAt
+        os_unfair_lock_unlock(lock)
+
+        let dt: Double = prior.map { now.timeIntervalSince($0) } ?? 0
+        var newSamples: [UUID: Sample] = [:]
+        var newTimes: [pid_t: UInt64] = [:]
+
+        for (surfaceId, provider) in providers {
+            guard let pid = provider() else { continue }
+            guard let cumulative = Self.proc_pid_cumulative_cpu_ns(pid) else { continue }
+            let rssBytes = Self.proc_pid_rss_bytes(pid) ?? 0
+
+            let cpuPct: Double
+            if dt > 0, let last = priorTimes[pid], cumulative >= last {
+                let deltaNs = Double(cumulative - last)
+                cpuPct = min(800.0, deltaNs / 1e9 / dt * 100.0)
+            } else {
+                cpuPct = 0
+            }
+            newTimes[pid] = cumulative
+            newSamples[surfaceId] = Sample(
+                cpuPct: cpuPct,
+                rssMb: Double(rssBytes) / 1024.0 / 1024.0,
+                sampledAt: now
+            )
+        }
+
+        os_unfair_lock_lock(lock)
+        samples = newSamples
+        lastCpuTimes = newTimes
+        lastSampleAt = now
+        os_unfair_lock_unlock(lock)
+
+        // Bump revision on main so SwiftUI re-evaluates the sidebar.
+        DispatchQueue.main.async { [weak self] in
+            self?.revision &+= 1
+        }
+    }
+
+    // MARK: - proc_pid_rusage helpers
+
+    /// Cumulative user+system CPU time in nanoseconds for `pid`, via
+    /// `proc_pid_rusage(RUSAGE_INFO_V4)`. Returns nil if the call fails
+    /// (e.g. the process exited).
+    private static func proc_pid_cumulative_cpu_ns(_ pid: pid_t) -> UInt64? {
+        var ri = rusage_info_v4()
+        let rc = withUnsafeMutablePointer(to: &ri) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { boxPtr in
+                proc_pid_rusage(pid, RUSAGE_INFO_V4, boxPtr)
+            }
+        }
+        guard rc == 0 else { return nil }
+        return ri.ri_user_time &+ ri.ri_system_time
+    }
+
+    /// Resident set size in bytes for `pid`, via the same call. Returns
+    /// nil on failure.
+    private static func proc_pid_rss_bytes(_ pid: pid_t) -> UInt64? {
+        var ri = rusage_info_v4()
+        let rc = withUnsafeMutablePointer(to: &ri) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { boxPtr in
+                proc_pid_rusage(pid, RUSAGE_INFO_V4, boxPtr)
+            }
+        }
+        guard rc == 0 else { return nil }
+        return ri.ri_resident_size
+    }
+}

--- a/Sources/SurfaceMetricsSampler.swift
+++ b/Sources/SurfaceMetricsSampler.swift
@@ -27,12 +27,14 @@ import Darwin
 ///   `os_unfair_lock`; the off-main `tick()` reads it as a scalar.
 ///   This avoids touching `WKWebView` (a `@MainActor` AppKit object)
 ///   from the sampler's utility queue.
-/// - Terminals: NOT YET IMPLEMENTED in C11-25. The TTY → child PID
-///   resolver requires either a libghostty surface accessor patch or a
-///   `lsof`-style process-listing helper. Plan §2 row 5 acknowledges
-///   this is a follow-up; for C11-25 commit 6 the terminal panel
-///   registers without supplying a pid, and the sidebar renders `—`
-///   for terminal CPU/RSS.
+/// - Terminals: a Sendable PID provider closure registered via
+///   `setPidProvider(surfaceId:provider:)`. The sampler re-invokes the
+///   closure on its utility queue every `pidProviderRefreshSeconds`
+///   (default 2s) and updates the cached scalar. The closure is
+///   typically `TerminalPIDResolver.foregroundPID(forTTYName:)` against
+///   the surface's reported tty — pure C-API (`stat` + `proc_listpids`
+///   + `proc_pidinfo`), so no main-actor dependency. Closes the DoD #5
+///   gap that was open after C11-25 commit 6 (browser-only).
 final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
     static let shared = SurfaceMetricsSampler()
 
@@ -61,6 +63,19 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
     private var cachedPids: [UUID: pid_t] = [:]
     private var lastCpuTimes: [pid_t: UInt64] = [:]
     private var lastSampleAt: Date?
+    /// C11-25 fix DoD #5: per-surface PID provider closures used for
+    /// surfaces (terminals) whose pid drifts over time as the foreground
+    /// command changes. Browsers don't use this — `setPid` from the
+    /// main actor on KVO drives them.
+    private typealias PidProvider = @Sendable () -> pid_t?
+    private var pidProviders: [UUID: PidProvider] = [:]
+    /// Throttle for re-invoking `pidProviders`: the providers themselves
+    /// run `proc_listpids` which scans every running process, so we
+    /// amortize across ticks rather than calling once per tick.
+    private var lastProviderResolveAt: [UUID: Date] = [:]
+    /// Default refresh window for terminal pid providers. Tunable via
+    /// `UserDefaults` key `c11.surfaceMetrics.terminalPidRefreshSeconds`.
+    private static let defaultPidProviderRefreshSeconds: Double = 2.0
 
     private let queue = DispatchQueue(
         label: "com.stage11.c11.surface-metrics",
@@ -138,12 +153,33 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
         os_unfair_lock_unlock(lock)
     }
 
+    /// C11-25 fix DoD #5: register a PID provider for a surface. The
+    /// sampler invokes `provider` off-main on its utility queue every
+    /// `pidProviderRefreshSeconds()` and updates the cached scalar.
+    /// Pass `nil` to drop the provider (e.g. when the surface's tty is
+    /// retracted). The closure must be Sendable: capture only value
+    /// types (the tty name string is the typical case).
+    func setPidProvider(surfaceId: UUID, provider: (@Sendable () -> pid_t?)?) {
+        os_unfair_lock_lock(lock)
+        if let provider {
+            pidProviders[surfaceId] = provider
+            // Force a fresh resolve on the next tick.
+            lastProviderResolveAt.removeValue(forKey: surfaceId)
+        } else {
+            pidProviders.removeValue(forKey: surfaceId)
+            lastProviderResolveAt.removeValue(forKey: surfaceId)
+        }
+        os_unfair_lock_unlock(lock)
+    }
+
     /// Drop a surface's registration and any cached sample / pid.
     func unregister(surfaceId: UUID) {
         os_unfair_lock_lock(lock)
         registered.remove(surfaceId)
         cachedPids.removeValue(forKey: surfaceId)
         samples.removeValue(forKey: surfaceId)
+        pidProviders.removeValue(forKey: surfaceId)
+        lastProviderResolveAt.removeValue(forKey: surfaceId)
         os_unfair_lock_unlock(lock)
     }
 
@@ -155,6 +191,22 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
         defer { os_unfair_lock_unlock(lock) }
         return samples[id]
     }
+
+    #if DEBUG
+    /// Test-only: synchronously run the pid-provider refresh path so a
+    /// unit test can drive the C11-25 fix DoD #5 wiring without
+    /// spinning the DispatchSourceTimer.
+    func testHookRefreshPidProviders(now: Date = Date()) {
+        refreshPidProviders(now: now)
+    }
+
+    /// Test-only: read back the cached pid for a surface.
+    func testHookCachedPid(forSurfaceId id: UUID) -> pid_t? {
+        os_unfair_lock_lock(lock)
+        defer { os_unfair_lock_unlock(lock) }
+        return cachedPids[id]
+    }
+    #endif
 
     deinit {
         timer?.cancel()
@@ -169,10 +221,22 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
         return raw > 0 ? raw : 2.0
     }
 
+    private static func pidProviderRefreshSeconds() -> Double {
+        let raw = UserDefaults.standard.double(forKey: "c11.surfaceMetrics.terminalPidRefreshSeconds")
+        return raw > 0 ? raw : defaultPidProviderRefreshSeconds
+    }
+
     // MARK: - Sampling tick
 
     private func tick() {
         let now = Date()
+        // C11-25 fix DoD #5: refresh terminal pid providers first so
+        // `cachedPids` already reflects the latest foreground process by
+        // the time the rusage loop runs below. Providers can be expensive
+        // (proc_listpids walks every process) so they're throttled by
+        // `pidProviderRefreshSeconds`.
+        refreshPidProviders(now: now)
+
         os_unfair_lock_lock(lock)
         // Snapshot the cached pids by surface. The off-main tick only
         // ever reads scalars from this dictionary — never the underlying
@@ -215,6 +279,56 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
         DispatchQueue.main.async { [weak self] in
             self?.revision &+= 1
         }
+    }
+
+    /// C11-25 fix DoD #5: invoke each registered terminal PID provider
+    /// at most once per `pidProviderRefreshSeconds()`. Captures the
+    /// providers + last-resolve timestamps under the lock, runs the
+    /// closures outside it (they may take milliseconds — proc_listpids
+    /// scans every running process), then writes results back under
+    /// the lock. Drops `cachedPids` entries whose provider returns nil
+    /// so a dead shell stops being sampled.
+    private func refreshPidProviders(now: Date) {
+        let refreshInterval = Self.pidProviderRefreshSeconds()
+        os_unfair_lock_lock(lock)
+        let providersSnapshot = pidProviders
+        let lastResolveSnapshot = lastProviderResolveAt
+        os_unfair_lock_unlock(lock)
+
+        guard !providersSnapshot.isEmpty else { return }
+
+        var resolvedPids: [UUID: pid_t] = [:]
+        var clearedPids: [UUID] = []
+        var newResolveAt: [UUID: Date] = [:]
+        for (surfaceId, provider) in providersSnapshot {
+            if let last = lastResolveSnapshot[surfaceId],
+               now.timeIntervalSince(last) < refreshInterval {
+                continue
+            }
+            newResolveAt[surfaceId] = now
+            if let pid = provider(), pid > 0 {
+                resolvedPids[surfaceId] = pid
+            } else {
+                clearedPids.append(surfaceId)
+            }
+        }
+
+        if resolvedPids.isEmpty && clearedPids.isEmpty && newResolveAt.isEmpty {
+            return
+        }
+
+        os_unfair_lock_lock(lock)
+        for (surfaceId, pid) in resolvedPids {
+            cachedPids[surfaceId] = pid
+        }
+        for surfaceId in clearedPids {
+            cachedPids.removeValue(forKey: surfaceId)
+            samples.removeValue(forKey: surfaceId)
+        }
+        for (surfaceId, ts) in newResolveAt {
+            lastProviderResolveAt[surfaceId] = ts
+        }
+        os_unfair_lock_unlock(lock)
     }
 
     // MARK: - proc_pid_rusage helpers

--- a/Sources/SurfaceMetricsSampler.swift
+++ b/Sources/SurfaceMetricsSampler.swift
@@ -21,13 +21,17 @@ import Darwin
 ///
 /// PID resolution differs by surface kind:
 ///
-/// - Browsers: `webView.c11_webProcessIdentifier` (the
-///   `_webProcessIdentifier` SPI). Cheap, in-process.
+/// - Browsers: cached scalar updated from the main actor whenever the
+///   panel binds a WKWebView or its WebContent process changes. The
+///   cache is a plain `pid_t` written under the sampler's existing
+///   `os_unfair_lock`; the off-main `tick()` reads it as a scalar.
+///   This avoids touching `WKWebView` (a `@MainActor` AppKit object)
+///   from the sampler's utility queue.
 /// - Terminals: NOT YET IMPLEMENTED in C11-25. The TTY → child PID
 ///   resolver requires either a libghostty surface accessor patch or a
 ///   `lsof`-style process-listing helper. Plan §2 row 5 acknowledges
 ///   this is a follow-up; for C11-25 commit 6 the terminal panel
-///   registers a provider that returns `nil`, the sidebar renders `—`
+///   registers without supplying a pid, and the sidebar renders `—`
 ///   for terminal CPU/RSS.
 final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
     static let shared = SurfaceMetricsSampler()
@@ -47,7 +51,14 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
 
     private let lock: UnsafeMutablePointer<os_unfair_lock_s>
     private var samples: [UUID: Sample] = [:]
-    private var pidProviders: [UUID: () -> pid_t?] = [:]
+    /// Per-surface registration set. Membership alone enables sampling;
+    /// `cachedPids` carries the pid when known. A surface in `registered`
+    /// without a `cachedPids` entry samples to nothing this tick.
+    private var registered: Set<UUID> = []
+    /// Cached WebContent / process pid for each registered surface, set
+    /// by callers from the main actor. The sampler reads the scalar
+    /// off-main without touching the source object (e.g. WKWebView).
+    private var cachedPids: [UUID: pid_t] = [:]
     private var lastCpuTimes: [pid_t: UInt64] = [:]
     private var lastSampleAt: Date?
 
@@ -96,21 +107,42 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
         t?.cancel()
     }
 
-    /// Register a surface + PID provider. The provider is invoked off-main
-    /// during sampling; it must be thread-safe (or read state that is).
-    /// Browser panels pass a closure that reads
-    /// `webView.c11_webProcessIdentifier` (KVC, safe off-main); terminal
-    /// panels pass `{ nil }` for C11-25.
-    func register(surfaceId: UUID, pidProvider: @escaping () -> pid_t?) {
+    /// Register a surface for sampling. Pid is updated separately via
+    /// `setPid(surfaceId:pid:)` — callers that already know the pid at
+    /// registration time may pass it through `initialPid`. A registered
+    /// surface with no cached pid yet samples to nothing this tick.
+    func register(surfaceId: UUID, initialPid: pid_t? = nil) {
         os_unfair_lock_lock(lock)
-        pidProviders[surfaceId] = pidProvider
+        registered.insert(surfaceId)
+        if let pid = initialPid, pid > 0 {
+            cachedPids[surfaceId] = pid
+        }
         os_unfair_lock_unlock(lock)
     }
 
-    /// Drop a surface's registration and any cached sample.
+    /// Update the cached pid for a registered surface. MUST be called
+    /// from the main actor (or any thread that owns the source object,
+    /// e.g. the @MainActor BrowserPanel reading `webView.c11_webProcessIdentifier`).
+    /// The sampler reads the cached scalar off-main without touching
+    /// the source object. Pass `nil` when the underlying process has
+    /// gone away or is unknown — the next tick samples to nothing for
+    /// this surface.
+    func setPid(surfaceId: UUID, pid: pid_t?) {
+        os_unfair_lock_lock(lock)
+        if let pid = pid, pid > 0 {
+            cachedPids[surfaceId] = pid
+        } else {
+            cachedPids.removeValue(forKey: surfaceId)
+            samples.removeValue(forKey: surfaceId)
+        }
+        os_unfair_lock_unlock(lock)
+    }
+
+    /// Drop a surface's registration and any cached sample / pid.
     func unregister(surfaceId: UUID) {
         os_unfair_lock_lock(lock)
-        pidProviders.removeValue(forKey: surfaceId)
+        registered.remove(surfaceId)
+        cachedPids.removeValue(forKey: surfaceId)
         samples.removeValue(forKey: surfaceId)
         os_unfair_lock_unlock(lock)
     }
@@ -142,7 +174,10 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
     private func tick() {
         let now = Date()
         os_unfair_lock_lock(lock)
-        let providers = pidProviders
+        // Snapshot the cached pids by surface. The off-main tick only
+        // ever reads scalars from this dictionary — never the underlying
+        // source objects (WKWebView, etc.) that produced the pid.
+        let pids = cachedPids
         let priorTimes = lastCpuTimes
         let prior = lastSampleAt
         os_unfair_lock_unlock(lock)
@@ -151,10 +186,9 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
         var newSamples: [UUID: Sample] = [:]
         var newTimes: [pid_t: UInt64] = [:]
 
-        for (surfaceId, provider) in providers {
-            guard let pid = provider() else { continue }
-            guard let cumulative = Self.proc_pid_cumulative_cpu_ns(pid) else { continue }
-            let rssBytes = Self.proc_pid_rss_bytes(pid) ?? 0
+        for (surfaceId, pid) in pids {
+            guard let usage = Self.proc_pid_rusage_v4(pid) else { continue }
+            let cumulative = usage.cpuNs
 
             let cpuPct: Double
             if dt > 0, let last = priorTimes[pid], cumulative >= last {
@@ -166,7 +200,7 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
             newTimes[pid] = cumulative
             newSamples[surfaceId] = Sample(
                 cpuPct: cpuPct,
-                rssMb: Double(rssBytes) / 1024.0 / 1024.0,
+                rssMb: Double(usage.rssBytes) / 1024.0 / 1024.0,
                 sampledAt: now
             )
         }
@@ -185,10 +219,9 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
 
     // MARK: - proc_pid_rusage helpers
 
-    /// Cumulative user+system CPU time in nanoseconds for `pid`, via
-    /// `proc_pid_rusage(RUSAGE_INFO_V4)`. Returns nil if the call fails
-    /// (e.g. the process exited).
-    private static func proc_pid_cumulative_cpu_ns(_ pid: pid_t) -> UInt64? {
+    /// Single-syscall reader for the two fields we need. Halves the
+    /// per-tick syscall load on the 2 Hz sampler.
+    private static func proc_pid_rusage_v4(_ pid: pid_t) -> (cpuNs: UInt64, rssBytes: UInt64)? {
         var ri = rusage_info_v4()
         let rc = withUnsafeMutablePointer(to: &ri) { ptr -> Int32 in
             ptr.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { boxPtr in
@@ -196,19 +229,6 @@ final class SurfaceMetricsSampler: ObservableObject, @unchecked Sendable {
             }
         }
         guard rc == 0 else { return nil }
-        return ri.ri_user_time &+ ri.ri_system_time
-    }
-
-    /// Resident set size in bytes for `pid`, via the same call. Returns
-    /// nil on failure.
-    private static func proc_pid_rss_bytes(_ pid: pid_t) -> UInt64? {
-        var ri = rusage_info_v4()
-        let rc = withUnsafeMutablePointer(to: &ri) { ptr -> Int32 in
-            ptr.withMemoryRebound(to: rusage_info_t?.self, capacity: 1) { boxPtr in
-                proc_pid_rusage(pid, RUSAGE_INFO_V4, boxPtr)
-            }
-        }
-        guard rc == 0 else { return nil }
-        return ri.ri_resident_size
+        return (ri.ri_user_time &+ ri.ri_system_time, ri.ri_resident_size)
     }
 }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -17769,6 +17769,14 @@ class TerminalController {
                 tab.surfaceTTYNames[scope.panelId] = ttyName
                 PortScanner.shared.registerTTY(workspaceId: scope.workspaceId, panelId: scope.panelId, ttyName: ttyName)
                 AgentDetector.shared.registerTTY(workspaceId: scope.workspaceId, panelId: scope.panelId, ttyName: ttyName)
+                // C11-25 fix DoD #5: install a Sendable PID provider so
+                // the per-surface CPU/MEM sampler can attribute usage to
+                // the foreground process running on this tty (typically
+                // the shell or its most-recently spawned child).
+                let capturedTTY = ttyName
+                SurfaceMetricsSampler.shared.setPidProvider(surfaceId: scope.panelId) {
+                    TerminalPIDResolver.foregroundPID(forTTYName: capturedTTY)
+                }
             }
             return "OK"
         }
@@ -17809,6 +17817,13 @@ class TerminalController {
             tab.surfaceTTYNames[surfaceId] = ttyName
             PortScanner.shared.registerTTY(workspaceId: tab.id, panelId: surfaceId, ttyName: ttyName)
             AgentDetector.shared.registerTTY(workspaceId: tab.id, panelId: surfaceId, ttyName: ttyName)
+            // C11-25 fix DoD #5: install a Sendable PID provider so the
+            // per-surface CPU/MEM sampler can attribute usage to the
+            // foreground process running on this tty.
+            let capturedTTY = ttyName
+            SurfaceMetricsSampler.shared.setPidProvider(surfaceId: surfaceId) {
+                TerminalPIDResolver.foregroundPID(forTTYName: capturedTTY)
+            }
         }
         return result
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6064,6 +6064,30 @@ class TerminalController {
                 if let markdownPanel = panel as? MarkdownPanel {
                     item["file_path"] = markdownPanel.filePath
                 }
+                // C11-25 fix DoD #5: expose the SurfaceMetricsSampler
+                // snapshot for terminal + browser surfaces so callers
+                // (smoke harness, `c11 tree --json`) can verify the
+                // CPU/RSS sidebar telemetry without a screenshot. Markdown
+                // surfaces have no process-level metric — omit the block.
+                // Lookup is a lock-protected dictionary read; safe on
+                // main. `cpu_pct` / `rss_mb` are NSNull until the sampler
+                // converges (~one tick after pid registration).
+                switch panel.panelType {
+                case .terminal, .browser:
+                    let sample = SurfaceMetricsSampler.shared.sample(forSurfaceId: panel.id)
+                    var metrics: [String: Any] = [
+                        "cpu_pct": v2OrNull(sample?.cpuPct),
+                        "rss_mb": v2OrNull(sample?.rssMb)
+                    ]
+                    if let sampledAt = sample?.sampledAt {
+                        metrics["sampled_at"] = ISO8601DateFormatter().string(from: sampledAt)
+                    } else {
+                        metrics["sampled_at"] = NSNull()
+                    }
+                    item["metrics"] = metrics
+                case .markdown:
+                    break
+                }
                 return item
             }
 

--- a/Sources/TerminalPIDResolver.swift
+++ b/Sources/TerminalPIDResolver.swift
@@ -54,10 +54,11 @@ enum TerminalPIDResolver {
         guard written > 0 else { return nil }
         let count = min(capacity, Int(written) / stride)
 
-        // pbi_tdev is uint32_t; dev_t on Darwin is int32_t. Compare as
-        // bit-equal raw pattern via `truncatingIfNeeded` so a sign
-        // extension can't mismatch and a future Swift bridging change
-        // (dev_t → UInt32) wouldn't trap on negative-looking values.
+        // e_tdev is uint32_t (controlling tty dev on proc_bsdinfo); dev_t on
+        // Darwin is int32_t. Compare as bit-equal raw pattern via
+        // `truncatingIfNeeded` so a sign extension can't mismatch and a
+        // future Swift bridging change wouldn't trap on negative-looking
+        // values.
         let target = UInt32(truncatingIfNeeded: dev)
         var bestPID: pid_t = 0
         var info = proc_bsdinfo()
@@ -67,7 +68,7 @@ enum TerminalPIDResolver {
             guard pid > 0 else { continue }
             let rc = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, infoSize)
             guard rc == infoSize else { continue }
-            if info.pbi_tdev == target && pid > bestPID {
+            if info.e_tdev == target && pid > bestPID {
                 bestPID = pid
             }
         }

--- a/Sources/TerminalPIDResolver.swift
+++ b/Sources/TerminalPIDResolver.swift
@@ -1,0 +1,76 @@
+import Darwin
+import Foundation
+
+/// C11-25 fix DoD #5 closure: resolves a terminal's controlling-TTY
+/// name (e.g. `ttys012` or `/dev/ttys012`) to the PID of the foreground
+/// process running on it. Used by `SurfaceMetricsSampler` to give
+/// terminal surfaces (not just browsers) live CPU/RSS in the sidebar.
+///
+/// Implementation: stat the tty path to read `st_rdev`, then enumerate
+/// processes via `proc_listpids` + `proc_pidinfo(PROC_PIDTBSDINFO)` and
+/// match `pbi_tdev`. When multiple processes share the controlling tty
+/// (shell + foreground child), the highest PID is selected — the
+/// most-recently spawned process, which is typically the active
+/// foreground command (`make`, `top`, etc.). When the surface is idle
+/// at the shell prompt, the shell itself is the only match and is
+/// returned.
+///
+/// Thread-safety: pure C-API; touches no AppKit / main-actor state.
+/// Safe to invoke off-main from the sampler's utility queue.
+enum TerminalPIDResolver {
+    /// Look up the foreground PID for `ttyName`. Returns `nil` when the
+    /// tty path can't be stat'd (e.g. the surface has not yet reported
+    /// its tty via `report_tty`) or when no process currently has the
+    /// tty as its controlling terminal.
+    static func foregroundPID(forTTYName ttyName: String) -> pid_t? {
+        guard let dev = ttyDevice(for: ttyName) else { return nil }
+        return foregroundPID(forDevice: dev)
+    }
+
+    /// Resolve `ttyName` to its `st_rdev`. Exposed so callers (and
+    /// tests) can hold the device number across calls and skip the
+    /// per-tick `stat` syscall.
+    static func ttyDevice(for ttyName: String) -> dev_t? {
+        let path = ttyName.hasPrefix("/") ? ttyName : "/dev/\(ttyName)"
+        var st = stat()
+        guard stat(path, &st) == 0 else { return nil }
+        return st.st_rdev
+    }
+
+    /// Walk every running process; return the highest PID whose
+    /// controlling tty matches `dev`. O(n) over running processes — the
+    /// sampler amortizes this by only re-resolving every couple of
+    /// seconds rather than every tick.
+    static func foregroundPID(forDevice dev: dev_t) -> pid_t? {
+        let byteSize = proc_listpids(UInt32(PROC_ALL_PIDS), 0, nil, 0)
+        guard byteSize > 0 else { return nil }
+        let stride = MemoryLayout<pid_t>.stride
+        let capacity = Int(byteSize) / stride
+        guard capacity > 0 else { return nil }
+        var pids = [pid_t](repeating: 0, count: capacity)
+        let written = pids.withUnsafeMutableBufferPointer { buf -> Int32 in
+            proc_listpids(UInt32(PROC_ALL_PIDS), 0, buf.baseAddress, Int32(buf.count * stride))
+        }
+        guard written > 0 else { return nil }
+        let count = min(capacity, Int(written) / stride)
+
+        // pbi_tdev is uint32_t; dev_t on Darwin is int32_t. Compare as
+        // bit-equal raw pattern via `truncatingIfNeeded` so a sign
+        // extension can't mismatch and a future Swift bridging change
+        // (dev_t → UInt32) wouldn't trap on negative-looking values.
+        let target = UInt32(truncatingIfNeeded: dev)
+        var bestPID: pid_t = 0
+        var info = proc_bsdinfo()
+        let infoSize = Int32(MemoryLayout<proc_bsdinfo>.stride)
+        for i in 0..<count {
+            let pid = pids[i]
+            guard pid > 0 else { continue }
+            let rc = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, infoSize)
+            guard rc == infoSize else { continue }
+            if info.pbi_tdev == target && pid > bestPID {
+                bestPID = pid
+            }
+        }
+        return bestPID > 0 ? bestPID : nil
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5106,6 +5106,14 @@ final class Workspace: Identifiable, ObservableObject {
     /// row pulse together. Visual-only; never affects selection.
     @Published private(set) var sidebarFlashToken: Int = 0
 
+    /// C11-25: workspace-level operator hibernate flag. True when the
+    /// operator has explicitly hibernated this workspace via the
+    /// "Hibernate Workspace" context menu (or socket equivalent). Survives
+    /// `c11 snapshot` / `restore` via the canonical `lifecycle_state`
+    /// metadata mirror on each panel — the workspace flag is rebuilt on
+    /// restore from "any panel hibernated".
+    @Published var isHibernated: Bool = false
+
     /// Subscriptions for panel updates (e.g., browser title changes)
     private var panelSubscriptions: [UUID: AnyCancellable] = [:]
 
@@ -5971,6 +5979,32 @@ final class Workspace: Identifiable, ObservableObject {
 
     func browserPanel(for panelId: UUID) -> BrowserPanel? {
         panels[panelId] as? BrowserPanel
+    }
+
+    /// C11-25: hibernate every browser panel in the workspace and flip
+    /// the workspace-level flag. Terminals stay on the auto-throttle
+    /// path (workspace deselect already pauses libghostty rendering;
+    /// SIGSTOP for terminals is deferred). Markdown surfaces are
+    /// unaffected. Idempotent.
+    func hibernate() {
+        for panel in panels.values {
+            if let browser = panel as? BrowserPanel {
+                browser.setHibernated(true)
+            }
+        }
+        isHibernated = true
+    }
+
+    /// C11-25: resume the workspace. Browser panels transition out of
+    /// `.hibernated` (back to `.active`); the auto-throttle path takes
+    /// it from there based on visibility. Idempotent.
+    func resume() {
+        for panel in panels.values {
+            if let browser = panel as? BrowserPanel {
+                browser.setHibernated(false)
+            }
+        }
+        isHibernated = false
     }
 
     func markdownPanel(for panelId: UUID) -> MarkdownPanel? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -266,6 +266,17 @@ extension Workspace {
         prunePaneMetadata(validPaneIds: Set(bonsplitController.allPaneIds.map { $0.id }))
 
         pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))
+
+        // C11-25 review fix I1: rehydrate per-surface lifecycle from the
+        // canonical metadata mirror. The blueprint-apply restore path
+        // (`WorkspaceLayoutExecutor.apply`) already calls this; the
+        // session-snapshot restore path used by `TabManager` /
+        // `TerminalController` / `AppDelegate` did not, so a hibernated
+        // browser restored on app relaunch landed with
+        // `lifecycle_state == "hibernated"` in metadata but was running
+        // as `.active` in runtime. Operator intent was silently dropped.
+        restoreLifecycleStateFromMetadata()
+
         applySessionDividerPositions(snapshotNode: snapshot.layout, liveNode: bonsplitController.treeSnapshot())
 
         let restoredStableDefaultTitle = snapshot.stableDefaultTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5981,6 +5981,46 @@ final class Workspace: Identifiable, ObservableObject {
         panels[panelId] as? BrowserPanel
     }
 
+    /// C11-25 commit 8: rehydrate workspace + panel lifecycle state from
+    /// `lifecycle_state` canonical metadata after a `c11 restore` /
+    /// blueprint apply. Called by `WorkspaceLayoutExecutor` once all
+    /// surfaces and metadata are materialized.
+    ///
+    /// For browser panels with `lifecycle_state == "hibernated"`:
+    ///   `setHibernated(true)` re-triggers the snapshot+terminate path
+    ///   so the restored panel ends up in the same operator-pinned
+    ///   state. Snapshots are in-memory only in C11-25, so the
+    ///   placeholder will render a neutral background until the
+    ///   operator resumes — operator accepted in §0a.
+    ///
+    /// For terminals/markdown the canonical metadata is preserved but
+    /// no runtime change is dispatched (auto-throttle handles
+    /// visibility; explicit terminal hibernate is deferred).
+    ///
+    /// `isHibernated` is rebuilt from "any browser panel hibernated".
+    func restoreLifecycleStateFromMetadata() {
+        var anyHibernated = false
+        for (panelId, panel) in panels {
+            let snapshot = SurfaceMetadataStore.shared.getMetadata(
+                workspaceId: id,
+                surfaceId: panelId
+            )
+            guard let stateStr = snapshot.metadata[MetadataKey.lifecycleState] as? String,
+                  let state = SurfaceLifecycleState(rawValue: stateStr) else {
+                continue
+            }
+            if state == .hibernated {
+                anyHibernated = true
+                if let browser = panel as? BrowserPanel {
+                    browser.setHibernated(true)
+                }
+            }
+        }
+        if isHibernated != anyHibernated {
+            isHibernated = anyHibernated
+        }
+    }
+
     /// C11-25: hibernate every browser panel in the workspace and flip
     /// the workspace-level flag. Terminals stay on the auto-throttle
     /// path (workspace deselect already pauses libghostty rendering;

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -810,12 +810,19 @@ extension Workspace {
             return terminalPanel.id
         case .browser:
             let initialURL = snapshot.browser?.urlString.flatMap { URL(string: $0) }
+            // C11-25 fix S4+E1: when the persisted snapshot says the panel
+            // was hibernated, construct it natively in `.hibernated` so the
+            // initial WKWebView load never fires for `initialURL` —
+            // matches the executor-driven restore path and closes the same
+            // privacy/billing leak on session-snapshot restore.
+            let restoredHibernated = snapshotRequestsHibernated(snapshot)
             guard let browserPanel = newBrowserSurface(
                 inPane: paneId,
                 url: initialURL,
                 focus: false,
                 preferredProfileID: snapshot.browser?.profileID,
-                panelId: restoredPanelId
+                panelId: restoredPanelId,
+                pendingHibernate: restoredHibernated
             ) else {
                 return nil
             }
@@ -833,6 +840,19 @@ extension Workspace {
             applySessionPanelMetadata(snapshot, toPanelId: markdownPanel.id)
             return markdownPanel.id
         }
+    }
+
+    /// C11-25 fix S4+E1: returns `true` when the persisted session
+    /// snapshot's per-surface metadata pinned the panel to
+    /// `lifecycle_state == "hibernated"`. Used by `createPanel` to
+    /// suppress the initial WKWebView navigate so a restored hibernated
+    /// browser never briefly hits the network for its persisted URL.
+    private func snapshotRequestsHibernated(_ snapshot: SessionPanelSnapshot) -> Bool {
+        guard let metadata = snapshot.metadata,
+              case .string(let raw)? = metadata[MetadataKey.lifecycleState] else {
+            return false
+        }
+        return raw == SurfaceLifecycleState.hibernated.rawValue
     }
 
     private func applySessionPanelMetadata(_ snapshot: SessionPanelSnapshot, toPanelId panelId: UUID) {
@@ -7725,6 +7745,10 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     /// Create a new browser panel split
+    /// - Parameter pendingHibernate: C11-25 fix S4+E1. When `true`, the
+    ///   panel is constructed natively in `.hibernated` and the initial
+    ///   URL navigate is suppressed. Used by `c11 restore` when the plan
+    ///   declares `lifecycle_state == "hibernated"` for the surface.
     @discardableResult
     func newBrowserSplit(
         from panelId: UUID,
@@ -7732,7 +7756,8 @@ final class Workspace: Identifiable, ObservableObject {
         insertFirst: Bool = false,
         url: URL? = nil,
         preferredProfileID: UUID? = nil,
-        focus: Bool = true
+        focus: Bool = true,
+        pendingHibernate: Bool = false
     ) -> BrowserPanel? {
         guard let paneId = paneIdForPanel(panelId) else { return nil }
 
@@ -7746,7 +7771,8 @@ final class Workspace: Identifiable, ObservableObject {
             initialURL: url,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,
-            remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil
+            remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil,
+            pendingHibernate: pendingHibernate
         )
         panels[browserPanel.id] = browserPanel
         panelTitles[browserPanel.id] = browserPanel.displayTitle
@@ -7801,6 +7827,10 @@ final class Workspace: Identifiable, ObservableObject {
     /// - Parameter focus: nil = focus only if the target pane is already focused (default UI behavior),
     ///                    true = force focus/selection of the new surface,
     ///                    false = never focus (used for internal placeholder repair paths).
+    /// - Parameter pendingHibernate: C11-25 fix S4+E1. When `true`, the
+    ///   panel is constructed natively in `.hibernated` and the initial
+    ///   URL navigate is suppressed. Used by `c11 restore` when the plan
+    ///   declares `lifecycle_state == "hibernated"` for the surface.
     @discardableResult
     func newBrowserSurface(
         inPane paneId: PaneID,
@@ -7809,7 +7839,8 @@ final class Workspace: Identifiable, ObservableObject {
         insertAtEnd: Bool = false,
         preferredProfileID: UUID? = nil,
         bypassInsecureHTTPHostOnce: String? = nil,
-        panelId: UUID? = nil
+        panelId: UUID? = nil,
+        pendingHibernate: Bool = false
     ) -> BrowserPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let sourcePanelId = effectiveSelectedPanelId(inPane: paneId)
@@ -7827,7 +7858,8 @@ final class Workspace: Identifiable, ObservableObject {
             bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,
-            remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil
+            remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil,
+            pendingHibernate: pendingHibernate
         )
         panels[browserPanel.id] = browserPanel
         panelTitles[browserPanel.id] = browserPanel.displayTitle

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -266,6 +266,15 @@ enum WorkspaceLayoutExecutor {
             ))
         }
 
+        // C11-25 commit 8 — rehydrate per-panel + workspace-level
+        // lifecycle from the canonical `lifecycle_state` metadata that
+        // has been applied above. For hibernated browsers this fires
+        // the snapshot+terminate path so the restored workspace
+        // matches the pre-snapshot operator intent. Cheap-tier
+        // throttled state is implicit from workspace-selection and
+        // does not need rehydration here.
+        workspace.restoreLifecycleStateFromMetadata()
+
         // Step 8 — assemble refs. The executor mints refs for every surface
         // and pane that was successfully created; plan-local surface ids map
         // 1:1 to live `surface:N` / `pane:N` refs via the injected minters.

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -832,7 +832,7 @@ enum WorkspaceLayoutExecutor {
                     insertFirst: false,
                     url: url,
                     focus: false,
-                    pendingHibernate: Self.specRequestsHibernated(spec)
+                    pendingHibernate: WorkspaceLayoutExecutor.specRequestsHibernated(spec)
                 )?.id
             case .markdown:
                 if spec.workingDirectory != nil {
@@ -1044,7 +1044,7 @@ enum WorkspaceLayoutExecutor {
                     inPane: paneId,
                     url: url,
                     focus: focus,
-                    pendingHibernate: Self.specRequestsHibernated(spec)
+                    pendingHibernate: WorkspaceLayoutExecutor.specRequestsHibernated(spec)
                 )?.id
             case .markdown:
                 if spec.workingDirectory != nil {

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -831,7 +831,8 @@ enum WorkspaceLayoutExecutor {
                     orientation: orientation,
                     insertFirst: false,
                     url: url,
-                    focus: false
+                    focus: false,
+                    pendingHibernate: Self.specRequestsHibernated(spec)
                 )?.id
             case .markdown:
                 if spec.workingDirectory != nil {
@@ -1042,7 +1043,8 @@ enum WorkspaceLayoutExecutor {
                 return workspace.newBrowserSurface(
                     inPane: paneId,
                     url: url,
-                    focus: focus
+                    focus: focus,
+                    pendingHibernate: Self.specRequestsHibernated(spec)
                 )?.id
             case .markdown:
                 if spec.workingDirectory != nil {
@@ -1163,6 +1165,21 @@ enum WorkspaceLayoutExecutor {
             }
         }
         return out
+    }
+
+    /// C11-25 fix S4+E1: returns `true` when the plan declares
+    /// `lifecycle_state == "hibernated"` for `spec`. Browser construction
+    /// uses this to skip the initial `WKWebView.load(URLRequest:)` so a
+    /// restored hibernated workspace never briefly hits the network for
+    /// `spec.url` before being re-hibernated. Returning `false` keeps the
+    /// legacy spin-up + `restoreLifecycleStateFromMetadata` fallback for
+    /// any panel kind whose construction path doesn't yet honor the flag.
+    fileprivate nonisolated static func specRequestsHibernated(_ spec: SurfaceSpec) -> Bool {
+        guard let metadata = spec.metadata,
+              case .string(let raw)? = metadata[MetadataKey.lifecycleState] else {
+            return false
+        }
+        return raw == SurfaceLifecycleState.hibernated.rawValue
     }
 
     // MARK: - Timing helper

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -1391,6 +1391,25 @@ struct cmuxApp: App {
 
         Divider()
 
+        // C11-25: hibernate / resume the workspace. Browser surfaces
+        // capture a snapshot, terminate their WebContent processes, and
+        // render a placeholder until resume; terminals stay on the auto
+        // throttle path. The menu flips between Hibernate and Resume
+        // based on `workspace.isHibernated`.
+        if workspace?.isHibernated == true {
+            Button(String(localized: "contextMenu.resumeWorkspace", defaultValue: "Resume Workspace")) {
+                workspace?.resume()
+            }
+            .disabled(workspace == nil)
+        } else {
+            Button(String(localized: "contextMenu.hibernateWorkspace", defaultValue: "Hibernate Workspace")) {
+                workspace?.hibernate()
+            }
+            .disabled(workspace == nil)
+        }
+
+        Divider()
+
         Button(String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read")) {
             markSelectedWorkspaceRead(in: manager)
         }

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -1406,6 +1406,10 @@ struct cmuxApp: App {
                 workspace?.hibernate()
             }
             .disabled(workspace == nil)
+            .help(String(
+                localized: "contextMenu.hibernateWorkspaceTooltip",
+                defaultValue: "Suspends browser surfaces in this workspace. Terminals stay on auto-throttle (already low-CPU when the workspace isn't focused)."
+            ))
         }
 
         Divider()

--- a/c11Tests/SurfaceLifecycleTests.swift
+++ b/c11Tests/SurfaceLifecycleTests.swift
@@ -1,11 +1,29 @@
 import XCTest
 import WebKit
+import Darwin
 
 #if canImport(c11_DEV)
 @testable import c11_DEV
 #elseif canImport(c11)
 @testable import c11
 #endif
+
+/// Lock-protected counter used by the C11-25 fix DoD #5 sampler tests
+/// to assert provider-invocation counts across the sampler's lock
+/// boundary. Cheap; doesn't need an XCTestExpectation because the
+/// refresh path is synchronous when driven through `testHook…`.
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value = 0
+    func increment() {
+        lock.lock(); defer { lock.unlock() }
+        _value += 1
+    }
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return _value
+    }
+}
 
 /// Unit tests for the C11-25 lifecycle primitive — the transition
 /// validator on `SurfaceLifecycleState`, the canonical metadata mirror
@@ -300,6 +318,91 @@ final class SurfaceLifecycleTests: XCTestCase {
         XCTAssertTrue(
             panel.shouldRenderWebView,
             "shouldRenderWebView flips to true for the default initialURL path"
+        )
+    }
+
+    // MARK: - Terminal CPU/MEM resolver (DoD #5)
+
+    /// C11-25 fix DoD #5: the resolver runs without crashing for a real
+    /// tty path (e.g. `/dev/tty`). The exact pid returned depends on
+    /// the test runner's environment — CI containers without a
+    /// controlling tty get nil; macOS runners with one return a pid.
+    /// Either is correct; the test asserts the contract: a returned
+    /// pid is positive, no crashes on the syscall path.
+    func testTerminalPIDResolverHandlesRealTTYPath() {
+        let pid = TerminalPIDResolver.foregroundPID(forTTYName: "/dev/tty")
+        if let pid {
+            XCTAssertTrue(pid > 0, "expected a positive pid, got \(pid)")
+        }
+    }
+
+    /// Resolver returns nil for a non-existent tty path.
+    func testTerminalPIDResolverReturnsNilForUnknownTTY() {
+        XCTAssertNil(
+            TerminalPIDResolver.foregroundPID(forTTYName: "/dev/ttys999not-a-real-device")
+        )
+    }
+
+    /// C11-25 fix DoD #5: a registered pid-provider is invoked by the
+    /// sampler's tick refresh path and its result is mirrored into
+    /// `cachedPids`, so a subsequent `proc_pid_rusage` sample for that
+    /// surface can attribute CPU/MEM. Drives the refresh path directly
+    /// (rather than spinning the timer) so the test stays deterministic
+    /// and CI-safe.
+    func testSamplerInvokesPidProviderAndCachesResult() {
+        let sampler = SurfaceMetricsSampler.shared
+        let surfaceId = UUID()
+        let providerPID: pid_t = getpid()
+        sampler.register(surfaceId: surfaceId)
+        defer { sampler.unregister(surfaceId: surfaceId) }
+
+        let counter = CallCounter()
+        sampler.setPidProvider(surfaceId: surfaceId) {
+            counter.increment()
+            return providerPID
+        }
+
+        // First refresh fires the provider (no prior resolve recorded).
+        sampler.testHookRefreshPidProviders()
+        XCTAssertEqual(
+            counter.value,
+            1,
+            "provider must run on the first refresh after registration"
+        )
+        XCTAssertEqual(
+            sampler.testHookCachedPid(forSurfaceId: surfaceId),
+            providerPID,
+            "cached pid must match what the provider returned"
+        )
+
+        // A second refresh inside the throttle window must NOT re-run
+        // the provider — proc_listpids is expensive enough that the
+        // refresh window protects every tick from amortizing it.
+        sampler.testHookRefreshPidProviders()
+        XCTAssertEqual(
+            counter.value,
+            1,
+            "provider must be throttled by pidProviderRefreshSeconds; "
+            + "got \(counter.value) calls"
+        )
+    }
+
+    /// C11-25 fix DoD #5: when the provider returns nil (e.g. the
+    /// shell's foreground job has exited and no replacement exists),
+    /// the sampler drops the cached pid so the sidebar can render `—`
+    /// instead of a stale value.
+    func testSamplerClearsCacheWhenProviderReturnsNil() {
+        let sampler = SurfaceMetricsSampler.shared
+        let surfaceId = UUID()
+        sampler.register(surfaceId: surfaceId, initialPid: getpid())
+        defer { sampler.unregister(surfaceId: surfaceId) }
+
+        sampler.setPidProvider(surfaceId: surfaceId) { nil }
+        sampler.testHookRefreshPidProviders()
+
+        XCTAssertNil(
+            sampler.testHookCachedPid(forSurfaceId: surfaceId),
+            "provider returning nil must drop the cached pid"
         )
     }
 

--- a/c11Tests/SurfaceLifecycleTests.swift
+++ b/c11Tests/SurfaceLifecycleTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WebKit
 
 #if canImport(c11_DEV)
 @testable import c11_DEV
@@ -228,6 +229,78 @@ final class SurfaceLifecycleTests: XCTestCase {
         XCTAssertEqual(calls.count, 1)
         XCTAssertEqual(calls[0].0, .active)
         XCTAssertEqual(calls[0].1, .throttled)
+    }
+
+    // MARK: - Native hibernated browser construction (S4 + E1)
+
+    /// C11-25 fix S4+E1: a `BrowserPanel` constructed with
+    /// `pendingHibernate: true` must come up natively in `.hibernated`,
+    /// must NOT fire the initial `WKWebView.load(URLRequest:)` for
+    /// `initialURL`, and must record the URL where resume can find it
+    /// (so `Resume Workspace` lands on the right page). Closes the
+    /// privacy/billing leak where a brief network hit attached cookies
+    /// and a billable pageview against the persisted URL during the
+    /// gap between construction and the legacy re-hibernate dispatch.
+    @MainActor
+    func testBrowserPanelPendingHibernateSkipsInitialLoad() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/c11-25-pending-hibernate"))
+        let surfaceId = UUID()
+        BrowserSnapshotStore.shared.clear(forSurfaceId: surfaceId)
+        defer { BrowserSnapshotStore.shared.clear(forSurfaceId: surfaceId) }
+
+        let panel = BrowserPanel(
+            id: surfaceId,
+            workspaceId: UUID(),
+            initialURL: url,
+            pendingHibernate: true
+        )
+
+        XCTAssertEqual(
+            panel.lifecycleState,
+            .hibernated,
+            "panel constructed with pendingHibernate=true must publish hibernated"
+        )
+        XCTAssertEqual(
+            panel.currentURL,
+            url,
+            "currentURL is preserved so the omnibar still presents the destination"
+        )
+        XCTAssertFalse(
+            panel.shouldRenderWebView,
+            "shouldRenderWebView must stay false; the placeholder owns the body"
+        )
+        XCTAssertNil(
+            panel.webView.url,
+            "WKWebView.url must remain nil — no request was dispatched for initialURL"
+        )
+        XCTAssertFalse(
+            panel.webView.isLoading,
+            "WKWebView must not be loading — no initial navigate fired"
+        )
+        let snapshot = try XCTUnwrap(
+            BrowserSnapshotStore.shared.snapshot(forSurfaceId: surfaceId),
+            "snapshot store must be primed with the initialURL so Resume can find it"
+        )
+        XCTAssertEqual(snapshot.url, url)
+        XCTAssertNil(snapshot.image, "no live page rendered yet, so no captured image")
+    }
+
+    /// Sanity check the legacy path: without `pendingHibernate`, the
+    /// panel still drives the initial navigate. Guards against an
+    /// over-broad fix that suppresses the navigate for the normal case.
+    @MainActor
+    func testBrowserPanelDefaultConstructionStillFiresInitialLoad() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.com/c11-25-default"))
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            initialURL: url
+        )
+
+        XCTAssertEqual(panel.lifecycleState, .active)
+        XCTAssertTrue(
+            panel.shouldRenderWebView,
+            "shouldRenderWebView flips to true for the default initialURL path"
+        )
     }
 
     @MainActor

--- a/c11Tests/SurfaceLifecycleTests.swift
+++ b/c11Tests/SurfaceLifecycleTests.swift
@@ -78,7 +78,9 @@ final class SurfaceLifecycleTests: XCTestCase {
         let store = SurfaceMetadataStore.shared
         defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
 
-        for state in SurfaceLifecycleState.allCases {
+        // C11-25 review fix I4: `.suspended` is reserved-only and rejected
+        // at the validator. Walk only the runtime-acceptable set here.
+        for state in SurfaceLifecycleState.allCases where state != .suspended {
             let result = try store.setMetadata(
                 workspaceId: workspace,
                 surfaceId: surface,
@@ -91,6 +93,28 @@ final class SurfaceLifecycleTests: XCTestCase {
                 true,
                 "expected \(state.rawValue) to be accepted"
             )
+        }
+    }
+
+    func testStoreRejectsSuspendedAsReservedOnly() {
+        let workspace = UUID()
+        let surface = UUID()
+        let store = SurfaceMetadataStore.shared
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        XCTAssertThrowsError(
+            try store.setMetadata(
+                workspaceId: workspace,
+                surfaceId: surface,
+                partial: [MetadataKey.lifecycleState: SurfaceLifecycleState.suspended.rawValue],
+                mode: .merge,
+                source: .explicit
+            )
+        ) { error in
+            guard let writeError = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(writeError.code, "reserved_key_invalid_type")
         }
     }
 
@@ -204,18 +228,6 @@ final class SurfaceLifecycleTests: XCTestCase {
         XCTAssertEqual(calls.count, 1)
         XCTAssertEqual(calls[0].0, .active)
         XCTAssertEqual(calls[0].1, .throttled)
-    }
-
-    @MainActor
-    func testSeedDoesNotFireHandler() {
-        var fired = false
-        let controller = SurfaceLifecycleController(
-            workspaceId: UUID(),
-            surfaceId: UUID()
-        ) { _, _ in fired = true }
-        controller.seed(from: .hibernated)
-        XCTAssertEqual(controller.state, .hibernated)
-        XCTAssertFalse(fired)
     }
 
     @MainActor

--- a/c11Tests/SurfaceLifecycleTests.swift
+++ b/c11Tests/SurfaceLifecycleTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Unit tests for the C11-25 lifecycle primitive — the transition
+/// validator on `SurfaceLifecycleState`, the canonical metadata mirror
+/// in `SurfaceMetadataStore`, and the controller's transition gating.
+///
+/// Per `CLAUDE.md`, never run locally — CI only.
+final class SurfaceLifecycleTests: XCTestCase {
+
+    // MARK: - Transition validator
+
+    func testActiveCanTransitionToThrottledAndHibernated() {
+        XCTAssertTrue(SurfaceLifecycleState.active.canTransition(to: .throttled))
+        XCTAssertTrue(SurfaceLifecycleState.active.canTransition(to: .hibernated))
+    }
+
+    func testThrottledCanTransitionToActiveAndHibernated() {
+        XCTAssertTrue(SurfaceLifecycleState.throttled.canTransition(to: .active))
+        XCTAssertTrue(SurfaceLifecycleState.throttled.canTransition(to: .hibernated))
+    }
+
+    func testHibernatedCanResumeToActive() {
+        XCTAssertTrue(SurfaceLifecycleState.hibernated.canTransition(to: .active))
+    }
+
+    func testHibernatedDoesNotAutoFlipToThrottled() {
+        // Hibernated is operator-pinned. A workspace selection change
+        // must not yank the surface back to throttled — the only legal
+        // exit is to active (via "Resume Workspace").
+        XCTAssertFalse(SurfaceLifecycleState.hibernated.canTransition(to: .throttled))
+    }
+
+    func testSuspendedIsReservedInC11_25() {
+        // Defined in the enum so the metadata key has an upgrade path,
+        // but no transitions are valid in C11-25 — guards against a
+        // stale snapshot or a typo flipping a surface into a state the
+        // dispatcher has no handler for.
+        for from in SurfaceLifecycleState.allCases {
+            if from == .suspended { continue }
+            XCTAssertFalse(
+                from.canTransition(to: .suspended),
+                "expected \(from.rawValue) → suspended to be rejected"
+            )
+        }
+        for to in SurfaceLifecycleState.allCases {
+            if to == .suspended { continue }
+            XCTAssertFalse(
+                SurfaceLifecycleState.suspended.canTransition(to: to),
+                "expected suspended → \(to.rawValue) to be rejected"
+            )
+        }
+    }
+
+    func testSelfTransitionsAreIdempotent() {
+        for state in SurfaceLifecycleState.allCases {
+            XCTAssertTrue(state.canTransition(to: state))
+        }
+    }
+
+    func testIsOperatorPinnedOnlyHibernated() {
+        XCTAssertFalse(SurfaceLifecycleState.active.isOperatorPinned)
+        XCTAssertFalse(SurfaceLifecycleState.throttled.isOperatorPinned)
+        XCTAssertFalse(SurfaceLifecycleState.suspended.isOperatorPinned)
+        XCTAssertTrue(SurfaceLifecycleState.hibernated.isOperatorPinned)
+    }
+
+    // MARK: - Canonical metadata mirror
+
+    func testStoreAcceptsValidLifecycleState() throws {
+        let workspace = UUID()
+        let surface = UUID()
+        let store = SurfaceMetadataStore.shared
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        for state in SurfaceLifecycleState.allCases {
+            let result = try store.setMetadata(
+                workspaceId: workspace,
+                surfaceId: surface,
+                partial: [MetadataKey.lifecycleState: state.rawValue],
+                mode: .merge,
+                source: .explicit
+            )
+            XCTAssertEqual(
+                result.applied[MetadataKey.lifecycleState],
+                true,
+                "expected \(state.rawValue) to be accepted"
+            )
+        }
+    }
+
+    func testStoreRejectsUnknownLifecycleStateValue() {
+        let workspace = UUID()
+        let surface = UUID()
+        let store = SurfaceMetadataStore.shared
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        XCTAssertThrowsError(
+            try store.setMetadata(
+                workspaceId: workspace,
+                surfaceId: surface,
+                partial: [MetadataKey.lifecycleState: "frozen"],
+                mode: .merge,
+                source: .explicit
+            )
+        ) { error in
+            guard let writeError = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(writeError.code, "reserved_key_invalid_type")
+        }
+    }
+
+    func testStoreRejectsNonStringLifecycleState() {
+        let workspace = UUID()
+        let surface = UUID()
+        let store = SurfaceMetadataStore.shared
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        XCTAssertThrowsError(
+            try store.setMetadata(
+                workspaceId: workspace,
+                surfaceId: surface,
+                partial: [MetadataKey.lifecycleState: 42],
+                mode: .merge,
+                source: .explicit
+            )
+        ) { error in
+            guard let writeError = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(writeError.code, "reserved_key_invalid_type")
+        }
+    }
+
+    func testLifecycleStateIsCanonicalKey() {
+        XCTAssertTrue(MetadataKey.canonical.contains(MetadataKey.lifecycleState))
+        XCTAssertTrue(SurfaceMetadataStore.reservedKeys.contains(MetadataKey.lifecycleState))
+    }
+
+    // MARK: - Controller
+
+    @MainActor
+    func testControllerStartsActiveByDefault() {
+        let controller = SurfaceLifecycleController(
+            workspaceId: UUID(),
+            surfaceId: UUID()
+        ) { _, _ in }
+        XCTAssertEqual(controller.state, .active)
+    }
+
+    @MainActor
+    func testControllerTransitionMirrorsToMetadata() throws {
+        let workspace = UUID()
+        let surface = UUID()
+        let store = SurfaceMetadataStore.shared
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+
+        let controller = SurfaceLifecycleController(
+            workspaceId: workspace,
+            surfaceId: surface
+        ) { _, _ in }
+
+        XCTAssertTrue(controller.transition(to: .throttled))
+        let snapshot = store.getMetadata(workspaceId: workspace, surfaceId: surface)
+        XCTAssertEqual(
+            snapshot.metadata[MetadataKey.lifecycleState] as? String,
+            SurfaceLifecycleState.throttled.rawValue
+        )
+    }
+
+    @MainActor
+    func testControllerRejectsInvalidTransition() {
+        let controller = SurfaceLifecycleController(
+            workspaceId: UUID(),
+            surfaceId: UUID(),
+            initial: .active
+        ) { _, _ in }
+        // active → suspended is not a legal transition in C11-25.
+        XCTAssertFalse(controller.transition(to: .suspended))
+        XCTAssertEqual(controller.state, .active)
+    }
+
+    @MainActor
+    func testControllerFiresHandlerOnRealTransitionOnly() {
+        var calls: [(SurfaceLifecycleState, SurfaceLifecycleState)] = []
+        let controller = SurfaceLifecycleController(
+            workspaceId: UUID(),
+            surfaceId: UUID(),
+            initial: .active
+        ) { from, to in
+            calls.append((from, to))
+        }
+        // Same-state transition is a no-op for the handler.
+        XCTAssertTrue(controller.transition(to: .active))
+        XCTAssertEqual(calls.count, 0)
+        // Real transition fires the handler with (prior, target).
+        XCTAssertTrue(controller.transition(to: .throttled))
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls[0].0, .active)
+        XCTAssertEqual(calls[0].1, .throttled)
+    }
+
+    @MainActor
+    func testSeedDoesNotFireHandler() {
+        var fired = false
+        let controller = SurfaceLifecycleController(
+            workspaceId: UUID(),
+            surfaceId: UUID()
+        ) { _, _ in fired = true }
+        controller.seed(from: .hibernated)
+        XCTAssertEqual(controller.state, .hibernated)
+        XCTAssertFalse(fired)
+    }
+
+    @MainActor
+    func testUpdateWorkspaceIdRedirectsMetadataWrites() throws {
+        let originalWorkspace = UUID()
+        let newWorkspace = UUID()
+        let surface = UUID()
+        let store = SurfaceMetadataStore.shared
+        defer {
+            store.removeSurface(workspaceId: originalWorkspace, surfaceId: surface)
+            store.removeSurface(workspaceId: newWorkspace, surfaceId: surface)
+        }
+
+        let controller = SurfaceLifecycleController(
+            workspaceId: originalWorkspace,
+            surfaceId: surface
+        ) { _, _ in }
+
+        controller.updateWorkspaceId(newWorkspace)
+        XCTAssertTrue(controller.transition(to: .throttled))
+
+        let newSnap = store.getMetadata(workspaceId: newWorkspace, surfaceId: surface)
+        XCTAssertEqual(
+            newSnap.metadata[MetadataKey.lifecycleState] as? String,
+            SurfaceLifecycleState.throttled.rawValue
+        )
+        let oldSnap = store.getMetadata(workspaceId: originalWorkspace, surfaceId: surface)
+        XCTAssertNil(oldSnap.metadata[MetadataKey.lifecycleState])
+    }
+}

--- a/tests_v2/test_surface_lifecycle.py
+++ b/tests_v2/test_surface_lifecycle.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""C11-25 surface lifecycle smoke test.
+
+Validates that the canonical `lifecycle_state` metadata key is wired
+through the surface.set_metadata / surface.get_metadata socket path:
+
+  - Accepted values: active, throttled, suspended, hibernated.
+  - Rejected values: anything else, including any non-string.
+  - Round-trips through the metadata store and is readable via
+    surface.get_metadata.
+
+Does NOT exercise the runtime hibernate dispatch end-to-end — that
+requires triggering the operator menu, which lives outside the socket
+PTY reach and is covered by the c11Tests Swift unit tests + a tagged-
+build computer-use scenario in the Validate phase.
+
+Per CLAUDE.md, never run locally — CI / VM only.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+LEGAL_STATES = ["active", "throttled", "suspended", "hibernated"]
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _fresh_surface(c) -> tuple[str, str]:
+    workspace_id = c.new_workspace()
+    current = c._call("surface.current", {"workspace_id": workspace_id}) or {}
+    surface_id = str(current.get("surface_id") or "")
+    _must(bool(surface_id), f"surface.current returned no surface_id: {current}")
+    return workspace_id, surface_id
+
+
+def _run_legal_values(c) -> None:
+    workspace_id, surface_id = _fresh_surface(c)
+    try:
+        for state in LEGAL_STATES:
+            res = (
+                c._call(
+                    "surface.set_metadata",
+                    {
+                        "surface_id": surface_id,
+                        "mode": "merge",
+                        "source": "explicit",
+                        "metadata": {"lifecycle_state": state},
+                    },
+                )
+                or {}
+            )
+            applied = res.get("applied") or {}
+            _must(
+                applied.get("lifecycle_state") is True,
+                f"lifecycle_state={state} should be accepted: {res}",
+            )
+
+            got = (
+                c._call("surface.get_metadata", {"surface_id": surface_id})
+                or {}
+            )
+            md = got.get("metadata") or {}
+            _must(
+                md.get("lifecycle_state") == state,
+                f"lifecycle_state should round-trip as {state!r}: {md}",
+            )
+    finally:
+        c.close_workspace(workspace_id)
+
+
+def _run_rejects_unknown_value(c) -> None:
+    workspace_id, surface_id = _fresh_surface(c)
+    try:
+        # The validator rejects anything outside the four enum values.
+        try:
+            c._call(
+                "surface.set_metadata",
+                {
+                    "surface_id": surface_id,
+                    "mode": "merge",
+                    "source": "explicit",
+                    "metadata": {"lifecycle_state": "frozen"},
+                },
+            )
+        except cmuxError as err:
+            msg = str(err)
+            _must(
+                "reserved_key_invalid_type" in msg or "lifecycle_state" in msg,
+                f"unknown value should be rejected with reserved_key_invalid_type, got: {msg!r}",
+            )
+        else:
+            raise cmuxError(
+                "lifecycle_state='frozen' was accepted; the validator is not wired"
+            )
+    finally:
+        c.close_workspace(workspace_id)
+
+
+def _run_rejects_non_string(c) -> None:
+    workspace_id, surface_id = _fresh_surface(c)
+    try:
+        try:
+            c._call(
+                "surface.set_metadata",
+                {
+                    "surface_id": surface_id,
+                    "mode": "merge",
+                    "source": "explicit",
+                    "metadata": {"lifecycle_state": 1},
+                },
+            )
+        except cmuxError as err:
+            msg = str(err)
+            _must(
+                "reserved_key_invalid_type" in msg or "lifecycle_state" in msg,
+                f"non-string value should be rejected, got: {msg!r}",
+            )
+        else:
+            raise cmuxError(
+                "lifecycle_state=1 was accepted; the validator is not wired"
+            )
+    finally:
+        c.close_workspace(workspace_id)
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as client:
+        _run_legal_values(client)
+        _run_rejects_unknown_value(client)
+        _run_rejects_non_string(client)
+    print("OK c11-25 surface lifecycle metadata roundtrip")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_v2/test_surface_lifecycle.py
+++ b/tests_v2/test_surface_lifecycle.py
@@ -173,13 +173,74 @@ def _run_rejects_suspended(c) -> None:
             c.close_workspace(workspace_id)
 
 
+def _surface_for_id(surfaces: list, surface_id: str) -> dict | None:
+    for s in surfaces:
+        if str(s.get("id") or "") == surface_id:
+            return s
+    return None
+
+
+def _run_metrics_in_surface_list(c) -> None:
+    """C11-25 fix DoD #5: a freshly-spawned terminal surface must expose
+    a `metrics` block with cpu_pct + rss_mb in surface.list once the
+    sampler converges. surface.list is the wire source `c11 tree --json`
+    decorates from, so this covers the tree-json contract too.
+    """
+    workspace_id, surface_id = _fresh_surface(c)
+    try:
+        # Sampler runs at 2 Hz by default; pid provider refreshes every
+        # 2s. Allow up to 8 s for: provider tick → proc_listpids resolve
+        # → first sample → next sample carrying CPU% delta.
+        deadline = time.monotonic() + 8.0
+        last_metrics: dict | None = None
+        while time.monotonic() < deadline:
+            res = c._call("surface.list", {"workspace_id": workspace_id}) or {}
+            surfaces = res.get("surfaces") or []
+            surface = _surface_for_id(surfaces, surface_id)
+            _must(surface is not None, f"surface.list missing surface {surface_id}: {res}")
+            assert surface is not None
+            _must(
+                surface.get("type") == "terminal",
+                f"expected terminal surface, got {surface.get('type')!r}: {surface}",
+            )
+            metrics = surface.get("metrics")
+            _must(
+                isinstance(metrics, dict),
+                f"terminal surface.list payload missing `metrics` block: {surface}",
+            )
+            assert isinstance(metrics, dict)
+            _must(
+                "cpu_pct" in metrics and "rss_mb" in metrics,
+                f"metrics block missing cpu_pct/rss_mb keys: {metrics}",
+            )
+            last_metrics = metrics
+            if metrics.get("cpu_pct") is not None and metrics.get("rss_mb") is not None:
+                _must(
+                    isinstance(metrics["cpu_pct"], (int, float)) and metrics["cpu_pct"] >= 0,
+                    f"cpu_pct should be a non-negative number once sampled: {metrics}",
+                )
+                _must(
+                    isinstance(metrics["rss_mb"], (int, float)) and metrics["rss_mb"] > 0,
+                    f"rss_mb should be a positive number once sampled: {metrics}",
+                )
+                return
+            time.sleep(0.5)
+        raise cmuxError(
+            f"sampler never produced non-null metrics for surface {surface_id} "
+            f"within 8s; last metrics: {last_metrics}"
+        )
+    finally:
+        c.close_workspace(workspace_id)
+
+
 def main() -> int:
     with cmux(SOCKET_PATH) as client:
         _run_legal_values(client)
         _run_rejects_unknown_value(client)
         _run_rejects_non_string(client)
         _run_rejects_suspended(client)
-    print("OK c11-25 surface lifecycle metadata roundtrip")
+        _run_metrics_in_surface_list(client)
+    print("OK c11-25 surface lifecycle metadata roundtrip + metrics surface.list exposure")
     return 0
 
 

--- a/tests_v2/test_surface_lifecycle.py
+++ b/tests_v2/test_surface_lifecycle.py
@@ -4,8 +4,9 @@
 Validates that the canonical `lifecycle_state` metadata key is wired
 through the surface.set_metadata / surface.get_metadata socket path:
 
-  - Accepted values: active, throttled, suspended, hibernated.
-  - Rejected values: anything else, including any non-string.
+  - Accepted values: active, throttled, hibernated.
+  - Rejected values: 'suspended' (reserved-only per review fix I4),
+    anything else outside the enum, and any non-string.
   - Round-trips through the metadata store and is readable via
     surface.get_metadata.
 
@@ -31,7 +32,11 @@ from cmux import cmux, cmuxError
 
 SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
 
-LEGAL_STATES = ["active", "throttled", "suspended", "hibernated"]
+# `suspended` is defined in the enum but rejected at the validator
+# (review fix I4) — it has no runtime consumer in C11-25 and accepting
+# it would let an external writer park a value the runtime ignores.
+LEGAL_STATES = ["active", "throttled", "hibernated"]
+RESERVED_STATES = ["suspended"]
 
 
 def _must(cond: bool, msg: str) -> None:
@@ -137,11 +142,43 @@ def _run_rejects_non_string(c) -> None:
         c.close_workspace(workspace_id)
 
 
+def _run_rejects_suspended(c) -> None:
+    """Review fix I4: 'suspended' is reserved-only — defined in the enum
+    but rejected at the validator until a runtime consumer exists."""
+    for state in RESERVED_STATES:
+        workspace_id, surface_id = _fresh_surface(c)
+        try:
+            try:
+                c._call(
+                    "surface.set_metadata",
+                    {
+                        "surface_id": surface_id,
+                        "mode": "merge",
+                        "source": "explicit",
+                        "metadata": {"lifecycle_state": state},
+                    },
+                )
+            except cmuxError as err:
+                msg = str(err)
+                _must(
+                    "reserved_key_invalid_type" in msg or "lifecycle_state" in msg,
+                    f"reserved value {state!r} should be rejected, got: {msg!r}",
+                )
+            else:
+                raise cmuxError(
+                    f"lifecycle_state={state!r} was accepted; "
+                    f"reserved-only validator (I4) is not wired"
+                )
+        finally:
+            c.close_workspace(workspace_id)
+
+
 def main() -> int:
     with cmux(SOCKET_PATH) as client:
         _run_legal_values(client)
         _run_rejects_unknown_value(client)
         _run_rejects_non_string(client)
+        _run_rejects_suspended(client)
     print("OK c11-25 surface lifecycle metadata roundtrip")
     return 0
 


### PR DESCRIPTION
Closes [C11-25](https://forgejo.s11.fyi/Stage-11-Agentics/c11/issues/25) — *Surface lifecycle perf: webview suspension, off-screen terminal throttling, per-surface frame budget*.

Lattice ticket: `C11-25` (`task_01KQTQ05R0G4CSMJRQPK7XVKY3`).

## What this PR ships

The per-surface lifecycle primitive (`active` / `throttled` / `suspended` / `hibernated`) plus five of the six behaviors from the ticket:

1. **Browser suspension cheap-tier** — NSView detach for non-focused workspaces. Compositor cost drops to ~0%.
2. **Browser suspension ARC-grade** — `WKWebView.takeSnapshot` → NSImage placeholder → `WKWebView.close` for hibernated workspaces. WebContent processes terminate; ~200 MB freed across two browsers in validation.
3. **Terminal occlusion throttle** — libghostty `setOcclusion(false)` for non-focused workspaces. ~3.3× CPU drop on a producer that pegs `c11`'s render loop while focused.
4. **Per-surface CPU/MEM in sidebar** — new `SurfaceMetricsSampler` reading `proc_pid_rusage`. Browser PID via `_webProcessIdentifier` SPI; terminal PID via `proc_listpids` + `proc_bsdinfo.e_tdev` matching the surface's controlling tty. Metrics also exposed in `c11 tree --json` for socket-driven verification.
5. **Right-click "Hibernate Workspace" / "Resume Workspace"** — sidebar tab context menu + App menu bar's Workspace submenu. Tooltip clarifies the scope (browsers suspend; terminals stay on auto-throttle). Six locales translated.

The sixth behavior — **per-surface 30 fps cap (DoD #4)** — is deliberately deferred to **C11-26** so the libghostty seam can get its own typing-latency review.

## DoD verification

Done as part of the Validate phase against tagged build `a36d65b2` (pre-Fix-3) on `c11-25-surface-lifecycle`:

| Criterion | Verdict | Evidence |
|-----------|---------|----------|
| Browsers <1% CPU non-focused | **MET** | spinner ~0.15% focused → 0.00% non-focused → 0.16% on rebind |
| Browsers <50 MB hibernated | **MET decisively** | both WebContent procs terminated; c11 host RSS delta ≈ -32 KB; ~200 MB freed |
| Terminal renderer <2 Hz non-focused | **MET (behavioral)** | c11 process CPU drops 3.3× on workspace deselect with infinite producer; output catches up cleanly on reselect |
| Per-surface 30 fps cap | **N/A — deferred to C11-26** | libghostty seam needs own typing-latency review |
| Sidebar shows CPU/MEM | **MET** for browsers + terminals | sidebar render confirmed; `tree --json` exposes `metrics.cpu_pct` / `metrics.rss_mb` per Fix-3 commit `b51b4cd2` |
| Right-click Hibernate works | **MET** | sidebar right-click + menu bar both wired; behavior end-to-end-tested via socket |

Plus an out-of-band privacy verification: hibernated workspaces persisted across `c11 restore`. Access log on a probe URL stayed empty for 8s after relaunch — no WebContent processes spun up for the persisted URL. Resume Workspace fired the URL exactly once.

Validate artifacts (CSVs, screenshots, access logs) are at `/tmp/c11-25-validate/`.

## Lifecycle process

This was driven through Lattice's plan → impl → review → fix → validate → fix → handoff lifecycle, with a delegator + sub-agent pattern (10 sibling surfaces total).

- **Plan** — design + scope + DoD measurement plan written to `.lattice/plans/task_01KQTQ05R0G4CSMJRQPK7XVKY3.md` (operator-amended after the original recommended split was rejected).
- **Impl** — 9 commits + Translator pass for 2 strings.
- **Review** — `/trident-code-review`. Verdict: rework-then-review. 11 fixes applied (4 commits) covering hibernate/resume hardening, sampler thread-safety, metadata rehydration, and validator/scope tightening. 11 surface-to-user items + 3 evolutionary items escalated.
- **Fix** — operator-routed: applied S1 (tooltip), S4+E1 (privacy fix — `pendingHibernate` native construction), and the DoD #5 terminal CPU/MEM resolver. 3 commits + Translator pass #2.
- **Validate** — first attempt blocked on 3 compile errors (3-line patch, applied directly). Second attempt: full DoD report, two gaps surfaced.
- **Fix-3** — closed both gaps from Validate (sidebar right-click placement; `tree --json` metrics exposure). 2 commits.

Total: 21 commits, ~2400 LoC across 22 files.

## Localization

Three new English keys × six locales (ja, uk, ko, zh-Hans, zh-Hant, ru) translated in two passes (`51a0ba0d`, `521cf99c`).

## Follow-up tickets filed

- **C11-26** — Per-surface 30 fps redraw cap (the explicit deferral).
- **C11-27** — Hibernate workspace UX (S2 in-place Resume affordance, S3 multi-selection).
- **C11-28** — Lifecycle hardening + observability (S5 sidebar perf at scale, S6 takeSnapshot timeout, S7 BrowserSnapshotStore LRU, S8 1024MB rounding, S9 SPI log-once, S11 cross-workspace metadata staleness, E3 lifecycle subscribe socket).

## Smoke test plan

- [ ] Spawn 2 workspaces, each with 1–2 browsers and a terminal. Switch between workspaces; observe sidebar CPU/MEM updating per surface.
- [ ] Right-click a workspace tab in the sidebar → confirm "Hibernate Workspace" appears with the tooltip. Click it. Confirm browsers go to placeholder and terminals continue.
- [ ] Right-click again → confirm menu shows "Resume Workspace". Click. Confirm browsers re-attach and load the persisted URL exactly once.
- [ ] Hibernate a workspace pointed at a URL you control. Quit c11. Relaunch. Verify the access log shows no requests until you click Resume.
- [ ] Run a CPU-spammy producer (`top -l 0 -s 0` or `yes > /dev/null`) in a terminal. Switch to another workspace. Confirm c11's process CPU drops noticeably (libghostty occlusion throttle).
- [ ] Open `c11 tree --json` (any workspace). Confirm each terminal/browser surface's manifest includes a `metrics` block with `cpu_pct` and `rss_mb`.

## Notes

- WebKit SPI use (`_webProcessIdentifier`) is consistent with existing c11 patterns (`BrowserWindowPortal` already uses several private selectors). Operator-approved.
- Pre-build environment hygiene: this worktree's ghostty submodule needed `git submodule update --init --recursive ghostty` and a `GhosttyKit.xcframework` symlink before build. Not a code regression — flagging for next worktree-bringup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)