### PR TITLE
perf(workspace-switch): Phase 8e — defer setActive(false) responder resign to next idle

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6404,6 +6404,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
+    private var pendingDeferredSetActiveFalseResign = false
     // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
 
     /// Tracks whether keyboard focus should go to the search field or the terminal
@@ -7666,9 +7667,58 @@ final class GhosttySurfaceScrollView: NSView {
         if active {
             scheduleAutomaticFirstResponderApply(reason: "setActive")
         } else {
-            resignOwnedFirstResponderIfNeeded(reason: "setActive(false)")
+            scheduleDeferredResignAfterSetActiveFalse()
         }
     }
+
+    // Phase 8e (C11-32): off-screen surfaces have no observable contract requiring
+    // synchronous responder-resignation inside the workspace-switch runloop iteration.
+    // The new active workspace's setActive(true) → applyFirstResponderIfNeeded →
+    // makeFirstResponder swaps the responder via the standard AppKit chain anyway.
+    // Pushing the resign call to the next idle removes Burst B (~60-300 ms) from
+    // the user-perceived switch frame.
+    private func scheduleDeferredResignAfterSetActiveFalse() {
+        guard !pendingDeferredSetActiveFalseResign else { return }
+        pendingDeferredSetActiveFalseResign = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.pendingDeferredSetActiveFalseResign = false
+            // Skip if we've been re-activated before this block runs — setActive(true)
+            // will have already swapped the responder via scheduleAutomaticFirstResponderApply.
+            guard !self.isActive else {
+#if DEBUG
+                let surfaceShort = self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+                dlog("setActive.deferredResign.skipped reason=reactivated surface=\(surfaceShort)")
+#endif
+                return
+            }
+#if DEBUG
+            let surfaceShort = self.surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+            dlog("setActive.deferredResign.fire surface=\(surfaceShort)")
+#endif
+            self.resignOwnedFirstResponderIfNeeded(reason: "setActive(false).deferred")
+#if DEBUG
+            self.assertOffScreenSurfaceNotKeyEventRoutable()
+#endif
+        }
+    }
+
+#if DEBUG
+    // Phase 8e DEBUG runtime check: after the deferred resign runs, an inactive
+    // surface should not own its window's first responder. If it does, key events
+    // would route to an off-screen surface — observable correctness regression.
+    private func assertOffScreenSurfaceNotKeyEventRoutable() {
+        guard !isActive,
+              let window,
+              let firstResponder = window.firstResponder as? NSView else { return }
+        let isOurResponder = firstResponder === surfaceView || firstResponder.isDescendant(of: surfaceView)
+        if isOurResponder {
+            let surfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+            dlog("ASSERT setActive.deferredResign.routable surface=\(surfaceShort) — off-screen surface still firstResponder after deferred resign")
+            assertionFailure("Off-screen surface still owns first responder after deferred setActive(false).resign")
+        }
+    }
+#endif
 
 #if DEBUG
     private func debugLogWorkspaceSwitchTiming(event: String, suffix: String) {


### PR DESCRIPTION
## Summary

Phase 8e of the C11-32 workspace-switch performance umbrella.

Off-screen surfaces have no observable contract requiring synchronous responder-resignation inside the workspace-switch runloop iteration. The cascade — `setActive(false)` across ~20 inactive-workspace surfaces, each calling `resignOwnedFirstResponderIfNeeded` — was Burst B in the heavy-switch silent-band trace (Phase 7 follow-up).

This PR pushes the resign call to the next runloop tick via a single coalesced `DispatchQueue.main.async`. The new active workspace's `setActive(true) → scheduleAutomaticFirstResponderApply → applyFirstResponderIfNeeded → makeFirstResponder` already swaps the window's first responder via the standard AppKit chain, so the explicit synchronous resign is redundant on the switch path.

Branch cut from `perf/workspace-switch-instrumentation`; rebased on top of Phase 4 (PR #132). Files touched: `Sources/GhosttyTerminalView.swift` only.

## Correctness

- `isActive` flips synchronously so subsequent reads see the right state.
- The deferred block re-checks `isActive` and bails early if `setActive(true)` ran in the meantime.
- New DEBUG runtime check `assertOffScreenSurfaceNotKeyEventRoutable` fires `assertionFailure` if a still-inactive surface is the window's first responder when the deferred resign completes — would catch any case where the standard responder swap didn't occur.

## Yield target

100–300 ms off heavy-switch p95 (per Phase 8e spec). Will be confirmed against the phase4-store baseline (n=32 median=322 ms p95=2152 ms) once the build is exercised.

## Test plan

- [ ] `./scripts/reload.sh --tag phase8e-setactive` builds clean.
- [ ] Tagged build launches; exercise heavy workspace switches.
- [ ] No `ASSERT setActive.deferredResign.routable` lines in `/tmp/c11-debug-phase8e-setactive.log` (assertion would also crash in DEBUG).
- [ ] `setActive.deferredResign.fire` events appear ~once per inactive-workspace surface per switch.
- [ ] `ws.select.asyncDone dt=` distribution shows yield vs phase4-store baseline.
- [ ] Typing latency hot paths unchanged (`TerminalSurface.forceRefresh`, `TabItemView.equatable`, `WindowTerminalHostView.hitTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
