### PR TITLE
Menu: About c11 inside Help (replaces the strip from #168)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2084,8 +2084,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var splitButtonTooltipRefreshScheduled = false
     private var ghosttyConfigObserver: NSObjectProtocol?
     private var appearanceObservation: NSKeyValueObservation?
-    private var helpMenuStripObserver: NSObjectProtocol?
-    private var helpMenuSink: NSMenu?
     private var ghosttyGotoSplitLeftShortcut: StoredShortcut?
     private var ghosttyGotoSplitRightShortcut: StoredShortcut?
     private var ghosttyGotoSplitUpShortcut: StoredShortcut?
@@ -2511,7 +2509,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         NSWindow.allowsAutomaticWindowTabbing = false
         disableNativeTabbingShortcut()
         installGhosttySettingsMenuItem()
-        removeHelpMenu()
         if !isRunningUnderXCTest {
             configureUserNotifications()
             installMenuBarVisibilityObserver()
@@ -11634,31 +11631,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if let submenu = item.submenu {
                 disableMenuItemShortcut(in: submenu, action: action)
             }
-        }
-    }
-
-    // SwiftUI's `CommandGroup(replacing: .help) { }` empties the Help menu's
-    // contents but AppKit still injects a Help menu with the auto-search
-    // field whenever NSApp.helpMenu is nil. Suppress that auto-injection by
-    // assigning a non-nil dummy menu, and strip any Help container SwiftUI
-    // hands us on every applicationDidUpdate tick.
-    private func removeHelpMenu() {
-        if helpMenuSink == nil { helpMenuSink = NSMenu(title: "") }
-        NSApp.helpMenu = helpMenuSink
-        stripHelpMenuItem()
-        helpMenuStripObserver = NotificationCenter.default.addObserver(
-            forName: NSApplication.didUpdateNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.stripHelpMenuItem()
-        }
-    }
-
-    private func stripHelpMenuItem() {
-        guard let mainMenu = NSApp.mainMenu else { return }
-        for item in mainMenu.items where item.submenu?.title == "Help" || item.title == "Help" {
-            mainMenu.removeItem(item)
         }
     }
 

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -486,8 +486,16 @@ struct cmuxApp: App {
                 .keyboardShortcut("p", modifiers: [.command, .shift])
             }
 
-            // C11-41: Remove the (dead) Help menu macOS draws by default.
-            CommandGroup(replacing: .help) { }
+            // AppKit auto-injects a Help menu (with its search field) whenever
+            // there isn't one — and reliably suppressing it from a SwiftUI app
+            // is an open battle. Embrace the slot instead: put a real action
+            // here so the menu earns its space. About c11 doubles as the app's
+            // identity card and a useful answer to "what is this thing?"
+            CommandGroup(replacing: .help) {
+                Button(String(localized: "menu.help.about", defaultValue: "About c11")) {
+                    showAboutPanel()
+                }
+            }
 
             // C11-41 Edit menu: Find items go flat (match Safari/Mail/Notes).
             CommandGroup(after: .textEditing) {


### PR DESCRIPTION
## Summary
- Replace `CommandGroup(replacing: .help) {}` with a real **About c11** entry so the AppKit-injected Help menu earns its space.
- Back out the runtime strip from #168 (`removeHelpMenu` / `stripHelpMenuItem` / `helpMenuStripObserver` / `helpMenuSink`) — it suppressed the menu most of the time but flashed it briefly on launch.
- **About c11** still lives in the c11 app menu too; this just adds discoverability where users instinctively reach for help.

## Why
SwiftUI's `CommandGroup(replacing: .help) {}` empties the help slot, but AppKit auto-injects a Help menu with its native search field whenever the slot is empty. Reliably suppressing that from a SwiftUI app turns out to be an open battle: the strip approach worked against `NSApp.mainMenu` but the auto-injected container kept reappearing in the menu bar. Cheaper to put a real menu item in there.

## Test plan
- [ ] Help menu shows in menu bar with `About c11` (alongside macOS's auto-injected search field)
- [ ] Clicking `About c11` opens the existing About panel
- [ ] App menu still has its own `About c11` (unchanged)
- [ ] No phantom Help flash on launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)