### PR TITLE
docs(cli): drop "in the current window" from new-workspace help

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -8074,7 +8074,7 @@ struct CMUXCLI {
             return """
             Usage: c11 new-workspace [--cwd <path>] [--command <text>] [--layout <path|name>]
 
-            Create a new workspace in the current window.
+            Create a new workspace.
 
             Flags:
               --cwd <path>           Set the working directory for the new workspace


### PR DESCRIPTION
## Summary
- The qualifier "in the current window" is implementation detail leaking into UX. A user asking for "a new workspace" doesn't think about which window.
- Tightening the help text also reduces the linguistic pull that nudges agents toward `new-workspace` when the operator actually asked for a surface. (One was triggered on a real session this morning — the available `--cwd` flag plus the "in the current window" phrasing combined to pull the model toward `new-workspace` despite the operator saying "surface.")

## Test plan
- [ ] `c11 new-workspace --help` shows the trimmed line
- [ ] No other call sites broke (single help-string change; grep'd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)