### PR TITLE
C11-26: anchor tab close X on left + Close Tab/Close Pane right-click

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5704,6 +5704,11 @@ final class Workspace: Identifiable, ObservableObject {
             autoCloseEmptyPanes: true,
             contentViewLifecycle: .keepAllAlive,
             newTabPosition: .current,
+            // C11-26: left-anchored always-visible close X + two-item
+            // right-click menu (Close Tab, Close Pane). Sidesteps the
+            // right-edge hit-collision bug and matches native macOS
+            // Cocoa tab convention (Finder, Terminal.app, Notes).
+            simplifiedTabContextMenu: true,
             appearance: appearance
         )
         self.bonsplitController = BonsplitController(configuration: config)
@@ -9113,6 +9118,11 @@ final class Workspace: Identifiable, ObservableObject {
                 shortcuts[contextAction] = KeyboardShortcut(key, modifiers: stored.eventModifiers)
             }
         }
+        // C11-26: ⌘W routes through AppDelegate's keyDown handler, not a
+        // SwiftUI .keyboardShortcut on a Button. Surface the hint in the
+        // context menu anyway so the gesture is discoverable. Hardcoded
+        // because there's no KeyboardShortcutSettings.Action for it.
+        shortcuts[.closeTab] = KeyboardShortcut("w", modifiers: .command)
         return shortcuts
     }
 
@@ -11613,6 +11623,18 @@ extension Workspace: BonsplitDelegate {
         case .clearName:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             setPanelCustomTitle(panelId: panelId, title: nil)
+        case .closeTab:
+            // Route through the same path as clicking the close X so the
+            // shouldCloseTab gate (pin protection, dirty-confirm dialog,
+            // workspace-on-last-surface routing) runs identically.
+            markExplicitClose(surfaceId: tab.id)
+            _ = controller.closeTab(tab.id, inPane: pane)
+        case .closePane:
+            // Reuse the existing pane-close confirmation flow (same as
+            // clicking the trailing-toolbar X on the tab bar). Handles the
+            // only-pane-in-workspace degenerate case via "Reset entire pane?"
+            // — the pane is reset with a fresh terminal rather than torn down.
+            splitTabBar(controller, didRequestClosePane: pane)
         case .closeToLeft:
             closeTabs(tabIdsToLeft(of: tab.id, inPane: pane))
         case .closeToRight:


### PR DESCRIPTION
## Summary
- Anchor the per-pane tab close X on the **left** edge of each tab; title fills the remaining width and truncates with `…` on the right.
- Replace the right-click context menu with exactly two items: **Close Tab** and **Close Pane**. The other entries (rename, close-others, move, pin, tab color, …) drop out — still reachable via the command palette, keyboard, and direct gestures.
- ⌘W unchanged: it continues to close the focused tab through `AppDelegate.keyDown` → `closePanelWithConfirmation`. The Close Tab menu entry now surfaces the ⌘W hint glyph for discoverability.

## Why
The right-anchored X was getting eaten by the pane separator / adjacent pane's toolbar when vertical splits crowded the strip — visible but unclickable. Closing a tab also depended on horizontal scroll position when titles overflowed, which is unreachable on a vertical-only mouse wheel. Left-anchoring removes both failure modes structurally and matches native macOS Cocoa tab convention (Finder, Terminal.app, Notes).

## Mechanism
Two commits, one per repo:
- **bonsplit submodule** `20b715b` — new `BonsplitConfiguration.simplifiedTabContextMenu` toggle, two new `TabContextAction` cases (`closeTab`, `closePane`), the leading-edge close accessory in `TabItemView`, and localized strings for the new menu items in `en/ja/ko/uk/ru/zh-Hans/zh-Hant`. Default off — bonsplit example and any future embedder see no behaviour change.
- **c11 worktree** `912fb5d` — `Workspace.swift` turns the toggle on, wires `.closeTab` / `.closePane` into the existing `shouldCloseTab` / `didRequestClosePane` flows, and registers a `⌘W` shortcut hint for the Close Tab context-menu entry.

## Degenerate "Close Pane" on the only pane
Routed into the existing pane-close confirmation flow — when the pane is the only one in the workspace, it's reset (every tab closed, a fresh terminal dropped in) rather than torn down. Matches the toolbar's trailing pane-close button.

## Test plan
- [x] Tagged build (`./scripts/reload.sh --tag c11-26`) builds clean
- [x] Visual: every tab in a four-pane workspace renders a left-anchored `xmark` glyph at rest (screenshot)
- [x] Visual: long titles truncate with `…` on the right; X stays clickable
- [x] Visual: tab strip horizontal scroll remains
- [x] Functional: closing a surface routes through the same `shouldCloseTab` delegate
- [ ] Manual ⌘W check inside the tagged build (path unchanged in this PR; trusted-by-construction but worth confirming once)
- [ ] Right-click: confirm exactly Close Tab and Close Pane render (code-deterministic; not captured via Accessibility automation in this pass)

Closes C11-26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)