### PR TITLE
C11-24: Right-click menu — Show surface manifest JSON viewer

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		D70A4BF0A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
 		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
 		D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */; };
+		D7C24001A1B2C3D4E5F60718 /* SurfaceManifestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C24002A1B2C3D4E5F60718 /* SurfaceManifestView.swift */; };
+		D7C24003A1B2C3D4E5F60718 /* SurfaceManifestViewerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C24004A1B2C3D4E5F60718 /* SurfaceManifestViewerWindowController.swift */; };
 		D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */; };
 		D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */; };
 		D7C11254A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */; };
@@ -353,6 +355,8 @@
 		D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
 		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
 		D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMetadataStore.swift; sourceTree = "<group>"; };
+		D7C24002A1B2C3D4E5F60718 /* SurfaceManifestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManifestView.swift; sourceTree = "<group>"; };
+		D7C24004A1B2C3D4E5F60718 /* SurfaceManifestViewerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceManifestViewerWindowController.swift; sourceTree = "<group>"; };
 		D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceLifecycle.swift; sourceTree = "<group>"; };
 		D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserSnapshotStore.swift; sourceTree = "<group>"; };
 		D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceMetricsSampler.swift; sourceTree = "<group>"; };
@@ -737,6 +741,8 @@
 				D70B3CF1A1B2C3D4E5F60718 /* SessionEndShutdownPolicy.swift */,
 				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
 				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
+				D7C24002A1B2C3D4E5F60718 /* SurfaceManifestView.swift */,
+				D7C24004A1B2C3D4E5F60718 /* SurfaceManifestViewerWindowController.swift */,
 				D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */,
 				D7C11253A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift */,
 				D7C11255A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift */,
@@ -1168,6 +1174,8 @@
 				D70B3CF0A1B2C3D4E5F60718 /* SessionEndShutdownPolicy.swift in Sources */,
 				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
 				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
+				D7C24001A1B2C3D4E5F60718 /* SurfaceManifestView.swift in Sources */,
+				D7C24003A1B2C3D4E5F60718 /* SurfaceManifestViewerWindowController.swift in Sources */,
 				D7C11250A1B2C3D4E5F60718 /* SurfaceLifecycle.swift in Sources */,
 				D7C11252A1B2C3D4E5F60718 /* BrowserSnapshotStore.swift in Sources */,
 				D7C11254A1B2C3D4E5F60718 /* SurfaceMetricsSampler.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53902,6 +53902,42 @@
             "state": "translated",
             "value": "Copied"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピー済み"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已复制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已複製"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사됨"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопировано"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопійовано"
+          }
         }
       }
     },
@@ -53912,6 +53948,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Copy JSON"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON をコピー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制 JSON"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製 JSON"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON 복사"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопировать JSON"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скопіювати JSON"
           }
         }
       }
@@ -53924,6 +53996,42 @@
             "state": "translated",
             "value": "No metadata set on this surface."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このサーフェスにはメタデータが設定されていません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此界面未设置元数据。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此介面未設定中繼資料。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 서피스에는 설정된 메타데이터가 없습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "На этой поверхности метаданные не заданы."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Для цієї поверхні метаданих не задано."
+          }
         }
       }
     },
@@ -53934,6 +54042,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Captured"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取得時刻"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "捕获于"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "擷取於"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "캡처 시각"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Снято"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Знято"
           }
         }
       }
@@ -53946,6 +54090,42 @@
             "state": "translated",
             "value": "Kind"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "種類"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "类型"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "類型"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "종류"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тип"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тип"
+          }
         }
       }
     },
@@ -53956,6 +54136,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Surface"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェス"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "界面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "介面"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхность"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверхня"
           }
         }
       }
@@ -53968,6 +54184,42 @@
             "state": "translated",
             "value": "Workspace"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作區"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рабочее пространство"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Робочий простір"
+          }
         }
       }
     },
@@ -53979,6 +54231,42 @@
             "state": "translated",
             "value": "Browser"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "浏览器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "瀏覽器"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "브라우저"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Браузер"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Браузер"
+          }
         }
       }
     },
@@ -53986,6 +54274,42 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
+          }
+        },
+        "uk": {
           "stringUnit": {
             "state": "translated",
             "value": "Markdown"
@@ -54001,6 +54325,42 @@
             "state": "translated",
             "value": "Terminal"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終端機"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Терминал"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Термінал"
+          }
         }
       }
     },
@@ -54011,6 +54371,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Show surface manifest…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスマニフェストを表示…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示界面清单…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示介面清單…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스 매니페스트 표시…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать манифест поверхности…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати маніфест поверхні…"
           }
         }
       }
@@ -54023,6 +54419,42 @@
             "state": "translated",
             "value": "Refresh"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重整"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로고침"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновити"
+          }
         }
       }
     },
@@ -54033,6 +54465,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Key"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "键"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "鍵"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "키"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ключ"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ключ"
           }
         }
       }
@@ -54045,6 +54513,42 @@
             "state": "translated",
             "value": "Source"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "来源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "來源"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소스"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Источник"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Джерело"
+          }
         }
       }
     },
@@ -54055,6 +54559,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Set at"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定時刻"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设置时间"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定時間"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정 시각"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Когда задано"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Коли задано"
           }
         }
       }
@@ -54067,6 +54607,42 @@
             "state": "translated",
             "value": "Show sources"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソースを表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示来源"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示來源"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소스 표시"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать источники"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати джерела"
+          }
         }
       }
     },
@@ -54078,6 +54654,42 @@
             "state": "translated",
             "value": "No source records."
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ソース記録はありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有来源记录。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有來源記錄。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "소스 기록이 없습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Записей об источниках нет."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає записів про джерела."
+          }
         }
       }
     },
@@ -54088,6 +54700,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Surface manifest"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスマニフェスト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "界面清单"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "介面清單"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스 매니페스트"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Манифест поверхности"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Маніфест поверхні"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53893,6 +53893,204 @@
           }
         }
       }
+    },
+    "surfaceManifest.copiedButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copied"
+          }
+        }
+      }
+    },
+    "surfaceManifest.copyButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy JSON"
+          }
+        }
+      }
+    },
+    "surfaceManifest.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No metadata set on this surface."
+          }
+        }
+      }
+    },
+    "surfaceManifest.header.capturedAt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Captured"
+          }
+        }
+      }
+    },
+    "surfaceManifest.header.kind": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kind"
+          }
+        }
+      }
+    },
+    "surfaceManifest.header.surface": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface"
+          }
+        }
+      }
+    },
+    "surfaceManifest.header.workspace": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace"
+          }
+        }
+      }
+    },
+    "surfaceManifest.kind.browser": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser"
+          }
+        }
+      }
+    },
+    "surfaceManifest.kind.markdown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown"
+          }
+        }
+      }
+    },
+    "surfaceManifest.kind.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        }
+      }
+    },
+    "surfaceManifest.menuItem": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show surface manifest…"
+          }
+        }
+      }
+    },
+    "surfaceManifest.refreshButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        }
+      }
+    },
+    "surfaceManifest.sources.column.key": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key"
+          }
+        }
+      }
+    },
+    "surfaceManifest.sources.column.source": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Source"
+          }
+        }
+      }
+    },
+    "surfaceManifest.sources.column.timestamp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set at"
+          }
+        }
+      }
+    },
+    "surfaceManifest.sources.disclosure": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show sources"
+          }
+        }
+      }
+    },
+    "surfaceManifest.sources.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No source records."
+          }
+        }
+      }
+    },
+    "surfaceManifest.windowTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Surface manifest"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5963,7 +5963,29 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             systemSymbolName: "rectangle.righthalf.inset.filled",
             accessibilityDescription: nil
         )
+        if tabId != nil, terminalSurface?.id != nil {
+            menu.addItem(.separator())
+            let manifestItem = menu.addItem(
+                withTitle: String(
+                    localized: "surfaceManifest.menuItem",
+                    defaultValue: "Show surface manifest…"
+                ),
+                action: #selector(showSurfaceManifest(_:)),
+                keyEquivalent: ""
+            )
+            manifestItem.target = self
+        }
         return menu
+    }
+
+    @objc private func showSurfaceManifest(_ sender: Any?) {
+        guard let workspaceId = tabId,
+              let surfaceId = terminalSurface?.id else { return }
+        SurfaceManifestViewerWindowController.show(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            kind: .terminal
+        )
     }
 
     private func canSplitCurrentSurface() -> Bool {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2518,6 +2518,14 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.onContextMenuOpenLinkInNewTab = { [weak self] url in
             self?.openLinkInNewTab(url: url)
         }
+        webView.onShowSurfaceManifest = { [weak self] in
+            guard let self else { return }
+            SurfaceManifestViewerWindowController.show(
+                workspaceId: self.workspaceId,
+                surfaceId: self.id,
+                kind: .browser
+            )
+        }
         configureNavigationDelegateCallbacks()
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -56,6 +56,7 @@ final class CmuxWebView: WKWebView {
     /// Called when "Open Link in New Tab" context menu is selected.
     /// Bypasses createWebViewWith so the link opens as a tab, not a popup.
     var onContextMenuOpenLinkInNewTab: ((URL) -> Void)?
+    var onShowSurfaceManifest: (() -> Void)?
     var contextMenuLinkURLProvider: ((CmuxWebView, NSPoint, @escaping (URL?) -> Void) -> Void)?
     var contextMenuDefaultBrowserOpener: ((URL) -> Bool)?
     /// Guard against background panes stealing first responder (e.g. page autofocus).
@@ -1270,6 +1271,25 @@ final class CmuxWebView: WKWebView {
             item.target = self
             menu.insertItem(item, at: min(openLinkInsertionIndex, menu.items.count))
         }
+
+        if onShowSurfaceManifest != nil {
+            menu.addItem(.separator())
+            let manifestItem = NSMenuItem(
+                title: String(
+                    localized: "surfaceManifest.menuItem",
+                    defaultValue: "Show surface manifest…"
+                ),
+                action: #selector(contextMenuShowSurfaceManifest(_:)),
+                keyEquivalent: ""
+            )
+            manifestItem.target = self
+            menu.addItem(manifestItem)
+        }
+    }
+
+    @objc private func contextMenuShowSurfaceManifest(_ sender: Any?) {
+        _ = sender
+        onShowSurfaceManifest?()
     }
 
     @objc private func contextMenuOpenLinkInDefaultBrowser(_ sender: Any?) {

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -30,6 +30,18 @@ struct MarkdownPanelView: View {
                 markdownContentView
             }
         }
+        .contextMenu {
+            Button(String(
+                localized: "surfaceManifest.menuItem",
+                defaultValue: "Show surface manifest…"
+            )) {
+                SurfaceManifestViewerWindowController.show(
+                    workspaceId: panel.workspaceId,
+                    surfaceId: panel.id,
+                    kind: .markdown
+                )
+            }
+        }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(backgroundColor)
         .overlay {

--- a/Sources/SurfaceManifestView.swift
+++ b/Sources/SurfaceManifestView.swift
@@ -1,0 +1,235 @@
+import AppKit
+import SwiftUI
+
+enum SurfaceManifestKind: String {
+    case terminal
+    case browser
+    case markdown
+
+    var localizedLabel: String {
+        switch self {
+        case .terminal:
+            return String(localized: "surfaceManifest.kind.terminal", defaultValue: "Terminal")
+        case .browser:
+            return String(localized: "surfaceManifest.kind.browser", defaultValue: "Browser")
+        case .markdown:
+            return String(localized: "surfaceManifest.kind.markdown", defaultValue: "Markdown")
+        }
+    }
+}
+
+struct SurfaceManifestSnapshot {
+    let metadata: [String: Any]
+    let sources: [String: [String: Any]]
+    let capturedAt: Date
+
+    static func capture(workspaceId: UUID, surfaceId: UUID) -> SurfaceManifestSnapshot {
+        let result = SurfaceMetadataStore.shared.getMetadata(workspaceId: workspaceId, surfaceId: surfaceId)
+        return SurfaceManifestSnapshot(metadata: result.metadata, sources: result.sources, capturedAt: Date())
+    }
+
+    var prettyJSON: String {
+        guard !metadata.isEmpty else { return "" }
+        let opts: JSONSerialization.WritingOptions = [.prettyPrinted, .sortedKeys]
+        guard JSONSerialization.isValidJSONObject(metadata),
+              let data = try? JSONSerialization.data(withJSONObject: metadata, options: opts),
+              let str = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return str
+    }
+}
+
+struct SurfaceManifestView: View {
+    let workspaceId: UUID
+    let surfaceId: UUID
+    let kind: SurfaceManifestKind
+
+    @State private var snapshot: SurfaceManifestSnapshot
+    @State private var copiedFlash: Bool = false
+    @State private var copyResetWorkItem: DispatchWorkItem?
+
+    init(workspaceId: UUID, surfaceId: UUID, kind: SurfaceManifestKind) {
+        self.workspaceId = workspaceId
+        self.surfaceId = surfaceId
+        self.kind = kind
+        _snapshot = State(initialValue: SurfaceManifestSnapshot.capture(workspaceId: workspaceId, surfaceId: surfaceId))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    bodyJSON
+                    sourcesDisclosure
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            Divider()
+            footer
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+        }
+        .frame(minWidth: 480, minHeight: 360)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            row(
+                label: String(localized: "surfaceManifest.header.workspace", defaultValue: "Workspace"),
+                value: workspaceId.uuidString
+            )
+            row(
+                label: String(localized: "surfaceManifest.header.surface", defaultValue: "Surface"),
+                value: surfaceId.uuidString
+            )
+            row(
+                label: String(localized: "surfaceManifest.header.kind", defaultValue: "Kind"),
+                value: kind.localizedLabel
+            )
+            row(
+                label: String(localized: "surfaceManifest.header.capturedAt", defaultValue: "Captured"),
+                value: Self.timestampFormatter.string(from: snapshot.capturedAt)
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func row(label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+                .frame(width: 80, alignment: .leading)
+            Text(value)
+                .font(.system(size: 11, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    @ViewBuilder
+    private var bodyJSON: some View {
+        if snapshot.metadata.isEmpty {
+            Text(String(localized: "surfaceManifest.empty", defaultValue: "No metadata set on this surface."))
+                .foregroundColor(.secondary)
+                .font(.system(size: 12))
+        } else {
+            Text(snapshot.prettyJSON)
+                .font(.system(size: 12, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    private var sourcesDisclosure: some View {
+        DisclosureGroup(String(localized: "surfaceManifest.sources.disclosure", defaultValue: "Show sources")) {
+            sourcesTable
+                .padding(.top, 6)
+        }
+        .font(.system(size: 12))
+    }
+
+    @ViewBuilder
+    private var sourcesTable: some View {
+        let rows = sourceRows
+        if rows.isEmpty {
+            Text(String(localized: "surfaceManifest.sources.empty", defaultValue: "No source records."))
+                .foregroundColor(.secondary)
+                .font(.system(size: 11))
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 12) {
+                    Text(String(localized: "surfaceManifest.sources.column.key", defaultValue: "Key"))
+                        .frame(width: 140, alignment: .leading)
+                    Text(String(localized: "surfaceManifest.sources.column.source", defaultValue: "Source"))
+                        .frame(width: 90, alignment: .leading)
+                    Text(String(localized: "surfaceManifest.sources.column.timestamp", defaultValue: "Set at"))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+                Divider()
+                ForEach(rows, id: \.key) { row in
+                    HStack(spacing: 12) {
+                        Text(row.key)
+                            .font(.system(size: 11, design: .monospaced))
+                            .frame(width: 140, alignment: .leading)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Text(row.source)
+                            .font(.system(size: 11, design: .monospaced))
+                            .frame(width: 90, alignment: .leading)
+                        Text(row.timestamp)
+                            .font(.system(size: 11, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                    }
+                }
+            }
+        }
+    }
+
+    private struct SourceRow {
+        let key: String
+        let source: String
+        let timestamp: String
+    }
+
+    private var sourceRows: [SourceRow] {
+        snapshot.sources.keys.sorted().map { key in
+            let entry = snapshot.sources[key] ?? [:]
+            let source = (entry["source"] as? String) ?? "—"
+            let ts: String
+            if let epoch = entry["ts"] as? Double {
+                ts = Self.timestampFormatter.string(from: Date(timeIntervalSince1970: epoch))
+            } else {
+                ts = "—"
+            }
+            return SourceRow(key: key, source: source, timestamp: ts)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Button(action: copyJSON) {
+                Text(copiedFlash
+                     ? String(localized: "surfaceManifest.copiedButton", defaultValue: "Copied")
+                     : String(localized: "surfaceManifest.copyButton", defaultValue: "Copy JSON"))
+            }
+            .disabled(snapshot.metadata.isEmpty)
+            Button(action: refresh) {
+                Text(String(localized: "surfaceManifest.refreshButton", defaultValue: "Refresh"))
+            }
+            Spacer()
+        }
+    }
+
+    private func copyJSON() {
+        let payload = snapshot.prettyJSON
+        guard !payload.isEmpty else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(payload, forType: .string)
+        copiedFlash = true
+        copyResetWorkItem?.cancel()
+        let work = DispatchWorkItem { copiedFlash = false }
+        copyResetWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
+    }
+
+    private func refresh() {
+        snapshot = SurfaceManifestSnapshot.capture(workspaceId: workspaceId, surfaceId: surfaceId)
+    }
+
+    private static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return f
+    }()
+}

--- a/Sources/SurfaceManifestViewerWindowController.swift
+++ b/Sources/SurfaceManifestViewerWindowController.swift
@@ -1,0 +1,53 @@
+import AppKit
+import SwiftUI
+
+final class SurfaceManifestViewerWindowController: NSWindowController, NSWindowDelegate {
+    private static var openControllers: [UUID: SurfaceManifestViewerWindowController] = [:]
+
+    private let surfaceId: UUID
+
+    private init(workspaceId: UUID, surfaceId: UUID, kind: SurfaceManifestKind) {
+        self.surfaceId = surfaceId
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 420),
+            styleMask: [.titled, .closable, .resizable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = String(localized: "surfaceManifest.windowTitle", defaultValue: "Surface manifest")
+        panel.titleVisibility = .visible
+        panel.isReleasedWhenClosed = false
+        panel.identifier = NSUserInterfaceItemIdentifier("c11.surfaceManifestViewer.\(surfaceId.uuidString)")
+        panel.center()
+        panel.contentView = NSHostingView(
+            rootView: SurfaceManifestView(workspaceId: workspaceId, surfaceId: surfaceId, kind: kind)
+        )
+        AppDelegate.shared?.applyWindowDecorations(to: panel)
+        super.init(window: panel)
+        panel.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @MainActor
+    class func show(workspaceId: UUID, surfaceId: UUID, kind: SurfaceManifestKind) {
+        if let existing = openControllers[surfaceId] {
+            existing.window?.makeKeyAndOrderFront(nil)
+            return
+        }
+        let controller = SurfaceManifestViewerWindowController(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            kind: kind
+        )
+        openControllers[surfaceId] = controller
+        controller.window?.makeKeyAndOrderFront(nil)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        Self.openControllers.removeValue(forKey: surfaceId)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a right-click context-menu entry **"Show surface manifest…"** on c11 surfaces that opens a read-only floating utility window pretty-printing the surface's manifest JSON. Works on all three surface kinds: terminal, browser, markdown.

Closes [Lattice C11-24](https://github.com/Stage-11-Agentics/c11/blob/main/.lattice/notes/c11-24).

## Why

The surface manifest is c11's first-class extension surface — agents read/write it via `c11 set-metadata` / `c11 get-metadata`. Today inspection is CLI-only: friction-heavy for the operator, hostile to live demos and debugging dialogues. A right-click entry collapses inspection to one gesture.

Three motivating modes from the ticket:
1. **Dialogue / demo** — explaining what each surface advertises while showing it.
2. **Debug** — confirming canonical keys (`role`, `status`, `task`, `model`, `progress`, `terminal_type`, `title`, `description`) and any third-party keys (Lattice, Mycelium) are what you expect.
3. **Test** — verifying agent writes landed on the right surface (especially after the `set-metadata` env-default footgun).

## What ships

### Right-click entry on each surface kind

- **Terminal** — `Sources/GhosttyTerminalView.swift` `menu(for event:)` appends the entry.
- **Browser** — `Sources/Panels/CmuxWebView.swift` `willOpenMenu` adds it to every WKWebView context menu (page, link, image), wired through a closure on `Sources/Panels/BrowserPanel.swift`.
- **Markdown** — `Sources/Panels/MarkdownPanelView.swift` `.contextMenu` covers rendered, empty-state, and unavailable-file cases.

### Read-only JSON viewer

- New `Sources/SurfaceManifestView.swift` (235 lines) — SwiftUI body.
- New `Sources/SurfaceManifestViewerWindowController.swift` (53 lines) — `NSWindowController` hosting a utility `NSPanel` (`[.titled, .closable, .resizable, .utilityWindow]`).
- Static `[UUID: Controller]` map keyed by surface UUID — re-opening on the same surface brings the existing window to front instead of stacking duplicates. `windowWillClose` cleans up.
- Reads via `SurfaceMetadataStore.shared.getMetadata(workspaceId:surfaceId:)` — direct in-process accessor, no socket round-trip, no focus stealing, no main-thread blocking.

The viewer:
- **Header** — Workspace, Surface, Kind, Captured (timestamp).
- **Body** — pretty-printed monospaced JSON (`JSONSerialization` with `.prettyPrinted, .sortedKeys`). Empty manifest renders the localized empty-state copy.
- **`Show sources` disclosure** (collapsed by default) — table of key / source / set-at timestamp from `metadata_sources`.
- **`Copy JSON`** — copies pretty JSON to `NSPasteboard.general`. Label flips to **`Copied`** for 1.5s with a cancellable `DispatchWorkItem` so rapid taps don't stack.
- **`Refresh`** — re-reads from the store on demand.

### Localization

18 new `surfaceManifest.*` keys in `Resources/Localizable.xcstrings`, all using `String(localized:defaultValue:)` at the call site. Translated to all six locales c11 ships in: `ja`, `uk`, `ko`, `zh-Hans`, `zh-Hant`, `ru` (108 total translations). Glossary aligned with prior c11 entries (`Workspace` / `Surface` / `Browser` / `Terminal` use existing forms; `manifest` follows `agentSkills.error.manifestMalformed`). U+2026 ellipsis preserved on the menu-item label across all locales.

## Commits

1. `ca318c762` — Add SurfaceManifestView + window controller (read-only manifest viewer chrome)
2. `8e9340d53` — Wire surface-manifest viewer into terminal, browser, markdown context menus
3. `bad2273cc` — Localize surface-manifest viewer strings (English entries)
4. `09f7d4c32` — Translate surface-manifest viewer strings (ja/uk/ko/zh-Hans/zh-Hant/ru)

Each commit built green individually via `xcodebuild -scheme c11-unit -configuration Debug build`.

## v1 scope (explicit)

**Ships:**
- Read-only one-shot snapshot of the surface manifest. Re-render on `Refresh` only.
- Provenance disclosure (the `--sources` view) — absorbed at zero extra commits because `SurfaceMetadataStore.getMetadata(...)` already returns sources in the same hop.
- Copy-to-clipboard with 1.5s feedback flip — also absorbed at zero extra commits.

**Does NOT ship (deferred):**
- Editing the manifest from the viewer.
- Live subscribe / push updates.
- Manifest viewer for non-c11 surface kinds (anything other than terminal / browser / markdown).
- Pane manifest viewer (`PaneMetadataStore`) — pane chrome doesn't have a distinct right-click target today; follow-up when it does.
- Save-to-file export.
- Keyboard shortcut binding.
- Localizing pre-existing terminal context-menu items (`Copy`, `Paste`, `Split…`) — separate localization sweep.

## Validation

**Operator-confirmed visual validation** on tagged debug build `c11-24-overnight` at 2026-05-07T02:31Z. Right-click entry surfaces correctly on terminal / browser / markdown surfaces and the read-only JSON viewer behaves as designed.

A Codex computer-use sub-sibling was launched in parallel for end-to-end automation, but operator manual confirmation arrived first; the Codex pass is mid-flight at handoff time and not on the critical path.

Build green: `xcodebuild -scheme c11-unit -configuration Debug build` after each of the four commits. No new tests added — the feature is a pure-UI gesture on a pre-existing store, and CLAUDE.md "Test quality policy" is explicit that AST/source-text tests are not the right shape for this seam.

## CLAUDE.md conformance (from review)

- **Localization** — every new user-facing string uses `String(localized:defaultValue:)`. 18 keys × 7 locales = 126 entries populated, `state: "translated"`.
- **Typing-latency hot paths** — zero touches to `WindowTerminalHostView.hitTest`, `TabItemView`, `TerminalSurface.forceRefresh`, or any keystroke path. The terminal menu entry lives inside `override func menu(for event:)` (event-driven only).
- **Socket threading policy** — no socket commands added; no `DispatchQueue.main.sync` introduced. Viewer reads use `SurfaceMetadataStore`'s own serial dispatch queue.
- **Socket focus policy** — `makeKeyAndOrderFront(nil)` keys the panel without app activation. No `NSApp.activate` / `orderFrontRegardless`.
- **Test quality policy** — no AST/text-pattern tests added.
- **Submodule discipline** — zero submodule pointer changes (verified across all four commits).

## Review

Trident-style review by `agent:overnight-c11-24-review`: **PASS** verdict. No blockers, no important findings, five minor polish notes documented (acceptable). No fixups absorbed.

## Deviations from plan (all flagged + accepted)

- 18 strings vs plan prose's 17 (the §5 table had 18 — went with the table; the prose miscounted the kind sub-group).
- `.contextMenu` attached to the outer `Group` in `body` (covers rendered + empty + unavailable) rather than to `markdownContentView` itself (which is a `ScrollView`, not a `Group`). Same intent.
- Panel style includes `.resizable` (plan didn't specify) — long manifests would otherwise force horizontal scrolling.
- Header values render full UUIDs (plan ambiguous on format).