### PR TITLE
observability: instrument App Hang triggers (sentry:C11-1)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2227,6 +2227,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var lastSessionAutosaveFingerprint: Int?
     private var lastSessionAutosavePersistedAt: Date = .distantPast
     private var lastTypingActivityAt: TimeInterval = 0
+    private var lastBackgroundedAt: Date?
     private var didHandleExplicitOpenIntentAtStartup = false
     private var isTerminatingApp = false
     private var didInstallLifecycleSnapshotObservers = false
@@ -2797,9 +2798,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
 
     func applicationDidBecomeActive(_ notification: Notification) {
-        sentryBreadcrumb("app.didBecomeActive", category: "lifecycle", data: [
+        var crumbData: [String: Any] = [
             "tabCount": tabManager?.tabs.count ?? 0
-        ])
+        ]
+        if let backgroundedAt = lastBackgroundedAt {
+            crumbData["seconds_since_background"] = Int(Date().timeIntervalSince(backgroundedAt))
+        }
+        lastBackgroundedAt = nil
+        sentryBreadcrumb("app.didBecomeActive", category: "lifecycle", data: crumbData)
         if TelemetrySettings.enabledForCurrentLaunch && !isRunningUnderXCTestCached {
             PostHogAnalytics.shared.trackActive(reason: "didBecomeActive")
         }
@@ -2862,6 +2868,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillResignActive(_ notification: Notification) {
         guard !isTerminatingApp else { return }
+        lastBackgroundedAt = Date()
+        sentryBreadcrumb("app.willResignActive", category: "lifecycle", data: [
+            "tabCount": tabManager?.tabs.count ?? 0
+        ])
         _ = saveSessionSnapshot(includeScrollback: false)
     }
 

--- a/Sources/Update/UpdateController.swift
+++ b/Sources/Update/UpdateController.swift
@@ -58,6 +58,7 @@ class UpdateController {
     private var noUpdateDismissWorkItem: DispatchWorkItem?
     private var readyCheckWorkItem: DispatchWorkItem?
     private var backgroundProbeTimer: Timer?
+    private var lastBackgroundProbeFiredAt: Date?
     private var didStartUpdater: Bool = false
     private let readyRetryDelay: TimeInterval = 0.25
     private let readyRetryCount: Int = 20
@@ -153,6 +154,15 @@ class UpdateController {
         backgroundProbeTimer?.invalidate()
         backgroundProbeTimer = Timer.scheduledTimer(withTimeInterval: backgroundProbeInterval, repeats: true) { [weak self] _ in
             guard let self, self.updater.automaticallyChecksForUpdates else { return }
+            let now = Date()
+            var crumbData: [String: Any] = [
+                "app_active": NSApp?.isActive ?? false
+            ]
+            if let last = self.lastBackgroundProbeFiredAt {
+                crumbData["seconds_since_last_tick"] = Int(now.timeIntervalSince(last))
+            }
+            self.lastBackgroundProbeFiredAt = now
+            sentryBreadcrumb("update.background_probe.tick", category: "update", data: crumbData)
             UpdateLogStore.shared.append("periodic background update probe")
             self.updater.checkForUpdateInformation()
         }

--- a/Sources/Update/UpdateViewModel.swift
+++ b/Sources/Update/UpdateViewModel.swift
@@ -4,7 +4,18 @@ import SwiftUI
 import Sparkle
 
 class UpdateViewModel: ObservableObject {
-    @Published var state: UpdateState = .idle
+    @Published var state: UpdateState = .idle {
+        didSet {
+            let oldLabel = oldValue.caseLabel
+            let newLabel = state.caseLabel
+            guard oldLabel != newLabel else { return }
+            sentryBreadcrumb("update.viewmodel.state_changed", category: "update", data: [
+                "from": oldLabel,
+                "to": newLabel,
+                "app_active": NSApp?.isActive ?? false
+            ])
+        }
+    }
     @Published var overrideState: UpdateState?
     @Published var detectedUpdateVersion: String?
     #if DEBUG
@@ -407,6 +418,20 @@ enum UpdateState: Equatable {
             return true
         default:
             return false
+        }
+    }
+
+    var caseLabel: String {
+        switch self {
+        case .idle: return "idle"
+        case .permissionRequest: return "permissionRequest"
+        case .checking: return "checking"
+        case .updateAvailable: return "updateAvailable"
+        case .notFound: return "notFound"
+        case .error: return "error"
+        case .downloading: return "downloading"
+        case .extracting: return "extracting"
+        case .installing: return "installing"
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5164,6 +5164,7 @@ final class Workspace: Identifiable, ObservableObject {
         let appearance: FlashAppearance
         let timer: Timer
         let startedAt: Date
+        var lastBreadcrumbAt: Date?
     }
 
     @Published private(set) var persistentFlashPanels: [UUID: PersistentFlashState] = [:]
@@ -9201,14 +9202,27 @@ final class Workspace: Identifiable, ObservableObject {
         let timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { [weak self] _ in
             DispatchQueue.main.async {
                 guard let self else { return }
-                guard self.persistentFlashPanels[panelId] != nil else { return }
+                guard var state = self.persistentFlashPanels[panelId] else { return }
+                let now = Date()
+                let lastEmittedAt = state.lastBreadcrumbAt ?? state.startedAt
+                if state.lastBreadcrumbAt == nil || now.timeIntervalSince(lastEmittedAt) >= 60 {
+                    sentryBreadcrumb("flash.persistent.tick", category: "flash", data: [
+                        "panelId": panelId.uuidString,
+                        "seconds_active": Int(now.timeIntervalSince(state.startedAt)),
+                        "seconds_since_last_tick_breadcrumb": Int(now.timeIntervalSince(lastEmittedAt)),
+                        "app_active": NSApp?.isActive ?? false
+                    ])
+                    state.lastBreadcrumbAt = now
+                    self.persistentFlashPanels[panelId] = state
+                }
                 self.runFlashPulse(panelId: panelId, appearance: appearance)
             }
         }
         persistentFlashPanels[panelId] = PersistentFlashState(
             appearance: appearance,
             timer: timer,
-            startedAt: Date()
+            startedAt: Date(),
+            lastBreadcrumbAt: nil
         )
 
         // Manifest overlay: write once on start so external agents asking


### PR DESCRIPTION
## Summary

Adds Sentry breadcrumbs at suspected trigger points for the only production-tagged unresolved Sentry issue — **sentry:C11-1** ("App Hanging: App hanging for at least 8000 ms"). The hangs sample consistently into SwiftUI's AttributeGraph / metadata-cache hot paths with no in-app frames in the watchdog output, so the existing breadcrumb buffer tells us *where* SwiftUI is busy but not *what triggered* it.

This is instrumentation only — no behaviour change. Goal is to capture the trigger chain on the next occurrence.

## Findings that motivated the change

- 45 events on the C11-1 group across 90d retention; one user (Mac16,8, macOS 26.4.1, `username=user`) accounted for 23 hangs on 2026-05-15 alone.
- The affected user's c11 was backgrounded at 09:48 UTC and never brought back to foreground; the cluster of hangs (21:28 – 21:52) all fired with the app invisible. So whatever triggers it runs while backgrounded.
- Stack signatures consistently land in `ChildEnvironment.updateValue`, `GraphHost.setEnvironment`, `propagate_dirty`, `swift_getTupleTypeMetadata`, `MetadataCacheKey::operator==`, `ShapeStyleResolver.updateValue` — different sample sites, same root cause (SwiftUI environment propagation thrashing).
- The 100-entry rolling breadcrumb buffer had 23-minute silent gaps right before each hang, with only Sparkle's hourly appcast HTTP entries visible. We need finer instrumentation at the suspect surfaces.

## What gets added

| File | New breadcrumb(s) |
|------|-------------------|
| `Sources/AppDelegate.swift` | Track `lastBackgroundedAt`; emit `app.willResignActive`; enrich `app.didBecomeActive` with `seconds_since_background` |
| `Sources/Update/UpdateController.swift` | `update.background_probe.tick` with `seconds_since_last_tick`, `app_active` |
| `Sources/Update/UpdateViewModel.swift` | `UpdateState.caseLabel`; `didSet` on `state` emits `update.viewmodel.state_changed` only on real case transitions |
| `Sources/Workspace.swift` | `flash.persistent.tick` — fires once per persistent flash and again only after >60s between ticks (catches App-Nap thaw pattern without flooding) |

All breadcrumbs go through the existing `sentryBreadcrumb()` helper (gated on `TelemetrySettings.enabledForCurrentLaunch`).

## Risk

- Additive only; no existing behaviour modified.
- `UpdateState.caseLabel` is a pure computed property; `didSet` on `@Published var state` is supported and only emits on actual case changes (filter avoids breadcrumb spam from `Equatable` re-assignments with the same case).
- Persistent flash breadcrumb is coalesced (60s cool-down between emits per-panel) so a long-lived flash doesn't burn the buffer.

## Test plan

- [x] `xcodebuild -scheme c11 -configuration Debug -destination "platform=macOS" build` — green
- [ ] Manual: trigger a Sparkle background probe (wait an hour with c11 open or call `checkForUpdates` from the menu) and confirm `update.background_probe.tick` appears in next Sentry event
- [ ] Manual: trigger a persistent flash, leave it for >60s, confirm `flash.persistent.tick` appears
- [ ] Wait for affected user to update to v0.47.x and hang again; triage the new event to identify the trigger chain

## Related

- Sentry issue: https://stage-11-kl.sentry.io/issues/7457599931/ (sentry:C11-1)
- Platform doc: `code/platform/sentry.md` (separate small fix landing alongside: slug correction + note on `C11-*` shortId vs Lattice ticket ID collision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)