### PR TITLE
perf(workspace-switch): Phase 8c — defer ensureFocus apply when window just became key

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8066,6 +8066,38 @@ final class GhosttySurfaceScrollView: NSView {
             let phase4aEnsureKeyMs = (CFAbsoluteTimeGetCurrent() - phase4aEnsureKeyT0) * 1000.0
             dlog("ensureFocus.step.notKeyWindow.makeKeyAndOrderFront surface=\(phase4aEnsureSurfaceShort) ms=\(String(format: "%.2f", phase4aEnsureKeyMs))")
 #endif
+            // Phase 8c (C11-32): window.makeFirstResponder synchronously costs
+            // 100-250 ms when the window isn't yet key (vs 67 ms once it is) —
+            // A3 / PR #134 measured this directly. After makeKeyAndOrderFront,
+            // the window-server hasn't completed its key transition yet, so
+            // calling safeMakeTerminalFirstResponder right now blocks the
+            // workspace-switch runloop iteration on AppKit's responder-chain
+            // validation against a not-yet-key window.
+            //
+            // Defer the apply: scheduleAutomaticFirstResponderApply queues a
+            // DispatchQueue.main.async that runs applyFirstResponderIfNeeded.
+            // It will retry — its own isKeyWindow guard skips quietly if the
+            // transition still hasn't completed, and the AppDelegate's
+            // didBecomeKey observer (line 7028) re-invokes scheduleAutomatic
+            // FirstResponderApply once the window actually becomes key, at
+            // which point makeFirstResponder takes the cheap path. Honour
+            // the existing TextBox intent guard so a TextBox the user is
+            // typing into doesn't get its focus stolen by the deferred apply.
+            if !(window.firstResponder is InputTextView) {
+#if DEBUG
+                let phase8cSurfaceShort = surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil"
+                let phase8cEnsureDtMs = (CFAbsoluteTimeGetCurrent() - phase4aEnsureT0) * 1000.0
+                dlog("focus.ensure.deferUntilKey surface=\(phase8cSurfaceShort) tab=\(tabId.uuidString.prefix(5)) panel=\(surfaceId.uuidString.prefix(5)) ms=\(String(format: "%.2f", phase8cEnsureDtMs))")
+                dlog("ensureFocus.end surface=\(phase4aEnsureSurfaceShort) result=defer path=windowJustBecameKey ms=\(String(format: "%.2f", phase8cEnsureDtMs))")
+#endif
+                scheduleAutomaticFirstResponderApply(reason: "ensureFocus.windowJustBecameKey")
+            } else {
+#if DEBUG
+                let phase8cEnsureDtMs = (CFAbsoluteTimeGetCurrent() - phase4aEnsureT0) * 1000.0
+                dlog("ensureFocus.end surface=\(phase4aEnsureSurfaceShort) result=skip path=windowJustBecameKey.textBoxFocused ms=\(String(format: "%.2f", phase8cEnsureDtMs))")
+#endif
+            }
+            return
         }
         // [TextBox] Do not steal focus from an active TextBox. ensureFocus
         // runs on tab switches, socket focus commands, and session restore.


### PR DESCRIPTION
## Summary

Phase 8c of the C11-32 workspace-switch performance umbrella.

A3 (PR #134) instrumentation pinpointed Stretch 3 of the heavy-switch silent band: the synchronous `window.makeFirstResponder(surfaceView)` inside `safeMakeTerminalFirstResponder` costs **100–250 ms when the window isn't yet key**, but only **67 ms once it is** — almost 4× cheaper. Phase 3's cost map predicted 140–200 ms; the heavy-switch capture measured 405 ms. A3's six-switch sample shows the discrepancy is entirely attributable to AppKit's responder-chain validation against a not-yet-key window after `makeKeyAndOrderFront(nil)`.

This PR defers the responder apply when ensureFocus enters with `!window.isKeyWindow`. After triggering `window.makeKeyAndOrderFront(nil)`, instead of synchronously calling `safeMakeTerminalFirstResponder` (which blocks 100–250 ms waiting for the windowserver round-trip), schedule the apply via `scheduleAutomaticFirstResponderApply`. The deferred path:

1. `scheduleAutomaticFirstResponderApply` queues a `DispatchQueue.main.async` that runs `applyFirstResponderIfNeeded`.
2. `applyFirstResponderIfNeeded` already has its own `window.isKeyWindow` guard and skips quietly if the WS round-trip from `makeKeyAndOrderFront` hasn't completed yet.
3. The `windowDidBecomeKey` observer in `viewDidMoveToWindow` fires when the window actually becomes key and re-invokes `scheduleAutomaticFirstResponderApply`. By then, `applyFirstResponderIfNeeded` reaches `safeMakeTerminalFirstResponder` on the cheap (~67 ms) path.

The synchronous switch path no longer pays the not-key penalty; the focus transition still happens, just one runloop tick + WS round-trip later — moved off the user-perceived workspace-switch frame.

Branch cut from `perf/phase4a-instrument-focus-churn` (PR #134) so the inner-step instrumentation is in the build for measurement. Files touched: `Sources/GhosttyTerminalView.swift` only.

## Correctness

- The existing TextBox intent guard (line 8075–8085) is preserved on the new deferred path: if `window.firstResponder is InputTextView`, we don't schedule the apply, exactly as we wouldn't have called `safeMakeTerminalFirstResponder` on the synchronous path.
- All other guards inside `ensureFocus` still run before reaching this block. If they fail, ensureFocus returns early as before.
- A3's instrumentation lets us verify that on heavy switches, `ensureFocus.end result=defer path=windowJustBecameKey` fires when the synchronous path used to pay 100–250 ms; subsequent `applyFirstResponder` events confirm the deferred completion.

## Yield target

100–300 ms off heavy-switch p95 (per Phase 8c spec). A3's measurement gives a tighter 100–250 ms estimate.

## Test plan

- [ ] `./scripts/reload.sh --tag phase8c-ensure-focus` builds clean.
- [ ] Tagged build launches; exercise heavy workspace switches.
- [ ] `ensureFocus.step.notKeyWindow.makeKeyAndOrderFront` continues to fire as before.
- [ ] `focus.ensure.deferUntilKey` events appear when the original synchronous path would have paid the not-key penalty.
- [ ] `ws.select.asyncDone dt=` distribution shows yield vs the phase4a-focusinst baseline (A3's six-switch sample).
- [ ] No regression in focus correctness: focus reaches the new active workspace's terminal after the switch.
- [ ] Typing latency hot paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
