### PR TITLE
C11-40: Fix new-workspace agent launch + close-pane veto on busy panes

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5971,7 +5971,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if let idx = injected.surfaces.firstIndex(where: { surface in
                 surface.kind == .terminal && (surface.command?.isEmpty ?? true)
             }) {
-                injected.surfaces[idx].command = command
+                // Trailing newline submits the command. The "A" tab-bar button
+                // appends "\n" at its call site (Workspace.launchAgentSurface);
+                // SurfaceSpec.command is delivered verbatim by the layout
+                // executor, so the newline has to live in the value itself.
+                injected.surfaces[idx].command = command + "\n"
             }
         }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11478,6 +11478,14 @@ extension Workspace: BonsplitDelegate {
                 _ = self.newTerminalSurface(inPane: pane)
             } else {
                 guard self.bonsplitController.allPaneIds.contains(pane) else { return }
+                // Pre-load forceCloseTabIds so Bonsplit's shouldClosePane veto
+                // (which fires when any terminal in the pane is busy / not at
+                // an idle prompt) doesn't silently swallow the close after the
+                // user already confirmed the pane-level action. Mirrors the
+                // isOnlyPane branch above.
+                for tab in self.bonsplitController.tabs(inPane: pane) {
+                    self.forceCloseTabIds.insert(tab.id)
+                }
                 _ = self.bonsplitController.closePane(pane)
             }
         }


### PR DESCRIPTION
## Summary

Two reliability bugs in c11 DEV staging-2026-05-14 (Lattice C11-40):

- **Bug A — New Workspace dialog typed the agent command but never sent Enter.** `AppDelegate.applyWorkspacePlanInPreferredMainWindow` injected `AgentLauncherSettings.shellCommand` into `SurfaceSpec.command` without a trailing newline; `WorkspaceLayoutExecutor`'s Phase 0 parity rule then delivered it verbatim via `sendText`, leaving the literal command sitting at the prompt. The tab-bar **A** button works only because `Workspace.launchAgentSurface` appends `"\n"` at its own call site — this PR mirrors that at the layout-plan injection site.
- **Bug B Mode A — Top-right / bottom-right pane X → confirm → nothing happens when the pane's terminal was busy.** `splitTabBar(_:didRequestClosePane:)`'s multi-pane branch called `bonsplitController.closePane(pane)` without pre-loading `forceCloseTabIds`. Bonsplit's `closePane` then consulted `shouldClosePane`, which vetoed whenever any terminal in the pane reported `panelNeedsConfirmClose == true` (active PTY). Idle panes closed normally; busy right-side panes (where agents run) silently absorbed the confirm. This PR mirrors the existing `isOnlyPane` branch's `forceCloseTabIds.insert` loop.

Bug B Mode B (X click produces no dialog at all) is **not** addressed here — landing this first to see whether it survives Mode A's fix or requires a separate investigation into `PaneCloseOverlayController` anchor lifecycle. Notes captured on C11-40.

## Files

- `Sources/AppDelegate.swift:5969-5980` — append `"\n"` to injected command.
- `Sources/Workspace.swift:11479-11488` — preload `forceCloseTabIds` for every tab before `closePane`.

13 insertions, 1 deletion. No tests; per the test-quality policy in `CLAUDE.md`, these would need runtime-behavior coverage rather than source-text assertions, and there's no existing harness for the workspace-create or close-pane interaction flows.

## Test plan

- [ ] Build a tagged debug app (`./scripts/reload.sh --tag c11-40`) and verify File → New Workspace with "Launch coding agent" checked actually starts the agent for all four kinds (Claude Code, Codex, OpenCode, Kimi).
- [ ] In a 2x2 quad with `claude --dangerously-skip-permissions` running in the top-right and bottom-right panes, click X on each → confirm dialog → "Close Entire Pane" — the pane should close.
- [ ] After Mode A is verified working, attempt to reproduce Mode B (X click with no dialog). If still reproducible, open a follow-up ticket scoped to the overlay anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)