### PR TITLE
perf(workspace-switch): Phase 4a — skip empty deferred portal sync

### DIFF
--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -790,6 +790,10 @@ final class WindowTerminalPortal: NSObject {
     private var installConstraints: [NSLayoutConstraint] = []
     private var hasDeferredFullSyncScheduled = false
     private var hasExternalGeometrySyncScheduled = false
+    // Per-entry dirty set consumed by scheduleDeferredFullSynchronizeAll's deferred body.
+    // Each schedule caller marks the hosted ids it touched; the deferred body iterates only
+    // those entries (skipping entirely when nothing's dirty) instead of sweeping all entries.
+    private var dirtyHostedIds: Set<ObjectIdentifier> = []
     private var geometryObservers: [NSObjectProtocol] = []
 #if DEBUG
     private var lastLoggedBonsplitContainerSignature: String?
@@ -1467,6 +1471,9 @@ final class WindowTerminalPortal: NSObject {
         ensureDividerOverlayOnTop()
 
         synchronizeHostedView(withId: hostedId)
+        // Re-check this hosted view on the next tick — the bind just reparented/resized it
+        // and ancestor layout may still settle. Other entries are unaffected by this bind.
+        dirtyHostedIds.insert(hostedId)
         scheduleDeferredFullSynchronizeAll()
         pruneDeadEntries()
     }
@@ -1485,6 +1492,13 @@ final class WindowTerminalPortal: NSObject {
         // geometry callback while another fires. Reconcile all mapped hosted views so no stale
         // frame remains "stuck" onscreen until the next interaction.
         synchronizeAllHostedViews(excluding: primaryHostedId)
+        // Only the primary hosted view (whose anchor moved) needs a deferred re-check after
+        // layout settles. Other entries were just synchronized inline above. When primaryHostedId
+        // is nil (anchor not bound to any hosted view), there's nothing to defer — the deferred
+        // body will skip cleanly.
+        if let primaryHostedId {
+            dirtyHostedIds.insert(primaryHostedId)
+        }
         scheduleDeferredFullSynchronizeAll()
     }
 
@@ -1505,7 +1519,38 @@ final class WindowTerminalPortal: NSObject {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.hasDeferredFullSyncScheduled = false
-            self.synchronizeAllHostedViews(excluding: nil)
+            self.runDeferredHostedSync()
+        }
+    }
+
+    /// Body of the deferred sync. Iterates only entries marked dirty since the schedule
+    /// call; skips entirely when nothing's dirty. Re-entrant marks added during iteration
+    /// (e.g., transient-recovery retries) re-arm a fresh deferred via the schedule call,
+    /// so they're handled on the next tick rather than in the current sweep.
+    private func runDeferredHostedSync() {
+        guard ensureInstalled() else {
+            dirtyHostedIds.removeAll(keepingCapacity: true)
+            return
+        }
+        let snapshot = dirtyHostedIds
+        dirtyHostedIds.removeAll(keepingCapacity: true)
+        guard !snapshot.isEmpty else {
+#if DEBUG
+            dlog("portal.deferredSync.skip count=0")
+#endif
+            return
+        }
+#if DEBUG
+        dlog("portal.deferredSync.run count=\(snapshot.count) full=0")
+#endif
+        synchronizeLayoutHierarchy()
+        pruneDeadEntries()
+        for hostedId in snapshot {
+            // Skip ids that no longer correspond to a live entry (detached/unbound between
+            // schedule and run). synchronizeHostedView would no-op anyway, but skipping here
+            // avoids the lookup churn.
+            guard entriesByHostedId[hostedId] != nil else { continue }
+            synchronizeHostedView(withId: hostedId)
         }
     }
 
@@ -1547,6 +1592,9 @@ final class WindowTerminalPortal: NSObject {
         )
 #endif
         if entry.transientRecoveryRetriesRemaining > 0 {
+            // Retry only the entry whose recovery is in flight; other entries aren't
+            // affected by this transient-recovery cycle.
+            dirtyHostedIds.insert(hostedId)
             scheduleDeferredFullSynchronizeAll()
         }
         return true
@@ -1674,6 +1722,9 @@ final class WindowTerminalPortal: NSObject {
                         reason: "hostBoundsNotReady"
                     )
                 } else {
+                    // Legacy fallback (transient recovery disabled): retry only this hosted
+                    // view on the next tick once host bounds settle.
+                    dirtyHostedIds.insert(hostedId)
                     scheduleDeferredFullSynchronizeAll()
                 }
             }


### PR DESCRIPTION
## Summary

`scheduleDeferredFullSynchronizeAll` queued an async body that ran `synchronizeAllHostedViews(excluding: nil)` on every call regardless of state. Added a per-entry `dirtyHostedIds: Set<ObjectIdentifier>` on the portal; the deferred body now iterates only the dirty subset and skips entirely when nothing's dirty.

Refs C11-32 ([umbrella plan](.lattice/plans/task_01KQZACEWKSA2E4WMX1HZY628N.md)), Tier A item A2. Builds on **A1 (#133)** — same file (`Sources/TerminalWindowPortal.swift`), sequential PR.

## Call-site classification

All four `scheduleDeferredFullSynchronizeAll` call sites are per-entry; none are full-sweep:

| Site | Line | Mark |
|---|---|---|
| Post-bind | ~1484 | `dirtyHostedIds.insert(hostedId)` (the just-bound entry) |
| Post-geometry-sync | ~1509 | `primaryHostedId` if non-nil; **nothing** if anchor is unbound — the clean skip path |
| Transient-recovery retry | ~1605 | the recovering `hostedId` |
| Legacy `hostBoundsNotReady` fallback | ~1735 | `hostedId` |

The skip path fires when post-geom-sync runs with no `primaryHostedId`. Under sustained workspace switching this is rare-but-real (anchor reconfiguration + spurious resize triggers). Future call sites that intend full-sweep semantics need to mark every entry; document this in code if/when it arises.

## DEBUG instrumentation

Added inside `runDeferredHostedSync`:
- `portal.deferredSync.skip count=0` when set is empty.
- `portal.deferredSync.run count=N full=0` when work was needed.

`full=0` is reserved as a knob for a future explicit full-sweep flag; today there is no caller that needs it.

## Validation

- Build: `./scripts/reload.sh --tag phase4a-skipsync` → `** BUILD SUCCEEDED **`.
- Tagged app launches; first observed event:

  ```
  18:42:05.240 portal.deferredSync.run count=2 full=0
  ```

  (Startup post-bind sweep — both initial hosted entries marked dirty; ran cleanly.)
- Skip path was not exercised in the brief startup window — it requires sustained workspace activity to surface a `primaryHostedId == nil` case. The instrumentation is in place for the operator (or the eventual heavy-load sample) to confirm.

## Constraints respected

- Single-file diff: only `Sources/TerminalWindowPortal.swift`.
- `WindowTerminalHostView.hitTest()` (file-local typing-latency hot path) untouched.
- All `dirtyHostedIds` reads/writes happen on the main queue (the schedule callers run inline; deferred body in `DispatchQueue.main.async`).
- Logging gated `#if DEBUG`; uses existing `dlog` style.

## Test plan

- [ ] Operator: drive sustained workspace switching against the tagged build for ~30 s; confirm both `portal.deferredSync.skip` and `portal.deferredSync.run` events appear in `/tmp/c11-debug-phase4a-skipsync.log`.
- [ ] Confirm no regression in workspace switch correctness (hosted views remain anchored after the deferred sweep).
- [ ] Verify typing latency unchanged in `WindowTerminalHostView.hitTest()` paths.

## Orchestrator note

A2's sub-agent stalled mid-flow before pushing. Implementation diff was complete and audited (every `scheduleDeferredFullSynchronizeAll` call site has a matching `dirtyHostedIds.insert(...)`); orchestrator finished the build / commit / push / PR steps directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)