### PR TITLE
Fire agent-skills onboarding on activation, not just from Help → Welcome

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2766,6 +2766,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             PostHogAnalytics.shared.trackActive(reason: "didBecomeActive")
         }
 
+        // Offer the agent-skills install sheet on activation when a supported
+        // agent (`~/.claude`, `~/.codex`, …) is detected and the bundled
+        // skill set isn't installed yet. The previous trigger lived only
+        // inside `openWelcomeWorkspace()` (Help → Welcome), so a fresh
+        // install whose first launch ran the auto-welcome path never saw
+        // the prompt. `shouldPresent()` self-suppresses across launches via
+        // `cmuxAgentSkillsOnboardingShown` and within a launch via the
+        // window's willClose observer, so calling on every activation is
+        // safe and lets us catch users who install a supported agent after
+        // c11 is already running. Skip under XCTest so a tester's `~/.claude`
+        // doesn't pop a modal mid-test.
+        if !isRunningUnderXCTestCached {
+            presentAgentSkillsOnboardingIfNeeded()
+        }
+
         guard let notificationStore else { return }
         notificationStore.handleApplicationDidBecomeActive()
         guard let tabManager else { return }


### PR DESCRIPTION
## Summary
- The skill-install prompt (`AgentSkillsOnboardingSheet`) was reachable only from the help/popover menu's "Welcome" item, which routes through `AppDelegate.openWelcomeWorkspace()`. Fresh installs go through the auto-welcome path in `TabManager.addWorkspace` instead, which never calls the prompt — so users with `~/.claude` (or any other detected agent) and no installed skill set were never asked.
- `AgentSkillsOnboarding.shouldPresent()` and `AppDelegate.presentAgentSkillsOnboardingIfNeeded()` already existed for this case. The `IfNeeded` helper had zero callers; this PR wires it into `applicationDidBecomeActive`.

## Why didBecomeActive
- Fires on first launch (after `applicationDidFinishLaunching`), so fresh installs see the prompt.
- Also fires on later activations, so users who install a supported agent (e.g. `~/.claude`) *after* c11 is already running get the prompt the next time the app becomes active.
- Repeated calls are cheap and idempotent: `shouldPresent()` returns false once `cmuxAgentSkillsOnboardingShown` is set (Don't ask again / Install) or `_dismissedThisLaunch` is set (Later, or close button via the willClose observer in `presentAgentSkillsOnboarding`). If the window is already up, `presentAgentSkillsOnboarding` early-returns and orderFronts.
- Skipped under XCTest (`isRunningUnderXCTestCached`) so a tester's `~/.claude` doesn't pop a modal mid-test, matching the telemetry guard three lines up.

## Considered alternative
Wiring the call into `TabManager.addWorkspace`'s auto-welcome branch would only cover first-launch users (gated by `WelcomeSettings.shownKey`); existing users who already saw welcome but never got the skill prompt would stay stuck. The activation-hook path covers both, with no coupling between TabManager and onboarding logic.

## Out of scope / follow-up
`AppDelegate.presentTCCPrimerIfNeeded()` is similarly orphaned — only callers are inside `openWelcomeWorkspace()` and a Settings button. Worth its own PR; that one also has to settle the primer-then-skills ordering that `openWelcomeWorkspace` already handles but the auto path does not.

## Test plan
- [ ] Fresh install on a machine with `~/.claude` present and no `~/.claude/skills/c11`: launch c11, expect the onboarding sheet on first activation.
- [ ] Click "Later": sheet closes; relaunch c11, sheet appears again on next activation.
- [ ] Click "Don't ask again": `defaults read <bundle> cmuxAgentSkillsOnboardingShown` reports 1; subsequent launches do not present.
- [ ] Click "Teach it" / install: skill files land under `~/.claude/skills/`; subsequent activations do not re-present.
- [ ] No `~/.claude` (or any supported agent dir): sheet never appears.
- [ ] Install `~/.claude` while c11 is already running, then bring c11 to foreground: sheet appears on activation.
- [ ] Existing `openWelcomeWorkspace()` flow (Help → Welcome) still presents the sheet correctly and is not double-triggered.
- [ ] UI test suite passes — modal is suppressed under XCTest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)