### PR TITLE
perf(workspace-switch): Phase 4a — collapse redundant portal layout calls

### DIFF
--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -912,10 +912,17 @@ final class WindowTerminalPortal: NSObject {
     }
 
     private func synchronizeLayoutHierarchy() {
-        installedContainerView?.layoutSubtreeIfNeeded()
-        installedReferenceView?.layoutSubtreeIfNeeded()
-        hostView.superview?.layoutSubtreeIfNeeded()
-        hostView.layoutSubtreeIfNeeded()
+        // Per ensureInstalled / installationTarget: hostView is added as a subview of
+        // installedContainerView, alongside installedReferenceView (a sibling). So
+        // installedContainerView is the topmost in-tree ancestor of all of:
+        //   installedReferenceView, hostView.superview (== installedContainerView),
+        //   and hostView itself.
+        // layoutSubtreeIfNeeded on the topmost ancestor settles the entire subtree;
+        // calls on the descendants that follow used to compound the cascade for no
+        // additional effect. Fall through to hostView.superview / hostView only if
+        // the install isn't current (tearDown, pre-install, or transient drift).
+        let topmost = installedContainerView ?? hostView.superview ?? hostView
+        topmost.layoutSubtreeIfNeeded()
         _ = synchronizeHostFrameToReference()
     }
 


### PR DESCRIPTION
## Summary

Item **A1** of three under Tier A of the workspace-switch performance umbrella ([C11-32](#)). Surgical, single-file change to `Sources/TerminalWindowPortal.swift`.

`synchronizeLayoutHierarchy()` called `layoutSubtreeIfNeeded()` on four ancestors in sequence:

```swift
installedContainerView?.layoutSubtreeIfNeeded()
installedReferenceView?.layoutSubtreeIfNeeded()
hostView.superview?.layoutSubtreeIfNeeded()
hostView.layoutSubtreeIfNeeded()
```

Per `ensureInstalled` / `installationTarget`, in the live tree:

- `hostView` is `addSubview`'d as a subview of `container` (lines 1113 / 1115) anchored to `reference` via leading/trailing/top/bottom constraints (lines 1118–1124).
- `reference.superview === container` is verified by `installedTargetIfStillValid` (line 1158).
- `installedContainerView = container` (line 1125), `installedReferenceView = reference` (line 1126).

So:
- `installedContainerView` is the **topmost in-tree ancestor**.
- `hostView.superview` is **the same view** as `installedContainerView` (call #3 is the same NSView as call #1).
- `installedReferenceView` and `hostView` are **siblings, both descendants** of `installedContainerView` (calls #2 and #4 are subtrees of #1).

`layoutSubtreeIfNeeded` on an ancestor settles the entire subtree; the descendant calls become no-ops on already-settled subtrees.

## Empirical confirmation

`/tmp/phase4-sample-heavy.txt` (the umbrella's heavy-load `sample(1)` baseline) shows the chain
`scheduleDeferredFullSynchronizeAll → synchronizeAllHostedViews → ensureInstalled → synchronizeLayoutHierarchy` accumulating **176 samples**, all attributed to the **first** `[NSView layoutSubtreeIfNeeded]` callsite — the `installedContainerView?` call. The other three calls do **not** appear in the hot path:

```
176 WindowTerminalPortal.scheduleDeferredFullSynchronizeAll  …:1508
176 WindowTerminalPortal.synchronizeAllHostedViews(excluding:) …:1513
176 WindowTerminalPortal.ensureInstalled()                   …:1142
176 WindowTerminalPortal.synchronizeLayoutHierarchy()        …:915  ← line of FIRST call
176 -[NSView layoutSubtreeIfNeeded]
176 -[NSView _layoutSubtreeIfNeededAndAllowTemporaryEngine:]
175 -[NSView _layoutSubtreeWithOldSize:]   ← deep cascade follows
…
```

This **confirms** the redundancy theory in shape but **disproves** the "2-4× cascade multiplier" form of it: the topmost call does 100% of the work; the remaining three calls are runtime no-ops (the subtree is already settled) and contribute zero samples.

## What this PR delivers

- **Correctness preserved.** The single call on `installedContainerView` covers the same subtree as all four prior calls.
- **Clarity.** Future readers no longer have to reason about whether four sequential `layoutSubtreeIfNeeded`s are duplicating cascades — they aren't, and the comment makes the contract explicit.
- **Tiny constant savings.** Three fewer ObjC method dispatches + optional unwraps per `synchronizeLayoutHierarchy` invocation. Not a measurable wallclock win on its own; the deep `_layoutSubtreeWithOldSize` cascade itself was already concentrated in the single topmost call we still make.
- **Latent-risk mitigation.** If the call ordering or view-tree topology ever changes such that descendant subtrees aren't settled by the topmost call, the previous code's appearance of "we cover all four bases" was misleading — the new shape forces any future divergence to be considered explicitly.

Falls through to `hostView.superview ?? hostView` when `installedContainerView` is `nil` (tearDown, pre-install, transient drift), preserving the previous safety behavior.

## Validation

- Tagged build: `./scripts/reload.sh --tag phase4a-collapse` → **BUILD SUCCEEDED**.
- Tagged app launches and is responsive on socket (`c11 ping` → `PONG`, `c11 list-workspaces` works).
- Drove ~10 workspace switches in a fresh tagged session while `sample(1)` ran for 5s → captured at `/tmp/phase4a-collapse-heavy.txt`. The post-change sample on a thin (no-terminal) workspace shows zero `synchronizeLayoutHierarchy` samples — expected, because the entries-loop has no work to do without panes. A heavy-load comparison (15 agents / 4 workspaces / multiple panes) would need fixture parity with the umbrella's baseline run to be apples-to-apples; the operator can re-sample on their running heavy session if a numerical comparison is needed, but the empirical baseline already establishes that only the first `layoutSubtreeIfNeeded` call carried the 176 samples — so the cascade-shrink yield from this PR is structurally bounded to "the three trailing calls' overhead", which the baseline shows is essentially zero on-CPU.

## Constraints honored

- Single file modified: `Sources/TerminalWindowPortal.swift`.
- No typing-latency hot paths touched (`hitTest`, `forceRefresh`, `TabItemView` Equatable).
- No `print` / `NSLog` added.
- No backwards-compatibility hacks.

## Test plan

- [x] Tagged build (`phase4a-collapse`) compiles cleanly.
- [x] Tagged app launches and accepts socket commands.
- [x] Workspace switch path exercised; no regressions observed in code review of all four `synchronizeLayoutHierarchy()` callers (lines 953, 1142, 1476, 1514).
- [ ] Operator: optional re-sample on heavy load if a numerical wallclock comparison is desired. Baseline guarantees no negative impact since the change is "do less of what's already a no-op."

🤖 Generated with [Claude Code](https://claude.com/claude-code)