### PR TITLE
feat: New Workspace dialog with layout blueprints + recents

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		CC401003A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */; };
 		CC401005A1B2C3D4E5F60719 /* AgentSkillsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */; };
 		CC401007A1B2C3D4E5F60719 /* TCCPrimerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */; };
+		CC401009A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401008A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift */; };
 		B900000BA1B2C3D4E5F60719 /* c11 in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* c11 */; };
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
 		C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1CDE00001A1B2C3D4E5F719 /* codex */; };
@@ -519,6 +520,7 @@
 		CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillInstaller.swift; sourceTree = "<group>"; };
 		CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSkillsView.swift; sourceTree = "<group>"; };
 		CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCCPrimerView.swift; sourceTree = "<group>"; };
+		CC401008A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateWorkspaceSheet.swift; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* c11 */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = c11; sourceTree = BUILT_PRODUCTS_DIR; };
 				B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
 					B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpToUnreadUITests.swift; sourceTree = "<group>"; };
@@ -831,6 +833,7 @@
 				CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */,
 				CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */,
 				CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */,
+				CC401008A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1260,6 +1263,7 @@
 				CC401002A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */,
 				CC401005A1B2C3D4E5F60719 /* AgentSkillsView.swift in Sources */,
 				CC401007A1B2C3D4E5F60719 /* TCCPrimerView.swift in Sources */,
+				CC401009A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/Blueprints/quad-terminal.json
+++ b/Resources/Blueprints/quad-terminal.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "name": "quad-terminal",
+  "description": "Four terminals in a 2x2 grid",
+  "plan": {
+    "version": 1,
+    "workspace": {},
+    "layout": {
+      "type": "split",
+      "split": {
+        "orientation": "horizontal",
+        "dividerPosition": 0.5,
+        "first": {
+          "type": "split",
+          "split": {
+            "orientation": "vertical",
+            "dividerPosition": 0.5,
+            "first": {
+              "type": "pane",
+              "pane": { "surfaceIds": ["s1"] }
+            },
+            "second": {
+              "type": "pane",
+              "pane": { "surfaceIds": ["s2"] }
+            }
+          }
+        },
+        "second": {
+          "type": "split",
+          "split": {
+            "orientation": "vertical",
+            "dividerPosition": 0.5,
+            "first": {
+              "type": "pane",
+              "pane": { "surfaceIds": ["s3"] }
+            },
+            "second": {
+              "type": "pane",
+              "pane": { "surfaceIds": ["s4"] }
+            }
+          }
+        }
+      }
+    },
+    "surfaces": [
+      { "id": "s1", "kind": "terminal" },
+      { "id": "s2", "kind": "terminal" },
+      { "id": "s3", "kind": "terminal" },
+      { "id": "s4", "kind": "terminal" }
+    ]
+  }
+}

--- a/Resources/Blueprints/six-terminal.json
+++ b/Resources/Blueprints/six-terminal.json
@@ -1,0 +1,76 @@
+{
+  "version": 1,
+  "name": "six-terminal",
+  "description": "Six terminals in a 3x2 grid",
+  "plan": {
+    "version": 1,
+    "workspace": {},
+    "layout": {
+      "type": "split",
+      "split": {
+        "orientation": "vertical",
+        "dividerPosition": 0.5,
+        "first": {
+          "type": "split",
+          "split": {
+            "orientation": "horizontal",
+            "dividerPosition": 0.3333333333333333,
+            "first": {
+              "type": "pane",
+              "pane": { "surfaceIds": ["s1"] }
+            },
+            "second": {
+              "type": "split",
+              "split": {
+                "orientation": "horizontal",
+                "dividerPosition": 0.5,
+                "first": {
+                  "type": "pane",
+                  "pane": { "surfaceIds": ["s2"] }
+                },
+                "second": {
+                  "type": "pane",
+                  "pane": { "surfaceIds": ["s3"] }
+                }
+              }
+            }
+          }
+        },
+        "second": {
+          "type": "split",
+          "split": {
+            "orientation": "horizontal",
+            "dividerPosition": 0.3333333333333333,
+            "first": {
+              "type": "pane",
+              "pane": { "surfaceIds": ["s4"] }
+            },
+            "second": {
+              "type": "split",
+              "split": {
+                "orientation": "horizontal",
+                "dividerPosition": 0.5,
+                "first": {
+                  "type": "pane",
+                  "pane": { "surfaceIds": ["s5"] }
+                },
+                "second": {
+                  "type": "pane",
+                  "pane": { "surfaceIds": ["s6"] }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "surfaces": [
+      { "id": "s1", "kind": "terminal" },
+      { "id": "s2", "kind": "terminal" },
+      { "id": "s3", "kind": "terminal" },
+      { "id": "s4", "kind": "terminal" },
+      { "id": "s5", "kind": "terminal" },
+      { "id": "s6", "kind": "terminal" }
+    ]
+  }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5888,6 +5888,85 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return workspace.id
     }
 
+    /// Materializes a workspace from a `WorkspaceApplyPlan` chosen via the
+    /// New Workspace dialog. Injects the dialog's working directory and
+    /// (optionally) the configured agent's launch command on the first
+    /// terminal surface that has none, then runs the plan through
+    /// `WorkspaceLayoutExecutor`.
+    @MainActor
+    @discardableResult
+    func applyWorkspacePlanInPreferredMainWindow(
+        plan: WorkspaceApplyPlan,
+        workingDirectory: String,
+        launchAgent: Bool,
+        debugSource: String = "createWorkspaceSheet"
+    ) -> UUID? {
+        guard let context = preferredMainWindowContextForWorkspaceCreation(debugSource: debugSource) else {
+            return nil
+        }
+        guard let window = resolvedWindow(for: context) else {
+            discardOrphanedMainWindowContext(context)
+            return nil
+        }
+        setActiveMainWindow(window)
+        bringToFront(window)
+
+        var injected = plan
+        injected.workspace.workingDirectory = workingDirectory
+        if launchAgent {
+            let command = AgentLauncherSettings.current().shellCommand
+            if let idx = injected.surfaces.firstIndex(where: { surface in
+                surface.kind == .terminal && (surface.command?.isEmpty ?? true)
+            }) {
+                injected.surfaces[idx].command = command
+            }
+        }
+
+        let dependencies = WorkspaceLayoutExecutorDependencies(
+            tabManager: context.tabManager,
+            workspaceRefMinter: { uuid in "workspace:\(uuid.uuidString)" },
+            surfaceRefMinter: { uuid in "surface:\(uuid.uuidString)" },
+            paneRefMinter: { uuid in "pane:\(uuid.uuidString)" }
+        )
+        let result = WorkspaceLayoutExecutor.apply(
+            injected,
+            options: ApplyOptions(select: true),
+            dependencies: dependencies
+        )
+        #if DEBUG
+        for failure in result.failures {
+            FocusLogStore.shared.append(
+                "createWorkspace.apply failure code=\(failure.code) step=\(failure.step) message=\(failure.message)"
+            )
+        }
+        #endif
+
+        guard !result.workspaceRef.isEmpty else { return nil }
+        CreateWorkspaceRecents.record(workingDirectory)
+        let prefix = "workspace:"
+        let uuidPart = result.workspaceRef.hasPrefix(prefix)
+            ? String(result.workspaceRef.dropFirst(prefix.count))
+            : result.workspaceRef
+        return UUID(uuidString: uuidPart)
+    }
+
+    /// Returns the working directory of the workspace currently selected in
+    /// the window that would host a new workspace. Used to pre-fill the
+    /// New Workspace dialog. Returns `nil` if no main window is available
+    /// or the focused workspace has no recorded cwd.
+    @MainActor
+    func focusedWorkspaceWorkingDirectory() -> String? {
+        guard let context = preferredMainWindowContextForWorkspaceCreation(debugSource: "createWorkspaceSheet.cwd") else {
+            return nil
+        }
+        guard let selectedId = context.tabManager.selectedTabId,
+              let workspace = context.tabManager.tabs.first(where: { $0.id == selectedId }) else {
+            return nil
+        }
+        let dir = workspace.currentDirectory
+        return dir.isEmpty ? nil : dir
+    }
+
     private func preferredMainWindowContextForWorkspaceCreation(
         event: NSEvent? = nil,
         debugSource: String = "unspecified"
@@ -6266,6 +6345,77 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 UserDefaults.standard.set(true, forKey: WelcomeSettings.shownKey)
             }
             WelcomeSettings.performQuadLayout(on: workspace, initialPanel: initialPanel)
+        }
+    }
+
+    // MARK: - New Workspace sheet
+
+    /// Strong reference for the New Workspace dialog window. Same AppKit
+    /// retention gotcha as `agentSkillsOnboardingWindow` — the willClose
+    /// observer below clears this on user-initiated close.
+    private var createWorkspaceSheetWindow: NSWindow?
+    private var createWorkspaceSheetCloseObserver: NSObjectProtocol?
+
+    /// Show the New Workspace dialog. Called from File → New Workspace, the
+    /// ⌘N shortcut, and the "+" buttons. If no main window exists yet, falls
+    /// back to spawning a new main window — the dialog has nothing to host
+    /// the new workspace into otherwise.
+    @MainActor
+    func presentCreateWorkspaceSheet() {
+        if mainWindowContexts.isEmpty {
+            openNewMainWindow(nil)
+            return
+        }
+        if let existing = createWorkspaceSheetWindow {
+            existing.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let initialDirectory = focusedWorkspaceWorkingDirectory()
+            ?? FileManager.default.homeDirectoryForCurrentUser.path
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 600, height: 480),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(
+            localized: "createWorkspace.windowTitle",
+            defaultValue: "New Workspace"
+        )
+        window.isReleasedWhenClosed = false
+        window.level = .modalPanel
+
+        let rootView = CreateWorkspaceSheet(
+            initialDirectory: initialDirectory,
+            onCancel: { [weak window] in window?.close() },
+            onCreate: { [weak self, weak window] outcome in
+                guard let self else { return }
+                _ = self.applyWorkspacePlanInPreferredMainWindow(
+                    plan: outcome.plan,
+                    workingDirectory: outcome.workingDirectory,
+                    launchAgent: outcome.launchAgent
+                )
+                window?.close()
+            }
+        )
+        window.contentView = NSHostingView(rootView: rootView)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        createWorkspaceSheetWindow = window
+        createWorkspaceSheetCloseObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            if let observer = self.createWorkspaceSheetCloseObserver {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            self.createWorkspaceSheetCloseObserver = nil
+            self.createWorkspaceSheetWindow = nil
         }
     }
 
@@ -9878,32 +10028,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
             dlog("shortcut.action name=newWorkspace \(debugShortcutRouteSnapshot(event: event))")
 #endif
-            // Cmd+N semantics:
-            // - If there are no main windows, create a new window.
-            // - Otherwise, create a new workspace in the active window.
-            if mainWindowContexts.isEmpty {
-                #if DEBUG
-                logWorkspaceCreationRouting(
-                    phase: "fallback_new_window",
-                    source: "shortcut.cmdN",
-                    reason: "no_main_windows",
-                    event: event,
-                    chosenContext: nil
-                )
-                #endif
-                openNewMainWindow(nil)
-            } else if addWorkspaceInPreferredMainWindow(event: event, debugSource: "shortcut.cmdN") == nil {
-                #if DEBUG
-                logWorkspaceCreationRouting(
-                    phase: "fallback_new_window",
-                    source: "shortcut.cmdN",
-                    reason: "workspace_creation_returned_nil",
-                    event: event,
-                    chosenContext: nil
-                )
-                #endif
-                openNewMainWindow(nil)
-            }
+            // Cmd+N: present the New Workspace dialog. The presenter falls
+            // back to `openNewMainWindow` when there are no main windows
+            // yet, so all callers (menu, shortcut, "+") share one entry
+            // point.
+            presentCreateWorkspaceSheet()
             return true
         }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2286,7 +2286,13 @@ struct ContentView: View {
                     anchorView: fullscreenControlsViewModel.notificationsAnchorView
                 )
             },
-            onNewTab: { tabManager.addTab() },
+            onNewTab: {
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.presentCreateWorkspaceSheet()
+                } else {
+                    tabManager.addTab()
+                }
+            },
             visibilityMode: .alwaysVisible
         )
     }
@@ -3254,7 +3260,11 @@ struct ContentView: View {
     }
 
     private func addTab() {
-        tabManager.addTab()
+        if let appDelegate = AppDelegate.shared {
+            appDelegate.presentCreateWorkspaceSheet()
+        } else {
+            tabManager.addTab()
+        }
         sidebarSelectionState.selection = .tabs
     }
 

--- a/Sources/CreateWorkspaceSheet.swift
+++ b/Sources/CreateWorkspaceSheet.swift
@@ -1,0 +1,519 @@
+import SwiftUI
+import AppKit
+import Foundation
+
+/// Lightweight ring of working directories the operator has previously used
+/// to spawn a workspace. Persisted in UserDefaults so the dialog can offer
+/// quick re-pick without complicating the schema.
+enum CreateWorkspaceRecents {
+    static let key = "createWorkspace.recentDirectories"
+    static let maxCount = 8
+
+    static func load(defaults: UserDefaults = .standard) -> [String] {
+        (defaults.array(forKey: key) as? [String]) ?? []
+    }
+
+    static func record(_ path: String, defaults: UserDefaults = .standard) {
+        let trimmed = path.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        var list = load(defaults: defaults)
+        list.removeAll { $0 == trimmed }
+        list.insert(trimmed, at: 0)
+        if list.count > maxCount { list = Array(list.prefix(maxCount)) }
+        defaults.set(list, forKey: key)
+    }
+}
+
+/// Modal shown when the operator triggers File → New Workspace (⌘N).
+/// Replaces the prior auto-quad behavior: the user picks a working directory,
+/// chooses a blueprint, and decides whether to auto-launch their configured
+/// agent in the initial terminal pane. The chosen plan is handed back to the
+/// AppDelegate, which runs it through `WorkspaceLayoutExecutor.apply`.
+@MainActor
+struct CreateWorkspaceSheet: View {
+    struct Outcome {
+        var workingDirectory: String
+        var plan: WorkspaceApplyPlan
+        var launchAgent: Bool
+    }
+
+    let initialDirectory: String
+    let onCancel: () -> Void
+    let onCreate: (Outcome) -> Void
+
+    @State private var directory: String
+    @State private var selectionId: String
+    @State private var launchAgent: Bool = true
+    @State private var entries: [BlueprintEntry] = []
+    @State private var recentDirectories: [String] = []
+    @State private var loadFailureMessage: String?
+    @State private var submitting: Bool = false
+
+    init(
+        initialDirectory: String,
+        onCancel: @escaping () -> Void,
+        onCreate: @escaping (Outcome) -> Void
+    ) {
+        self.initialDirectory = initialDirectory
+        _directory = State(initialValue: initialDirectory)
+        _selectionId = State(initialValue: BlueprintEntry.starterIds.first ?? "")
+        self.onCancel = onCancel
+        self.onCreate = onCreate
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            header
+            directorySection
+            blueprintsSection
+            footer
+        }
+        .padding(24)
+        .frame(width: 600)
+        .background(BrandColors.surfaceSwiftUI)
+        .environment(\.colorScheme, .dark)
+        .onAppear {
+            reloadEntries()
+            recentDirectories = CreateWorkspaceRecents.load()
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "createWorkspace.title", defaultValue: "New Workspace"))
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(BrandColors.whiteSwiftUI)
+            Text(String(
+                localized: "createWorkspace.subtitle",
+                defaultValue: "Pick a working directory and a blueprint to start from."
+            ))
+            .font(.system(size: 12))
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.66))
+        }
+    }
+
+    // MARK: - Directory
+
+    private var directorySection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "createWorkspace.workingDirectory", defaultValue: "Working directory"))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
+            HStack(spacing: 8) {
+                TextField("", text: $directory)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.system(size: 12, design: .monospaced))
+                if !recentDirectories.isEmpty {
+                    Menu {
+                        ForEach(recentDirectories, id: \.self) { path in
+                            Button(displayPath(path)) {
+                                directory = path
+                            }
+                        }
+                    } label: {
+                        Image(systemName: "clock")
+                    }
+                    .menuStyle(.borderlessButton)
+                    .menuIndicator(.hidden)
+                    .fixedSize()
+                    .help(String(
+                        localized: "createWorkspace.recentDirectories.help",
+                        defaultValue: "Recent directories"
+                    ))
+                }
+                Button(String(localized: "createWorkspace.browse", defaultValue: "Browse…")) {
+                    chooseDirectory()
+                }
+            }
+        }
+    }
+
+    private func displayPath(_ path: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if path == home { return "~" }
+        if path.hasPrefix(home + "/") {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+
+    private func chooseDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.title = String(
+            localized: "createWorkspace.browse.panelTitle",
+            defaultValue: "Choose Working Directory"
+        )
+        if !directory.isEmpty {
+            let expanded = (directory as NSString).expandingTildeInPath
+            panel.directoryURL = URL(fileURLWithPath: expanded)
+        }
+        if panel.runModal() == .OK, let url = panel.url {
+            directory = url.path
+        }
+    }
+
+    // MARK: - Blueprints
+
+    private var blueprintsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "createWorkspace.layoutSelection", defaultValue: "Layout selection"))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
+
+            VStack(spacing: 6) {
+                ForEach(starterEntries) { entry in
+                    blueprintRow(entry)
+                }
+            }
+
+            agentToggle
+                .padding(.top, 4)
+
+            if !savedEntries.isEmpty {
+                Text(String(
+                    localized: "createWorkspace.savedBlueprints",
+                    defaultValue: "Saved blueprints"
+                ))
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.42))
+                .padding(.top, 6)
+
+                VStack(spacing: 6) {
+                    ForEach(savedEntries) { entry in
+                        blueprintRow(entry)
+                    }
+                }
+            }
+
+            if let loadFailureMessage {
+                Text(loadFailureMessage)
+                    .font(.system(size: 10))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.5))
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    private func blueprintRow(_ entry: BlueprintEntry) -> some View {
+        let isSelected = entry.id == selectionId
+        return Button {
+            selectionId = entry.id
+        } label: {
+            HStack(spacing: 12) {
+                BlueprintShapeIcon(shape: entry.shape, isSelected: isSelected)
+                    .frame(width: 36, height: 26)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.label)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(BrandColors.whiteSwiftUI)
+                    if let description = entry.description {
+                        Text(description)
+                            .font(.system(size: 11))
+                            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.6))
+                            .lineLimit(2)
+                    }
+                }
+                Spacer()
+                if let badge = entry.sourceBadge {
+                    Text(badge)
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.42))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: 3)
+                                .stroke(BrandColors.ruleSwiftUI, lineWidth: 0.5)
+                        )
+                }
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(isSelected ? BrandColors.goldFaintSwiftUI : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(
+                        isSelected ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI,
+                        lineWidth: isSelected ? 1 : 0.5
+                    )
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var starterEntries: [BlueprintEntry] {
+        entries.filter { $0.kind == .starter }
+    }
+
+    private var savedEntries: [BlueprintEntry] {
+        entries.filter { $0.kind == .saved }
+    }
+
+    // MARK: - Agent toggle
+
+    private var agentToggle: some View {
+        Toggle(isOn: $launchAgent) {
+            Text(String(
+                localized: "createWorkspace.launchAgent",
+                defaultValue: "Launch coding agent in initial pane"
+            ))
+            .font(.system(size: 12))
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.86))
+        }
+        .toggleStyle(.checkbox)
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            Spacer()
+            Button(String(localized: "common.cancel", defaultValue: "Cancel")) {
+                onCancel()
+            }
+            .keyboardShortcut(.cancelAction)
+
+            Button(String(localized: "createWorkspace.create", defaultValue: "Create")) {
+                submit()
+            }
+            .keyboardShortcut(.defaultAction)
+            .disabled(!canSubmit)
+        }
+    }
+
+    private var canSubmit: Bool {
+        !submitting
+            && !directory.trimmingCharacters(in: .whitespaces).isEmpty
+            && entries.contains(where: { $0.id == selectionId })
+    }
+
+    private func submit() {
+        guard !submitting else { return }
+        guard let entry = entries.first(where: { $0.id == selectionId }) else { return }
+        submitting = true
+        let plan: WorkspaceApplyPlan
+        do {
+            plan = try entry.loadPlan()
+        } catch {
+            loadFailureMessage = String(
+                format: String(
+                    localized: "createWorkspace.loadFailed",
+                    defaultValue: "Could not load blueprint: %@"
+                ),
+                "\(error)"
+            )
+            submitting = false
+            return
+        }
+        let resolvedDir = (directory as NSString).expandingTildeInPath
+        onCreate(Outcome(
+            workingDirectory: resolvedDir,
+            plan: plan,
+            launchAgent: launchAgent
+        ))
+    }
+
+    // MARK: - Loading
+
+    private func reloadEntries() {
+        let store = WorkspaceBlueprintStore()
+        let cwdURL: URL? = {
+            let trimmed = directory.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return nil }
+            return URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)
+        }()
+        let allIndex = store.merged(cwd: cwdURL)
+        var collected: [BlueprintEntry] = []
+        let starterDefs = BlueprintEntry.starterDefinitions
+        for def in starterDefs {
+            if let match = allIndex.first(where: { $0.name == def.fileName }) {
+                collected.append(BlueprintEntry(
+                    id: def.starterId,
+                    kind: .starter,
+                    label: def.label,
+                    description: def.description,
+                    shape: def.shape,
+                    sourceBadge: nil,
+                    loader: .index(match)
+                ))
+            }
+        }
+        let starterFileNames = Set(starterDefs.map(\.fileName))
+        for index in allIndex where !starterFileNames.contains(index.name) {
+            collected.append(BlueprintEntry(
+                id: "saved:\(index.url)",
+                kind: .saved,
+                label: index.name,
+                description: index.description,
+                shape: .custom,
+                sourceBadge: badge(for: index.source),
+                loader: .index(index)
+            ))
+        }
+        entries = collected
+        if !entries.contains(where: { $0.id == selectionId }) {
+            selectionId = entries.first?.id ?? ""
+        }
+    }
+
+    private func badge(for source: WorkspaceBlueprintIndex.Source) -> String {
+        switch source {
+        case .repo:    return String(localized: "createWorkspace.badge.repo", defaultValue: "Repo")
+        case .user:    return String(localized: "createWorkspace.badge.user", defaultValue: "User")
+        case .builtIn: return String(localized: "createWorkspace.badge.builtIn", defaultValue: "Built-in")
+        }
+    }
+}
+
+// MARK: - Internal blueprint entry model
+
+private struct BlueprintEntry: Identifiable {
+    enum Kind { case starter, saved }
+    enum Loader {
+        case index(WorkspaceBlueprintIndex)
+    }
+
+    let id: String
+    let kind: Kind
+    let label: String
+    let description: String?
+    let shape: BlueprintShape
+    let sourceBadge: String?
+    let loader: Loader
+
+    func loadPlan() throws -> WorkspaceApplyPlan {
+        switch loader {
+        case .index(let index):
+            let url = URL(fileURLWithPath: index.url)
+            let file = try WorkspaceBlueprintStore().read(url: url)
+            return file.plan
+        }
+    }
+
+    struct Definition {
+        let starterId: String
+        let label: String
+        let description: String
+        let fileName: String
+        let shape: BlueprintShape
+    }
+
+    static let starterDefinitions: [Definition] = [
+        Definition(
+            starterId: "starter:one-column",
+            label: String(localized: "createWorkspace.starter.oneColumn.label", defaultValue: "One column"),
+            description: String(
+                localized: "createWorkspace.starter.oneColumn.description",
+                defaultValue: "Single terminal."
+            ),
+            fileName: "basic-terminal",
+            shape: .oneColumn
+        ),
+        Definition(
+            starterId: "starter:two-columns",
+            label: String(localized: "createWorkspace.starter.twoColumns.label", defaultValue: "Two columns"),
+            description: String(
+                localized: "createWorkspace.starter.twoColumns.description",
+                defaultValue: "Two terminals split side by side."
+            ),
+            fileName: "side-by-side",
+            shape: .twoColumns
+        ),
+        Definition(
+            starterId: "starter:quad",
+            label: String(localized: "createWorkspace.starter.quad.label", defaultValue: "2x2 grid"),
+            description: String(
+                localized: "createWorkspace.starter.quad.description",
+                defaultValue: "Four terminals in a 2x2 grid."
+            ),
+            fileName: "quad-terminal",
+            shape: .quad
+        ),
+        Definition(
+            starterId: "starter:six",
+            label: String(localized: "createWorkspace.starter.six.label", defaultValue: "3x2 grid"),
+            description: String(
+                localized: "createWorkspace.starter.six.description",
+                defaultValue: "Six terminals: three columns, two rows."
+            ),
+            fileName: "six-terminal",
+            shape: .sixGrid
+        ),
+    ]
+
+    static let starterIds: [String] = starterDefinitions.map(\.starterId)
+}
+
+// MARK: - Shape icon
+
+private enum BlueprintShape {
+    case oneColumn
+    case twoColumns
+    case quad
+    case sixGrid
+    case custom
+}
+
+private struct BlueprintShapeIcon: View {
+    let shape: BlueprintShape
+    let isSelected: Bool
+
+    var body: some View {
+        let stroke = isSelected ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.55)
+        GeometryReader { geo in
+            ZStack {
+                RoundedRectangle(cornerRadius: 2)
+                    .stroke(stroke, lineWidth: 1)
+                shapeOverlay(in: geo.size, color: stroke)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func shapeOverlay(in size: CGSize, color: Color) -> some View {
+        switch shape {
+        case .oneColumn:
+            EmptyView()
+        case .twoColumns:
+            Rectangle()
+                .fill(color)
+                .frame(width: 1, height: size.height)
+        case .quad:
+            ZStack {
+                Rectangle()
+                    .fill(color)
+                    .frame(width: 1, height: size.height)
+                Rectangle()
+                    .fill(color)
+                    .frame(width: size.width, height: 1)
+            }
+        case .sixGrid:
+            ZStack {
+                Rectangle()
+                    .fill(color)
+                    .frame(width: size.width, height: 1)
+                Rectangle()
+                    .fill(color)
+                    .frame(width: 1, height: size.height)
+                    .offset(x: -size.width / 6)
+                Rectangle()
+                    .fill(color)
+                    .frame(width: 1, height: size.height)
+                    .offset(x: size.width / 6)
+            }
+        case .custom:
+            Rectangle()
+                .fill(color.opacity(0.35))
+                .frame(width: size.width * 0.4, height: 1)
+        }
+    }
+}

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -562,7 +562,13 @@ struct HiddenTitlebarSidebarControlsView: View {
                     anchorView: viewModel.notificationsAnchorView
                 )
             },
-            onNewTab: { _ = AppDelegate.shared?.tabManager?.addTab() },
+            onNewTab: {
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.presentCreateWorkspaceSheet()
+                } else {
+                    _ = AppDelegate.shared?.tabManager?.addTab()
+                }
+            },
             visibilityMode: .onHover
         )
         .frame(width: hostWidth, height: hostHeight, alignment: .leading)
@@ -786,7 +792,13 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         self.notificationStore = notificationStore
         let toggleSidebar = { _ = AppDelegate.shared?.sidebarState?.toggle() }
         let toggleNotifications: () -> Void = { _ = AppDelegate.shared?.toggleNotificationsPopover(animated: true) }
-        let newTab = { _ = AppDelegate.shared?.tabManager?.addTab() }
+        let newTab = {
+            if let appDelegate = AppDelegate.shared {
+                appDelegate.presentCreateWorkspaceSheet()
+            } else {
+                _ = AppDelegate.shared?.tabManager?.addTab()
+            }
+        }
 
         hostingView = NonDraggableHostingView(
             rootView: TitlebarControlsView(

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -747,14 +747,7 @@ struct cmuxApp: App {
 
                 splitCommandButton(title: String(localized: "menu.file.newWorkspace", defaultValue: "New Workspace"), shortcut: newWorkspaceMenuShortcut) {
                     if let appDelegate = AppDelegate.shared {
-                        if appDelegate.addWorkspaceInPreferredMainWindow(debugSource: "menu.newWorkspace") == nil {
-#if DEBUG
-                            FocusLogStore.shared.append(
-                                "cmdn.route phase=fallback_new_window src=menu.newWorkspace reason=workspace_creation_returned_nil"
-                            )
-#endif
-                            appDelegate.openNewMainWindow(nil)
-                        }
+                        appDelegate.presentCreateWorkspaceSheet()
                     } else {
                         activeTabManager.addTab()
                     }

--- a/notes/CR-create-workspace-dialog-Claude-Standard-20260509-0653.md
+++ b/notes/CR-create-workspace-dialog-Claude-Standard-20260509-0653.md
@@ -1,0 +1,110 @@
+# Code Review
+
+- **Date:** 2026-05-09T06:53:37Z
+- **Model:** Claude Opus 4.7 (claude-opus-4-7)
+- **Branch:** main (uncommitted; will be moved to a feature branch for the PR)
+- **Latest Commit on main:** 40e9ee1dcc5197912b7e8da80b538922c7739ff9
+- **Linear Story:** n/a (no Lattice ticket; direct user request)
+
+---
+
+## Summary
+
+Adds a "New Workspace" dialog that replaces the prior auto-quad behavior on ⌘N, File → New Workspace, and the "+" button. The dialog lets the operator pick a working directory, choose a layout blueprint (One column / Two columns / 2x2 grid / 3x2 grid), opt in to launching the configured agent in the initial pane, and pick from saved blueprints discovered via `WorkspaceBlueprintStore`. Recently-used directories are persisted and offered via a clock-icon menu adjacent to Browse.
+
+### Files changed
+
+- New: `Sources/CreateWorkspaceSheet.swift` (514 lines) — the SwiftUI sheet, recents helper, blueprint icon shapes.
+- New: `Resources/Blueprints/quad-terminal.json` — 2x2 of four terminals.
+- New: `Resources/Blueprints/six-terminal.json` — 3x2 of six terminals.
+- Modified: `Sources/AppDelegate.swift` — `presentCreateWorkspaceSheet()`, `applyWorkspacePlanInPreferredMainWindow()`, `focusedWorkspaceWorkingDirectory()`, ⌘N keyboard route now opens the sheet, recents recorded on success.
+- Modified: `Sources/c11App.swift` — File → New Workspace menu opens the sheet.
+- Modified: `Sources/ContentView.swift` — tab-strip "+" opens the sheet.
+- Modified: `Sources/Update/UpdateTitlebarAccessory.swift` — titlebar accessory "+" opens the sheet.
+- Modified: `GhosttyTabs.xcodeproj/project.pbxproj` — registers `CreateWorkspaceSheet.swift`.
+
+## Logic flow
+
+```
+User trigger (⌘N | File→New | + button)
+        │
+        ▼
+AppDelegate.presentCreateWorkspaceSheet()
+        │   strong-ref retain pattern (matches AgentSkillsOnboardingSheet)
+        │   pre-fills cwd from focusedWorkspaceWorkingDirectory() ?? $HOME
+        ▼
+NSWindow + NSHostingView(CreateWorkspaceSheet)
+        │
+        │   user picks blueprint, edits cwd, toggles launchAgent, clicks Create
+        ▼
+CreateWorkspaceSheet.submit()
+        │   resolves selected entry → WorkspaceApplyPlan (read from disk)
+        ▼
+AppDelegate.applyWorkspacePlanInPreferredMainWindow()
+        │   1. resolves main window context (returns nil if none)
+        │   2. injects plan.workspace.workingDirectory = chosen cwd
+        │   3. if launchAgent: injects AgentLauncherSettings.current().shellCommand
+        │      onto the first terminal SurfaceSpec with no command set
+        │   4. WorkspaceLayoutExecutor.apply(plan, options, deps)
+        │      — executor calls tabManager.addWorkspace(autoWelcomeIfNeeded:false)
+        │        so the welcome quad / default-grid auto-spawn is bypassed
+        │   5. CreateWorkspaceRecents.record(workingDirectory) on success
+        ▼
+Workspace materialized; sheet window closes.
+```
+
+## Architecture
+
+The dialog is intentionally thin: it composes a `WorkspaceApplyPlan` (the existing CMUX-37 primitive) and hands it to `WorkspaceLayoutExecutor.apply` — the same entry point socket commands and the existing CLI use. No new app-level layout machinery, no parallel "create workspace from preset" path. The four starter shapes are file-backed JSON blueprints in `Resources/Blueprints/`, which means saving a workspace via `c11 workspace export-blueprint --name foo` and re-opening the dialog automatically surfaces it under "Saved blueprints".
+
+The auto-quad / default-grid behavior is bypassed cleanly because `WorkspaceLayoutExecutor.apply` always calls `tabManager.addWorkspace(autoWelcomeIfNeeded: false)`, so the dialog never collides with the welcome flow.
+
+`addWorkspaceInPreferredMainWindow` is preserved for non-dialog flows (`File → Open Folder…`, drag-and-drop a folder onto the dock, external URL handlers). That seems right: those have a directory in hand and don't need a layout choice.
+
+The synthetic ref minters in `applyWorkspacePlanInPreferredMainWindow` (`{ uuid in "workspace:\(uuid.uuidString)" }`) bypass `TerminalController.v2EnsureHandleRef` so the produced refs are not valid v2 socket refs. That's fine for the dialog flow because we don't expose the result to socket clients, but it does mean the ApplyResult.workspaceRef won't match what a subsequent socket query would mint. Not a regression — the socket layer mints lazily on first reference anyway — but worth a note.
+
+## Tactical
+
+### Blockers
+
+None.
+
+### Important
+
+1. **`File → New Workspace` (menu item) regresses the no-windows fallback** — `Sources/c11App.swift:748–755`. The old code called `addWorkspaceInPreferredMainWindow(debugSource:)`, and if it returned `nil` (no main window context), opened a new window. The new code unconditionally calls `presentCreateWorkspaceSheet()`, which renders a free-standing modal but, on Create, hits the same nil-context path inside `applyWorkspacePlanInPreferredMainWindow` and silently does nothing. The keyboard ⌘N handler at `Sources/AppDelegate.swift:10028–10050` still has the right gate (`mainWindowContexts.isEmpty → openNewMainWindow`); the menu path lost it. **Fix:** move the gate into `presentCreateWorkspaceSheet` itself so all three trigger paths (menu, ⌘N, "+") behave consistently.
+
+2. **Sidebar selection update fires before the dialog completes** — `Sources/ContentView.swift:3260–3268`. `private func addTab()` now calls `presentCreateWorkspaceSheet()` (async UX) followed immediately by `sidebarSelectionState.selection = .tabs`. The selection switches before the user has confirmed. If the user cancels the dialog, the sidebar has still moved. Minor, but worth fixing — either set the selection in the onCreate callback, or rely on the workspace-selection notification to drive it.
+
+3. **Dialog doesn't auto-update recents after a manual edit** — `Sources/CreateWorkspaceSheet.swift:reloadEntries()` reads recents on appear. Editing the textbox to a new path doesn't refresh the menu (that's fine), but if the user opens the dialog twice in one launch, the second open doesn't reflect the recent recorded by the first because the AppDelegate writes to UserDefaults *after* the dialog closes. This is actually correct — UserDefaults will be re-read on the second `onAppear` — verified by re-reading the code. ⬇️ false positive once I traced it.
+
+### Potential
+
+4. **No keyboard navigation between blueprint cards** — `Sources/CreateWorkspaceSheet.swift:blueprintRow(...)`. The cards are SwiftUI `Button`s in a `VStack`; users can tab to them but arrow-key navigation between siblings isn't wired. The existing `AgentSkillsOnboardingSheet` uses an `OnboardingKeyboardMonitor` for this. Acceptable for v1 but worth a follow-up if dialog gets heavier use.
+
+5. **Rapid double-click on Create** — `Sources/CreateWorkspaceSheet.swift:submit()`. `.keyboardShortcut(.defaultAction)` typically debounces, but a fast double-mouse-click on the visible button could fire `submit()` twice before `window?.close()` runs. Mitigation: track `@State private var submitting = false` and disable the button on first call. Low risk — `WorkspaceLayoutExecutor.apply` is fast (~50–200ms) — but a defensive flip is one line.
+
+6. **Recents max=8 not user-configurable** — `Sources/CreateWorkspaceSheet.swift:CreateWorkspaceRecents.maxCount`. Hardcoded; fine for v1. If users start asking for "remember more", expose via UserDefaults.
+
+7. **Dialog doesn't reload recents inside the same launch if a sibling flow records one** — only the dialog and `applyWorkspacePlanInPreferredMainWindow` interact with recents today, and the dialog only opens once at a time, so this is moot. Note in case future code paths begin recording.
+
+8. **The inline fallback `_ = AppDelegate.shared?.tabManager?.addTab()` re-checks `AppDelegate.shared`** — `Sources/Update/UpdateTitlebarAccessory.swift:566–570, 795–799`. Inside the `else` branch `AppDelegate.shared` was just established to be `nil`, so the optional chain trivially short-circuits. Cosmetic; the explicit form `appDelegate.tabManager?.addTab()` is dead code in this branch. Leaving as-is is harmless.
+
+9. **`CreateWorkspaceRecents` lives at file scope inside `CreateWorkspaceSheet.swift`** — visible internal-wide. Fine for the AppDelegate caller, but if more code wants to hook into the recents (e.g. command palette suggesting recent dirs), it'll grow. Refactor to its own file when the second consumer arrives.
+
+10. **No tests** — c11 testing policy forbids running `xcodebuild test` locally and the project's testing posture for socket/UI tests is CI-only. The dialog is exercised end-to-end by the user clicking through the tagged build (`c11 DEV ws-create-dialog`), which is the canonical validation path here. The compile-time guarantees from `WorkspaceApplyPlan` codability + `WorkspaceLayoutExecutor.validate` cover most of what unit tests would assert.
+
+## Validation pass
+
+Re-read each finding against the actual code:
+
+1. ✅ **Fixed.** Baked the `mainWindowContexts.isEmpty → openNewMainWindow` fallback into `presentCreateWorkspaceSheet` itself (`AppDelegate.swift`). All three trigger paths (menu, ⌘N keyboard handler, "+" buttons) now share one entry point. Simplified the duplicate gate inside the ⌘N keyboard handler.
+2. ⬇️ Downgraded to cosmetic. The eager `sidebarSelectionState.selection = .tabs` matches the prior behavior; on cancel the user lands on `.tabs` instead of their previous sidebar state, but the value of staying consistent with prior behavior outweighs the small UX wobble. Defer.
+3. ❌ ~~False positive.~~ `onAppear` re-reads UserDefaults on each open.
+4. ⬇️ Valid, deferred. Not a blocker.
+5. ✅ **Fixed.** Added `@State private var submitting: Bool = false` and gated `submit()` + `canSubmit`. Reset on the load-failure path so the dialog isn't stranded.
+6–9. ⬇️ Valid, deferred.
+10. ⬇️ Valid, accepted per project policy.
+
+## Outcome
+
+Two fixes applied, build green. Moving to commit + PR.


### PR DESCRIPTION
## Summary

- ⌘N, File → New Workspace, and the "+" buttons now open a dialog instead of materializing the legacy auto-quad immediately.
- The dialog lets the operator pick a working directory, a layout (One column / Two columns / 2x2 / 3x2 / saved blueprints), and whether to launch the configured coding agent in the initial pane.
- Routes through the existing `WorkspaceApplyPlan` + `WorkspaceLayoutExecutor.apply` primitive — same path as socket `workspace.apply` and CLI `export-blueprint` — so saved user/repo blueprints surface automatically and the welcome auto-quad is bypassed.
- Recently-used directories are persisted to UserDefaults and offered via a clock-icon menu beside Browse. The pre-filled cwd defaults to the focused workspace's `currentDirectory`.
- `File → Open Folder…` keeps its immediate-create behavior as the power-user quick path.

## Files

| Path | Change |
|------|--------|
| `Sources/CreateWorkspaceSheet.swift` | New |
| `Resources/Blueprints/quad-terminal.json` | New (2x2 of four terminals) |
| `Resources/Blueprints/six-terminal.json` | New (3x2 of six terminals) |
| `Sources/AppDelegate.swift` | `presentCreateWorkspaceSheet`, `applyWorkspacePlanInPreferredMainWindow`, `focusedWorkspaceWorkingDirectory`; ⌘N keyboard handler simplified |
| `Sources/c11App.swift` | File → New Workspace menu re-routed |
| `Sources/ContentView.swift` | Tab-strip "+" re-routed |
| `Sources/Update/UpdateTitlebarAccessory.swift` | Titlebar accessory "+" re-routed |
| `GhosttyTabs.xcodeproj/project.pbxproj` | Registers `CreateWorkspaceSheet.swift` |
| `notes/CR-…-20260509-0653.md` | Self-review with the two review-pass fixes |

## Architecture notes

- The dialog is intentionally thin: it composes a `WorkspaceApplyPlan` and hands it to `WorkspaceLayoutExecutor.apply`. No new app-level layout machinery, no parallel "create workspace from preset" path.
- The auto-quad / default-grid welcome flow is bypassed because `WorkspaceLayoutExecutor.apply` always calls `tabManager.addWorkspace(autoWelcomeIfNeeded: false)`.
- `addWorkspaceInPreferredMainWindow` is preserved for non-dialog flows (`File → Open Folder…`, drag-and-drop a folder, external URL handlers) — those have a directory in hand and skip the layout-choice step.
- `presentCreateWorkspaceSheet` falls back to `openNewMainWindow` when no main window exists, so all three trigger paths share one entry point.

## Test plan

- [ ] ⌘N opens the dialog (not the auto-quad).
- [ ] File → New Workspace opens the same dialog.
- [ ] "+" button in the tab strip opens the dialog.
- [ ] "+" button in the titlebar accessory opens the dialog.
- [ ] Working directory pre-fills with the focused workspace's cwd; Browse… picks a directory; clock-icon menu offers recents after at least one create.
- [ ] One column + checkbox ON → single terminal running `claude --dangerously-skip-permissions` (or whatever `AgentLauncherSettings.current()` resolves to).
- [ ] Two columns / 2x2 / 3x2 produce the corresponding terminal grids; checkbox injects only into the first terminal.
- [ ] Custom blueprints saved via `c11 workspace export-blueprint --name foo` appear under "Saved blueprints".
- [ ] Saved blueprints with their own `command` on a terminal surface aren't overridden by the agent toggle (only first terminal *with no command* gets it).
- [ ] File → Open Folder… still creates immediately with no dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)