### PR TITLE
claude wrapper: pass through Agent View subcommands

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -111,6 +111,13 @@ fi
 # Find real claude.
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
+# Unset CLAUDECODE to avoid "nested session" detection — c11 terminals are
+# independent sessions even when the parent shell was launched from Claude Code.
+# Applied before the passthrough case below so Agent View subcommands like
+# `claude agents` and `claude attach <id>` (which open interactive Claude UIs)
+# do not inherit a stale nested-session marker from the c11 parent.
+unset CLAUDECODE
+
 # Pass through subcommands that don't support session/hook flags.
 #
 # Agent View (Claude Code 2.1.139+, shipped 2026-05-11) added a family of
@@ -127,10 +134,6 @@ case "${1:-}" in
         exec "$REAL_CLAUDE" "$@"
         ;;
 esac
-
-# Unset CLAUDECODE to avoid "nested session" detection — c11 terminals are
-# independent sessions even when the parent shell was launched from Claude Code.
-unset CLAUDECODE
 
 # Check if the user already specified a session/resume flag.
 # If so, don't inject our own --session-id (it would conflict).

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -112,8 +112,20 @@ fi
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
 # Pass through subcommands that don't support session/hook flags.
+#
+# Agent View (Claude Code 2.1.139+, shipped 2026-05-11) added a family of
+# subcommands that act on the per-user supervisor's pool of background
+# sessions, not on a fresh interactive session: `agents` opens the TUI;
+# `attach`/`logs`/`stop`/`kill`/`respawn`/`rm` operate by short session id.
+# Injecting `--session-id <uuid>` and `--settings <hooks>` into any of them
+# either replaces the real argv target with the wrapper's synthetic uuid or
+# wedges the TUI into launching a new session instead of listing existing
+# ones. They all bypass the session-resume rail.
+# Docs: https://code.claude.com/docs/en/agent-view
 case "${1:-}" in
-    mcp|config|api-key|rc|remote-control) exec "$REAL_CLAUDE" "$@" ;;
+    mcp|config|api-key|rc|remote-control|agents|attach|logs|stop|kill|respawn|rm)
+        exec "$REAL_CLAUDE" "$@"
+        ;;
 esac
 
 # Unset CLAUDECODE to avoid "nested session" detection — c11 terminals are


### PR DESCRIPTION
## Summary

The c11 `claude` wrapper at `Resources/bin/claude` injects `--session-id <uuid>` and `--settings <hooks>` into every invocation that isn't on its passthrough whitelist. Claude Code 2.1.139 (shipped 2026-05-11) introduced **Agent View** — a TUI opened with `claude agents` for managing background sessions, plus six shell subcommands that act on existing background sessions by short id. None of them are on the whitelist, so inside c11 they all get clobbered.

## What breaks

```bash
# Outside c11 (plain Terminal): opens the Agent View dashboard.
claude agents

# Inside c11 (CMUX_SURFACE_ID set, socket live): the wrapper rewrites argv to
claude --session-id <new-uuid> --settings /tmp/c11-claude-hooks-NNNN.json agents
# …which wedges the TUI into spawning a fresh interactive session instead of
# listing the supervisor's existing background sessions.
```

The same breakage applies to every Agent View shell subcommand:
- `claude attach <id>` — attach to a background session
- `claude logs <id>` — print recent output
- `claude stop <id>` / `claude kill <id>` — stop a session
- `claude respawn <id>` / `claude respawn --all` — restart a stopped session
- `claude rm <id>` — remove a session

All of these operate on the per-user supervisor's pool, not on a fresh interactive session — they have no use for the wrapper's session-id/hooks injection.

## Fix

One-line change to the passthrough case in `Resources/bin/claude`:

```diff
 case "${1:-}" in
-    mcp|config|api-key|rc|remote-control) exec "$REAL_CLAUDE" "$@" ;;
+    mcp|config|api-key|rc|remote-control|agents|attach|logs|stop|kill|respawn|rm)
+        exec "$REAL_CLAUDE" "$@"
+        ;;
 esac
```

Plus a comment block explaining why these subcommands bypass the session-resume rail. Confirmed clean with `bash -n`.

## Follow-up not in this PR

`claude --bg "<prompt>"` dispatches a session straight to the background. It's a flag, not a subcommand, so the case statement doesn't catch it — the wrapper still injects `--session-id` and `--settings`. The background session detaches from the c11 surface under the per-user supervisor, so c11's surface-scoped lifecycle hooks then fire against a process that is no longer attached to that surface. Worth handling, but it's a different code path (extend the `SKIP_SESSION_ID` argv-scan loop) and deserves its own PR with thought on whether c11 wants to track bg-dispatched sessions at all.

## Upstream

Same bug exists in `manaflow-ai/cmux` and is tracked at [manaflow-ai/cmux#4005](https://github.com/manaflow-ai/cmux/issues/4005) (opened by an external contributor today). The upstream issue's suggested fix also adds a `clear_inherited_claude_auth_selection_env` call, which is a cmux-only refactor not present in c11; this PR is the c11-shaped version of the same fix.

Docs: https://code.claude.com/docs/en/agent-view

## Test plan

- [ ] Tagged build: `./scripts/reload.sh --tag agents-fix`
- [ ] In a c11 surface on the tagged build, run `claude agents` — confirm the Agent View dashboard opens (not a fresh interactive session)
- [ ] In a c11 surface, dispatch a bg session in a different terminal, then `claude attach <id>` from c11 — confirm it attaches to the supervisor session, not a new one
- [ ] In a c11 surface, `claude logs <id>` prints session output
- [ ] Regression: `claude` (no args) and `claude --resume <id>` still get the session-resume rail (sidebar shows `claude_code` status, hooks fire)
- [ ] Regression: `claude mcp` still passes through cleanly (no session injection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)