### PR TITLE
C11-103: per-entry merge in state-dir migration

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		E6C1381837332D3B253A0C42 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		E7E728D3008386FFA3E28065 /* WorkspacePullRequestSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */; };
 		E81B5FA9C3AF8FAB6C10C623 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
+		EC224F7B0F7E77A981DFEC5A /* StateDirectoryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */; };
 		F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
 		F2DFDC31F79D62CC65B97C66 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 		F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */; };
@@ -527,6 +528,7 @@
 		C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyChromeScaleTests.swift; sourceTree = "<group>"; };
 		C1ADE00001A1B2C3D4E5F719 /* claude */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/claude; sourceTree = SOURCE_ROOT; };
 		C1CDE00001A1B2C3D4E5F719 /* codex */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/codex; sourceTree = SOURCE_ROOT; };
+		C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StateDirectoryMigrationTests.swift; sourceTree = "<group>"; };
 		CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkillInstaller.swift; sourceTree = "<group>"; };
 		CC401004A1B2C3D4E5F60719 /* AgentSkillsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSkillsView.swift; sourceTree = "<group>"; };
 		CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCCPrimerView.swift; sourceTree = "<group>"; };
@@ -1035,6 +1037,7 @@
 				D7113BF1A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift */,
 				3BF9D5EC78046EDA9B54AC68 /* DefaultAgentConfigTests.swift */,
 				8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */,
+				C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1341,6 +1344,7 @@
 				F2DFDC31F79D62CC65B97C66 /* TerminalControllerSocketSecurityTests.swift in Sources */,
 				B8C573A037A27127A9F04EF5 /* DefaultAgentConfigTests.swift in Sources */,
 				629F9C54FEC34F811A25CC65 /* DefaultAgentResolverTests.swift in Sources */,
+				EC224F7B0F7E77A981DFEC5A /* StateDirectoryMigrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Mailbox/MailboxLayout.swift
+++ b/Sources/Mailbox/MailboxLayout.swift
@@ -170,13 +170,23 @@ enum MailboxLayout {
 /// its URL. Idempotent and thread-safe; cross-process safety is best-effort
 /// via `moveItem`'s atomicity.
 ///
-/// Migration steps (only when legacy exists and current does not):
-///   1. `moveItem` `~/Library/Application Support/c11mux` →
-///      `~/Library/Application Support/c11` (atomic on same volume).
-///   2. Create a relative symlink at the legacy path pointing at `c11`,
-///      so downgraded older binaries continue to find their state.
-///      The symlink can be dropped in a later release once the downgrade
-///      window has closed; see `docs/c11-state-dir-rename-plan.md`.
+/// Migration shape: when legacy (`~/Library/Application Support/c11mux`) exists,
+/// merge its entries into current (`~/Library/Application Support/c11`),
+/// creating current first if necessary. Per-entry policy is `c11/` wins on
+/// same-name collision; the `workspaces/` subdir is recursed one level so
+/// per-workspace UUID directories present only in legacy still come over.
+/// After the merge, if legacy is empty, replace it with a relative symlink
+/// pointing at `c11` so downgraded older binaries continue to find their
+/// state. The symlink can be dropped in a later release once the downgrade
+/// window has closed; see `docs/c11-state-dir-rename-plan.md`.
+///
+/// The pre-C11-103 implementation rebuilt the dir with a single atomic rename
+/// and bailed when both paths already existed. That left dogfooders who had
+/// run tagged debug builds (which pre-create `c11/`) stranded on an empty
+/// session after the prod rename release landed, because the migration was
+/// a no-op and the prod build wrote a fresh empty snapshot. The per-entry
+/// merge fixes that case at the cost of whole-dir atomicity, which the
+/// `didRun` latch + per-entry `moveItem` atomicity make a non-issue.
 enum StateDirectoryMigration {
     static let legacyName = "c11mux"
     static let currentName = "c11"
@@ -184,38 +194,179 @@ enum StateDirectoryMigration {
     private static let lock = NSLock()
     private static var didRun = false
 
-    static func ensureMigrated(fileManager: FileManager = .default) {
+    /// Performs the legacy → current merge once per process. The `appSupport`
+    /// parameter is a testing seam (matches the convention used by
+    /// `SessionPersistence.defaultSnapshotFileURL`); production callers leave
+    /// it nil and accept the user-domain Application Support directory.
+    static func ensureMigrated(
+        fileManager: FileManager = .default,
+        appSupport: URL? = nil
+    ) {
         lock.lock()
         defer { lock.unlock() }
         if didRun { return }
         didRun = true
 
-        guard let appSupport = fileManager.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first else {
+        let resolvedAppSupport: URL
+        if let appSupport {
+            resolvedAppSupport = appSupport
+        } else {
+            // Defensive: when no override is supplied AND the process is an
+            // xctest host, bail without touching real Application Support.
+            // `c11Tests` and `c11LogicTests` indirectly invoke this path via
+            // `SessionPersistence.defaultSnapshotFileURL` and friends; without
+            // this guard a passing test on a dogfooder's machine could merge
+            // their actual session state. Tests that need to exercise the
+            // migration must pass an explicit `appSupport:` temp-dir override.
+            if isRunningUnderXCTest() { return }
+            guard let discovered = fileManager.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else {
+                return
+            }
+            resolvedAppSupport = discovered
+        }
+
+        let legacyURL = resolvedAppSupport.appendingPathComponent(legacyName, isDirectory: true)
+        let currentURL = resolvedAppSupport.appendingPathComponent(currentName, isDirectory: true)
+
+        // Fresh install (legacy never existed): nothing to do.
+        guard fileManager.fileExists(atPath: legacyURL.path) else { return }
+
+        mergeLegacyIntoCurrent(
+            legacyURL: legacyURL,
+            currentURL: currentURL,
+            fileManager: fileManager
+        )
+
+        // Drop the now-empty legacy dir and replace with a relative symlink so
+        // downgraded older binaries still resolve their state. If collisions
+        // kept entries in legacy, leave it alone — retiring the legacy path is
+        // a future release.
+        if isDirectoryEmpty(at: legacyURL, fileManager: fileManager) {
+            do {
+                try fileManager.removeItem(at: legacyURL)
+                try fileManager.createSymbolicLink(
+                    atPath: legacyURL.path,
+                    withDestinationPath: currentName
+                )
+            } catch {
+                logFailure(stage: "replace legacy with symlink", error: error)
+            }
+        }
+    }
+
+    /// Clears the `didRun` latch. Tests use this to run the migration
+    /// multiple times against fresh temp-dir fixtures within a single process.
+    static func resetForTests() {
+        lock.lock()
+        defer { lock.unlock() }
+        didRun = false
+    }
+
+    private static func mergeLegacyIntoCurrent(
+        legacyURL: URL,
+        currentURL: URL,
+        fileManager: FileManager
+    ) {
+        do {
+            try fileManager.createDirectory(
+                at: currentURL,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            logFailure(stage: "create current dir", error: error)
             return
         }
 
-        let legacyURL = appSupport.appendingPathComponent(legacyName, isDirectory: true)
-        let currentURL = appSupport.appendingPathComponent(currentName, isDirectory: true)
-
-        // Fresh install (neither exists) or already migrated (current exists)
-        // or co-existing (both exist, leave alone): nothing to do.
-        let legacyExists = fileManager.fileExists(atPath: legacyURL.path)
-        let currentExists = fileManager.fileExists(atPath: currentURL.path)
-        guard legacyExists, !currentExists else { return }
-
+        let entries: [String]
         do {
-            try fileManager.moveItem(at: legacyURL, to: currentURL)
-            try fileManager.createSymbolicLink(
-                atPath: legacyURL.path,
-                withDestinationPath: currentName
-            )
+            entries = try fileManager.contentsOfDirectory(atPath: legacyURL.path)
         } catch {
-            FileHandle.standardError.write(Data(
-                "c11: state-directory migration failed: \(error.localizedDescription)\n".utf8
-            ))
+            logFailure(stage: "list legacy entries", error: error)
+            return
         }
+
+        for entry in entries {
+            let legacyEntryURL = legacyURL.appendingPathComponent(entry)
+            let currentEntryURL = currentURL.appendingPathComponent(entry)
+
+            if entry == MailboxLayout.workspacesDirectoryName,
+               fileManager.fileExists(atPath: currentEntryURL.path) {
+                mergeWorkspacesShallow(
+                    legacyWorkspacesURL: legacyEntryURL,
+                    currentWorkspacesURL: currentEntryURL,
+                    fileManager: fileManager
+                )
+                continue
+            }
+
+            if fileManager.fileExists(atPath: currentEntryURL.path) {
+                // Same-name collision: current wins. Leave legacy in place.
+                continue
+            }
+
+            do {
+                try fileManager.moveItem(at: legacyEntryURL, to: currentEntryURL)
+            } catch {
+                logFailure(stage: "move \(entry)", error: error)
+            }
+        }
+    }
+
+    private static func mergeWorkspacesShallow(
+        legacyWorkspacesURL: URL,
+        currentWorkspacesURL: URL,
+        fileManager: FileManager
+    ) {
+        let workspaces: [String]
+        do {
+            workspaces = try fileManager.contentsOfDirectory(atPath: legacyWorkspacesURL.path)
+        } catch {
+            logFailure(stage: "list legacy workspaces", error: error)
+            return
+        }
+
+        for workspace in workspaces {
+            let legacyEntryURL = legacyWorkspacesURL.appendingPathComponent(workspace)
+            let currentEntryURL = currentWorkspacesURL.appendingPathComponent(workspace)
+            if fileManager.fileExists(atPath: currentEntryURL.path) {
+                continue
+            }
+            do {
+                try fileManager.moveItem(at: legacyEntryURL, to: currentEntryURL)
+            } catch {
+                logFailure(stage: "move workspaces/\(workspace)", error: error)
+            }
+        }
+    }
+
+    private static func isDirectoryEmpty(at url: URL, fileManager: FileManager) -> Bool {
+        guard let entries = try? fileManager.contentsOfDirectory(atPath: url.path) else {
+            return false
+        }
+        return entries.isEmpty
+    }
+
+    private static func logFailure(stage: String, error: Error) {
+        FileHandle.standardError.write(Data(
+            "c11: state-directory migration: \(stage) failed: \(error.localizedDescription)\n".utf8
+        ))
+    }
+
+    /// Detects when this process is running as an XCTest host. Mirrors the
+    /// signals used by `SessionRestorePolicy` and `AppDelegate` so behavior
+    /// stays consistent across modules that need to skip side-effects in
+    /// tests.
+    private static func isRunningUnderXCTest() -> Bool {
+        let env = ProcessInfo.processInfo.environment
+        if env["XCTestConfigurationFilePath"] != nil { return true }
+        if env["XCTestBundlePath"] != nil { return true }
+        if env["XCTestSessionIdentifier"] != nil { return true }
+        if env["XCInjectBundle"] != nil { return true }
+        if env["XCInjectBundleInto"] != nil { return true }
+        if env["DYLD_INSERT_LIBRARIES"]?.contains("libXCTest") == true { return true }
+        return false
     }
 }

--- a/c11Tests/StateDirectoryMigrationTests.swift
+++ b/c11Tests/StateDirectoryMigrationTests.swift
@@ -1,0 +1,256 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Behavioral tests for the C11-103 per-entry merge fix. Each test runs the
+/// migration against an isolated temp dir treated as the fake Application
+/// Support root, so tests never touch the real `~/Library/Application Support`.
+final class StateDirectoryMigrationTests: XCTestCase {
+
+    private var tempAppSupport: URL!
+    private let legacyName = StateDirectoryMigration.legacyName
+    private let currentName = StateDirectoryMigration.currentName
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        StateDirectoryMigration.resetForTests()
+        tempAppSupport = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("c11-103-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempAppSupport,
+            withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        if let tempAppSupport {
+            try? FileManager.default.removeItem(at: tempAppSupport)
+        }
+        // Intentionally do NOT reset `didRun` here. Each test method's call to
+        // `ensureMigrated(appSupport: tempAppSupport)` latches `didRun = true`,
+        // and we want that latch to outlive this test class so subsequent
+        // suites in the same xctest process cannot trigger the migration
+        // against the operator's real `~/Library/Application Support/`.
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    private var legacyURL: URL {
+        tempAppSupport.appendingPathComponent(legacyName, isDirectory: true)
+    }
+
+    private var currentURL: URL {
+        tempAppSupport.appendingPathComponent(currentName, isDirectory: true)
+    }
+
+    private func makeLegacy() throws {
+        try FileManager.default.createDirectory(at: legacyURL, withIntermediateDirectories: true)
+    }
+
+    private func makeCurrent() throws {
+        try FileManager.default.createDirectory(at: currentURL, withIntermediateDirectories: true)
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data(contents.utf8).write(to: url, options: .atomic)
+    }
+
+    private func read(_ url: URL) throws -> String {
+        String(decoding: try Data(contentsOf: url), as: UTF8.self)
+    }
+
+    private func runMigration() {
+        StateDirectoryMigration.ensureMigrated(
+            fileManager: .default,
+            appSupport: tempAppSupport
+        )
+    }
+
+    // MARK: - AC1: clean-rename happy path preserved
+
+    func testCleanRenameWhenOnlyLegacyExists() throws {
+        try makeLegacy()
+        let legacySession = legacyURL.appendingPathComponent("session-com.stage11.c11.json")
+        try write("legacy-session", to: legacySession)
+
+        runMigration()
+
+        let currentSession = currentURL.appendingPathComponent("session-com.stage11.c11.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: currentSession.path),
+                      "Session file should land in current dir")
+        XCTAssertEqual(try read(currentSession), "legacy-session")
+
+        // Legacy should now be a symlink pointing at current (relative).
+        let attrs = try FileManager.default.attributesOfItem(atPath: legacyURL.path)
+        XCTAssertEqual(attrs[.type] as? FileAttributeType, .typeSymbolicLink)
+        let target = try FileManager.default.destinationOfSymbolicLink(atPath: legacyURL.path)
+        XCTAssertEqual(target, currentName)
+    }
+
+    // MARK: - AC2: prod-bundle-id session in legacy, debug files in current
+
+    func testDualDirMigratesProdSessionWhenCurrentHasOnlyDebugFiles() throws {
+        try makeLegacy()
+        try makeCurrent()
+        let prodSession = legacyURL.appendingPathComponent("session-com.stage11.c11.json")
+        let debugSession = currentURL.appendingPathComponent("session-com.stage11.c11.debug.tag.json")
+        try write("real-state", to: prodSession)
+        try write("debug-build-state", to: debugSession)
+
+        runMigration()
+
+        let movedProd = currentURL.appendingPathComponent("session-com.stage11.c11.json")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: movedProd.path),
+                      "Prod session must migrate into current")
+        XCTAssertEqual(try read(movedProd), "real-state")
+        // Debug session untouched.
+        XCTAssertEqual(try read(debugSession), "debug-build-state")
+        // Legacy was emptied of its single entry and replaced by a symlink.
+        // (`fileExists` follows the symlink, so checking prodSession.path
+        // would resolve back to the moved file in current — instead check
+        // the legacy dir itself is now a symlink.)
+        let attrs = try FileManager.default.attributesOfItem(atPath: legacyURL.path)
+        XCTAssertEqual(attrs[.type] as? FileAttributeType, .typeSymbolicLink,
+                       "Legacy dir should be a symlink after its only entry migrated")
+    }
+
+    // MARK: - AC3: same-name collision → current wins
+
+    func testFileCollisionLeavesCurrentBytesIntact() throws {
+        try makeLegacy()
+        try makeCurrent()
+        let legacyFile = legacyURL.appendingPathComponent("foo.json")
+        let currentFile = currentURL.appendingPathComponent("foo.json")
+        try write("legacy-bytes", to: legacyFile)
+        try write("current-bytes", to: currentFile)
+
+        runMigration()
+
+        XCTAssertEqual(try read(currentFile), "current-bytes",
+                       "Current file must not be overwritten")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacyFile.path),
+                      "Legacy file stays put when there's a name collision in current")
+        XCTAssertEqual(try read(legacyFile), "legacy-bytes")
+    }
+
+    // MARK: - AC4: workspaces/<uuid>/ shallow recursion
+
+    func testWorkspacesShallowRecursionMergesUuidsOneLevelDeep() throws {
+        try makeLegacy()
+        try makeCurrent()
+        let legacyWS = legacyURL.appendingPathComponent("workspaces", isDirectory: true)
+        let currentWS = currentURL.appendingPathComponent("workspaces", isDirectory: true)
+        let uuidA = "A0000000-0000-0000-0000-000000000000"
+        let uuidB = "B0000000-0000-0000-0000-000000000000"
+        let uuidC = "C0000000-0000-0000-0000-000000000000"
+        // Legacy has {A, B}, current has {B, C}.
+        try write("A-legacy", to: legacyWS.appendingPathComponent(uuidA).appendingPathComponent("snapshot.json"))
+        try write("B-legacy", to: legacyWS.appendingPathComponent(uuidB).appendingPathComponent("snapshot.json"))
+        try write("B-current", to: currentWS.appendingPathComponent(uuidB).appendingPathComponent("snapshot.json"))
+        try write("C-current", to: currentWS.appendingPathComponent(uuidC).appendingPathComponent("snapshot.json"))
+
+        runMigration()
+
+        let afterMerge = Set(
+            try FileManager.default.contentsOfDirectory(atPath: currentWS.path)
+        )
+        XCTAssertEqual(afterMerge, Set([uuidA, uuidB, uuidC]),
+                       "Current workspaces should contain union of UUIDs")
+        // B in current must remain the current copy.
+        XCTAssertEqual(
+            try read(currentWS.appendingPathComponent(uuidB).appendingPathComponent("snapshot.json")),
+            "B-current"
+        )
+        // A's snapshot came from legacy.
+        XCTAssertEqual(
+            try read(currentWS.appendingPathComponent(uuidA).appendingPathComponent("snapshot.json")),
+            "A-legacy"
+        )
+    }
+
+    // MARK: - AC5: fresh install (neither dir exists)
+
+    func testFreshInstallIsNoOp() throws {
+        // tempAppSupport exists but contains neither c11 nor c11mux.
+        runMigration()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path),
+                       "Fresh install should not create legacy dir")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: currentURL.path),
+                       "Fresh install should not create current dir")
+    }
+
+    // MARK: - AC6: didRun guard prevents re-execution
+
+    func testDidRunGuardSkipsSecondCall() throws {
+        try makeLegacy()
+        try write("first-run", to: legacyURL.appendingPathComponent("snapshot.json"))
+
+        runMigration()
+        // After first run: snapshot landed in current; legacy is a symlink.
+        let firstHop = currentURL.appendingPathComponent("snapshot.json")
+        XCTAssertEqual(try read(firstHop), "first-run")
+
+        // Plant a new file at the *legacy resolved path* (which is now a
+        // symlink pointing at current). To prove the guard, plant a file
+        // somewhere the migration WOULD move if it ran a second time.
+        // We restore a non-symlink legacy dir + a fresh file, then call
+        // ensureMigrated() again without resetForTests.
+        try FileManager.default.removeItem(at: legacyURL)
+        try makeLegacy()
+        let postRunFile = legacyURL.appendingPathComponent("second-run.json")
+        try write("would-move-if-not-guarded", to: postRunFile)
+
+        // Second call must be a no-op because didRun is still latched.
+        StateDirectoryMigration.ensureMigrated(
+            fileManager: .default,
+            appSupport: tempAppSupport
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: postRunFile.path),
+                      "didRun guard must prevent the second migration from moving anything")
+        let currentSecond = currentURL.appendingPathComponent("second-run.json")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: currentSecond.path),
+                       "second-run.json must not appear in current")
+    }
+
+    // MARK: - AC8: symlink only when legacy is empty after merge
+
+    func testSymlinkCreatedWhenLegacyEmptyAfterMerge() throws {
+        try makeLegacy()
+        try write("payload", to: legacyURL.appendingPathComponent("a.json"))
+
+        runMigration()
+
+        let attrs = try FileManager.default.attributesOfItem(atPath: legacyURL.path)
+        XCTAssertEqual(attrs[.type] as? FileAttributeType, .typeSymbolicLink,
+                       "Empty legacy should be replaced with a symlink")
+    }
+
+    func testSymlinkNotCreatedWhenLegacyRetainsCollidedEntries() throws {
+        try makeLegacy()
+        try makeCurrent()
+        // Force a collision so legacy keeps the file.
+        try write("legacy", to: legacyURL.appendingPathComponent("foo.json"))
+        try write("current", to: currentURL.appendingPathComponent("foo.json"))
+
+        runMigration()
+
+        // Legacy should still be a real directory with foo.json inside.
+        let attrs = try FileManager.default.attributesOfItem(atPath: legacyURL.path)
+        XCTAssertEqual(attrs[.type] as? FileAttributeType, .typeDirectory,
+                       "Legacy must remain a directory when collisions kept entries")
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: legacyURL.appendingPathComponent("foo.json").path
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes C11-103. `StateDirectoryMigration.ensureMigrated` previously bailed when both `~/Library/Application Support/c11mux/` and `~/Library/Application Support/c11/` existed. Anyone who ran a tagged debug build (which pre-creates `c11/`) before the prod release with the rename landed got an empty session on first prod launch — the migration was a no-op, the prod build wrote a fresh empty snapshot, and the legacy session orphaned in `c11mux/`.

This PR replaces the dir-level guard with a **per-entry merge**:

- Move any file present in legacy but absent in current.
- For `workspaces/`, recurse one level so per-workspace UUID directories present only in legacy come over.
- Conflict policy: **current wins** on same-name collision (it's the newer, post-rename copy).
- If legacy is empty after the merge, replace it with a relative symlink → `c11` (preserves the downgrade window).
- Per-entry errors log via `FileHandle.standardError.write` and continue; one bad entry does not abort the merge.

`ensureMigrated` gains an optional `appSupport: URL?` parameter (matching the convention from `SessionPersistence.defaultSnapshotFileURL`) as the testing seam, plus a `static func resetForTests()` to clear the `didRun` latch.

## Why

Affects anyone who ran a c11 build using the new state-dir code (any tagged debug build, anyone on internal dogfooding builds) before the prod release with the rename landed. Pure end users with no debug-build history got a clean rename. See C11-103 for full root-cause analysis, recovery path, and references.

## Beyond the validation plan: XCTest defensive guard

The new merge logic does real work when both dirs already exist. The previous bail-out was inherently test-safe — a dogfooder's local test run could call `ensureMigrated()` (via `SessionPersistence.defaultSnapshotFileURL`) and the migration would no-op against their real Application Support. Without further safety, the new code would silently mutate their real session state during any test that touches that code path.

`ensureMigrated` now bails when invoked with no `appSupport:` override AND the process is an xctest host (using the same env-var detection pattern as `SessionRestorePolicy` / `AppDelegate`). Tests that need to exercise the migration pass an explicit `appSupport:` temp-dir URL, which sidesteps the guard.

This wasn't in the run-state plan but is a justified addition; baseline (without the guard) would mutate Atin's real `c11mux/` during local `xcodebuild test` runs.

## Test plan

- [x] `xcodebuild -scheme c11-logic test` — 8 new tests covering AC1-AC6 + AC8 of `.lattice/orchestration/c11-103/validation-plan.md` (clean-rename happy path, dual-dir prod-session migration, same-name collision policy, `workspaces/` shallow recursion, fresh install no-op, `didRun` idempotency, symlink-or-not based on post-merge legacy state). All pass locally.
- [x] Full `c11-logic` suite regression check: identical failure set on `HEAD` vs `origin/main` (9 pre-existing failures, this PR introduces zero new failures).
- [ ] CI green on the PR.

### AC7 — gapped

AC7 (per-entry failure isolation: one `moveItem` failure does not abort other entries) is not tested. A `FileManager` subclass that throws on a targeted path would exercise the `do/catch + logFailure + continue` block, but the substitution surface (FileManager exposes many overrideable methods that need to behave consistently with Foundation's expectations) is fragile relative to the value. Production code's per-entry try/catch is short and self-evident. Happy to add a `FileManager` substitution-based test if reviewer disagrees.

## References

- Lattice ticket: C11-103
- Validation plan: `.lattice/orchestration/c11-103/validation-plan.md`
- Run-state (BUILDPLAN): `.lattice/orchestration/c11-103/run-state.md`
- Code-review artifact: attached to C11-103 as `role=review` note

🤖 Generated with [Claude Code](https://claude.com/claude-code)