### PR TITLE
CMUX-10: Persistent, themable surface flash across pane and sidebar tab

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2289,11 +2289,16 @@ struct CMUXCLI {
             let tfWsFlag = optionValue(commandArgs, name: "--workspace")
             let workspaceArg = tfWsFlag ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceArg = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel") ?? (tfWsFlag == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+            let colorArg = optionValue(commandArgs, name: "--color")
+            if let colorArg, !isValidFlashColorHex(colorArg) {
+                throw CLIError(message: "--color must be a hex value like #F5C518.")
+            }
             var params: [String: Any] = [:]
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)
             if let sfId { params["surface_id"] = sfId }
+            if let colorArg { params["color"] = colorArg }
             let payload = try client.sendV2(method: "surface.trigger_flash", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
 
@@ -8332,7 +8337,7 @@ struct CMUXCLI {
             """
         case "trigger-flash":
             return """
-            Usage: c11 trigger-flash [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]
+            Usage: c11 trigger-flash [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>] [--color <#hex>]
 
             Trigger the unread flash indicator for a surface.
 
@@ -8340,10 +8345,13 @@ struct CMUXCLI {
               --workspace <id|ref>   Workspace context (default: $CMUX_WORKSPACE_ID)
               --surface <id|ref>     Target surface (default: $CMUX_SURFACE_ID)
               --panel <id|ref>       Alias for --surface
+              --color <#hex>         One-shot color override (e.g. "#F5C518" or "#F5C518FF").
+                                     Defaults to the c11 yellow signal color.
 
             Example:
               c11 trigger-flash
               c11 trigger-flash --workspace workspace:2 --surface surface:3
+              c11 trigger-flash --surface surface:3 --color "#FF00FF"
             """
         case "list-panels":
             return """
@@ -10633,6 +10641,17 @@ struct CMUXCLI {
 
     private func hasFlag(_ args: [String], name: String) -> Bool {
         args.contains(name)
+    }
+
+    /// CMUX-10: client-side hex validation for `--color`. The socket re-validates
+    /// authoritatively (server is the source of truth), but rejecting obviously
+    /// wrong shapes here gives the operator a fast, clear error without a
+    /// round-trip. Accepts `#RRGGBB`, `#RRGGBBAA`, with or without leading `#`.
+    private func isValidFlashColorHex(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stripped = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard stripped.count == 6 || stripped.count == 8 else { return false }
+        return stripped.allSatisfy { $0.isHexDigit }
     }
 
     private func replaceToken(_ args: [String], from: String, to: String) -> [String] {

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -8360,7 +8360,11 @@ struct CMUXCLI {
               --surface <id|ref>     Target surface (default: $CMUX_SURFACE_ID)
               --panel <id|ref>       Alias for --surface
               --color <#hex>         One-shot color override (e.g. "#F5C518" or "#F5C518FF").
-                                     Defaults to the c11 yellow signal color.
+                                     Defaults to the c11 yellow signal color. Tints the
+                                     terminal pane ring and the sidebar workspace-row pulse.
+                                     Browser and Markdown panel overlays and the Bonsplit
+                                     tab pulse keep their default accent — color override
+                                     for those surfaces is a follow-up.
               --persistent           Keep pulsing until the operator clicks the surface or
                                      `c11 cancel-flash` is called. Auto-degrades to a single
                                      one-shot when the target is the focused surface in the

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2293,13 +2293,27 @@ struct CMUXCLI {
             if let colorArg, !isValidFlashColorHex(colorArg) {
                 throw CLIError(message: "--color must be a hex value like #F5C518.")
             }
+            let persistent = hasFlag(commandArgs, name: "--persistent")
             var params: [String: Any] = [:]
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)
             if let sfId { params["surface_id"] = sfId }
             if let colorArg { params["color"] = colorArg }
+            if persistent { params["persistent"] = true }
             let payload = try client.sendV2(method: "surface.trigger_flash", params: params)
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+
+        case "cancel-flash":
+            let cfWsFlag = optionValue(commandArgs, name: "--workspace")
+            let workspaceArg = cfWsFlag ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            let surfaceArg = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel") ?? (cfWsFlag == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+            var params: [String: Any] = [:]
+            let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
+            if let wsId { params["workspace_id"] = wsId }
+            let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)
+            if let sfId { params["surface_id"] = sfId }
+            let payload = try client.sendV2(method: "surface.cancel_flash", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
 
         case "list-panels":
@@ -8337,7 +8351,7 @@ struct CMUXCLI {
             """
         case "trigger-flash":
             return """
-            Usage: c11 trigger-flash [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>] [--color <#hex>]
+            Usage: c11 trigger-flash [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>] [--color <#hex>] [--persistent]
 
             Trigger the unread flash indicator for a surface.
 
@@ -8347,11 +8361,32 @@ struct CMUXCLI {
               --panel <id|ref>       Alias for --surface
               --color <#hex>         One-shot color override (e.g. "#F5C518" or "#F5C518FF").
                                      Defaults to the c11 yellow signal color.
+              --persistent           Keep pulsing until the operator clicks the surface or
+                                     `c11 cancel-flash` is called. Auto-degrades to a single
+                                     one-shot when the target is the focused surface in the
+                                     focused window.
 
             Example:
               c11 trigger-flash
               c11 trigger-flash --workspace workspace:2 --surface surface:3
               c11 trigger-flash --surface surface:3 --color "#FF00FF"
+              c11 trigger-flash --surface surface:3 --persistent
+            """
+        case "cancel-flash":
+            return """
+            Usage: c11 cancel-flash [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]
+
+            Cancel any in-flight persistent flash on a surface. No-op for one-shot flashes
+            and for surfaces with no active persistent flash.
+
+            Flags:
+              --workspace <id|ref>   Workspace context (default: $CMUX_WORKSPACE_ID)
+              --surface <id|ref>     Target surface (default: $CMUX_SURFACE_ID)
+              --panel <id|ref>       Alias for --surface
+
+            Example:
+              c11 cancel-flash
+              c11 cancel-flash --workspace workspace:2 --surface surface:3
             """
         case "list-panels":
             return """
@@ -15085,7 +15120,8 @@ struct CMUXCLI {
           refresh-surfaces
           surface-health [--workspace <id|ref>]
           health [--since <duration> | --since-boot] [--rail <name>] [--json]
-          trigger-flash [--workspace <id|ref>] [--surface <id|ref>]
+          trigger-flash [--workspace <id|ref>] [--surface <id|ref>] [--color <#hex>] [--persistent]
+          cancel-flash [--workspace <id|ref>] [--surface <id|ref>]
           list-panels [--workspace <id|ref>]
           focus-panel --panel <id|ref> [--workspace <id|ref>]
           close-workspace --workspace <id|ref>

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		D8007BF0A1B2C3D4E5F60718 /* AgentRestartRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8007BF1A1B2C3D4E5F60718 /* AgentRestartRegistry.swift */; };
 		D8008BF0A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */; };
 		D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */; };
+		A5FA5710 /* WorkspaceFlashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FA5711 /* WorkspaceFlashTests.swift */; };
+		A5FA5712 /* FlashColorParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FA5713 /* FlashColorParsingTests.swift */; };
 		DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */; };
 		DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */; };
 		DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */; };
@@ -362,6 +364,8 @@
 		D8007BF1A1B2C3D4E5F60718 /* AgentRestartRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRestartRegistry.swift; sourceTree = "<group>"; };
 		D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotConverterTests.swift; sourceTree = "<group>"; };
 		D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRestartRegistryTests.swift; sourceTree = "<group>"; };
+		A5FA5711 /* WorkspaceFlashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFlashTests.swift; sourceTree = "<group>"; };
+		A5FA5713 /* FlashColorParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashColorParsingTests.swift; sourceTree = "<group>"; };
 		DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthIPSParserTests.swift; sourceTree = "<group>"; };
 		DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthSentryParserTests.swift; sourceTree = "<group>"; };
 		DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthMetricKitParserTests.swift; sourceTree = "<group>"; };
@@ -961,6 +965,8 @@
 					D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */,
 					D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */,
 					D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */,
+					A5FA5711 /* WorkspaceFlashTests.swift */,
+					A5FA5713 /* FlashColorParsingTests.swift */,
 					DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */,
 					DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */,
 					DH012BF1A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift */,
@@ -1359,6 +1365,8 @@
 					D8004BF0A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift in Sources */,
 					D8008BF0A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift in Sources */,
 					D8009BF0A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift in Sources */,
+				A5FA5710 /* WorkspaceFlashTests.swift in Sources */,
+				A5FA5712 /* FlashColorParsingTests.swift in Sources */,
 					DH010BF0A1B2C3D4E5F60718 /* HealthIPSParserTests.swift in Sources */,
 					DH011BF0A1B2C3D4E5F60718 /* HealthSentryParserTests.swift in Sources */,
 					DH012BF0A1B2C3D4E5F60718 /* HealthMetricKitParserTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		A5001610 /* SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001611 /* SessionPersistence.swift */; };
 		A5005B02 /* BrandColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5005B01 /* BrandColors.swift */; };
+		A5FA5702 /* FlashAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FA5701 /* FlashAppearance.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
 		A5001230 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A5001231 /* Sparkle */; };
 		B9000002A1B2C3D4E5F60719 /* c11.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* c11.swift */; };
@@ -498,6 +499,7 @@
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		A5001611 /* SessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistence.swift; sourceTree = "<group>"; };
 		A5005B01 /* BrandColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrandColors.swift; sourceTree = "<group>"; };
+		A5FA5701 /* FlashAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlashAppearance.swift; sourceTree = "<group>"; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
@@ -821,6 +823,7 @@
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
 				A5005B01 /* BrandColors.swift */,
+				A5FA5701 /* FlashAppearance.swift */,
 				CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */,
 				CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */,
 				CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */,
@@ -1247,6 +1250,7 @@
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
 				A5005B02 /* BrandColors.swift in Sources */,
+				A5FA5702 /* FlashAppearance.swift in Sources */,
 				CC401002A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */,
 				CC401005A1B2C3D4E5F60719 /* AgentSkillsView.swift in Sources */,
 				CC401007A1B2C3D4E5F60719 /* TCCPrimerView.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -36800,6 +36800,39 @@
         }
       }
     },
+    "settings.notifications.flashDuration.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How long the flash pulse lasts before fading."
+          }
+        }
+      }
+    },
+    "settings.notifications.flashDuration.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flash Duration"
+          }
+        }
+      }
+    },
+    "settings.notifications.flashDuration.unit.ms": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d ms"
+          }
+        }
+      }
+    },
     "settings.notifications.paneFlash.subtitle": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11594,8 +11594,9 @@ private struct TabItemView: View, Equatable {
                     // signals "a panel in this workspace was flashed" without
                     // shouting from the sidebar. Hit testing is disabled so
                     // the pulse never intercepts clicks/drags.
+                    // CMUX-10: color sourced via FlashAppearance seam.
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(cmuxAccentColor().opacity(sidebarFlashOpacity))
+                        .fill(FlashAppearance.current(envelope: .sidebarFill).swiftUIColor.opacity(sidebarFlashOpacity))
                         .allowsHitTesting(false)
                 }
         )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8512,6 +8512,7 @@ struct VerticalTabsSidebar: View {
                                     allRemoteContextMenuTargetsConnecting: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting },
                                     allRemoteContextMenuTargetsDisconnected: !remoteContextMenuTargets.isEmpty && remoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected },
                                     sidebarFlashToken: tab.sidebarFlashToken,
+                                    sidebarFlashColorHex: tab.sidebarFlashColorHex,
                                     chromeTokens: chromeTokens
                                 )
                                 .equatable()
@@ -10959,6 +10960,7 @@ private struct TabItemView: View, Equatable {
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
         lhs.sidebarFlashToken == rhs.sidebarFlashToken &&
+        lhs.sidebarFlashColorHex == rhs.sidebarFlashColorHex &&
         lhs.chromeTokens == rhs.chromeTokens
     }
 
@@ -11032,6 +11034,23 @@ private struct TabItemView: View, Equatable {
     /// running a single, gentle pulse in the same accent color used for
     /// other workspace affordances. Visual-only; never selects.
     let sidebarFlashToken: Int
+    /// CMUX-10: hex color (#RRGGBBAA) for the sidebar pulse on the most
+    /// recent flash. Sourced from `--color` via `Workspace.runFlashPulse`
+    /// so a per-call color override tints the workspace row, not just the
+    /// terminal pane ring. nil → fall back to the default sidebar-fill
+    /// color.
+    let sidebarFlashColorHex: String?
+
+    /// CMUX-10: resolves `sidebarFlashColorHex` to a SwiftUI `Color`. Falls
+    /// back to the default `FlashAppearance` sidebar fill when the most
+    /// recent flash carried no per-call color.
+    private var sidebarFlashFillColor: Color {
+        if let hex = sidebarFlashColorHex,
+           let nsColor = FlashAppearance.parseHex(hex) {
+            return Color(nsColor: nsColor)
+        }
+        return FlashAppearance.current(envelope: .sidebarFill).swiftUIColor
+    }
     /// Chrome scale tokens (sidebar+tab strip font/sizing multipliers). Value-typed
     /// and Equatable so it folds into `==` as a single multiplier compare. (C11-6)
     let chromeTokens: ChromeScaleTokens
@@ -11594,9 +11613,10 @@ private struct TabItemView: View, Equatable {
                     // signals "a panel in this workspace was flashed" without
                     // shouting from the sidebar. Hit testing is disabled so
                     // the pulse never intercepts clicks/drags.
-                    // CMUX-10: color sourced via FlashAppearance seam.
+                    // CMUX-10: color sourced via FlashAppearance seam, or
+                    // tinted by `--color` when the trigger carried one.
                     RoundedRectangle(cornerRadius: 6)
-                        .fill(FlashAppearance.current(envelope: .sidebarFill).swiftUIColor.opacity(sidebarFlashOpacity))
+                        .fill(sidebarFlashFillColor.opacity(sidebarFlashOpacity))
                         .allowsHitTesting(false)
                 }
         )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11662,6 +11662,10 @@ private struct TabItemView: View, Equatable {
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex
         ))
         .onTapGesture {
+            // CMUX-10: clicking the workspace row dismisses any persistent
+            // flash inside it (across all panels). The operator clicked,
+            // they're acknowledging — give them the surface clean.
+            tab.cancelAllPersistentFlashes()
             updateSelection()
         }
         .onHover { hovering in

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11684,9 +11684,13 @@ private struct TabItemView: View, Equatable {
     }
 
     private func runSidebarFlashAnimation(token: Int) {
-        // Reset to the envelope start in case a prior flash is mid-flight.
-        sidebarFlashOpacity = SidebarFlashPattern.values.first ?? 0
-        for segment in SidebarFlashPattern.segments {
+        // CMUX-10: drive the sidebar pulse from the unified `FocusFlashPattern`
+        // envelope (same temporal shape as the pane ring), with the per-channel
+        // peak scalar applied so the row tint reads as a signal without
+        // overpowering the sidebar.
+        let peakScale = FlashEnvelope.sidebarFill.peakScale
+        sidebarFlashOpacity = (FocusFlashPattern.values.first ?? 0) * peakScale
+        for segment in FocusFlashPattern.segments {
             DispatchQueue.main.asyncAfter(deadline: .now() + segment.delay) {
                 // Bail if a newer flash superseded this run.
                 guard token == lastObservedSidebarFlashToken else { return }
@@ -11698,7 +11702,7 @@ private struct TabItemView: View, Equatable {
                     animation = .easeOut(duration: segment.duration)
                 }
                 withAnimation(animation) {
-                    sidebarFlashOpacity = segment.targetOpacity
+                    sidebarFlashOpacity = segment.targetOpacity * peakScale
                 }
             }
         }

--- a/Sources/FlashAppearance.swift
+++ b/Sources/FlashAppearance.swift
@@ -12,7 +12,7 @@ import SwiftUI
 // pair (`.paneRing` / `.sidebarFill`). Later commits in CMUX-10 swap the
 // default color (#F5C518) and unify the envelope.
 
-enum FlashEnvelope: Equatable {
+public enum FlashEnvelope: Equatable {
     /// Two-peak ring envelope used by the pane ring (`FocusFlashPattern`,
     /// 0.9s, peaks at full opacity). Carried forward unchanged from the
     /// pre-CMUX-10 implementation.
@@ -25,27 +25,66 @@ enum FlashEnvelope: Equatable {
     case sidebarFill
 }
 
-struct FlashAppearance: Equatable {
-    let color: NSColor
-    let envelope: FlashEnvelope
+public struct FlashAppearance: Equatable {
+    public let color: NSColor
+    public let envelope: FlashEnvelope
+
+    public init(color: NSColor, envelope: FlashEnvelope) {
+        self.color = color
+        self.envelope = envelope
+    }
 
     /// SwiftUI-compatible projection of `color`. SwiftUI's sidebar fill needs a
     /// `Color`, not an `NSColor`; pane renderer needs the `NSColor` directly.
-    var swiftUIColor: Color {
+    public var swiftUIColor: Color {
         Color(nsColor: color)
     }
 
     /// The default flash color used when no per-call override is provided.
-    /// Commit 1 keeps the historical gold accent; commit 2 swaps to the
-    /// CMUX-10 yellow.
-    static var defaultColor: NSColor {
-        cmuxAccentNSColor()
+    /// Resolved by the CMUX-10 ticket: a warm yellow distinct from the gold
+    /// accent so the flash reads as a *signal*, not just chrome.
+    ///
+    /// TODO(theme-engine, CMUX-9): read `flash.color` from the active theme
+    /// when the theme engine ships; until then this constant is the source of
+    /// truth and per-call overrides come through `--color`.
+    public static var defaultColor: NSColor {
+        // sRGB #F5C518 — warm signal yellow.
+        NSColor(srgbRed: 0xF5 / 255.0, green: 0xC5 / 255.0, blue: 0x18 / 255.0, alpha: 1.0)
+    }
+
+    /// Parse a hex color string of the form `#RRGGBB` or `#RRGGBBAA`
+    /// (case-insensitive, optional leading `#`). Returns `nil` for any other
+    /// shape so callers can surface a clear error message rather than rendering
+    /// garbage. Used by both the CLI parser and the socket handler.
+    public static func parseHex(_ raw: String) -> NSColor? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        let stripped = trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed
+        guard stripped.count == 6 || stripped.count == 8 else { return nil }
+        guard stripped.allSatisfy({ $0.isHexDigit }) else { return nil }
+        var value: UInt64 = 0
+        guard Scanner(string: stripped).scanHexInt64(&value) else { return nil }
+        let r: CGFloat
+        let g: CGFloat
+        let b: CGFloat
+        let a: CGFloat
+        if stripped.count == 8 {
+            r = CGFloat((value >> 24) & 0xFF) / 255.0
+            g = CGFloat((value >> 16) & 0xFF) / 255.0
+            b = CGFloat((value >> 8) & 0xFF) / 255.0
+            a = CGFloat(value & 0xFF) / 255.0
+        } else {
+            r = CGFloat((value >> 16) & 0xFF) / 255.0
+            g = CGFloat((value >> 8) & 0xFF) / 255.0
+            b = CGFloat(value & 0xFF) / 255.0
+            a = 1.0
+        }
+        return NSColor(srgbRed: r, green: g, blue: b, alpha: a)
     }
 
     /// Snapshot of the current default appearance for the given envelope.
     /// Call sites that don't yet know which envelope they want pick `.paneRing`
     /// (the historical pane behavior) so the refactor stays a no-op.
-    static func current(envelope: FlashEnvelope = .paneRing) -> FlashAppearance {
+    public static func current(envelope: FlashEnvelope = .paneRing) -> FlashAppearance {
         FlashAppearance(color: defaultColor, envelope: envelope)
     }
 }

--- a/Sources/FlashAppearance.swift
+++ b/Sources/FlashAppearance.swift
@@ -32,11 +32,12 @@ public enum FlashEnvelope: Equatable {
         }
     }
 
-    /// Duration of one flash pulse in seconds. Until commit 5 wires the
-    /// configurable Flash Duration setting, this resolves to the historical
-    /// `FocusFlashPattern.duration` (0.9s). Commit 5 swaps the source to
-    /// `NotificationFlashDurationSettings.currentMs / 1000.0` without changing
-    /// the call shape.
+    /// Duration of one flash pulse in seconds. Sourced from the user-tunable
+    /// Flash Duration setting (Notifications panel, 500–4000ms, default 1500ms).
+    /// Pane and sidebar share this duration; the sidebar applies `peakScale`
+    /// to amplitude only, not time. Goes through `FocusFlashPattern.duration`
+    /// so every renderer (pane ring, sidebar fill, Browser/Markdown overlays)
+    /// scales together.
     public var duration: TimeInterval {
         FocusFlashPattern.duration
     }

--- a/Sources/FlashAppearance.swift
+++ b/Sources/FlashAppearance.swift
@@ -13,16 +13,24 @@ import SwiftUI
 // default color (#F5C518) and unify the envelope.
 
 public enum FlashEnvelope: Equatable {
-    /// Two-peak ring envelope used by the pane ring (`FocusFlashPattern`,
-    /// 0.9s, peaks at full opacity). Carried forward unchanged from the
-    /// pre-CMUX-10 implementation.
+    /// Pane ring channel: drives the ring overlay around the focused pane at
+    /// full peak amplitude (1.0).
     case paneRing
 
-    /// Single-peak low-amplitude envelope used by the sidebar workspace row
-    /// (`SidebarFlashPattern`, 0.6s, peak 0.18). Carried forward unchanged for
-    /// the refactor commit; commit 3 retires this in favor of `.paneRing` with
-    /// a per-channel amplitude scalar.
+    /// Sidebar workspace-row channel: same temporal pattern as `.paneRing` but
+    /// with peak amplitude scaled to 0.6 so the row tint reads as a signal
+    /// without overpowering the rest of the sidebar.
     case sidebarFill
+
+    /// Per-channel amplitude scalar applied to the unified envelope's
+    /// `targetOpacity` values. CMUX-10 retired the historical "polite ambient
+    /// nudge" sidebar envelope in favor of this single shared envelope.
+    public var peakScale: Double {
+        switch self {
+        case .paneRing: return 1.0
+        case .sidebarFill: return 0.6
+        }
+    }
 }
 
 public struct FlashAppearance: Equatable {

--- a/Sources/FlashAppearance.swift
+++ b/Sources/FlashAppearance.swift
@@ -1,0 +1,51 @@
+import AppKit
+import SwiftUI
+
+// CMUX-10: Single seam for flash visuals (color + envelope) used by both the
+// pane ring renderer (`GhosttySurfaceScrollView`) and the sidebar workspace row
+// fill (`TabItemView`). Lifting these behind one type lets later commits swap
+// the default color, accept a per-call override, and unify the temporal
+// envelope across surfaces without touching every renderer.
+//
+// Commit 1 (this file's introduction) is a pure refactor: `FlashAppearance.current()`
+// still returns the existing gold accent and the existing two-pattern envelope
+// pair (`.paneRing` / `.sidebarFill`). Later commits in CMUX-10 swap the
+// default color (#F5C518) and unify the envelope.
+
+enum FlashEnvelope: Equatable {
+    /// Two-peak ring envelope used by the pane ring (`FocusFlashPattern`,
+    /// 0.9s, peaks at full opacity). Carried forward unchanged from the
+    /// pre-CMUX-10 implementation.
+    case paneRing
+
+    /// Single-peak low-amplitude envelope used by the sidebar workspace row
+    /// (`SidebarFlashPattern`, 0.6s, peak 0.18). Carried forward unchanged for
+    /// the refactor commit; commit 3 retires this in favor of `.paneRing` with
+    /// a per-channel amplitude scalar.
+    case sidebarFill
+}
+
+struct FlashAppearance: Equatable {
+    let color: NSColor
+    let envelope: FlashEnvelope
+
+    /// SwiftUI-compatible projection of `color`. SwiftUI's sidebar fill needs a
+    /// `Color`, not an `NSColor`; pane renderer needs the `NSColor` directly.
+    var swiftUIColor: Color {
+        Color(nsColor: color)
+    }
+
+    /// The default flash color used when no per-call override is provided.
+    /// Commit 1 keeps the historical gold accent; commit 2 swaps to the
+    /// CMUX-10 yellow.
+    static var defaultColor: NSColor {
+        cmuxAccentNSColor()
+    }
+
+    /// Snapshot of the current default appearance for the given envelope.
+    /// Call sites that don't yet know which envelope they want pick `.paneRing`
+    /// (the historical pane behavior) so the refactor stays a no-op.
+    static func current(envelope: FlashEnvelope = .paneRing) -> FlashAppearance {
+        FlashAppearance(color: defaultColor, envelope: envelope)
+    }
+}

--- a/Sources/FlashAppearance.swift
+++ b/Sources/FlashAppearance.swift
@@ -31,6 +31,15 @@ public enum FlashEnvelope: Equatable {
         case .sidebarFill: return 0.6
         }
     }
+
+    /// Duration of one flash pulse in seconds. Until commit 5 wires the
+    /// configurable Flash Duration setting, this resolves to the historical
+    /// `FocusFlashPattern.duration` (0.9s). Commit 5 swaps the source to
+    /// `NotificationFlashDurationSettings.currentMs / 1000.0` without changing
+    /// the call shape.
+    public var duration: TimeInterval {
+        FocusFlashPattern.duration
+    }
 }
 
 public struct FlashAppearance: Equatable {

--- a/Sources/FlashAppearance.swift
+++ b/Sources/FlashAppearance.swift
@@ -62,13 +62,20 @@ public struct FlashAppearance: Equatable {
     /// Resolved by the CMUX-10 ticket: a warm yellow distinct from the gold
     /// accent so the flash reads as a *signal*, not just chrome.
     ///
+    /// `static let` (not `var`) so the `NSColor` is allocated once at class
+    /// initialization, not on every read. Sidebar overlay reads this on each
+    /// pulse animation tick; a computed accessor would build a fresh
+    /// `NSColor` per tick per row.
+    ///
     /// TODO(theme-engine, CMUX-9): read `flash.color` from the active theme
     /// when the theme engine ships; until then this constant is the source of
     /// truth and per-call overrides come through `--color`.
-    public static var defaultColor: NSColor {
-        // sRGB #F5C518 — warm signal yellow.
-        NSColor(srgbRed: 0xF5 / 255.0, green: 0xC5 / 255.0, blue: 0x18 / 255.0, alpha: 1.0)
-    }
+    public static let defaultColor: NSColor = NSColor(
+        srgbRed: 0xF5 / 255.0,
+        green: 0xC5 / 255.0,
+        blue: 0x18 / 255.0,
+        alpha: 1.0
+    )
 
     /// Parse a hex color string of the form `#RRGGBB` or `#RRGGBBAA`
     /// (case-insensitive, optional leading `#`). Returns `nil` for any other

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5843,6 +5843,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         requestPointerFocusRecovery()
         window?.makeFirstResponder(self)
         if let terminalSurface {
+            // CMUX-10: click cancels any persistent flash on this surface. Mouse-only
+            // path; the keyDown / typing hot path is not touched here.
+            if let workspace = AppDelegate.shared?.tabManager?.tabs.first(where: { $0.id == terminalSurface.tabId }),
+               workspace.persistentFlashPanels[terminalSurface.id] != nil {
+                workspace.cancelPersistentFlash(panelId: terminalSurface.id)
+            }
             AppDelegate.shared?.tabManager?.dismissNotificationOnDirectInteraction(
                 tabId: terminalSurface.tabId,
                 surfaceId: terminalSurface.id

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6636,11 +6636,14 @@ final class GhosttySurfaceScrollView: NSView {
         flashOverlayView.layer?.masksToBounds = false
         flashOverlayView.autoresizingMask = [.width, .height]
         flashLayer.fillColor = NSColor.clear.cgColor
-        flashLayer.strokeColor = cmuxAccentNSColor().cgColor
+        // CMUX-10: color sourced via FlashAppearance seam (still gold here in
+        // commit 1; commit 2 swaps the default and adds per-call overrides).
+        let initialFlashColor = FlashAppearance.current(envelope: .paneRing).color
+        flashLayer.strokeColor = initialFlashColor.cgColor
         flashLayer.lineWidth = 3
         flashLayer.lineJoin = .round
         flashLayer.lineCap = .round
-        flashLayer.shadowColor = cmuxAccentNSColor().cgColor
+        flashLayer.shadowColor = initialFlashColor.cgColor
         flashLayer.shadowOpacity = 0.6
         flashLayer.shadowRadius = 6
         flashLayer.shadowOffset = .zero

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7578,6 +7578,14 @@ final class GhosttySurfaceScrollView: NSView {
 #endif
 
     func triggerFlash(style: FlashStyle = .standardFocus) {
+        triggerFlash(style: style, appearance: FlashAppearance.current(envelope: .paneRing))
+    }
+
+    /// CMUX-10: variant that re-tints the flash layer with a per-call color
+    /// before firing the animation. Color is applied off the layer's
+    /// presentation tree (sublayer property), not via a redraw of the surface,
+    /// so this stays out of the typing hot path.
+    func triggerFlash(style: FlashStyle, appearance: FlashAppearance) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
 #if DEBUG
@@ -7588,6 +7596,8 @@ final class GhosttySurfaceScrollView: NSView {
             self.updateFlashPath(style: style)
             self.flashLayer.removeAllAnimations()
             self.flashLayer.opacity = 0
+            self.flashLayer.strokeColor = appearance.color.cgColor
+            self.flashLayer.shadowColor = appearance.color.cgColor
             let animation = CAKeyframeAnimation(keyPath: "opacity")
             animation.values = FocusFlashPattern.values.map { NSNumber(value: $0) }
             animation.keyTimes = FocusFlashPattern.keyTimes.map { NSNumber(value: $0) }

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -116,6 +116,12 @@ public protocol Panel: AnyObject, Identifiable, ObservableObject where ID == UUI
     /// Trigger a focus flash animation for this panel.
     func triggerFlash()
 
+    /// Trigger a focus flash animation with a specific appearance (color +
+    /// envelope). Default impl falls back to the no-arg `triggerFlash()` so
+    /// existing call sites keep working — panels that want to honor a per-
+    /// call color override implement this directly.
+    func triggerFlash(appearance: FlashAppearance)
+
     /// Capture the panel-local focus target that should be restored later.
     func captureFocusIntent(in window: NSWindow?) -> PanelFocusIntent
 
@@ -141,6 +147,13 @@ public protocol Panel: AnyObject, Identifiable, ObservableObject where ID == UUI
 extension Panel {
     public var displayIcon: String? { nil }
     public var isDirty: Bool { false }
+
+    /// Default impl: panels that don't yet honor per-call appearance fall
+    /// through to the legacy `triggerFlash()` path.
+    func triggerFlash(appearance: FlashAppearance) {
+        _ = appearance
+        triggerFlash()
+    }
 
     func captureFocusIntent(in window: NSWindow?) -> PanelFocusIntent {
         _ = window

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -61,30 +61,12 @@ enum FocusFlashPattern {
     }
 }
 
-/// Single-pulse, low-peak envelope used for the sidebar workspace row flash.
-/// Calibrated to be a polite ambient nudge: noticeable enough to draw the eye,
-/// gentle enough not to startle when it fires from a workspace the operator
-/// is not actively viewing.
-enum SidebarFlashPattern {
-    static let values: [Double] = [0, 0.18, 0]
-    static let keyTimes: [Double] = [0, 0.5, 1]
-    static let duration: TimeInterval = 0.6
-    static let curves: [FocusFlashCurve] = [.easeOut, .easeIn]
-
-    static var segments: [FocusFlashSegment] {
-        let stepCount = min(curves.count, values.count - 1, keyTimes.count - 1)
-        return (0..<stepCount).map { index in
-            let startTime = keyTimes[index]
-            let endTime = keyTimes[index + 1]
-            return FocusFlashSegment(
-                delay: startTime * duration,
-                duration: (endTime - startTime) * duration,
-                targetOpacity: values[index + 1],
-                curve: curves[index]
-            )
-        }
-    }
-}
+// CMUX-10: the historical `SidebarFlashPattern` (single-peak, 0.6s, peak 0.18)
+// was retired in favor of a single unified envelope shared across the pane
+// ring and the sidebar workspace row. The sidebar now reuses
+// `FocusFlashPattern` with `FlashEnvelope.sidebarFill.peakScale` (0.6) applied
+// at render time, so a flash signal is a single recognizable shape across
+// surfaces rather than two visually-distinct treatments.
 
 /// Protocol for all panel types (terminal, browser, etc.)
 @MainActor

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -41,7 +41,12 @@ struct FocusFlashSegment: Equatable {
 enum FocusFlashPattern {
     static let values: [Double] = [0, 1, 0, 1, 0]
     static let keyTimes: [Double] = [0, 0.25, 0.5, 0.75, 1]
-    static let duration: TimeInterval = 0.9
+    /// CMUX-10: total duration of one flash pulse, sourced from the
+    /// configurable `NotificationFlashDurationSettings` (500–4000ms, default
+    /// 1500ms). Both pane and sidebar segments scale with this.
+    static var duration: TimeInterval {
+        Double(NotificationFlashDurationSettings.currentMs()) / 1000.0
+    }
     static let curves: [FocusFlashCurve] = [.easeOut, .easeIn, .easeOut, .easeIn]
     static let ringInset: Double = 6
     static let ringCornerRadius: Double = 10

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -280,6 +280,11 @@ final class TerminalPanel: Panel, ObservableObject {
         hostedView.triggerFlash()
     }
 
+    func triggerFlash(appearance: FlashAppearance) {
+        guard NotificationPaneFlashSettings.isEnabled() else { return }
+        hostedView.triggerFlash(style: .standardFocus, appearance: appearance)
+    }
+
     func triggerNotificationDismissFlash() {
         guard NotificationPaneFlashSettings.isEnabled() else { return }
         hostedView.triggerFlash(style: .notificationDismiss)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2350,6 +2350,8 @@ class TerminalController {
         // mis-routed request before it reaches this switch.
         case "surface.trigger_flash":
             return v2Result(id: id, self.v2SurfaceTriggerFlash(params: params))
+        case "surface.cancel_flash":
+            return v2Result(id: id, self.v2SurfaceCancelFlash(params: params))
         case "surface.set_metadata":
             return v2Result(id: id, self.v2SurfaceSetMetadata(params: params))
         case "surface.get_metadata":
@@ -2727,6 +2729,7 @@ class TerminalController {
             "surface.read_text",
             "surface.clear_history",
             "surface.trigger_flash",
+            "surface.cancel_flash",
             "surface.set_metadata",
             "surface.get_metadata",
             "surface.clear_metadata",
@@ -7743,6 +7746,7 @@ class TerminalController {
         } else {
             appearance = FlashAppearance.current(envelope: .paneRing)
         }
+        let persistent = (params["persistent"] as? Bool) ?? false
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to trigger flash", data: nil)
         v2MainSync {
@@ -7764,8 +7768,52 @@ class TerminalController {
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
-            ws.triggerFocusFlash(panelId: surfaceId, appearance: appearance)
-            result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
+            ws.triggerFocusFlash(panelId: surfaceId, appearance: appearance, persistent: persistent)
+            result = .ok([
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager)),
+                "persistent": persistent
+            ])
+        }
+        return result
+    }
+
+    /// CMUX-10: cancel an in-flight persistent flash on a single surface.
+    /// Idempotent — succeeds even when no flash is registered (the operator
+    /// or agent doesn't need to know the current state to cancel).
+    private func v2SurfaceCancelFlash(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to cancel flash", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+
+            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            guard let surfaceId else {
+                result = .err(code: "not_found", message: "No focused surface", data: nil)
+                return
+            }
+            guard ws.panels[surfaceId] != nil else {
+                result = .err(code: "not_found", message: "Surface not found", data: ["surface_id": surfaceId.uuidString])
+                return
+            }
+
+            ws.cancelPersistentFlash(panelId: surfaceId)
+            result = .ok([
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId)
+            ])
         }
         return result
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7728,6 +7728,22 @@ class TerminalController {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
         }
 
+        // CMUX-10: parse + validate the optional color override off-main, before
+        // hopping to the main actor. Per CLAUDE.md socket-threading policy.
+        let appearance: FlashAppearance
+        if let raw = params["color"] as? String {
+            guard let color = FlashAppearance.parseHex(raw) else {
+                return .err(
+                    code: "invalid_argument",
+                    message: "--color must be a hex value like #F5C518.",
+                    data: ["color": raw]
+                )
+            }
+            appearance = FlashAppearance(color: color, envelope: .paneRing)
+        } else {
+            appearance = FlashAppearance.current(envelope: .paneRing)
+        }
+
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to trigger flash", data: nil)
         v2MainSync {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
@@ -7748,7 +7764,7 @@ class TerminalController {
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
-            ws.triggerFocusFlash(panelId: surfaceId)
+            ws.triggerFocusFlash(panelId: surfaceId, appearance: appearance)
             result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
         }
         return result

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -544,6 +544,33 @@ enum NotificationPaneFlashSettings {
     }
 }
 
+/// CMUX-10: configurable Flash Duration. Scales both the pane and sidebar
+/// envelopes — the sidebar inherits the same temporal pattern and just applies
+/// its `peakScale` (commit 3), so a single duration tunes the whole signal.
+/// Persisted in UserDefaults under `notificationFlashDurationMs`.
+enum NotificationFlashDurationSettings {
+    static let enabledKey = "notificationFlashDurationMs"
+    static let defaultMs: Int = 1500
+    static let minMs: Int = 500
+    static let maxMs: Int = 4000
+
+    static func currentMs(defaults: UserDefaults = .standard) -> Int {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultMs
+        }
+        let raw = defaults.integer(forKey: enabledKey)
+        return clamp(raw)
+    }
+
+    static func setMs(_ ms: Int, defaults: UserDefaults = .standard) {
+        defaults.set(clamp(ms), forKey: enabledKey)
+    }
+
+    private static func clamp(_ ms: Int) -> Int {
+        return min(maxMs, max(minMs, ms))
+    }
+}
+
 enum TaggedRunBadgeSettings {
     static let environmentKey = "CMUX_TAG"
     private static let maxTagLength = 10

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -549,21 +549,21 @@ enum NotificationPaneFlashSettings {
 /// its `peakScale` (commit 3), so a single duration tunes the whole signal.
 /// Persisted in UserDefaults under `notificationFlashDurationMs`.
 enum NotificationFlashDurationSettings {
-    static let enabledKey = "notificationFlashDurationMs"
+    static let storageKey = "notificationFlashDurationMs"
     static let defaultMs: Int = 1500
     static let minMs: Int = 500
     static let maxMs: Int = 4000
 
     static func currentMs(defaults: UserDefaults = .standard) -> Int {
-        if defaults.object(forKey: enabledKey) == nil {
+        if defaults.object(forKey: storageKey) == nil {
             return defaultMs
         }
-        let raw = defaults.integer(forKey: enabledKey)
+        let raw = defaults.integer(forKey: storageKey)
         return clamp(raw)
     }
 
     static func setMs(_ ms: Int, defaults: UserDefaults = .standard) {
-        defaults.set(clamp(ms), forKey: enabledKey)
+        defaults.set(clamp(ms), forKey: storageKey)
     }
 
     private static func clamp(_ ms: Int) -> Int {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9157,14 +9157,21 @@ final class Workspace: Identifiable, ObservableObject {
 
         // Manifest overlay: write once on start so external agents asking
         // "is this surface still calling for attention?" can find out via
-        // get-metadata without subscribing to per-frame state.
-        _ = try? SurfaceMetadataStore.shared.setMetadata(
-            workspaceId: id,
-            surfaceId: panelId,
-            partial: ["flash_state": "persistent"],
-            mode: .merge,
-            source: .declare
-        )
+        // get-metadata without subscribing to per-frame state. Failure is
+        // non-fatal (the timer still drives the visual pulse) but the
+        // manifest contract is briefly out of sync, so log instead of
+        // silently swallowing.
+        do {
+            try SurfaceMetadataStore.shared.setMetadata(
+                workspaceId: id,
+                surfaceId: panelId,
+                partial: ["flash_state": "persistent"],
+                mode: .merge,
+                source: .declare
+            )
+        } catch {
+            dlog("flash.manifest.set workspace=\(id.uuidString.prefix(8)) panel=\(panelId.uuidString.prefix(8)) error=\(error)")
+        }
     }
 
     /// CMUX-10: clear a persistent flash on a single panel. Idempotent —
@@ -9172,12 +9179,16 @@ final class Workspace: Identifiable, ObservableObject {
     func cancelPersistentFlash(panelId: UUID) {
         guard let state = persistentFlashPanels.removeValue(forKey: panelId) else { return }
         state.timer.invalidate()
-        _ = try? SurfaceMetadataStore.shared.clearMetadata(
-            workspaceId: id,
-            surfaceId: panelId,
-            keys: ["flash_state"],
-            source: .declare
-        )
+        do {
+            try SurfaceMetadataStore.shared.clearMetadata(
+                workspaceId: id,
+                surfaceId: panelId,
+                keys: ["flash_state"],
+                source: .declare
+            )
+        } catch {
+            dlog("flash.manifest.clear workspace=\(id.uuidString.prefix(8)) panel=\(panelId.uuidString.prefix(8)) error=\(error)")
+        }
     }
 
     /// CMUX-10: clear all persistent flashes on this workspace. Used by the

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6999,8 +6999,14 @@ final class Workspace: Identifiable, ObservableObject {
             let persistedSources = panelSnapshot.metadataSources ?? [:]
             let newPanelId = oldToNewPanelIds[panelSnapshot.id] ?? panelSnapshot.id
             guard panels[newPanelId] != nil else { continue }
-            let values = PersistedMetadataBridge.decodeValues(persistedValues)
-            let sources = PersistedMetadataBridge.decodeSources(persistedSources)
+            var values = PersistedMetadataBridge.decodeValues(persistedValues)
+            var sources = PersistedMetadataBridge.decodeSources(persistedSources)
+            // CMUX-10: persistent-flash timers are process-local and never
+            // survive a restart. Drop any persisted `flash_state` entry on
+            // restore so external agents reading `surface.get_metadata`
+            // do not see an attention state with no live timer behind it.
+            values.removeValue(forKey: "flash_state")
+            sources.removeValue(forKey: "flash_state")
             SurfaceMetadataStore.shared.restoreFromSnapshot(
                 workspaceId: id,
                 surfaceId: newPanelId,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5766,6 +5766,19 @@ final class Workspace: Identifiable, ObservableObject {
         activeRemoteSessionControllerID = nil
         remoteSessionController?.stop()
         mailboxDispatcher?.stop()
+        // CMUX-10: invalidate any in-flight persistent-flash timers so the
+        // run loop drops its retain on them. Direct invalidate here rather
+        // than `cancelAllPersistentFlashes()` — the panel/pane/teardown paths
+        // already remove surface metadata, and routing through the metadata
+        // store during deallocation is unnecessary noise. `Workspace` is
+        // `@MainActor` so the last release must run on main; `assumeIsolated`
+        // lets the iso-checker see that.
+        MainActor.assumeIsolated {
+            for state in persistentFlashPanels.values {
+                state.timer.invalidate()
+            }
+            persistentFlashPanels.removeAll()
+        }
     }
 
     /// Creates a per-workspace mailbox dispatcher bound to this workspace's
@@ -8147,6 +8160,12 @@ final class Workspace: Identifiable, ObservableObject {
         paneInteractionRuntime.clearAll()
         paneCloseInteractionRuntime.clearAll()
         paneCloseOverlayController.cleanup()
+
+        // CMUX-10: cancel every persistent-flash timer + manifest entry so
+        // teardown does not leak repeating timers or stale `flash_state`
+        // metadata. Must precede `panels.removeAll` since the cancel path
+        // is keyed on panel id.
+        cancelAllPersistentFlashes()
 
         let panelEntries = Array(panels)
         for (panelId, panel) in panelEntries {
@@ -10776,6 +10795,11 @@ extension Workspace: BonsplitDelegate {
         // still resolves against a consistent view.
         paneInteractionRuntime.clear(panelId: panelId)
 
+        // CMUX-10: clear any persistent-flash timer + manifest entry before
+        // removing the panel. Without this, the repeating timer keeps firing
+        // and increments `sidebarFlashToken` for a panel that no longer exists.
+        cancelPersistentFlash(panelId: panelId)
+
         panels.removeValue(forKey: panelId)
         untrackRemoteTerminalSurface(panelId)
         surfaceIdToPanelId.removeValue(forKey: tabId)
@@ -10940,6 +10964,10 @@ extension Workspace: BonsplitDelegate {
                 // with .dismissed. Matches the cleanup invariant in
                 // teardownAllPanels (synthesis-standard §1.1).
                 paneInteractionRuntime.clear(panelId: panelId)
+                // CMUX-10: drop any persistent-flash timer + manifest entry
+                // before the panel disappears. Same invariant as the
+                // single-panel close path above.
+                cancelPersistentFlash(panelId: panelId)
                 panels[panelId]?.close()
                 panels.removeValue(forKey: panelId)
                 untrackRemoteTerminalSurface(panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5146,6 +5146,19 @@ final class Workspace: Identifiable, ObservableObject {
     /// row pulse together. Visual-only; never affects selection.
     @Published private(set) var sidebarFlashToken: Int = 0
 
+    /// CMUX-10: state for in-flight persistent flashes (one entry per panel).
+    /// The Timer is process-local; the manifest is not abused for per-frame
+    /// state (per Plan note: write `flash_state=persistent` once on start,
+    /// clear once on cancel). Operator/agent visibility comes from the
+    /// metadata key, not from persistent timers.
+    struct PersistentFlashState {
+        let appearance: FlashAppearance
+        let timer: Timer
+        let startedAt: Date
+    }
+
+    @Published private(set) var persistentFlashPanels: [UUID: PersistentFlashState] = [:]
+
     /// C11-25: workspace-level operator hibernate flag. True when the
     /// operator has explicitly hibernated this workspace via the
     /// "Hibernate Workspace" context menu (or socket equivalent). Survives
@@ -9073,13 +9086,99 @@ final class Workspace: Identifiable, ObservableObject {
     /// Bonsplit's `flashTab` does not accept a color callback, so the tab-
     /// strip pulse stays on the bonsplit-internal accent and is intentionally
     /// not retinted here.
-    func triggerFocusFlash(panelId: UUID, appearance: FlashAppearance) {
+    func triggerFocusFlash(panelId: UUID, appearance: FlashAppearance, persistent: Bool = false) {
         guard NotificationPaneFlashSettings.isEnabled() else { return }
+
+        // CMUX-10: persistent on the focused surface in the focused window
+        // degrades to a one-shot. Persistence is "look at this when you
+        // eventually look back" — meaningless when the operator is already
+        // looking. The color override is still honored.
+        if persistent && isFocusedTargetForPersistentFlash(panelId: panelId) {
+            runFlashPulse(panelId: panelId, appearance: appearance)
+            return
+        }
+
+        runFlashPulse(panelId: panelId, appearance: appearance)
+
+        guard persistent else { return }
+
+        // Replace any existing timer for this panel before installing a new one,
+        // so back-to-back persistent triggers don't leak timers.
+        if let existing = persistentFlashPanels[panelId] {
+            existing.timer.invalidate()
+        }
+
+        let interval = appearance.envelope.duration + 0.6
+        let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                guard self.persistentFlashPanels[panelId] != nil else { return }
+                self.runFlashPulse(panelId: panelId, appearance: appearance)
+            }
+        }
+        persistentFlashPanels[panelId] = PersistentFlashState(
+            appearance: appearance,
+            timer: timer,
+            startedAt: Date()
+        )
+
+        // Manifest overlay: write once on start so external agents asking
+        // "is this surface still calling for attention?" can find out via
+        // get-metadata without subscribing to per-frame state.
+        _ = try? SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: id,
+            surfaceId: panelId,
+            partial: ["flash_state": "persistent"],
+            mode: .merge,
+            source: .declare
+        )
+    }
+
+    /// CMUX-10: clear a persistent flash on a single panel. Idempotent —
+    /// safe to call from click-to-dismiss handlers without checking state.
+    func cancelPersistentFlash(panelId: UUID) {
+        guard let state = persistentFlashPanels.removeValue(forKey: panelId) else { return }
+        state.timer.invalidate()
+        _ = try? SurfaceMetadataStore.shared.clearMetadata(
+            workspaceId: id,
+            surfaceId: panelId,
+            keys: ["flash_state"],
+            source: .declare
+        )
+    }
+
+    /// CMUX-10: clear all persistent flashes on this workspace. Used by the
+    /// sidebar-row tap-to-dismiss path so clicking a workspace clears any
+    /// pending persistent flashes inside it.
+    func cancelAllPersistentFlashes() {
+        guard !persistentFlashPanels.isEmpty else { return }
+        let panelIds = Array(persistentFlashPanels.keys)
+        for panelId in panelIds {
+            cancelPersistentFlash(panelId: panelId)
+        }
+    }
+
+    /// CMUX-10: shared fan-out used by both one-shot and persistent flash
+    /// pulses. Stays small to keep pulse-firing predictable; lifecycle and
+    /// timer management live in `triggerFocusFlash` / `cancelPersistentFlash`.
+    private func runFlashPulse(panelId: UUID, appearance: FlashAppearance) {
         panels[panelId]?.triggerFlash(appearance: appearance)
         if let tabId = surfaceIdFromPanelId(panelId) {
             bonsplitController.flashTab(tabId)
         }
         sidebarFlashToken &+= 1
+    }
+
+    /// CMUX-10: true when a persistent-flash request would target the panel
+    /// the operator is already looking at — i.e. this workspace is selected,
+    /// the panel is the focused panel, and the focused window owns the app.
+    /// Used to degrade `--persistent` to a one-shot pulse in that case.
+    private func isFocusedTargetForPersistentFlash(panelId: UUID) -> Bool {
+        guard let tabManager = AppDelegate.shared?.tabManager else { return false }
+        guard tabManager.selectedTabId == self.id else { return false }
+        guard self.focusedPanelId == panelId else { return false }
+        guard NSApp.isActive else { return false }
+        return true
     }
 
     func triggerNotificationFocusFlash(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7013,8 +7013,8 @@ final class Workspace: Identifiable, ObservableObject {
             // survive a restart. Drop any persisted `flash_state` entry on
             // restore so external agents reading `surface.get_metadata`
             // do not see an attention state with no live timer behind it.
-            values.removeValue(forKey: "flash_state")
-            sources.removeValue(forKey: "flash_state")
+            values.removeValue(forKey: FlashState.metadataKey)
+            sources.removeValue(forKey: FlashState.metadataKey)
             SurfaceMetadataStore.shared.restoreFromSnapshot(
                 workspaceId: id,
                 surfaceId: newPanelId,
@@ -9102,6 +9102,20 @@ final class Workspace: Identifiable, ObservableObject {
 
     // MARK: - Flash/Notification Support
 
+    /// CMUX-10: typed values for the `flash_state` surface-manifest key.
+    /// The JSON wire format stays a plain string ("persistent"), so existing
+    /// socket clients (CLI, Python e2e, agent polling) keep working unchanged.
+    /// The enum exists only to narrow the in-process write/read sites so a
+    /// future second state value cannot drift across call sites as a typo.
+    enum FlashState: String {
+        case persistent
+
+        /// Manifest key under which the value is written. Centralized here so
+        /// the start, cancel, and session-restore paths all reference the
+        /// same constant instead of repeating the literal.
+        static let metadataKey = "flash_state"
+    }
+
     /// Single fan-out for a focus flash. Drives, in order:
     ///   (a) the targeted panel's pane-content flash (existing behavior),
     ///   (b) the Bonsplit tab strip — scrolls the matching tab into view and
@@ -9165,7 +9179,7 @@ final class Workspace: Identifiable, ObservableObject {
             try SurfaceMetadataStore.shared.setMetadata(
                 workspaceId: id,
                 surfaceId: panelId,
-                partial: ["flash_state": "persistent"],
+                partial: [FlashState.metadataKey: FlashState.persistent.rawValue],
                 mode: .merge,
                 source: .declare
             )
@@ -9183,7 +9197,7 @@ final class Workspace: Identifiable, ObservableObject {
             try SurfaceMetadataStore.shared.clearMetadata(
                 workspaceId: id,
                 surfaceId: panelId,
-                keys: ["flash_state"],
+                keys: [FlashState.metadataKey],
                 source: .declare
             )
         } catch {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9065,8 +9065,17 @@ final class Workspace: Identifiable, ObservableObject {
     /// Gated on `NotificationPaneFlashSettings` so disabling the user-facing
     /// "Pane Flash" toggle silences all three channels consistently.
     func triggerFocusFlash(panelId: UUID) {
+        triggerFocusFlash(panelId: panelId, appearance: FlashAppearance.current(envelope: .paneRing))
+    }
+
+    /// CMUX-10: variant that threads a per-call appearance (color override
+    /// from the CLI / socket) through to the pane and sidebar render paths.
+    /// Bonsplit's `flashTab` does not accept a color callback, so the tab-
+    /// strip pulse stays on the bonsplit-internal accent and is intentionally
+    /// not retinted here.
+    func triggerFocusFlash(panelId: UUID, appearance: FlashAppearance) {
         guard NotificationPaneFlashSettings.isEnabled() else { return }
-        panels[panelId]?.triggerFlash()
+        panels[panelId]?.triggerFlash(appearance: appearance)
         if let tabId = surfaceIdFromPanelId(panelId) {
             bonsplitController.flashTab(tabId)
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5146,6 +5146,14 @@ final class Workspace: Identifiable, ObservableObject {
     /// row pulse together. Visual-only; never affects selection.
     @Published private(set) var sidebarFlashToken: Int = 0
 
+    /// CMUX-10: hex color (sRGB w/ alpha) used by the sidebar workspace row
+    /// pulse. Set in `runFlashPulse` from the per-call `FlashAppearance` so
+    /// `c11 trigger-flash --color "#FF00FF"` tints the sidebar pulse, not
+    /// just the terminal pane ring. Stored as a hex string so it can fold
+    /// cleanly into `TabItemView.==` without touching `NSColor` reference
+    /// equality. nil → fall back to the default sidebar-fill color.
+    @Published private(set) var sidebarFlashColorHex: String?
+
     /// CMUX-10: state for in-flight persistent flashes (one entry per panel).
     /// The Timer is process-local; the manifest is not abused for per-frame
     /// state (per Plan note: write `flash_state=persistent` once on start,
@@ -9191,6 +9199,11 @@ final class Workspace: Identifiable, ObservableObject {
         if let tabId = surfaceIdFromPanelId(panelId) {
             bonsplitController.flashTab(tabId)
         }
+        // CMUX-10: thread the per-call appearance into the sidebar pulse so
+        // `--color` tints the workspace row, not just the terminal pane ring.
+        // Stored as a hex string so `TabItemView.==` can fold it in without
+        // tripping NSColor reference equality.
+        sidebarFlashColorHex = appearance.color.hexString(includeAlpha: true)
         sidebarFlashToken &+= 1
     }
 

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4387,7 +4387,7 @@ struct SettingsView: View {
     @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
     @AppStorage(NotificationPaneRingSettings.enabledKey) private var notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
     @AppStorage(NotificationPaneFlashSettings.enabledKey) private var notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
-    @AppStorage(NotificationFlashDurationSettings.enabledKey) private var notificationFlashDurationMs: Int = NotificationFlashDurationSettings.defaultMs
+    @AppStorage(NotificationFlashDurationSettings.storageKey) private var notificationFlashDurationMs: Int = NotificationFlashDurationSettings.defaultMs
     @AppStorage(MenuBarExtraSettings.showInMenuBarKey) private var showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
     @AppStorage(QuitWarningSettings.warnBeforeQuitKey) private var warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4387,6 +4387,7 @@ struct SettingsView: View {
     @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
     @AppStorage(NotificationPaneRingSettings.enabledKey) private var notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
     @AppStorage(NotificationPaneFlashSettings.enabledKey) private var notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
+    @AppStorage(NotificationFlashDurationSettings.enabledKey) private var notificationFlashDurationMs: Int = NotificationFlashDurationSettings.defaultMs
     @AppStorage(MenuBarExtraSettings.showInMenuBarKey) private var showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
     @AppStorage(QuitWarningSettings.warnBeforeQuitKey) private var warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
@@ -5760,6 +5761,40 @@ struct SettingsView: View {
                     .accessibilityLabel(
                         String(localized: "settings.notifications.paneFlash.title", defaultValue: "Pane Flash")
                     )
+            }
+
+            SettingsCardDivider()
+
+            SettingsCardRow(
+                String(localized: "settings.notifications.flashDuration.title", defaultValue: "Flash Duration"),
+                subtitle: String(localized: "settings.notifications.flashDuration.subtitle", defaultValue: "How long the flash pulse lasts before fading.")
+            ) {
+                HStack(spacing: 8) {
+                    Slider(
+                        value: Binding<Double>(
+                            get: { Double(notificationFlashDurationMs) },
+                            set: { newValue in
+                                let clamped = min(
+                                    Double(NotificationFlashDurationSettings.maxMs),
+                                    max(Double(NotificationFlashDurationSettings.minMs), newValue)
+                                )
+                                notificationFlashDurationMs = Int((clamped / 100.0).rounded()) * 100
+                            }
+                        ),
+                        in: Double(NotificationFlashDurationSettings.minMs)...Double(NotificationFlashDurationSettings.maxMs),
+                        step: 100
+                    )
+                    .controlSize(.small)
+                    .frame(width: 140)
+                    .accessibilityLabel(
+                        String(localized: "settings.notifications.flashDuration.title", defaultValue: "Flash Duration")
+                    )
+                    Text(String(format: String(localized: "settings.notifications.flashDuration.unit.ms", defaultValue: "%d ms"), notificationFlashDurationMs))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .frame(minWidth: 56, alignment: .trailing)
+                }
             }
         }
 

--- a/c11Tests/FlashColorParsingTests.swift
+++ b/c11Tests/FlashColorParsingTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+import AppKit
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// CMUX-10: hex parser feeding both `c11 trigger-flash --color` and the
+/// socket re-validation path. Ensures the same shapes the CLI's local
+/// `isValidFlashColorHex` accepts also produce a usable NSColor server-side.
+final class FlashColorParsingTests: XCTestCase {
+    func testParsesSixDigitHexWithLeadingHash() throws {
+        let color = try XCTUnwrap(FlashAppearance.parseHex("#F5C518"))
+        let srgb = try XCTUnwrap(color.usingColorSpace(.sRGB))
+        XCTAssertEqual(srgb.redComponent, 0xF5 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(srgb.greenComponent, 0xC5 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(srgb.blueComponent, 0x18 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(srgb.alphaComponent, 1.0, accuracy: 0.001)
+    }
+
+    func testParsesSixDigitHexWithoutLeadingHash() throws {
+        let color = try XCTUnwrap(FlashAppearance.parseHex("F5C518"))
+        let srgb = try XCTUnwrap(color.usingColorSpace(.sRGB))
+        XCTAssertEqual(srgb.redComponent, 0xF5 / 255.0, accuracy: 0.001)
+    }
+
+    func testParsesEightDigitHexWithAlpha() throws {
+        let color = try XCTUnwrap(FlashAppearance.parseHex("#F5C51880"))
+        let srgb = try XCTUnwrap(color.usingColorSpace(.sRGB))
+        XCTAssertEqual(srgb.redComponent, 0xF5 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(srgb.alphaComponent, 0x80 / 255.0, accuracy: 0.001)
+    }
+
+    func testIsCaseInsensitive() throws {
+        let lower = try XCTUnwrap(FlashAppearance.parseHex("#f5c518"))
+        let upper = try XCTUnwrap(FlashAppearance.parseHex("#F5C518"))
+        XCTAssertEqual(
+            lower.usingColorSpace(.sRGB)?.redComponent,
+            upper.usingColorSpace(.sRGB)?.redComponent
+        )
+    }
+
+    func testRejectsThreeDigitShorthand() {
+        XCTAssertNil(FlashAppearance.parseHex("#F5C"))
+        XCTAssertNil(FlashAppearance.parseHex("FFF"))
+    }
+
+    func testRejectsNonHexCharacters() {
+        XCTAssertNil(FlashAppearance.parseHex("#GGGGGG"))
+        XCTAssertNil(FlashAppearance.parseHex("#12345Z"))
+    }
+
+    func testRejectsEmptyAndWhitespaceOnly() {
+        XCTAssertNil(FlashAppearance.parseHex(""))
+        XCTAssertNil(FlashAppearance.parseHex("   "))
+    }
+
+    func testRejectsWrongLength() {
+        XCTAssertNil(FlashAppearance.parseHex("#F5C5"))
+        XCTAssertNil(FlashAppearance.parseHex("#F5C5180000"))
+    }
+
+    func testTrimsLeadingAndTrailingWhitespace() throws {
+        let color = try XCTUnwrap(FlashAppearance.parseHex("  #F5C518\n"))
+        let srgb = try XCTUnwrap(color.usingColorSpace(.sRGB))
+        XCTAssertEqual(srgb.redComponent, 0xF5 / 255.0, accuracy: 0.001)
+    }
+
+    func testDefaultColorMatchesCmux10Yellow() throws {
+        let srgb = try XCTUnwrap(FlashAppearance.defaultColor.usingColorSpace(.sRGB))
+        XCTAssertEqual(srgb.redComponent, 0xF5 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(srgb.greenComponent, 0xC5 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(srgb.blueComponent, 0x18 / 255.0, accuracy: 0.001)
+        XCTAssertEqual(srgb.alphaComponent, 1.0, accuracy: 0.001)
+    }
+}

--- a/c11Tests/WindowAndDragTests.swift
+++ b/c11Tests/WindowAndDragTests.swift
@@ -263,10 +263,26 @@ final class AppDelegateLaunchServicesRegistrationTests: XCTestCase {
 
 
 final class FocusFlashPatternTests: XCTestCase {
+    /// CMUX-10 made `FocusFlashPattern.duration` a computed `static var` that
+    /// reads from `NotificationFlashDurationSettings`. Pin a known value in
+    /// setUp so the segment math is deterministic regardless of any leaked
+    /// UserDefaults state from prior runs.
+    private let pinnedMs: Int = 900
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.set(pinnedMs, forKey: NotificationFlashDurationSettings.enabledKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: NotificationFlashDurationSettings.enabledKey)
+        super.tearDown()
+    }
+
     func testFocusFlashPatternMatchesTerminalDoublePulseShape() {
         XCTAssertEqual(FocusFlashPattern.values, [0, 1, 0, 1, 0])
         XCTAssertEqual(FocusFlashPattern.keyTimes, [0, 0.25, 0.5, 0.75, 1])
-        XCTAssertEqual(FocusFlashPattern.duration, 0.9, accuracy: 0.0001)
+        XCTAssertEqual(FocusFlashPattern.duration, Double(pinnedMs) / 1000.0, accuracy: 0.0001)
         XCTAssertEqual(FocusFlashPattern.curves, [.easeOut, .easeIn, .easeOut, .easeIn])
         XCTAssertEqual(FocusFlashPattern.ringInset, 6, accuracy: 0.0001)
         XCTAssertEqual(FocusFlashPattern.ringCornerRadius, 10, accuracy: 0.0001)

--- a/c11Tests/WindowAndDragTests.swift
+++ b/c11Tests/WindowAndDragTests.swift
@@ -271,11 +271,11 @@ final class FocusFlashPatternTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        UserDefaults.standard.set(pinnedMs, forKey: NotificationFlashDurationSettings.enabledKey)
+        UserDefaults.standard.set(pinnedMs, forKey: NotificationFlashDurationSettings.storageKey)
     }
 
     override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: NotificationFlashDurationSettings.enabledKey)
+        UserDefaults.standard.removeObject(forKey: NotificationFlashDurationSettings.storageKey)
         super.tearDown()
     }
 

--- a/c11Tests/WorkspaceFlashTests.swift
+++ b/c11Tests/WorkspaceFlashTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+import AppKit
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// CMUX-10: persistent-flash registration + cancel + sidebar fan-out.
+@MainActor
+final class WorkspaceFlashTests: XCTestCase {
+    /// A short pulse duration so persistent timers can't fire mid-test if the
+    /// run is slower than expected. The tests don't assert on the timer
+    /// firing — they assert on the registration/cancel state machine.
+    private let pinnedMs: Int = 600
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.set(pinnedMs, forKey: NotificationFlashDurationSettings.enabledKey)
+        UserDefaults.standard.set(true, forKey: NotificationPaneFlashSettings.enabledKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: NotificationFlashDurationSettings.enabledKey)
+        UserDefaults.standard.removeObject(forKey: NotificationPaneFlashSettings.enabledKey)
+        super.tearDown()
+    }
+
+    func testOneShotFlashFansOutToSidebarTokenWithoutRegisteringPersistentState() {
+        let workspace = Workspace(title: "flash-test")
+        let panelId = UUID()
+        let initialToken = workspace.sidebarFlashToken
+
+        workspace.triggerFocusFlash(
+            panelId: panelId,
+            appearance: FlashAppearance.current(envelope: .paneRing)
+        )
+
+        XCTAssertEqual(workspace.sidebarFlashToken, initialToken &+ 1)
+        XCTAssertNil(workspace.persistentFlashPanels[panelId])
+    }
+
+    func testPersistentFlashRegistersStateAndKeepsRegistrationUntilCancel() {
+        let workspace = Workspace(title: "flash-test")
+        let panelId = UUID()
+
+        workspace.triggerFocusFlash(
+            panelId: panelId,
+            appearance: FlashAppearance.current(envelope: .paneRing),
+            persistent: true
+        )
+
+        let registered = workspace.persistentFlashPanels[panelId]
+        XCTAssertNotNil(registered, "Persistent flash should register state on the workspace")
+
+        workspace.cancelPersistentFlash(panelId: panelId)
+        XCTAssertNil(workspace.persistentFlashPanels[panelId])
+    }
+
+    func testCancelAllPersistentFlashesClearsEveryRegistration() {
+        let workspace = Workspace(title: "flash-test")
+        let panelA = UUID()
+        let panelB = UUID()
+
+        workspace.triggerFocusFlash(
+            panelId: panelA,
+            appearance: FlashAppearance.current(envelope: .paneRing),
+            persistent: true
+        )
+        workspace.triggerFocusFlash(
+            panelId: panelB,
+            appearance: FlashAppearance(color: .red, envelope: .paneRing),
+            persistent: true
+        )
+        XCTAssertEqual(workspace.persistentFlashPanels.count, 2)
+
+        workspace.cancelAllPersistentFlashes()
+        XCTAssertTrue(workspace.persistentFlashPanels.isEmpty)
+    }
+
+    func testCancelOnUnregisteredPanelIsIdempotent() {
+        let workspace = Workspace(title: "flash-test")
+        let panelId = UUID()
+        // No prior persistent flash; cancel should not crash or alter state.
+        workspace.cancelPersistentFlash(panelId: panelId)
+        XCTAssertTrue(workspace.persistentFlashPanels.isEmpty)
+    }
+
+    func testRetriggerPersistentReplacesExistingTimerWithoutLeaking() {
+        let workspace = Workspace(title: "flash-test")
+        let panelId = UUID()
+
+        workspace.triggerFocusFlash(
+            panelId: panelId,
+            appearance: FlashAppearance.current(envelope: .paneRing),
+            persistent: true
+        )
+        let firstTimer = workspace.persistentFlashPanels[panelId]?.timer
+
+        workspace.triggerFocusFlash(
+            panelId: panelId,
+            appearance: FlashAppearance(color: .blue, envelope: .paneRing),
+            persistent: true
+        )
+        let secondTimer = workspace.persistentFlashPanels[panelId]?.timer
+
+        XCTAssertNotNil(firstTimer)
+        XCTAssertNotNil(secondTimer)
+        XCTAssertFalse(firstTimer === secondTimer, "Re-trigger should replace the timer instance")
+
+        workspace.cancelPersistentFlash(panelId: panelId)
+    }
+
+    func testPaneFlashDisabledGuardSilencesAllChannels() {
+        UserDefaults.standard.set(false, forKey: NotificationPaneFlashSettings.enabledKey)
+        defer { UserDefaults.standard.set(true, forKey: NotificationPaneFlashSettings.enabledKey) }
+
+        let workspace = Workspace(title: "flash-test")
+        let panelId = UUID()
+        let initialToken = workspace.sidebarFlashToken
+
+        workspace.triggerFocusFlash(
+            panelId: panelId,
+            appearance: FlashAppearance.current(envelope: .paneRing),
+            persistent: true
+        )
+
+        XCTAssertEqual(workspace.sidebarFlashToken, initialToken)
+        XCTAssertNil(workspace.persistentFlashPanels[panelId])
+    }
+}

--- a/c11Tests/WorkspaceFlashTests.swift
+++ b/c11Tests/WorkspaceFlashTests.swift
@@ -108,8 +108,63 @@ final class WorkspaceFlashTests: XCTestCase {
         XCTAssertNotNil(firstTimer)
         XCTAssertNotNil(secondTimer)
         XCTAssertFalse(firstTimer === secondTimer, "Re-trigger should replace the timer instance")
+        // CMUX-10: identity-difference alone does not prove the previous
+        // timer was invalidated. Without explicit `isValid == false`, a
+        // regression that replaced the entry without calling
+        // `existing.timer.invalidate()` would still pass.
+        XCTAssertEqual(firstTimer?.isValid, false, "Re-trigger must invalidate the previous timer")
 
         workspace.cancelPersistentFlash(panelId: panelId)
+    }
+
+    func testTeardownAllPanelsCancelsEveryPersistentFlash() {
+        let workspace = Workspace(title: "flash-test")
+        let panelA = UUID()
+        let panelB = UUID()
+
+        workspace.triggerFocusFlash(
+            panelId: panelA,
+            appearance: FlashAppearance.current(envelope: .paneRing),
+            persistent: true
+        )
+        workspace.triggerFocusFlash(
+            panelId: panelB,
+            appearance: FlashAppearance.current(envelope: .paneRing),
+            persistent: true
+        )
+        let timerA = workspace.persistentFlashPanels[panelA]?.timer
+        let timerB = workspace.persistentFlashPanels[panelB]?.timer
+        XCTAssertEqual(workspace.persistentFlashPanels.count, 2)
+
+        workspace.teardownAllPanels()
+
+        XCTAssertTrue(workspace.persistentFlashPanels.isEmpty)
+        XCTAssertEqual(timerA?.isValid, false, "teardown must invalidate persistent timers")
+        XCTAssertEqual(timerB?.isValid, false, "teardown must invalidate persistent timers")
+    }
+
+    func testDeinitInvalidatesPersistentFlashTimers() {
+        // Capture timers from a workspace that is allowed to deallocate.
+        // Without `cancelPersistentFlash` cleanup in `deinit`, the run loop
+        // would keep firing the timer forever after `[weak self]` resolves nil.
+        weak var weakRef: Workspace?
+        var capturedTimer: Timer?
+        autoreleasepool {
+            let workspace = Workspace(title: "flash-test")
+            weakRef = workspace
+            let panelId = UUID()
+            workspace.triggerFocusFlash(
+                panelId: panelId,
+                appearance: FlashAppearance.current(envelope: .paneRing),
+                persistent: true
+            )
+            capturedTimer = workspace.persistentFlashPanels[panelId]?.timer
+            XCTAssertNotNil(capturedTimer)
+        }
+        // After the autoreleasepool drains, `Workspace` should deallocate;
+        // `deinit` must invalidate the timer so the run loop drops its retain.
+        XCTAssertNil(weakRef, "Workspace should deallocate")
+        XCTAssertEqual(capturedTimer?.isValid, false, "deinit must invalidate persistent timers")
     }
 
     func testPaneFlashDisabledGuardSilencesAllChannels() {

--- a/c11Tests/WorkspaceFlashTests.swift
+++ b/c11Tests/WorkspaceFlashTests.swift
@@ -17,12 +17,12 @@ final class WorkspaceFlashTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        UserDefaults.standard.set(pinnedMs, forKey: NotificationFlashDurationSettings.enabledKey)
+        UserDefaults.standard.set(pinnedMs, forKey: NotificationFlashDurationSettings.storageKey)
         UserDefaults.standard.set(true, forKey: NotificationPaneFlashSettings.enabledKey)
     }
 
     override func tearDown() {
-        UserDefaults.standard.removeObject(forKey: NotificationFlashDurationSettings.enabledKey)
+        UserDefaults.standard.removeObject(forKey: NotificationFlashDurationSettings.storageKey)
         UserDefaults.standard.removeObject(forKey: NotificationPaneFlashSettings.enabledKey)
         super.tearDown()
     }

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -316,6 +316,39 @@ c11 clear-status task
 
 **Constraint**: these only work from a direct c11 child process. Headless `claude -p` subprocesses are reparented to `launchd` and lose the auth chain — they cannot call any `c11` command. Interactive `claude` keeps the chain intact.
 
+## Surface flash — asynchronous attention
+
+Flash is c11's per-surface attention primitive: a brief or persistent visual pulse on the pane content and the sidebar workspace row. Reach for it when an agent produces something the operator should look at but the agent does not want to steal focus.
+
+```bash
+# One-shot pulse on a non-focused surface
+c11 trigger-flash --surface <ref>
+
+# Persistent pulse — keeps repeating until dismissed
+c11 trigger-flash --surface <ref> --persistent
+
+# Per-call color override (6- or 8-digit sRGB hex; default #F5C518)
+c11 trigger-flash --surface <ref> --persistent --color "#FF5C5C"
+
+# Programmatic cancel — clears any in-flight persistent pulse
+c11 cancel-flash --surface <ref>
+```
+
+**`--persistent`** repeats the pulse until *either* the operator dismisses it (clicking the pane content or the sidebar workspace row) *or* an agent calls `c11 cancel-flash`. Use it for "look at this eventually," not "look right now": the operator may be deep in another workspace, and the recurring pulse is what makes the surface findable later. A `--persistent` call on a surface that is already focused degrades to a one-shot pulse — persisting where the operator is already looking would be noise.
+
+**`--color`** distinguishes signals from different agents on the same workspace. Default is `#F5C518` (Stage 11 warm yellow). Validation accepts `#RRGGBB` or `#RRGGBBAA` (case-insensitive, optional `#`); anything else errors. The override tints the pane ring and the sidebar row pulse; the Bonsplit tab-strip pulse keeps its internal accent.
+
+**`flash_state` metadata key.** When a persistent flash starts, c11 writes `flash_state=persistent` into the surface manifest; cancellation clears it. Other agents can poll the manifest instead of subscribing to per-frame visual state:
+
+```bash
+c11 get-metadata --surface <ref> --key flash_state
+# → "persistent" if a persistent flash is live; empty otherwise
+```
+
+Treat `flash_state` as a forward-compatible enum — future c11 versions may add states. Match the value you care about; don't assume the field is binary. Cancel when the signal is stale: an agent that triggered a persistent flash to wait on a long-running task should call `c11 cancel-flash` if the task completes by another path.
+
+**Flash Duration is operator-tuned.** Settings → Notifications → Flash Duration ranges 500–4000ms (default 1500ms) and scales every channel together (pane ring, sidebar row, persistent ticks). Agents do not need to read it — fire the signal, c11 paces it.
+
 ## Launching sub-agents
 
 Use **`claude --dangerously-skip-permissions`** — never bare `claude` (stalls on approvals) or `claude -p` (headless, breaks the auth chain):

--- a/tests_v2/test_trigger_flash_persistent.py
+++ b/tests_v2/test_trigger_flash_persistent.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""CMUX-10: persistent flash + color override + cancel-flash round-trip.
+
+Connects to a tagged-build socket per CLAUDE.md (do not launch an untagged
+``c11 DEV.app``). The test exercises:
+
+  * one-shot ``surface.trigger_flash`` (control case)
+  * persistent variant writes ``flash_state=persistent`` to surface metadata
+  * cancel clears the metadata key
+  * malformed ``--color`` is rejected with ``invalid_argument``
+
+Visual assertions are deferred to the Validate phase; this is a state /
+contract round-trip only.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = (
+    os.environ.get("C11_SOCKET")
+    or os.environ.get("CMUX_SOCKET")
+    or "/tmp/cmux-debug.sock"
+)
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        ident = c.identify()
+        focused = ident.get("focused") or {}
+        surface_id = focused.get("surface_id")
+        _must(bool(surface_id), f"identify should return a focused surface_id: {focused}")
+
+        # 1. One-shot trigger (control case): no metadata side effect.
+        result = c._call("surface.trigger_flash", {"surface_id": surface_id})
+        _must(result.get("surface_id") == surface_id, f"one-shot: surface_id round-trip: {result}")
+        _must(result.get("persistent") is False, f"one-shot: persistent flag should be False: {result}")
+
+        # 2. Persistent trigger writes flash_state=persistent.
+        result = c._call(
+            "surface.trigger_flash",
+            {"surface_id": surface_id, "persistent": True},
+        )
+        _must(result.get("persistent") is True, f"persistent: result echoes flag: {result}")
+
+        meta = c._call("surface.get_metadata", {"surface_id": surface_id}) or {}
+        meta_dict = meta.get("metadata") or {}
+        _must(
+            meta_dict.get("flash_state") == "persistent",
+            f"persistent: flash_state should be 'persistent', got {meta_dict.get('flash_state')!r}",
+        )
+
+        # 3. Color override is honored.
+        result = c._call(
+            "surface.trigger_flash",
+            {"surface_id": surface_id, "color": "#FF00FF"},
+        )
+        _must(result.get("surface_id") == surface_id, f"color: surface_id round-trip: {result}")
+
+        # 4. Malformed color is rejected with invalid_argument.
+        try:
+            c._call("surface.trigger_flash", {"surface_id": surface_id, "color": "not-a-hex"})
+        except cmuxError as e:
+            _must("invalid_argument" in str(e) or "hex" in str(e).lower(), f"bad color: expected invalid_argument-ish error, got: {e}")
+        else:
+            raise cmuxError("bad color: expected error, got success")
+
+        # 5. cancel_flash clears the metadata key.
+        result = c._call("surface.cancel_flash", {"surface_id": surface_id})
+        _must(result.get("surface_id") == surface_id, f"cancel: surface_id round-trip: {result}")
+
+        meta = c._call("surface.get_metadata", {"surface_id": surface_id}) or {}
+        meta_dict = meta.get("metadata") or {}
+        _must(
+            "flash_state" not in meta_dict,
+            f"cancel: flash_state should be cleared, got {meta_dict.get('flash_state')!r}",
+        )
+
+        # 6. cancel_flash is idempotent (no error on a surface with no active flash).
+        result = c._call("surface.cancel_flash", {"surface_id": surface_id})
+        _must(result.get("surface_id") == surface_id, f"cancel idempotent: {result}")
+
+    print("test_trigger_flash_persistent: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_v2/test_trigger_flash_persistent.py
+++ b/tests_v2/test_trigger_flash_persistent.py
@@ -39,8 +39,28 @@ def main() -> int:
     with cmux(SOCKET_PATH) as c:
         ident = c.identify()
         focused = ident.get("focused") or {}
-        surface_id = focused.get("surface_id")
-        _must(bool(surface_id), f"identify should return a focused surface_id: {focused}")
+        focused_surface_id = focused.get("surface_id")
+        _must(bool(focused_surface_id), f"identify should return a focused surface_id: {focused}")
+
+        # CMUX-10: persistent triggers degrade to one-shot when targeting the
+        # focused surface in the focused window (Workspace.swift:isFocused-
+        # TargetForPersistentFlash). Targeting `focused.surface_id` makes the
+        # `flash_state=persistent` assertion below depend on whether c11 is
+        # the frontmost macOS app at test time, which the harness does not
+        # control. Create a sibling surface and target the original (now
+        # non-focused) so the persistent path is exercised deterministically.
+        sibling_surface_id = c.new_surface()
+        _must(bool(sibling_surface_id), f"new_surface should return an id: {sibling_surface_id!r}")
+        # Re-read identify; whichever surface is not currently focused is our
+        # safe target. `surface.create` typically auto-focuses the new
+        # surface, so the original `focused_surface_id` becomes non-focused —
+        # but we read identify again rather than assume.
+        ident2 = c.identify()
+        focused2 = (ident2.get("focused") or {}).get("surface_id")
+        candidates = [focused_surface_id, sibling_surface_id]
+        non_focused = [sid for sid in candidates if sid and sid != focused2]
+        _must(bool(non_focused), f"need a non-focused surface; got candidates={candidates} focused={focused2}")
+        surface_id = non_focused[0]
 
         # 1. One-shot trigger (control case): no metadata side effect.
         result = c._call("surface.trigger_flash", {"surface_id": surface_id})
@@ -60,6 +80,11 @@ def main() -> int:
             meta_dict.get("flash_state") == "persistent",
             f"persistent: flash_state should be 'persistent', got {meta_dict.get('flash_state')!r}",
         )
+
+        # CMUX-10: clear the persistent state before continuing so subsequent
+        # asserts run against a clean surface (steps 3+ should not race the
+        # in-flight repeating timer).
+        c._call("surface.cancel_flash", {"surface_id": surface_id})
 
         # 3. Color override is honored.
         result = c._call(
@@ -90,6 +115,14 @@ def main() -> int:
         # 6. cancel_flash is idempotent (no error on a surface with no active flash).
         result = c._call("surface.cancel_flash", {"surface_id": surface_id})
         _must(result.get("surface_id") == surface_id, f"cancel idempotent: {result}")
+
+        # 7. Tear down the sibling surface so the test leaves the workspace
+        # in roughly the same shape it found it. Best-effort; failures here
+        # do not change the result.
+        try:
+            c.close_surface(sibling_surface_id)
+        except cmuxError:
+            pass
 
     print("test_trigger_flash_persistent: OK")
     return 0


### PR DESCRIPTION
## Summary

- **`c11 trigger-flash --persistent`** keeps a surface pulsing until the operator clicks the pane content or the sidebar workspace row to dismiss. Programmatic cancel via `c11 cancel-flash --surface <ref>`. Default behavior remains one-shot.
- **Default flash color is yellow `#F5C518`** with `--color <hex>` per-call override and a forward-compatible `flash.color` theme key. Sidebar pulse and pane ring both honor the per-call color.
- **`Settings → Notifications → Flash Duration`** slider (500–4000 ms, default 1500 ms). Both pane and sidebar pulses scale together.
- **Unified flash envelope** across pane content + sidebar workspace row + Bonsplit tab pulse — same color, same temporal envelope, treated as one signal.
- **Hot path discipline preserved**: `TabItemView` still skips body re-evaluation during typing (`Equatable` + `.equatable()`); the new sidebar color and flash-token threading go through precomputed `let` parameters with `==` updated. `mouseDown` click-cancel hook stays out of the keystroke path; persistent timers invalidate on close + deinit.

## Implementation

16 commits on `cmux-10-persistent-flash`. Plan note: `.lattice/notes/task_01KPHCWXCQ91ZEG9W0N9WBBC7W.md`. Trident review pack: `notes/trident-review-CMUX-10-pack-20260506-0128/`.

```
8eb96933  refactor: extract FlashAppearance seam (no behavior change)
5810d4f7  default yellow #F5C518; add --color override; flash.color theme key shim
2fbcc731  unify sidebar + pane flash envelope (single FlashEnvelope)
f440ffdf  persistent flash mode + cancel-flash CLI + click-to-dismiss     ← load-bearing
abd68e1f  add Flash Duration setting (500–4000ms, default 1500ms)
736b532c  tests for flash + persistence + color parsing; CLI help; docs
f104dfe1  review-fix: invalidate persistent-flash timers on close + deinit
e96397f0  review-fix: scrub stale flash_state on session restore
12009b3e  review-fix: add Flash Duration strings to xcstrings catalog
8cf37e40  review-fix: thread --color into sidebar pulse + document scope
33a85214  review-fix: log flash_state metadata write/clear failures
d7bdb6e2  review-fix: rename NotificationFlashDurationSettings.enabledKey → storageKey
28cfc29f  review-fix: target a non-focused surface in persistent test
4db2689d  docs: teach c11 skill the new persistent-flash + cancel-flash commands
e1db60ee  review-fix: hoist FlashAppearance.defaultColor to static let
f634d7f0  typed FlashState enum for surface metadata key
```

## Process

- **Plan**: refreshed the 2026-04-18 grooming-pass note for the 2026-05-05 expanded asks; verified anchors against worktree HEAD.
- **Impl**: 6 commits per plan, build-verified per commit.
- **Review**: 9-agent Trident (Claude+Codex; Gemini timed out on auth) → 4 syntheses → 7 fix commits absorbed (B1, B2, I1, I2, I4, M1, M2; I3 bundled with B1; M3 skipped — no O(1) helper to use).
- **Fix-absorb**: 3 escalated items pulled into this PR (S6 c11 skill update for new commands, S7 `static let defaultColor`, E3 typed `FlashState` enum).
- **Validate**: tagged build (`./scripts/reload.sh --tag cmux-10-flash`) + Codex socket smoke. All automatable items pass; visual + click-dismiss + Settings slider deferred to operator's last-mile.

## Test plan

CI runs the unit + e2e suites. For local smoke against the tagged app:

- [ ] `./scripts/reload.sh --tag cmux-10-flash` builds and launches `c11 DEV cmux-10-flash.app`.
- [ ] In the tagged app, trigger a one-shot flash on a focused pane: pane shows a single yellow ring pulse + sidebar row pulses.
- [ ] Switch to a different workspace, trigger flash on a surface in the FIRST workspace: that workspace's sidebar row pulses yellow even though its content is off-screen.
- [ ] `c11-dev trigger-flash --surface <non-focused-ref> --persistent`: surface keeps pulsing every ~2.1 s. Click the pane content → flash dismisses. Trigger again, click the sidebar row → dismisses.
- [ ] `c11-dev cancel-flash --surface <ref>` while pulsing: stops cleanly. `get-metadata --key flash_state` returns empty after cancel.
- [ ] `c11-dev trigger-flash --color "#FF00FF" --surface <ref>`: pulse renders magenta in BOTH the pane ring AND the sidebar row.
- [ ] `c11-dev trigger-flash --color notahex` exits non-zero with a clear hex error.
- [ ] **Bring the tagged app to the front first**, then `c11-dev trigger-flash --surface <focused-ref> --persistent`: degrades to a one-shot pulse, no `flash_state` metadata. (Without bringing tagged app to front, the `NSApp.isActive` gate correctly leaves persistent registered for an off-screen-from-the-OS-perspective surface.)
- [ ] Settings → Notifications → Flash Duration: drag to ~3000 ms, dismiss; trigger a fresh flash → pulse is visibly longer; reset to 1500 ms.
- [ ] Type into a focused terminal pane after the build: latency unchanged subjectively.

## Follow-up tickets to consider after merge

(Triaged from Trident escalations; surfaced for operator decision, not auto-created.)

- **CMUX-10b candidate**: Browser/Markdown panel direct-content-click parity for cancel + an operator-facing attention inbox driven by `flash_state` metadata. Reviewer flagged this as the highest-leverage near-term follow-up.
- **CMUX-10c candidate**: integration-style flash test (real panel + workspace, not just unit tests on `persistentFlashPanels`).
- **Discovery ticket**: generalize `FlashAppearance` → `AttentionAppearance` with multiple signal kinds (status pills, progress rings, unread badges) — natural arc once persistent flash proves out.

## Lattice

CMUX-10 (`task_01KPHCWXCQ91ZEG9W0N9WBBC7W`) — leaving at `review` for operator merge per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)