### PR TITLE
feat(c11-40): New Workspace dialog UX — workspace name, Recent/Browse affordances, agent-room polish

### DIFF
--- a/Resources/Blueprints/agent-room.json
+++ b/Resources/Blueprints/agent-room.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "name": "agent-room",
-  "description": "Three-pane agent layout: main terminal left, log tail top-right, browser bottom-right",
+  "description": "Three-pane agent layout: main terminal left, browser top-right, server terminal bottom-right",
   "plan": {
     "version": 1,
     "workspace": {},
@@ -21,11 +21,11 @@
             "dividerPosition": 0.5,
             "first": {
               "type": "pane",
-              "pane": { "surfaceIds": ["s2"] }
+              "pane": { "surfaceIds": ["s3"] }
             },
             "second": {
               "type": "pane",
-              "pane": { "surfaceIds": ["s3"] }
+              "pane": { "surfaceIds": ["s2"] }
             }
           }
         }
@@ -35,16 +35,18 @@
       {
         "id": "s1",
         "kind": "terminal",
-        "title": "main"
+        "title": "example main terminal"
       },
       {
         "id": "s2",
         "kind": "terminal",
-        "title": "logs"
+        "title": "example server terminal"
       },
       {
         "id": "s3",
-        "kind": "browser"
+        "kind": "browser",
+        "title": "example browser",
+        "url": "https://www.stage11.ai"
       }
     ]
   }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5951,6 +5951,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func applyWorkspacePlanInPreferredMainWindow(
         plan: WorkspaceApplyPlan,
         workingDirectory: String,
+        workspaceName: String? = nil,
         launchAgent: Bool,
         debugSource: String = "createWorkspaceSheet"
     ) -> UUID? {
@@ -5966,6 +5967,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         var injected = plan
         injected.workspace.workingDirectory = workingDirectory
+        if let trimmed = workspaceName?.trimmingCharacters(in: .whitespaces), !trimmed.isEmpty {
+            injected.workspace.title = trimmed
+        }
         if launchAgent {
             let command = AgentLauncherSettings.current().shellCommand
             if let idx = injected.surfaces.firstIndex(where: { surface in
@@ -6439,6 +6443,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 _ = self.applyWorkspacePlanInPreferredMainWindow(
                     plan: outcome.plan,
                     workingDirectory: outcome.workingDirectory,
+                    workspaceName: outcome.workspaceName,
                     launchAgent: outcome.launchAgent
                 )
                 self.createWorkspaceSheetWindow?.close()

--- a/Sources/CreateWorkspaceSheet.swift
+++ b/Sources/CreateWorkspaceSheet.swift
@@ -33,6 +33,7 @@ enum CreateWorkspaceRecents {
 struct CreateWorkspaceSheet: View {
     struct Outcome {
         var workingDirectory: String
+        var workspaceName: String
         var plan: WorkspaceApplyPlan
         var launchAgent: Bool
     }
@@ -42,6 +43,7 @@ struct CreateWorkspaceSheet: View {
     let onCreate: (Outcome) -> Void
 
     @State private var directory: String
+    @State private var workspaceName: String = ""
     @State private var selectionId: String
     @State private var launchAgent: Bool = true
     @State private var entries: [BlueprintEntry] = []
@@ -75,6 +77,7 @@ struct CreateWorkspaceSheet: View {
         VStack(alignment: .leading, spacing: 18) {
             header
             directorySection
+            workspaceNameSection
             blueprintsSection
             footer
         }
@@ -116,29 +119,87 @@ struct CreateWorkspaceSheet: View {
                 TextField("", text: $directory)
                     .textFieldStyle(.roundedBorder)
                     .font(.system(size: 12, design: .monospaced))
-                if !recentDirectories.isEmpty {
-                    Menu {
+                Menu {
+                    if recentDirectories.isEmpty {
+                        Button(String(
+                            localized: "createWorkspace.recentDirectories.empty",
+                            defaultValue: "No recent directories yet"
+                        )) {}
+                        .disabled(true)
+                    } else {
                         ForEach(recentDirectories, id: \.self) { path in
                             Button(displayPath(path)) {
                                 directory = path
                             }
                         }
-                    } label: {
-                        Image(systemName: "clock")
                     }
-                    .menuStyle(.borderlessButton)
-                    .menuIndicator(.hidden)
-                    .fixedSize()
-                    .help(String(
-                        localized: "createWorkspace.recentDirectories.help",
-                        defaultValue: "Recent directories"
-                    ))
+                } label: {
+                    Label(
+                        String(
+                            localized: "createWorkspace.recentDirectories.label",
+                            defaultValue: "Recent"
+                        ),
+                        systemImage: "clock"
+                    )
+                    .labelStyle(.titleAndIcon)
                 }
-                Button(String(localized: "createWorkspace.browse", defaultValue: "Browse…")) {
+                .menuStyle(.button)
+                .controlSize(.large)
+                .fixedSize()
+                .help(String(
+                    localized: "createWorkspace.recentDirectories.help",
+                    defaultValue: "Pick a recently-used directory"
+                ))
+                Button {
                     chooseDirectory()
+                } label: {
+                    Label(
+                        String(localized: "createWorkspace.browse", defaultValue: "Browse…"),
+                        systemImage: "folder"
+                    )
+                    .labelStyle(.titleAndIcon)
                 }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
             }
         }
+    }
+
+    // MARK: - Workspace name
+
+    private var workspaceNameSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(String(localized: "createWorkspace.name", defaultValue: "Workspace name"))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
+            TextField(
+                "",
+                text: $workspaceName,
+                prompt: Text(defaultWorkspaceName)
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.4))
+            )
+            .textFieldStyle(.roundedBorder)
+            .font(.system(size: 12))
+            Text(String(
+                localized: "createWorkspace.name.hint",
+                defaultValue: "Defaults to the directory name. Yours to override."
+            ))
+            .font(.system(size: 10))
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.42))
+        }
+    }
+
+    private var defaultWorkspaceName: String {
+        let trimmed = directory.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return "Workspace" }
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        let last = URL(fileURLWithPath: expanded).lastPathComponent
+        return last.isEmpty ? "Workspace" : last
+    }
+
+    private var effectiveWorkspaceName: String {
+        let trimmed = workspaceName.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? defaultWorkspaceName : trimmed
     }
 
     private func displayPath(_ path: String) -> String {
@@ -172,7 +233,7 @@ struct CreateWorkspaceSheet: View {
 
     private var blueprintsSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(String(localized: "createWorkspace.layoutSelection", defaultValue: "Layout selection"))
+            Text(String(localized: "createWorkspace.defaultLayouts", defaultValue: "Default layouts"))
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.62))
 
@@ -187,8 +248,8 @@ struct CreateWorkspaceSheet: View {
 
             if !savedEntries.isEmpty {
                 Text(String(
-                    localized: "createWorkspace.savedBlueprints",
-                    defaultValue: "Saved blueprints"
+                    localized: "createWorkspace.customBlueprints",
+                    defaultValue: "Custom blueprints"
                 ))
                 .font(.system(size: 10, weight: .medium))
                 .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.42))
@@ -328,6 +389,7 @@ struct CreateWorkspaceSheet: View {
         let resolvedDir = (directory as NSString).expandingTildeInPath
         onCreate(Outcome(
             workingDirectory: resolvedDir,
+            workspaceName: effectiveWorkspaceName,
             plan: plan,
             launchAgent: launchAgent
         ))


### PR DESCRIPTION
## Summary
Second pass on the New Workspace dialog after the 0.47.0 prod-tiny regression fix (#159) landed. Operator-driven UX polish so the dialog orients first-timers and gets out of the way for everyone else.

### CreateWorkspaceSheet
- New **Workspace name** field under Working directory. Empty input falls back to the directory's basename via `WorkspaceSpec.title → Workspace.setCustomTitle`; the placeholder previews the fallback so the operator doesn't have to commit just to see what they'd get.
- **"Layout selection" → "Default layouts"** and **"Saved blueprints" → "Custom blueprints"** — clearer split between starters c11 ships and what the operator (or the repo) has saved.
- **Recent-directories control is now always visible** as a bordered menu button labelled `Recent` with a clock icon. Previously a flat glyph that vanished entirely on fresh installs (no recents ⇒ no button); the empty state now shows a single disabled "No recent directories yet" item so the affordance stays discoverable.
- **Browse…** upgraded to a bordered button with folder icon at `.controlSize(.large)` so it reads as a primary action next to Recent rather than inline text.
- Hint copy under the name field tightened to the c11 register: *"Defaults to the directory name. Yours to override."*

### AppDelegate
- `applyWorkspacePlanInPreferredMainWindow` gains a `workspaceName: String?` parameter; injects it into `plan.workspace.title` before apply. Default `nil` keeps existing callers (none today besides the dialog itself) unaffected.

### agent-room.json
- Browser moves to **top-right**, server terminal to **bottom-right** (was: log tail top-right, browser bottom-right). The browser is the higher-glance-rate surface and earns the eye-line slot.
- Browser defaults to **https://www.stage11.ai** instead of a blank new-tab.
- Surface titles renamed to onboarding-friendly placeholders: `example main terminal` / `example browser` / `example server terminal`. Operators rename them once they know what each pane is going to be for; the placeholder names tell newcomers what the layout is *for* without making them read the description.

## Test plan
- [x] `xcodebuild -scheme c11-unit -configuration Debug build` passes locally.
- [x] Tagged DEV reload (`./scripts/reload.sh --tag c11-ws-name`) — operator visually verified each round: workspace name field + placeholder, Recent always visible, Browse styling, agent-room pane geometry + titles, hint copy.
- [ ] Spawn a workspace from agent-room: browser opens at stage11.ai in top-right; bottom-right pane carries the "example server terminal" title; left pane carries "example main terminal".
- [ ] Fresh-install regression: open the dialog with no recents in UserDefaults — the Recent button should still render, click should open a menu with a single disabled "No recent directories yet" item.
- [ ] Submit with a custom workspace name → workspace title in the sidebar matches; submit with an empty field → workspace title matches the directory basename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)