### PR TITLE
perf(workspace-switch): Phase 3 — instrument dark spots + drop duplicate layout flush

### DIFF
--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -153,11 +153,32 @@ final class TerminalPanel: Panel, ObservableObject {
     }
 
     func focus() {
+#if DEBUG
+        let focusStart = CACurrentMediaTime()
+#endif
         surface.setFocus(true)
+#if DEBUG
+        let postSetFocus = (CACurrentMediaTime() - focusStart) * 1000
+#endif
         // `unfocus()` force-disables active state to stop stale retries from stealing focus.
         // Re-enable it immediately for explicit focus requests (socket/UI) so ensureFocus can run.
         hostedView.setActive(true)
+#if DEBUG
+        let postSetActive = (CACurrentMediaTime() - focusStart) * 1000
+#endif
         hostedView.ensureFocus(for: workspaceId, surfaceId: id)
+#if DEBUG
+        let postEnsureFocus = (CACurrentMediaTime() - focusStart) * 1000
+        if postEnsureFocus > 5 {
+            dlog(
+                "terminalPanel.focus.timing panel=\(id.uuidString.prefix(5)) " +
+                "setFocus=\(String(format: "%.2f", postSetFocus))ms " +
+                "setActive=\(String(format: "%.2f", postSetActive - postSetFocus))ms " +
+                "ensureFocus=\(String(format: "%.2f", postEnsureFocus - postSetActive))ms " +
+                "total=\(String(format: "%.2f", postEnsureFocus))ms"
+            )
+        }
+#endif
     }
 
     func unfocus() {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -889,11 +889,42 @@ class TabManager: ObservableObject {
                     WorkspaceSwitchSignpost.end(switchSignpostID, "superseded")
                     return
                 }
+#if DEBUG
+                let asyncBlockStart = CACurrentMediaTime()
+                let switchDtAtAsyncEnter = self.debugWorkspaceSwitchStartTime > 0
+                    ? (asyncBlockStart - self.debugWorkspaceSwitchStartTime) * 1000
+                    : 0
+                dlog(
+                    "ws.select.asyncEnter id=\(self.debugWorkspaceSwitchId) " +
+                    "dt=\(Self.debugMsText(switchDtAtAsyncEnter))"
+                )
+#endif
                 self.focusSelectedTabPanel(previousTabId: previousTabId)
+#if DEBUG
+                let postFocusDt = (CACurrentMediaTime() - asyncBlockStart) * 1000
+                dlog(
+                    "ws.select.asyncPostFocusPanel id=\(self.debugWorkspaceSwitchId) " +
+                    "phaseDt=\(Self.debugMsText(postFocusDt))"
+                )
+#endif
                 self.updateWindowTitleForSelectedTab()
+#if DEBUG
+                let postTitleDt = (CACurrentMediaTime() - asyncBlockStart) * 1000
+                dlog(
+                    "ws.select.asyncPostTitleUpdate id=\(self.debugWorkspaceSwitchId) " +
+                    "phaseDt=\(Self.debugMsText(postTitleDt))"
+                )
+#endif
                 if let selectedTabId = self.selectedTabId {
                     self.markFocusedPanelReadIfActive(tabId: selectedTabId)
                 }
+#if DEBUG
+                let postMarkReadDt = (CACurrentMediaTime() - asyncBlockStart) * 1000
+                dlog(
+                    "ws.select.asyncPostMarkRead id=\(self.debugWorkspaceSwitchId) " +
+                    "phaseDt=\(Self.debugMsText(postMarkReadDt))"
+                )
+#endif
 
                 // Phase 0: close the signpost interval and post a release-safe
                 // Sentry breadcrumb with the duration so production traces
@@ -2920,6 +2951,21 @@ class TabManager: ObservableObject {
     }
 
     private func focusSelectedTabPanel(previousTabId: UUID?) {
+#if DEBUG
+        let phaseStart = CACurrentMediaTime()
+        func phaseDlog(_ marker: String) {
+            let dtMs = (CACurrentMediaTime() - phaseStart) * 1000
+            let switchDtMs = debugWorkspaceSwitchStartTime > 0
+                ? (CACurrentMediaTime() - debugWorkspaceSwitchStartTime) * 1000
+                : 0
+            dlog(
+                "ws.focusPanel.\(marker) id=\(debugWorkspaceSwitchId) " +
+                "phaseDt=\(Self.debugMsText(dtMs)) switchDt=\(Self.debugMsText(switchDtMs))"
+            )
+        }
+        phaseDlog("enter")
+        defer { phaseDlog("exit") }
+#endif
         guard let selectedTabId,
               let tab = tabs.first(where: { $0.id == selectedTabId }) else { return }
 
@@ -2944,12 +2990,21 @@ class TabManager: ObservableObject {
                 with: (tabId: previousTabId, panelId: previousPanelId)
             )
         }
+#if DEBUG
+        phaseDlog("preFocus")
+#endif
 
         panel.focus()
+#if DEBUG
+        phaseDlog("postPanelFocus")
+#endif
 
         // For terminal panels, ensure proper focus handling
         if let terminalPanel = panel as? TerminalPanel {
             terminalPanel.hostedView.ensureFocus(for: selectedTabId, surfaceId: panelId)
+#if DEBUG
+            phaseDlog("postEnsureFocus")
+#endif
         }
     }
 

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -2152,7 +2152,9 @@ enum TerminalWindowPortalRegistry {
            oldWindowId != windowId {
             portalsByWindowId[oldWindowId]?.detachHostedView(withId: hostedId)
         }
-
+#if DEBUG
+        let bindStart = CACurrentMediaTime()
+#endif
         nextPortal.bind(
             hostedView: hostedView,
             to: anchorView,
@@ -2162,6 +2164,15 @@ enum TerminalWindowPortalRegistry {
         )
         hostedToWindowId[hostedId] = windowId
         pruneHostedMappings(for: windowId, validHostedIds: nextPortal.hostedIds())
+#if DEBUG
+        let bindMs = (CACurrentMediaTime() - bindStart) * 1000
+        if bindMs > 5 {
+            dlog(
+                "portal.bind.timing hosted=\(portalDebugToken(hostedView)) " +
+                "bindMs=\(String(format: "%.2f", bindMs))"
+            )
+        }
+#endif
     }
 
     static func synchronizeForAnchor(_ anchorView: NSView) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9224,8 +9224,14 @@ final class Workspace: Identifiable, ObservableObject {
         guard layoutFollowUpTimeoutWorkItem != nil, !isAttemptingLayoutFollowUp else { return }
         isAttemptingLayoutFollowUp = true
         defer { isAttemptingLayoutFollowUp = false }
+#if DEBUG
+        let attemptStart = CACurrentMediaTime()
+#endif
 
         flushWorkspaceWindowLayouts()
+#if DEBUG
+        let postFlushMs = (CACurrentMediaTime() - attemptStart) * 1000
+#endif
 
         let geometryPendingBefore = layoutFollowUpNeedsGeometryPass
         let terminalPortalPendingBefore = terminalPortalVisibilityNeedsFollowUp()
@@ -9323,17 +9329,32 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             layoutFollowUpStalledAttemptCount += 1
         }
+#if DEBUG
+        let totalMs = (CACurrentMediaTime() - attemptStart) * 1000
+        dlog(
+            "ws.layoutFollowUp.attempt workspace=\(id.uuidString.prefix(5)) " +
+            "totalMs=\(String(format: "%.2f", totalMs)) " +
+            "flushMs=\(String(format: "%.2f", postFlushMs)) " +
+            "didMakeProgress=\(didMakeProgress ? 1 : 0) needsMoreWork=\(needsMoreWork ? 1 : 0) " +
+            "stalled=\(layoutFollowUpStalledAttemptCount) reason=\(layoutFollowUpReason ?? "nil")"
+        )
+#endif
     }
 
     /// Reconcile remaining terminal view geometries after split topology changes.
     /// This keeps AppKit bounds and Ghostty surface sizes in sync in the next runloop turn.
     private func reconcileTerminalGeometryPass() -> Bool {
         var needsFollowUpPass = false
+#if DEBUG
+        let passStart = CACurrentMediaTime()
+        var refreshedCount = 0
+        var skippedCount = 0
+#endif
 
-        // Flush pending AppKit layout first so terminal-host bounds reflect latest split topology.
-        for window in NSApp.windows {
-            window.contentView?.layoutSubtreeIfNeeded()
-        }
+        // `attemptEventDrivenLayoutFollowUp` already flushes all window layouts via
+        // `flushWorkspaceWindowLayouts()` before invoking this pass, so we do not re-flush
+        // here. Phase 3 — removing the duplicate `layoutSubtreeIfNeeded` loop saves a
+        // full-window layout pass on every reconcile attempt.
 
         for panel in panels.values {
             guard let terminalPanel = panel as? TerminalPanel else { continue }
@@ -9352,14 +9373,35 @@ final class Workspace: Identifiable, ObservableObject {
             hostedView.reconcileGeometryNow()
             // Re-check surface after reconcileGeometryNow() which can trigger AppKit
             // layout and view lifecycle changes that free surfaces (#432).
-            if terminalPanel.surface.surface != nil {
+            //
+            // Phase 3 — only refresh when the surface is actually attachable. The
+            // `forceRefresh()` body already early-returns on detached / zero-bounds
+            // views, but skipping the call entirely avoids the per-panel dlog
+            // emission and the entry into the Ghostty C bridge during the cascade
+            // of follow-up passes that fire on every workspace switch.
+            if terminalPanel.surface.surface != nil, isAttached, hasUsableBounds {
                 terminalPanel.surface.forceRefresh()
+#if DEBUG
+                refreshedCount += 1
+#endif
+            } else {
+#if DEBUG
+                skippedCount += 1
+#endif
             }
             if terminalPanel.surface.surface == nil, isAttached && hasUsableBounds {
                 terminalPanel.surface.requestBackgroundSurfaceStartIfNeeded()
                 needsFollowUpPass = true
             }
         }
+#if DEBUG
+        let passMs = (CACurrentMediaTime() - passStart) * 1000
+        dlog(
+            "ws.geometryReconcile.pass workspace=\(id.uuidString.prefix(5)) " +
+            "ms=\(String(format: "%.2f", passMs)) refreshed=\(refreshedCount) skipped=\(skippedCount) " +
+            "needsFollowUp=\(needsFollowUpPass ? 1 : 0)"
+        )
+#endif
 
         return needsFollowUpPass
     }


### PR DESCRIPTION
## Summary
Stacks on top of #127 (Phase 1 + Phase 2). Phase 3 maps and trims cost in the dominant post-handoff cascade.

**Instrumentation (DEBUG-only):** new dlog markers — `ws.select.async*`, `ws.focusPanel.*`, `terminalPanel.focus.timing`, `portal.bind.timing`, `ws.geometryReconcile.pass`, `ws.layoutFollowUp.attempt` — give a per-phase view of every workspace switch.

**Optimization:**
- Drop duplicate `layoutSubtreeIfNeeded` loop in `reconcileTerminalGeometryPass` (the caller already flushes immediately before).
- Skip `forceRefresh()` per panel when hostedView is detached or zero-bounds.

## Findings (15 agents, 4 workspaces)

| phase | ms (Phase 3 build) |
|---|---|
| didSet → handoff.complete | 20–24 |
| **handoff → asyncEnter** | **880–1450** (dominant — AppKit layout cascade) |
| panel.focus() | 140–200 |
| post-focus → asyncDone | ~3 |
| layout follow-up attempts | 4–9ms each, ~8/switch (~40ms total) |
| flushWorkspaceWindowLayouts | <1ms per call |

The follow-up chain is **not** the dominant cost. Phase 3's optimization saves a small amount (~5–15ms est.); the bigger value is the instrumentation: it gives the next investigator a precise map showing the real attack surface is the SwiftUI mount + splitView tree settling in the runloop iteration triggered by didSet.

## Test plan
- [x] Build green (`./scripts/reload.sh --tag phase3-instr`).
- [x] Operator confirmed terminals + sidebar work in heavy-load build (15 agents, 4 workspaces).
- [x] New dlog markers fire as expected; per-pass / per-attempt timings recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)