### PR TITLE
fix(c11-40): New Workspace dialog opens at correct size on first show

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6431,33 +6431,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let initialDirectory = focusedWorkspaceWorkingDirectory()
             ?? FileManager.default.homeDirectoryForCurrentUser.path
 
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 480),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        window.title = String(
-            localized: "createWorkspace.windowTitle",
-            defaultValue: "New Workspace"
-        )
-        window.isReleasedWhenClosed = false
-        window.level = .modalPanel
-
         let rootView = CreateWorkspaceSheet(
             initialDirectory: initialDirectory,
-            onCancel: { [weak window] in window?.close() },
-            onCreate: { [weak self, weak window] outcome in
+            onCancel: { [weak self] in self?.createWorkspaceSheetWindow?.close() },
+            onCreate: { [weak self] outcome in
                 guard let self else { return }
                 _ = self.applyWorkspacePlanInPreferredMainWindow(
                     plan: outcome.plan,
                     workingDirectory: outcome.workingDirectory,
                     launchAgent: outcome.launchAgent
                 )
-                window?.close()
+                self.createWorkspaceSheetWindow?.close()
             }
         )
-        window.contentView = NSHostingView(rootView: rootView)
+        // NSHostingController with .preferredContentSize keeps the window's
+        // content size synced to SwiftUI's intrinsic size. Plain NSHostingView
+        // assigned to contentView leaves the window stuck at its initial
+        // contentRect, which on first layout clamps the SwiftUI content to
+        // a too-short frame; the dialog only snaps to its real size after a
+        // focus-driven relayout. See the new-workspace tiny-dialog regression
+        // observed in the 0.47.0 prod build.
+        let controller = NSHostingController(rootView: rootView)
+        controller.sizingOptions = [.preferredContentSize]
+        let window = NSWindow(contentViewController: controller)
+        window.styleMask = [.titled, .closable]
+        window.title = String(
+            localized: "createWorkspace.windowTitle",
+            defaultValue: "New Workspace"
+        )
+        window.isReleasedWhenClosed = false
+        window.level = .modalPanel
         window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/CreateWorkspaceSheet.swift
+++ b/Sources/CreateWorkspaceSheet.swift
@@ -56,7 +56,17 @@ struct CreateWorkspaceSheet: View {
     ) {
         self.initialDirectory = initialDirectory
         _directory = State(initialValue: initialDirectory)
-        _selectionId = State(initialValue: BlueprintEntry.starterIds.first ?? "")
+        // Seed entries + recents synchronously so the very first SwiftUI
+        // layout pass reflects the full dialog height. Doing this in
+        // .onAppear caused NSHostingController's preferredContentSize to
+        // first publish the entries-empty size, then resize once entries
+        // loaded — which read as a flash of a tiny dialog on prod builds.
+        let seededEntries = Self.computeEntries(forDirectory: initialDirectory)
+        _entries = State(initialValue: seededEntries)
+        _recentDirectories = State(initialValue: CreateWorkspaceRecents.load())
+        _selectionId = State(
+            initialValue: seededEntries.first?.id ?? (BlueprintEntry.starterIds.first ?? "")
+        )
         self.onCancel = onCancel
         self.onCreate = onCreate
     }
@@ -70,6 +80,7 @@ struct CreateWorkspaceSheet: View {
         }
         .padding(24)
         .frame(width: 600)
+        .fixedSize(horizontal: false, vertical: true)
         .background(BrandColors.surfaceSwiftUI)
         .environment(\.colorScheme, .dark)
         .onAppear {
@@ -325,6 +336,14 @@ struct CreateWorkspaceSheet: View {
     // MARK: - Loading
 
     private func reloadEntries() {
+        let collected = Self.computeEntries(forDirectory: directory)
+        entries = collected
+        if !entries.contains(where: { $0.id == selectionId }) {
+            selectionId = entries.first?.id ?? ""
+        }
+    }
+
+    private static func computeEntries(forDirectory directory: String) -> [BlueprintEntry] {
         let store = WorkspaceBlueprintStore()
         let cwdURL: URL? = {
             let trimmed = directory.trimmingCharacters(in: .whitespaces)
@@ -359,19 +378,17 @@ struct CreateWorkspaceSheet: View {
                 loader: .index(index)
             ))
         }
-        entries = collected
-        if !entries.contains(where: { $0.id == selectionId }) {
-            selectionId = entries.first?.id ?? ""
-        }
+        return collected
     }
 
-    private func badge(for source: WorkspaceBlueprintIndex.Source) -> String {
+    private static func badge(for source: WorkspaceBlueprintIndex.Source) -> String {
         switch source {
         case .repo:    return String(localized: "createWorkspace.badge.repo", defaultValue: "Repo")
         case .user:    return String(localized: "createWorkspace.badge.user", defaultValue: "User")
         case .builtIn: return String(localized: "createWorkspace.badge.builtIn", defaultValue: "Built-in")
         }
     }
+
 }
 
 // MARK: - Internal blueprint entry model


### PR DESCRIPTION
## Summary
- Switch `presentCreateWorkspaceSheet` from `NSHostingView` assigned to `window.contentView` to `NSHostingController` with `sizingOptions = [.preferredContentSize]`. The old pattern pinned the window at its initial 600×480 content rect and never propagated SwiftUI's intrinsic size back, so the dialog rendered tiny on first show until a focus event triggered a relayout.
- Seed `CreateWorkspaceSheet`'s `@State entries` + `@State recentDirectories` synchronously in `init` (via a new static `computeEntries(forDirectory:)`) so the very first SwiftUI layout pass already includes all blueprint rows — previously the entries loaded in `.onAppear` after the initial measurement, contributing to the under-sized first frame.
- Add `.fixedSize(horizontal: false, vertical: true)` to the dialog's root layout as belt-and-suspenders against vertical stretching during the initial controller↔window sizing handshake.

## Why this matters
Bug only surfaced in the 0.47.0 prod build (dev/staging masked it via timing differences). When the user clicked **+** or **File → New Workspace**, the dialog appeared with only a thin middle slice visible (~"One column" through "Launch coding agent"); top header and Cancel/Create footer were clipped. Moving focus anywhere outside the dialog re-laid it out at the correct ~600×~600 size. High-urgency — currently affecting the live release.

## Test plan
- [x] `xcodebuild -scheme c11-unit -configuration Debug build` passes locally (verified before commit).
- [ ] Tagged DEV reload (`./scripts/reload.sh --tag c11-fix-tiny-newws`) — open dialog via the **+** button and via File → New Workspace; both should appear at full size from first paint with no resize-on-focus snap.
- [ ] Click each starter blueprint row + toggle "Launch coding agent in initial pane"; submit and verify a workspace actually applies (regression check on the changed closure capture pattern — closures now reference `self.createWorkspaceSheetWindow` instead of a `[weak window]` capture taken before the window exists).
- [ ] Open dialog twice in one session — second show should still re-render correctly (single-instance guard at top of `presentCreateWorkspaceSheet`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)