### PR TITLE
C11-40 follow-up: pane-close dialog mounts at wrong pane after sibling reflow

### DIFF
--- a/Sources/Panels/PaneCloseOverlayController.swift
+++ b/Sources/Panels/PaneCloseOverlayController.swift
@@ -16,6 +16,13 @@ final class PaneCloseOverlayController {
     private var hosts: [UUID: PaneInteractionOverlayHost] = [:]
     private var activeIds: Set<UUID> = []
     private var subscription: AnyCancellable?
+    // Weak registry of every live AnchorView so the controller can ask
+    // them to re-query their window-coord frames after a sibling-close
+    // reflow has settled. Required because reportFrame is called by
+    // SwiftUI (updateNSView) and AppKit (viewDidMoveToWindow) DURING
+    // the reflow, when convert(bounds, to: nil) can return transient
+    // half-applied coordinates that the system never corrects.
+    private let liveAnchorViews = NSHashTable<PaneInteractionOverlayHostView.AnchorView>.weakObjects()
 
     private struct AnchorRecord {
         var frameInWindow: NSRect
@@ -52,6 +59,33 @@ final class PaneCloseOverlayController {
         hosts.removeAll()
         anchors.removeAll()
         activeIds.removeAll()
+    }
+
+    /// Called by AnchorView the first time it gains a window. The hash table is
+    /// weak, so dead entries auto-prune when SwiftUI deallocates the view —
+    /// no explicit unregister needed.
+    func registerAnchorView(_ view: PaneInteractionOverlayHostView.AnchorView) {
+        liveAnchorViews.add(view)
+    }
+
+    /// After Bonsplit fires its authoritative didClosePane, ask every live
+    /// AnchorView to re-publish its window-coord frame. We schedule the walk
+    /// on `main.async` (next runloop tick) and again at +60ms because the
+    /// SwiftUI/Bonsplit reflow can take more than one layout pass to settle —
+    /// the in-flight reportFrame calls fire mid-reflow with transient values
+    /// (we've logged `convert(bounds, to: nil)` returning a 923-wide frame
+    /// for a 461-wide pane) and no post-settle event corrects them. Without
+    /// this re-query the controller's anchors map stays stale and the
+    /// confirmation overlay mounts at the wrong pane position.
+    func refreshAllAnchorsAfterReflow() {
+        let refresh: @MainActor () -> Void = { [weak self] in
+            guard let self else { return }
+            for view in self.liveAnchorViews.allObjects {
+                view.reportFrame()
+            }
+        }
+        DispatchQueue.main.async(execute: refresh)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: refresh)
     }
 
     private func synchronize() {

--- a/Sources/Panels/PaneInteractionOverlayHostView.swift
+++ b/Sources/Panels/PaneInteractionOverlayHostView.swift
@@ -72,6 +72,12 @@ struct PaneInteractionOverlayHostView: View {
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            if window != nil {
+                // Register so the controller can ask us to re-poll our
+                // window-coord frame after a sibling-pane close reflow.
+                // The hash table is weak — no explicit unregister needed.
+                controller?.registerAnchorView(self)
+            }
             reportFrame()
         }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11116,6 +11116,14 @@ extension Workspace: BonsplitDelegate {
         // removing on every dismantle orphans surviving panes). This is the
         // one place where we know the pane is actually gone.
         paneCloseOverlayController.removeAnchor(paneIdentity: paneId.id)
+        // After Bonsplit removes a pane, surviving siblings get reflowed into
+        // their new positions but the existing reportFrame paths (SwiftUI
+        // updateNSView, AppKit viewDidMoveToWindow) all fire DURING the
+        // reflow and capture transient/half-applied coordinates. Without
+        // this nudge the controller's anchors map stays stale and the
+        // confirmation overlay mounts at the wrong pane position. Triggers
+        // twice (next tick + ~60ms) to cover multi-pass layouts.
+        paneCloseOverlayController.refreshAllAnchorsAfterReflow()
 
         let closedPanelIds = pendingPaneClosePanelIds.removeValue(forKey: paneId.id) ?? []
         let shouldScheduleFocusReconcile = !isDetachingCloseTransaction


### PR DESCRIPTION
## Summary

Third bug in the C11-40 close-pane reliability chain, discovered during v0.47.0 staging validation. Mode A (busy-PTY veto) shipped in #154; Mode B (X click does nothing) shipped in #155. This is **Mode C**: X click does open the dialog, but it mounts on the **wrong pane**.

Repro (the original report): right column split into 3 panes, close the bottom one to force a reflow, click X on the middle pane. The black scrim + confirmation card appears on the bottom-right pane instead of the middle.

## Root cause

#155 fixed orphaning by keeping anchors alive through SwiftUI's transient dismantle cycles. But it left a second failure mode in place: when a sibling closes and the survivors reflow, the existing `reportFrame` paths fire DURING the reflow — SwiftUI's `updateNSView` and AppKit's `viewDidMoveToWindow` both call into `reportFrame` at moments when `convert(bounds, to: nil)` returns transient half-applied coordinates. No post-settle event corrects them, so the stale values stick in `PaneCloseOverlayController.anchors`.

Smoking gun from an instrumented staging build:

```
18:23:41.956 anchor.reportFrame pane=0A306 source=viewDidMoveToWindow frame=(1124,545 923x271)
18:23:41.956 paneClose.updateAnchor pane=0A306 prior=(1587,545 461x271) new=(1124,545 923x271)
18:23:42.002 anchor.reportFrame pane=0A306 source=updateNSView frame=(1124,0 461x271)
18:23:42.002 paneClose.updateAnchor pane=0A306 prior=(1124,545 923x271) new=(1124,0 461x271)
```

A 461-wide pane is reporting a 923-wide frame mid-reflow, then settles on `(1124,0)` — the bottom-right — even though visually it's the middle pane. Another survivor in the same trace ended at `(1124,-545 461x544)`, entirely below the window.

## Fix

`PaneCloseOverlayController` now keeps a weak hash table of every live `AnchorView`. After Bonsplit fires its authoritative `didClosePane`, `Workspace.splitTabBar(_:didClosePane:)` calls a new `refreshAllAnchorsAfterReflow()` which schedules a re-poll of every live AnchorView's window-coord frame via `DispatchQueue.main.async` — plus a second pass at +60ms to cover multi-layout-pass reflows. The deferred `convert(bounds, to: nil)` hits the settled geometry instead of the in-flight transient.

`AnchorView` registers itself in `viewDidMoveToWindow` (only when `window != nil`); the hash table is `weakObjects()` so deallocated views auto-prune — no explicit unregister needed.

## Files

- `Sources/Panels/PaneCloseOverlayController.swift` — `liveAnchorViews` registry, `registerAnchorView`, `refreshAllAnchorsAfterReflow`.
- `Sources/Panels/PaneInteractionOverlayHostView.swift` — `AnchorView.viewDidMoveToWindow` registers self.
- `Sources/Workspace.swift` — `splitTabBar(_:didClosePane:)` calls `refreshAllAnchorsAfterReflow()` after the existing `removeAnchor`.

48 net lines added, no removals.

## Test plan

- [x] Validated against the original repro with diagnostic logs (kept on a separate branch). With the fix, every X click mounts the dialog on the actual clicked pane through repeated open/close/reflow cycles. Without the fix, ~1 in 3 clicks mounted on a stale anchor.
- [ ] CI green.
- [ ] No new tests — regression is layout-timing-dependent and behavioral; existing E2E coverage of pane close should catch the broad case if it regresses.

## Release coordination

This is a release blocker for v0.47.0 (PR #156). Once this lands on main, the release branch will rebase + add the entry to CHANGELOG.md.