### PR TITLE
perf(workspace-switch): Phase 2 — skip portal bind when host frame is zero

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9364,6 +9364,28 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 ) else { return }
                 guard host.window != nil else { return }
                 guard portalBindingStillLive() else { return }
+                // Phase 2: skip the bind here when the host's frame hasn't been laid
+                // out yet. AppKit fires `viewDidMoveToWindow` during `addSubview`,
+                // BEFORE SwiftUI's layout pass sizes the host. Binding now would
+                // run with a zero anchor frame, hide the hosted view, and force
+                // a second bind+sync cycle once the frame became real, which is
+                // the source of the post-handoff layout cascade. `onGeometryChanged`
+                // below performs the bind on the first geometry tick — by that
+                // point the host has its real frame and the hosted view appears
+                // in one pass.
+                let hostBounds = host.bounds
+                let geometryReady = hostBounds.width > 1 && hostBounds.height > 1
+                if !geometryReady {
+#if DEBUG
+                    dlog(
+                        "ws.hostState.deferBindOnDidMove surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                        "reason=hostBoundsNotReady visible=\(coordinator.desiredIsVisibleInUI ? 1 : 0) " +
+                        "active=\(coordinator.desiredIsActive ? 1 : 0) z=\(coordinator.desiredPortalZPriority) " +
+                        "bounds=\(String(format: "%.1fx%.1f", hostBounds.width, hostBounds.height))"
+                    )
+#endif
+                    return
+                }
                 TerminalWindowPortalRegistry.bind(
                     hostedView: hostedView,
                     to: host,


### PR DESCRIPTION
## Summary
Stacks on top of #127 (Phase 1). Adds a defensive guard in `host.onDidMoveToWindow` so the portal bind is skipped when AppKit fires the callback before SwiftUI has sized the host. The existing flow bound with a zero anchor frame, hid the hosted view, then needed an async sync to recover with real geometry — a redundant bind+sync cycle every workspace mount. With this guard, `onGeometryChanged` performs the bind once SwiftUI's layout has set a real frame, so the hosted view is bound exactly once with valid geometry in a single pass.

## Caveat (read before merging)
In the live trace from the operator's test session, AppKit consistently fires `viewDidMoveToWindow` with the host **already sized**, so `ws.hostState.deferBindOnDidMove` never fires. Under that timing the change is a no-op safety check rather than an active improvement. Heavy-load measurement (the 11-workspaces / 20-agents scenario from the original baseline) is the right way to confirm whether the trailing silent gap (~1825ms last `ws.swiftui.update` → `ws.select.asyncDone` in the small-workspace test) actually shrinks. Operator chose to ship as a defensive guard while the heavy-load test runs in parallel.

## Test plan
- [x] Local build green (`./scripts/reload.sh --tag phase2-portal-bind`).
- [x] Operator confirmed terminals appear correctly in the new tagged build (after first-attempt prebind regression was reverted).
- [ ] Heavy-load workspace-switch trace to confirm whether the silent gap shrinks under realistic conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)