### PR TITLE
Mailbox stdin: submit framed block instead of leaving it in the input buffer

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5816,6 +5816,21 @@ final class Workspace: Identifiable, ObservableObject {
     /// UUID and starts watching `$C11_STATE/workspaces/<id>/mailboxes/_outbox/`.
     /// Idempotent. A no-op `silent` handler is registered so topic-silent
     /// flows work before Step 10 lands the real stdin handler.
+    ///
+    /// The `stdin` handler writes via `TextBoxSubmit.send(_:via:)` rather
+    /// than raw `sendText`. Ghostty wraps `sendText` bytes in bracketed-paste
+    /// markers (`ESC[200~…ESC[201~`), and bracketed paste is specifically
+    /// designed so embedded `\n`/`\r` do NOT auto-execute — line discipline
+    /// (zsh ZLE, bash readline) and TUI raw-mode input handlers only submit
+    /// when a real Return arrives outside the paste. So `sendText` alone
+    /// leaves the framed `<c11-msg>` block sitting in the recipient's
+    /// input buffer without ever reaching the agent. `TextBoxSubmit.send`
+    /// bracketed-pastes the content and then dispatches a synthetic Return
+    /// key (with the 200 ms gap Claude CLI's paste-processing requires),
+    /// which submits the multi-line block as one user turn for TUI
+    /// recipients (Claude Code, codex) and as a (failing) command for
+    /// cooked-mode shells — the latter being undefined behavior anyway,
+    /// since `mailbox.delivery=stdin` only makes sense on agent surfaces.
     func startMailboxDispatcher() {
         guard mailboxDispatcher == nil else { return }
         let stateURL: URL
@@ -5852,7 +5867,7 @@ final class Workspace: Identifiable, ObservableObject {
             guard let terminalPanel = panel as? TerminalPanel else {
                 return .surfaceNotTerminal
             }
-            terminalPanel.sendText(text)
+            TextBoxSubmit.send(text, via: terminalPanel.surface)
             return .ok(bytes: text.utf8.count)
         }
         dispatcher.registerHandler(

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -484,6 +484,16 @@ c11 mailbox recv --drain    # list + print + unlink (default)
 c11 mailbox recv --peek     # list + print only
 ```
 
+**Opting in to stdin delivery.** Stdin delivery is per-recipient and off by default. Set `mailbox.delivery` on the surface that should auto-receive — it is a **comma-separated string** (not a JSON array), and the only handlers registered today are `stdin` and `silent`:
+
+```bash
+c11 set-metadata --surface "$CMUX_SURFACE_ID" --key mailbox.delivery --value stdin --type string
+# multiple handlers run in order on the same envelope:
+c11 set-metadata --surface "$CMUX_SURFACE_ID" --key mailbox.delivery --value stdin,silent --type string
+```
+
+Writing the value as JSON (e.g. `--type json --value '["stdin"]'`) is the canonical footgun: the dispatcher splits the stringified blob on commas, doesn't match the literal token `["stdin"]` against `{stdin, silent}`, and silently registers zero handlers — the envelope still lands in the inbox, but the framed block never reaches the PTY. Use `--type string` with the bare token(s) above.
+
 ### Debugging
 
 ```bash


### PR DESCRIPTION
## Summary

- `stdin` mailbox handler currently writes the framed `<c11-msg>` block to the recipient PTY via `terminalPanel.sendText(text)`. Ghostty wraps `sendText` bytes in bracketed-paste markers, by design suppressing embedded `\n`/`\r` so TUI raw-mode input handlers and shell line discipline don't auto-execute pasted content. Result: the block appears in the recipient's input box but is never submitted to the receiving agent until someone hits Enter — defeating the whole point of stdin delivery.
- Switch the production writer in `startMailboxDispatcher` to `TextBoxSubmit.send(_:via:)`, the same helper `scheduleAgentRestart` already uses for exactly this reason (`Sources/Workspace.swift:408-412`). It bracketed-pastes the content, waits 200ms (the documented minimum for Claude CLI's paste-processing), then dispatches a real synthetic Return. Multi-line `<c11-msg>` is now delivered as one user turn for TUI recipients (Claude Code, codex).
- `StdinMailboxHandler.formatFramedBlock` byte shape is unchanged — `c11Tests/StdinHandlerFormattingTests.swift` is untouched. The change is solely in the production writer closure injected into the handler; unit tests use a separately-injected writer and aren't affected. The dispatcher's 500ms reporting bound is unaffected — `TextBoxSubmit.send` schedules the Return asynchronously and the writer closure returns immediately.
- `skills/c11/SKILL.md` gains a short "Opting in to stdin delivery" snippet documenting the canonical form: `mailbox.delivery` is a comma-separated string (`stdin`, `stdin,silent`), not a JSON array. Writing it as `--type json --value '["stdin"]'` silently registers zero handlers — the literal token `["stdin"]` doesn't match the registered `{stdin, silent}` handler set, so the envelope lands in the inbox but no `handler` event appears in `_dispatch.log` and nothing reaches the PTY. This is a real footgun an operator just hit.

## Why this matters

Discovered while debugging why an Expanded Cinema sub-agent's status report to its sibling orchestrator landed in the recipient inbox but never appeared as a `<c11-msg>` block in the recipient PTY. Two issues compounded: (1) the recipient never had `mailbox.delivery` set so no handler was registered at all; (2) once registered, the registered handler couldn't actually submit. This PR fixes (2); the SKILL snippet keeps the next operator from re-hitting (1) in the same misleading way.

## Test plan

- [ ] Build and reinstall c11 from this branch.
- [ ] Set `mailbox.delivery=stdin` on a Claude Code surface (using the `--type string` form from the updated SKILL).
- [ ] From a sibling surface, `c11 mailbox send --to <recipient>` with a small body.
- [ ] Verify `c11 mailbox trace <id>` shows the `handler` event between `copied` and `cleaned`.
- [ ] Verify the framed `<c11-msg>` block appears in the recipient PTY **and** is submitted automatically (the recipient agent processes it as a user turn without operator pressing Enter).
- [ ] Repeat with `mailbox.delivery=stdin,silent` to confirm multi-handler ordering still works.
- [ ] Confirm `c11Tests/StdinHandlerFormattingTests.swift` still passes (byte shape unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)