### PR TITLE
Default agent prompt: orient new agents before the skill load

### DIFF
--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -48,7 +48,7 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
     var factoryInitialPrompt: String {
         switch self {
         case .custom: return ""
-        default:      return "load the c11 skill"
+        default:      return "you are operating inside a c11 workspace. load the skill."
         }
     }
 }
@@ -132,7 +132,7 @@ struct DefaultAgentConfig: Codable, Equatable {
     }
 
     /// Factory shape: claude-code is the default, every agent pre-filled with
-    /// its built-in command + "load the c11 skill".
+    /// its built-in command + the c11-orientation prompt.
     static let factory: DefaultAgentConfig = {
         var agents: [AgentType: AgentConfig] = [:]
         for type in AgentType.allCases {

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -21,13 +21,13 @@ final class DefaultAgentConfigTests: XCTestCase {
     func testFactoryClaudeCommandIncludesDangerouslySkipPermissions() {
         let entry = AgentConfig.factory(for: .claudeCode)
         XCTAssertEqual(entry.command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(entry.initialPrompt, "load the c11 skill")
+        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
     }
 
     func testFactoryCodexCommandIncludesYolo() {
         let entry = AgentConfig.factory(for: .codex)
         XCTAssertEqual(entry.command, "codex --yolo")
-        XCTAssertEqual(entry.initialPrompt, "load the c11 skill")
+        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
     }
 
     func testFactoryCustomHasEmptyDefaults() {
@@ -121,7 +121,7 @@ final class DefaultAgentConfigTests: XCTestCase {
         let (store, _) = makeStore()
         XCTAssertEqual(store.current.defaultAgent, .claudeCode)
         XCTAssertEqual(store.current.config(for: .claudeCode).command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "load the c11 skill")
+        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "you are operating inside a c11 workspace. load the skill.")
     }
 
     func testStoreReturnsFactoryOnGarbageData() {

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -18,7 +18,7 @@ final class DefaultAgentResolverTests: XCTestCase {
             projectConfig: nil
         )
         XCTAssertEqual(agent, .claudeCode)
-        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions 'load the c11 skill'")
+        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions 'you are operating inside a c11 workspace. load the skill.'")
     }
 
     func testProjectConfigDefaultAgentBeatsUserDefault() {
@@ -88,12 +88,12 @@ final class DefaultAgentResolverTests: XCTestCase {
     func testBuildCommandClaudeAppendsInitialPromptAsPositional() {
         let cfg = AgentConfig(
             command: "claude --dangerously-skip-permissions",
-            initialPrompt: "load the c11 skill",
+            initialPrompt: "you are operating inside a c11 workspace. load the skill.",
             envOverridesText: ""
         )
         XCTAssertEqual(
             DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
-            "claude --dangerously-skip-permissions 'load the c11 skill'"
+            "claude --dangerously-skip-permissions 'you are operating inside a c11 workspace. load the skill.'"
         )
     }
 
@@ -113,7 +113,7 @@ final class DefaultAgentResolverTests: XCTestCase {
         // Non-claude agents preserve the prompt in config but don't auto-append.
         let cfg = AgentConfig(
             command: "codex --yolo",
-            initialPrompt: "load the c11 skill",
+            initialPrompt: "you are operating inside a c11 workspace. load the skill.",
             envOverridesText: ""
         )
         XCTAssertEqual(


### PR DESCRIPTION
## Summary
- Updates the factory `initialPrompt` for every built-in agent (claude-code, codex, kimi, opencode) from `load the c11 skill` to `you are operating inside a c11 workspace. load the skill.`
- Naming the room first gives a freshly-spawned coding agent the framing it needs to interpret the rest of the instruction.
- `Sources/DefaultAgentConfig.swift` + the two host-required tests that pin to the literal string.

## Test plan
- [ ] CI: c11Tests / c11LogicTests green
- [ ] Spot check: launch a fresh A-button agent in a tagged build and confirm the new prompt is what gets typed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)