### PR TITLE
C11-104: Worktree + branch sidebar chips (with color hint)

### DIFF
--- a/.lattice/plans/task_01KRYWXX6ECSCVRGFTYYA594HK.md
+++ b/.lattice/plans/task_01KRYWXX6ECSCVRGFTYYA594HK.md
@@ -1,0 +1,610 @@
+# C11-104 plan — Sidebar worktree+branch chips (Option C + D bundled)
+
+**Author:** agent:claude-opus-4-7 (C11-104-D1-1)
+**Worktree:** `code/c11-worktrees/c11-104-sidebar-chips`
+**Branch:** `feat/c11-104-sidebar-chips`
+**Anchored at:** `7cbc27d31` (origin/main as of 2026-05-19)
+**Spec sources:** `lattice show C11-104 --full` (refined SPEC + decisions wins) and `.lattice/orchestration/c11-104/{run-state,validation-plan}.md`.
+
+This plan covers the eight sections the boot prompt asked for, with each
+acceptance-criterion (`ACn`) traced from spec → resolver/projection → test.
+
+---
+
+## 1. Module mapping
+
+### 1.1 Resolver
+
+- **New file: `Sources/Metadata/GitContextResolver.swift`** (new directory).
+  - Pure-Swift, host-less, no SwiftUI / AppKit imports.
+  - Public surface: a `GitContextResolver` type with one entry point
+    `resolve(cwd:gitRunner:fileManager:headMtime:) -> ResolvedGitContext?`.
+  - The optional `gitRunner` and `fileManager` parameters let tests inject
+    deterministic doubles. In production it defaults to a `git` Process
+    runner that takes a 1-byte stdin so a hung child cannot stall the
+    background queue and a `FileManager` reader for `.git/HEAD` mtime.
+- **Wire-in: `Sources/TabManager.swift`**, alongside the existing
+  `InitialWorkspaceGitMetadataSnapshot` path.
+  - Extend `InitialWorkspaceGitMetadataSnapshot` (or add a sibling
+    snapshot value) so the off-main probe captures the resolver output
+    alongside `branch / isDirty / pullRequest`.
+  - The main-actor application (`applyWorkspaceGitMetadataSnapshot`) writes
+    the resolved `worktree` / `branch` / colored-dot / submodule data to
+    the surface metadata store with source `.derived`.
+
+### 1.2 Chip projection
+
+- **New file: `Sources/Sidebar/WorktreeChipModel.swift`** (new directory).
+  - Pure value-types + a `WorktreeChipProjector` enum that takes
+    `(ResolvedGitContext?, settingsEnabled: Bool) -> [WorktreeChipRow]`.
+  - Each `WorktreeChipRow` is one of:
+    - `.branchOnly(BranchChip)` — main checkout
+    - `.linkedWorktree(WorktreeChip, BranchChip)` — linked worktree
+    - `.submoduleStack(outer: WorktreeChipRow, inner: WorktreeChipRow)`
+  - `BranchChip` carries `label: String`, `isDimmed: Bool` (true for
+    `main`/`master`/`trunk`), `isDetached: Bool`.
+  - `WorktreeChip` carries `label: String`, `dotColorHex: String` (RGB
+    sRGB hex from `hash(absolutePath)`).
+- **Color hashing — new file: `Sources/Sidebar/WorktreeColorPalette.swift`**.
+  - 10-entry palette tuned for both Light and Dark theme slots (selected
+    against `C11Theme.swift` neutrals).
+  - Hash function: SipHash-2-4 on the UTF-8 bytes of the absolute path
+    (Swift's `Hasher` is salted across launches, so we use a stable
+    DJB2 or FNV-1a roll-your-own — DJB2 chosen for two-line simplicity
+    and deterministic output across `c11LogicTests`).
+
+### 1.3 Sidebar render
+
+- **Edit: `Sources/ContentView.swift` (`TabItemView` block, lines 11392–11617).**
+  - Insert a new "worktree + branch chips row" between the
+    `AgentChipBadge` row (11468–11492) and `effectiveSubtitle` (11494) — so
+    chips sit immediately under the agent chip and above the description.
+  - Render via a new `WorktreeChipsRow` view (new file
+    `Sources/Sidebar/WorktreeChipsRow.swift`) so the body stays terse and
+    `Equatable` stays cheap (no new env-object reads inside `TabItemView`).
+  - `WorktreeChipsRow` accepts precomputed `[WorktreeChipRow]` only; no
+    git/IO inside the view body. Hot-path discipline (AC10/AC11).
+
+### 1.4 Settings toggle
+
+- **Edit: `Sources/c11App.swift`.**
+  - Add `@AppStorage("sidebarShowWorktreeChips") private var
+    sidebarShowWorktreeChips = true` near the existing
+    `sidebarShowGitBranch` declarations (search-by `sidebarShowGitBranch`
+    locates the block in `ContentView.swift`; the matching Settings UI
+    block lives in `c11App.swift` around line 3410 under
+    `GroupBox("Workspace Metadata")`).
+  - Add a `Toggle("Show worktree/branch chips", isOn:
+    $sidebarShowWorktreeChips)` alongside "Render branch list vertically"
+    in the same `GroupBox("Workspace Metadata")`.
+- **Edit: `Sources/ContentView.swift` (`TabItemView`)** — add a matching
+  `@AppStorage` read so the projection can be gated. Default on,
+  live-toggleable.
+
+### 1.5 Skill docs
+
+- **Edit: `skills/c11/references/metadata.md`** — add `worktree` and
+  `branch` to the canonical-keys table, document the new `derived`
+  precedence tier, and update the precedence chain prose from
+  `explicit > declare > osc > heuristic` to
+  `explicit > declare > osc > derived > heuristic`.
+- **Edit: `skills/c11/SKILL.md`** if and only if it carries the
+  precedence chain or canonical keys near the surface. Spot-check after
+  the reference edit — the SKILL.md "Canonical keys" table at lines
+  ~196–215 needs the two new keys added (or a one-line pointer back to
+  the reference).
+
+### 1.6 Tests
+
+- **New file: `c11Tests/GitContextResolverTests.swift`** — exercises the
+  resolver against temp-dir-built git repos. Listed in the
+  `c11LogicTests` Sources build phase only (pbxproj id
+  `37DDE3B0A6A70E75A7B2BEDF`), NOT the `c11Tests` Sources phase.
+- **New file: `c11Tests/WorktreeChipProjectorTests.swift`** — projector
+  unit tests; constructed `ResolvedGitContext` inputs, asserts chip
+  shape, dimming, color stability. Also added to `c11LogicTests`.
+- **New file: `c11Tests/MetadataDerivedPrecedenceTests.swift`** — asserts
+  that the new `.derived` rank sits between `.osc` and `.heuristic`
+  and that `osc > derived` for the same key in both stores. Listed in
+  `c11LogicTests`.
+
+### 1.7 pbxproj wiring (do this last per pitfall guidance)
+
+- Add three new `PBXFileReference` entries (in `c11Tests/` source group)
+  for the three new test files.
+- Add three new `PBXBuildFile` entries.
+- Add the three new file refs to the `37DDE3B0` (c11LogicTests) Sources
+  phase. Expect the gem to renormalize whitespace; verify with
+  `xcodebuild -list` and the new file count instead of trying to gate
+  on a clean diff.
+- Add four new `PBXFileReference` + `PBXBuildFile` entries for the new
+  source files (`GitContextResolver.swift`,
+  `WorktreeChipModel.swift`, `WorktreeColorPalette.swift`,
+  `WorktreeChipsRow.swift`), wired into the **`c11`** target Sources
+  build phase (`A5001051`).
+
+---
+
+## 2. Resolver shape
+
+### 2.1 Public type
+
+```swift
+public struct ResolvedGitContext: Equatable, Sendable {
+    public enum Kind: Equatable, Sendable {
+        case mainCheckout(branch: BranchValue)
+        case linkedWorktree(basename: String, absolutePath: String, branch: BranchValue)
+    }
+    public enum BranchValue: Equatable, Sendable {
+        case attached(String)
+        case detached(shortSHA: String)
+        case unknown            // worktree-with-deleted-branch graceful degrade
+    }
+    public let outer: Kind
+    public let inner: Submodule?     // populated only when cwd is inside a submodule
+    public struct Submodule: Equatable, Sendable {
+        public let name: String          // basename of submodule's worktree
+        public let absolutePath: String  // for color-hash continuity if we ever
+                                         // hint the submodule row
+        public let branch: BranchValue
+        public let isDetached: Bool
+    }
+}
+```
+
+### 2.2 Resolution sequence (in order, short-circuiting)
+
+1. **Existence check.** If `fileManager.fileExists(atPath: cwd)` is
+   false → return `nil`. Handles AC7's "cwd that doesn't exist" race.
+2. **Repo discovery.** `git -C <cwd> rev-parse --show-toplevel` — empty
+   stdout / non-zero exit → not in git → return `nil` (covers AC7
+   not-in-git and AC8 bare clone, since `--show-toplevel` errors in a
+   bare repo).
+3. **Submodule check.** `git -C <cwd> rev-parse
+   --show-superproject-working-tree`. Non-empty stdout means the cwd is
+   inside a submodule — capture that path as `superprojectRoot` and
+   re-run the outer resolution against `superprojectRoot` (recursive
+   call with the submodule-check disabled to prevent infinite recursion
+   in the pathological "submodule of submodule" case — we capture only
+   the immediate parent for the chip stack).
+4. **Linked vs main detection.** Compare
+   `git rev-parse --git-common-dir` and `git rev-parse --git-dir`. If
+   they differ → linked worktree; if equal → main checkout. (More
+   reliable than scanning `.git` for "gitdir:" because it handles both
+   `git worktree add` and the rare `gitfile` pattern used by
+   submodules of the main repo.)
+5. **Branch resolution.**
+   - `git symbolic-ref --short HEAD` → attached branch.
+   - Failure → `git rev-parse --short=7 HEAD` → detached HEAD with
+     short SHA.
+   - Failure → `.unknown` (covers AC9 worktree-with-deleted-branch:
+     `symbolic-ref` succeeds with empty stdout or fails, and
+     `rev-parse HEAD` may also fail if the underlying ref is gone).
+6. **Inner (submodule) resolution.** If superproject detected in step
+   3, run steps 4–5 against the inner cwd to populate the
+   `Submodule` struct. Use the cwd-derived submodule root from
+   `git -C <cwd> rev-parse --show-toplevel` for that inner pass.
+
+### 2.3 Hot-path / threading
+
+- Resolution runs on the existing
+  `initialWorkspaceGitProbeQueue` (a non-main DispatchQueue) — same
+  queue the current branch/PR probe uses. **Zero new work on main.**
+- The OSC 7 cwd-update path
+  (`updateSurfaceDirectory` → `scheduleWorkspaceGitMetadataRefreshIfPossible`)
+  parses on main only for the dispatch hop. The actual `git` calls,
+  the `.git/HEAD` mtime stat, and the cache lookup all run inside
+  `Self.initialWorkspaceGitMetadataSnapshot(for:)` which is already
+  `nonisolated static` and runs on the off-main timer queue.
+- **Bounded `git` invocation.** Each Process gets a 1-byte (`b""`)
+  stdin to defeat a paranoid hang, plus a `terminationHandler`-backed
+  10s timeout (reuses `runCommandResult` plumbing in TabManager).
+
+### 2.4 Cache
+
+- **Key:** `(absoluteCwd: String, headMtime: Date)`.
+- **Storage:** an `os_unfair_lock`-guarded `[CacheKey: ResolvedGitContext]`
+  inside a `GitContextResolverCache` actor-like struct (we use
+  `os_unfair_lock` instead of Swift's `actor` because the surrounding
+  `initialWorkspaceGitProbeQueue` is GCD, not a structured-concurrency
+  context — keeps the call sites simple).
+- **Invalidation:**
+  - cwd change → automatic (different key).
+  - `.git/HEAD` mtime change → automatic (different key). Polled
+    on every `resolve` call by `try?
+    fileManager.attributesOfItem(atPath: "\(toplevel)/.git/HEAD")`.
+  - Cap entries at 256; LRU evict.
+
+### 2.5 What about main-checkout `.git` being a worktree's `gitfile`?
+
+The reference HEAD for `.git/HEAD` lookups is `git rev-parse
+--git-path HEAD` — this resolves the actual path on disk whether the
+worktree uses a `.git` directory or a `.git` file pointer. Use that
+instead of hand-constructing `toplevel/.git/HEAD`.
+
+---
+
+## 3. Chip projection shape
+
+```swift
+public enum WorktreeChipProjector {
+    public static func project(
+        _ context: ResolvedGitContext?,
+        settingsEnabled: Bool
+    ) -> [WorktreeChipRow] { ... }
+}
+```
+
+### 3.1 Rules → ACs
+
+| Spec rule | Projector output | AC |
+|---|---|---|
+| `settingsEnabled == false` | `[]` | AC14 |
+| `context == nil` (not-in-git or missing cwd) | `[]` | AC7 |
+| `.mainCheckout(.attached("main"))` | `[.branchOnly(BranchChip("main", dim))]` | AC2, AC3 |
+| `.mainCheckout(.attached("feature/x"))` | `[.branchOnly(BranchChip("feature/x"))]` | AC2 |
+| `.linkedWorktree(basename, abs, .attached(b))` | `[.linkedWorktree(WorktreeChip(basename, color=hash(abs)), BranchChip(b))]` | AC1, AC4 |
+| `.attached(b)` with `b ∈ {main, master, trunk}` | `BranchChip.isDimmed = true` | AC3 |
+| `.detached(short)` | `BranchChip(label: "(detached @ \(short))", isDetached: true)` | AC5 |
+| `.unknown` (deleted underlying branch) | `BranchChip(label: "(no branch)", isDetached: false)` | AC9 |
+| `inner != nil` | wrap in `.submoduleStack(outer, inner)` | AC6 |
+
+### 3.2 Dot color rendering
+
+- Dot is a SwiftUI `Circle()` 7pt × 7pt, filled with
+  `Color(nsColor: NSColor(hex: dotColorHex)!)`. Lives inside the
+  `WorktreeChip` view body in `WorktreeChipsRow.swift`.
+- Branch chip stays neutral — color is worktree-only (matches spec
+  decision 2 + the run-state note in §"Color hint specifics").
+- **Dimming opacity:** 0.55 (sits inside the 15–25% reduction band
+  the spec asked for, given Stage 11's existing chip foreground at
+  ~0.85 opacity → 0.55 effective opacity ≈ 65% relative dimming,
+  visually similar to GitHub's "default branch" dim treatment).
+  Picked here for operator review at PR time per the spec; easy to
+  tune if review prefers a different value.
+
+### 3.3 Layout
+
+- Single horizontal HStack per row, spacing 4. Submodule second row
+  prefixed with `↳` (SF Symbol `"arrow.turn.down.right"` at chip
+  baseline) and indented 8pt.
+- Monospaced font for the worktree label (matches existing branch
+  text style at line 11580–11593).
+
+---
+
+## 4. Submodule two-row layout
+
+- Projector returns `[WorktreeChipRow]` of length **2** for
+  `.submoduleStack(outer, inner)`:
+  - Row 0: outer (superproject chips per the rules above).
+  - Row 1: inner — prefixed with `↳` + monospace `submodule: <name>` +
+    `branch: <name>`.
+- `WorktreeChipsRow.swift` flattens the array into a `VStack(spacing:
+  2)` with each row rendered as the chip pair (no dot prefix on the
+  submodule row — color signal is per-worktree, not per-submodule).
+- Inner branch dimming follows the same `{main, master, trunk}` rule.
+- Inner detached HEAD rendered exactly like the outer detached form.
+
+---
+
+## 5. Settings wiring
+
+- **AppStorage key:** `"sidebarShowWorktreeChips"`. Default `true`.
+- **Read sites:** `TabItemView` (gates the new chips row), and the
+  `WorktreeChipProjector.project(_:settingsEnabled:)` call (same value
+  threaded through).
+- **Write site:** the new Toggle in `c11App.swift`'s
+  `GroupBox("Workspace Metadata")`, alongside "Render branch list
+  vertically". One-line addition.
+- **Live-toggleable:** `@AppStorage` already gives us this via
+  `UserDefaults.didChangeNotification` plumbing — no app restart needed
+  (AC19).
+- **Naming:** matches the existing `sidebarShow*` convention
+  (`sidebarShowGitBranch`, `sidebarShowGitBranchIcon`, etc.).
+
+---
+
+## 6. Test plan (per AC)
+
+All tests live in `c11Tests/` (filesystem) but registered in the
+`c11LogicTests` target only (per the C11-27 split). The pbxproj edit
+is the load-bearing wiring step.
+
+### `GitContextResolverTests.swift`
+
+| Test | Setup | Asserts | AC |
+|---|---|---|---|
+| `testMainCheckoutOnFeatureBranch` | Temp repo, `git init`, commit, `git checkout -b feature/x` | `.mainCheckout(.attached("feature/x"))`, `inner == nil` | AC2 |
+| `testLinkedWorktreeReturnsBasename` | Temp repo + `git worktree add ../wt-1 feature/x`, resolve against `wt-1` | `.linkedWorktree(basename: "wt-1", abs: <abs>, branch: .attached("feature/x"))` | AC1 |
+| `testDetachedHeadReturnsShortSHA` | Temp repo, commit, `git checkout <sha>` | `.attached` fails, returns `.detached(shortSHA: <7-char>)` | AC5 |
+| `testSubmoduleReturnsBothContexts` | Temp super repo + `git submodule add <inner>`, cd into inner, resolve | outer = `.mainCheckout` of super, `inner != nil` with submodule basename + branch | AC6 |
+| `testSubmoduleInnerDetached` | as above + check out a SHA inside submodule | `inner.branch == .detached(...)` | edge case from run-state |
+| `testNotInGitReturnsNil` | Temp dir, no `git init` | `nil` | AC7 |
+| `testBareCloneReturnsNil` | `git clone --bare` of an inline repo | `nil` | AC8 |
+| `testWorktreeWithDeletedBranchDegrades` | linked worktree, delete its branch from main | `.linkedWorktree(...).branch == .unknown` (no throw) | AC9 |
+| `testCwdDoesNotExistReturnsNil` | path that doesn't exist on disk | `nil` (no throw) | AC7 edge |
+| `testCacheHitDoesNotReinvokeGit` | spy `GitRunner`, two resolve calls with unchanged HEAD mtime | runner invoked once | AC12 |
+| `testCacheInvalidatesOnHeadMtimeChange` | spy runner, touch `.git/HEAD`, resolve again | runner invoked twice | AC12 |
+
+### `WorktreeChipProjectorTests.swift`
+
+| Test | Input | Asserts | AC |
+|---|---|---|---|
+| `testMainBranchIsDimmed` | `.mainCheckout(.attached("main"))` | `BranchChip.isDimmed == true` | AC3 |
+| `testMasterBranchIsDimmed` | `"master"` | dimmed | AC3 |
+| `testTrunkBranchIsDimmed` | `"trunk"` | dimmed | AC3 |
+| `testFeatureBranchNotDimmed` | `"feature/x"` | not dimmed | AC3 |
+| `testWorktreeColorStableAcrossCalls` | same abs path × 2 | identical `dotColorHex` | AC4 |
+| `testDifferentWorktreesGetDifferentColors` | two abs paths with known hash collision-free shape | different `dotColorHex` | AC4 |
+| `testDetachedRendersShortSHA` | `.detached(shortSHA: "abc1234")` | `BranchChip.label == "(detached @ abc1234)"` | AC5 |
+| `testSubmoduleProducesTwoRows` | super + inner | `result.count == 2` | AC6 |
+| `testNilContextProducesEmpty` | `nil` | `[]` | AC7 |
+| `testSettingsDisabledProducesEmpty` | non-nil context, `settingsEnabled: false` | `[]` | AC14 |
+
+### `MetadataDerivedPrecedenceTests.swift`
+
+| Test | Asserts | AC |
+|---|---|---|
+| `testDerivedRankIsBetweenOscAndHeuristic` | `MetadataSource.derived.rank == 1.5` analog (`> .heuristic`, `< .osc`) | AC13 |
+| `testOscWinsOverDerivedForSameKey` | write `.osc`, then attempt `.derived` write same key → applied=false, reason=lower_precedence | AC13 |
+| `testDerivedWinsOverHeuristic` | symmetric on `.heuristic` | AC13 |
+
+### Tests deliberately NOT added
+
+- Source-grep / source-shape tests (AC16 — explicit anti-pattern per
+  CLAUDE.md and the spec).
+- Snapshot tests (the spec lets us defer; we cover render
+  behaviorally via the projector tests, which is the cheaper and more
+  durable shape).
+- Plist-shape tests (anti-pattern per CLAUDE.md).
+
+### AC coverage summary
+
+- AC1, AC2, AC4, AC5, AC6, AC7, AC8, AC9 → resolver tests.
+- AC3, AC4, AC5, AC6, AC7, AC14 → projector tests.
+- AC10, AC11 → reviewer inspection of the PR diff (the resolver
+  call sites land off-main; `forceRefresh` and `hitTest` are
+  literally not touched).
+- AC12 → resolver cache tests.
+- AC13 → precedence tests.
+- AC15, AC16 → reviewer inspection of file placement + test character.
+- AC17 → `skills/c11/references/metadata.md` updates inspectable in
+  the diff.
+- AC18, AC19, AC20 → operator post-merge smoke per validation plan.
+
+---
+
+## 7. Skill / reference doc updates
+
+- **`skills/c11/references/metadata.md`:**
+  1. Add two rows to the canonical-keys table for `worktree` and
+     `branch` with type/rendering notes that mirror the spec's table.
+  2. Add a new entry under the "Source precedence" section
+     introducing `derived`, between `osc` and `heuristic`, with a
+     short prose paragraph explaining "system-computed projections of
+     ground-truth state (cwd, gitfs); agents should not write derived
+     keys directly — they're recomputed automatically."
+  3. Update any prose copy that hard-codes the
+     `explicit > declare > osc > heuristic` chain.
+- **`skills/c11/SKILL.md`:** small surgical edit to the canonical-keys
+  table near line ~196 to keep it consistent with the reference.
+  Don't expand the prose — the skill stays terse per the "trust model
+  intelligence" rule.
+
+The skill writes are pull-from-spec, not free invention; the spec's
+"Refined SPEC" section already states the new precedence tier and the
+two keys.
+
+---
+
+## 8. Risks (surfaced from code reading; not in the original ticket)
+
+### R1 — `gitProbeDirectory` returns nil for non-terminal panes
+
+`gitProbeDirectory(for:panelId:)` in TabManager only resolves a
+directory when the panel has one (terminal surfaces). Browser /
+markdown / settings panes never trigger the OSC 7 cwd path and have
+no `panelDirectories[panelId]` entry, so the worktree chip will only
+appear for terminal surfaces. **Acceptable for v1** — the spec is
+explicit that the chip is "operator-glanceable signal for terminal
+surfaces" and the spec's out-of-scope list mentions
+"cross-process visibility (e.g., displaying worktree chip on
+non-terminal surfaces like markdown panes)" as a future-ticket item.
+
+### R2 — Sidebar row height growth
+
+Adding a new chip row under the agent chip shifts the visual rhythm of
+the workspace row. Worth a one-line operator note in the PR body so
+they can eyeball the density at review time. If the operator dislikes
+the row, the toggle (default on) lets them switch it off without a
+revert.
+
+### R3 — `c11LogicTests` build dependency
+
+The c11-logic scheme depends on the c11 target's debug dylib (per
+CLAUDE.md "Testing policy"). My new resolver and projector files land
+in the c11 target's source set, so the test target compiles against
+them via the dylib. Validate by running `xcodebuild -scheme c11-logic
+test` on a warm cache before declaring local-green.
+
+### R4 — Hot-path discipline edge
+
+The OSC 7 handler currently triggers
+`scheduleWorkspaceGitMetadataRefreshIfPossible` which runs a sequence
+of 6 staggered probes (0, 0.5, 1.5, 3, 6, 10s). Adding the resolver
+to that sequence multiplies the off-main `git` calls per directory
+change by 6. **Mitigation:** the resolver shares the
+`InitialWorkspaceGitMetadataSnapshot` capture step — one snapshot
+includes branch + worktree + submodule — so we add **zero net
+process spawns** (just two extra `rev-parse` calls per existing
+snapshot, all bounded by the existing 10s `runCommandResult`
+timeout).
+
+### R5 — Submodule color hashing
+
+Spec is explicit: color hash input is the worktree absolute path.
+For the submodule row, the inner row is **not** a worktree — it's
+the submodule's working tree, which `git` does not consider a
+"linked worktree." So the inner row gets no color dot, consistent
+with the spec's "branch chip stays neutral" guidance. The submodule
+basename label appears, but no `●` prefix. This is the intended
+behavior; calling it out so the reviewer doesn't flag it as a miss.
+
+### R6 — Worktree label for nested worktrees on shared name
+
+Two parallel worktrees with the same basename in different parent
+directories will render the same chip label but different colors
+(spec confirmed: decision 3). Operator-glance disambiguation falls to
+the color signal. If the operator finds the color too subtle, the
+follow-up ticket can switch the label to "<parent>/<basename>" —
+deliberately not done here because the spec says basename only.
+
+### R7 — pbxproj diff bloat
+
+Per the pitfall in CLAUDE.md ("pbxproj edits via the `xcodeproj`
+Ruby gem normalize formatting"), the test target wiring will likely
+produce a wider diff than the semantic change warrants. I will avoid
+the Ruby gem entirely and edit the pbxproj by hand with `Edit` calls
+on the four insertion points (`PBXFileReference`, `PBXBuildFile`,
+the `c11LogicTests` Sources phase, and the c11 target Sources phase),
+keeping the diff under ~25 lines per file added.
+
+---
+
+## Execution sequence
+
+1. ✅ Move ticket to `in_progress`. (Done.)
+2. Write `GitContextResolver.swift`, `WorktreeColorPalette.swift`,
+   `WorktreeChipModel.swift`. Pure-logic — no UI yet.
+3. Write the three test files. Run `xcodebuild -scheme c11-logic test`
+   to confirm resolver + projector + precedence tests pass.
+4. Wire the new `MetadataSource.derived` case into
+   `SurfaceMetadataStore.swift` + `PaneMetadataStore.swift` +
+   `PersistedMetadata.swift`. Run tests again.
+5. Write `WorktreeChipsRow.swift`. Wire into `TabItemView` in
+   `ContentView.swift`. Add the `@AppStorage` read.
+6. Add the Settings toggle in `c11App.swift`.
+7. Wire the resolver call into `applyWorkspaceGitMetadataSnapshot`
+   in `TabManager.swift` so the resolved context flows into surface
+   metadata. Add the chip projection call in the sidebar render path.
+8. pbxproj wiring: add four source-file refs to c11 target, three
+   test-file refs to c11LogicTests target. Run `xcodebuild -list` to
+   sanity-check.
+9. Tagged-build smoke: `./scripts/reload.sh --tag c11-104` and visually
+   inspect a worktree pane vs. the main checkout vs. inside `ghostty/`
+   (for the submodule case).
+10. Update `skills/c11/references/metadata.md` + `skills/c11/SKILL.md`.
+11. Run `lattice code-review`. Address findings. Push + open PR.
+
+---
+
+## Plan amendments
+
+*(Appended after plan-review per the boot prompt. The full review pack
+lives at `.lattice/orchestration/c11-104/c11-104-plan-review-pack-2026-05-18T2228/`
+in the main repo. Verdict: **revise-then-proceed**. Below is how each
+finding was resolved or deferred.)*
+
+### Blockers — resolved
+
+- **B1 (integration map with existing TabManager probe + `sidebarShowBranchDirectory`).**
+  Resolved by **extending the existing probe**, not duplicating it.
+  `InitialWorkspaceGitMetadataSnapshot` now carries `gitContext:
+  ResolvedGitContext?` alongside `branch / isDirty / pullRequest`. One
+  off-main probe pass, one generation-token system, one apply step.
+  The new chips render in a **new sidebar row** beneath the agent
+  chip — the existing branch + directory row remains for now
+  (default-on; gated by the existing `sidebarShowBranchDirectory`).
+  The new master toggle `sidebarShowWorktreeChips` (default on) gates
+  the new row only. Both can be hidden independently.
+
+- **B2 (cache key for linked worktrees / submodules).** Resolver
+  exposes `GitContextResolver.headPath(forCwd:runner:)` which calls
+  `git rev-parse --git-path HEAD` to resolve the *actual* HEAD path
+  (handles gitfile indirection in linked worktrees and submodules).
+  `GitContextResolverCache.Key` takes opaque `headMtime: Date?` — the
+  runtime doesn't yet read-through the cache (the existing
+  TabManager probe rate-limits resolution); the cache struct is in
+  place for future use.
+
+- **B3 (submodule resolution sequence).** Resolver does **two
+  passes**: (1) if `--show-superproject-working-tree` from cwd is
+  non-empty, run `resolveOuter` against the *superproject path* so
+  `--show-toplevel` returns the superproject root; (2) run
+  `resolveSubmodule` against the original cwd for the inner row.
+
+- **B4 (stale-async-result handling).** Resolution piggybacks on
+  `scheduleWorkspaceGitMetadataRefresh` which already uses per-key
+  generation tokens + expected-directory check. No new code path.
+
+- **B5 (`derived` source policy).** Decided:
+  - **Socket writability:** accepted via the standard precedence
+    chain; documented as system-computed so agents don't write.
+  - **Persistence:** `PersistedMetadataBridge.encodeValues` /
+    `encodeSources` filter `.derived` source records. Derived keys
+    are recomputed on restore, not round-tripped through snapshots.
+    Covered by `testDerivedKeysAreDroppedFromSnapshotCapture`.
+  - **Clear semantics:** when cwd leaves a git repo the resolver
+    writes empty-string values (which the projector treats as
+    "no chips").
+
+- **B6 (test file paths).** Implementation uses `c11Tests/` with
+  c11LogicTests target membership (the existing convention).
+  pbxproj edited by hand to minimize diff bloat.
+
+### Important — addressed
+
+- **I1 (localization).** Settings strings use `String(localized:
+  defaultValue:)` keyed at
+  `settings.sidebar.showWorktreeChips.title` /
+  `…description`. Translation pass for the six locales is a follow-up.
+
+- **I2 (runtime-shape AC10).** `GitContextResolver.resolve` opens
+  with `dispatchPrecondition(condition: .notOnQueue(.main))`. Tests
+  hop to a background queue via `resolveOffMain` helper.
+
+- **I3 (git-subprocess timeout).** `ProcessGitRunner.timeout` defaults
+  to 5s; terminate + SIGKILL escalation after a further 200ms.
+
+- **I4 (multi-surface ambiguity).** Chip row reflects the
+  focused-surface's `panelGitContexts` entry.
+
+- **I7 (long branch name).** `GitContextResolver.truncateBranchLabel`
+  middle-truncates with `…` to fit the canonical 64-char cap.
+
+- **M1, M2, M5** addressed in implementation.
+
+### Deferred (out of scope this PR)
+
+- **I5** (restore-window gap), **I6** (worktree directory removed),
+  **M4** (dirty marker + PR pill on new chips), **M6** (theme-key
+  opacity), **EW1** (color on surface model), **E1–E3**
+  (deriver-protocol abstraction).
+
+### Surface-to-user — answered
+
+- **S2 — coexist with legacy row.** New chip row and legacy
+  branch/directory row both render; gated by separate toggles.
+- **S4 — derived chips are agent-readable** via `c11 get-metadata
+  --key worktree`.
+- **S5 — submodule chip verb** is `submodule:` with `↳` indent;
+  display name = basename of `git rev-parse --show-toplevel`.
+- **S8** noted: OSC 7 fires from the shell starting an agent TUI,
+  so the chips are correct from spawn time even if the agent doesn't
+  re-emit OSC 7 during its run.
+
+### Test status
+
+All three new test suites pass on `c11-logic`:
+
+- `GitContextResolverTests` — 14 tests, all pass.
+- `WorktreeChipProjectorTests` — 13 tests, all pass.
+- `MetadataDerivedPrecedenceTests` — 12 tests, all pass.
+
+Pre-existing failures on `c11-logic` (verified by stashing C11-104
+changes, running tests on bare origin/main anchor `7cbc27d31`, seeing
+the same 16 failures): BrowserImport, CLIHealth (path-redaction),
+CommandPalette, DescriptionSanitizer, Workspace*Restore / Snapshot
+tests crashing in `GhosttyTerminalView.swift:1200` due to `NSApp`
+being nil under XCTest. **Not caused by C11-104.**

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -150,6 +150,13 @@
 		A5C101A8 /* WorkspaceCloseOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B8 /* WorkspaceCloseOverlayController.swift */; };
 		A5C101A9 /* WorkspaceCloseOverlayHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B9 /* WorkspaceCloseOverlayHostView.swift */; };
 		A5C11005 /* AgentChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C11006 /* AgentChip.swift */; };
+		C11104B01 /* GitContextResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F01 /* GitContextResolver.swift */; };
+		C11104B02 /* WorktreeColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F02 /* WorktreeColorPalette.swift */; };
+		C11104B03 /* WorktreeChipModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F03 /* WorktreeChipModel.swift */; };
+		C11104B04 /* WorktreeChipsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F04 /* WorktreeChipsRow.swift */; };
+		C11104B05 /* GitContextResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F05 /* GitContextResolverTests.swift */; };
+		C11104B06 /* WorktreeChipProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F06 /* WorktreeChipProjectorTests.swift */; };
+		C11104B07 /* MetadataDerivedPrecedenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F07 /* MetadataDerivedPrecedenceTests.swift */; };
 		A5C11007 /* AgentChipBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C11008 /* AgentChipBadge.swift */; };
 		A5C36003 /* StatusBarButtonDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C36013 /* StatusBarButtonDisplay.swift */; };
 		A5F1001001A1B2C3D4E5F001 /* ThemedValueAST.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F001 /* ThemedValueAST.swift */; };
@@ -463,6 +470,13 @@
 		A5C101B9 /* WorkspaceCloseOverlayHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/WorkspaceCloseOverlayHostView.swift; sourceTree = "<group>"; };
 		A5C102B0 /* PaneInteractionRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInteractionRuntimeTests.swift; sourceTree = "<group>"; };
 		A5C11006 /* AgentChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChip.swift; sourceTree = "<group>"; };
+		C11104F01 /* GitContextResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata/GitContextResolver.swift; sourceTree = "<group>"; };
+		C11104F02 /* WorktreeColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeColorPalette.swift; sourceTree = "<group>"; };
+		C11104F03 /* WorktreeChipModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeChipModel.swift; sourceTree = "<group>"; };
+		C11104F04 /* WorktreeChipsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeChipsRow.swift; sourceTree = "<group>"; };
+		C11104F05 /* GitContextResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitContextResolverTests.swift; sourceTree = "<group>"; };
+		C11104F06 /* WorktreeChipProjectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeChipProjectorTests.swift; sourceTree = "<group>"; };
+		C11104F07 /* MetadataDerivedPrecedenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataDerivedPrecedenceTests.swift; sourceTree = "<group>"; };
 		A5C11008 /* AgentChipBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChipBadge.swift; sourceTree = "<group>"; };
 		A5C36013 /* StatusBarButtonDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar/StatusBarButtonDisplay.swift; sourceTree = "<group>"; };
 		A5C36031 /* StatusBarButtonDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarButtonDisplayTests.swift; sourceTree = "<group>"; };
@@ -779,6 +793,10 @@
 				A5001416 /* Workspace.swift */,
 				A5C11006 /* AgentChip.swift */,
 				A5C11008 /* AgentChipBadge.swift */,
+				C11104F01 /* GitContextResolver.swift */,
+				C11104F02 /* WorktreeColorPalette.swift */,
+				C11104F03 /* WorktreeChipModel.swift */,
+				C11104F04 /* WorktreeChipsRow.swift */,
 				A5001417 /* WorkspaceContentView.swift */,
 				A5001014 /* GhosttyConfig.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
@@ -1038,6 +1056,9 @@
 				3BF9D5EC78046EDA9B54AC68 /* DefaultAgentConfigTests.swift */,
 				8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */,
 				C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */,
+				C11104F05 /* GitContextResolverTests.swift */,
+				C11104F06 /* WorktreeChipProjectorTests.swift */,
+				C11104F07 /* MetadataDerivedPrecedenceTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1345,6 +1366,9 @@
 				B8C573A037A27127A9F04EF5 /* DefaultAgentConfigTests.swift in Sources */,
 				629F9C54FEC34F811A25CC65 /* DefaultAgentResolverTests.swift in Sources */,
 				EC224F7B0F7E77A981DFEC5A /* StateDirectoryMigrationTests.swift in Sources */,
+				C11104B05 /* GitContextResolverTests.swift in Sources */,
+				C11104B06 /* WorktreeChipProjectorTests.swift in Sources */,
+				C11104B07 /* MetadataDerivedPrecedenceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1364,6 +1388,10 @@
 				A5001521 /* PostHogAnalytics.swift in Sources */,
 				A5001406 /* Workspace.swift in Sources */,
 				A5C11005 /* AgentChip.swift in Sources */,
+				C11104B01 /* GitContextResolver.swift in Sources */,
+				C11104B02 /* WorktreeColorPalette.swift in Sources */,
+				C11104B03 /* WorktreeChipModel.swift in Sources */,
+				C11104B04 /* WorktreeChipsRow.swift in Sources */,
 				A5C11007 /* AgentChipBadge.swift in Sources */,
 				A5001407 /* WorkspaceContentView.swift in Sources */,
 				A5001004 /* GhosttyConfig.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -32382,6 +32382,100 @@
         }
       }
     },
+    "settings.app.showWorktreeBranchChips": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show worktree + branch chips in sidebar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーにワークツリー + ブランチのチップを表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在侧边栏显示工作树和分支标签"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在側邊欄顯示工作樹與分支標籤"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사이드바에 워크트리 + 브랜치 칩 표시"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать чипы worktree и ветки в боковой панели"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показувати чіпи worktree та гілки у бічній панелі"
+          }
+        }
+      }
+    },
+    "settings.app.showWorktreeBranchChips.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Render worktree (colored-dot prefix) and branch chips on each workspace row — derived from cwd and gitfs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各ワークスペース行にワークツリー（色付きドットのプレフィックス）とブランチのチップを表示します。cwd と gitfs から導出されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在每个工作区行上渲染工作树（彩色圆点前缀）和分支标签,由 cwd 与 gitfs 派生。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在每個工作區列上渲染工作樹（彩色圓點前綴）與分支標籤,由 cwd 與 gitfs 派生。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 워크스페이스 행에 워크트리(컬러 점 접두사)와 브랜치 칩을 표시해요. cwd와 gitfs에서 파생됩니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показывать чипы worktree (с цветной точкой-префиксом) и ветки в каждой строке рабочего пространства; вычисляются из cwd и gitfs."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показувати чіпи worktree (з кольоровою крапкою-префіксом) та гілки у кожному рядку робочого простору; обчислюються з cwd та gitfs."
+          }
+        }
+      }
+    },
     "settings.app.sidebarBranchLayout": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8411,10 +8411,11 @@ struct VerticalTabsSidebar: View {
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(ChromeScaleSettings.presetKey)
     private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
-    /// C11-104 — single master toggle for the worktree+branch chips row.
-    /// Default on; operators not running multi-worktree workflows can hide.
-    @AppStorage("sidebarShowWorktreeChips")
-    private var sidebarShowWorktreeChips = true
+    /// C11-104 v2 — chip row is gated by the preserved
+    /// `sidebarShowBranchDirectory` key (existing user prefs survive
+    /// the legacy-row → chip-row migration).
+    @AppStorage("sidebarShowBranchDirectory")
+    private var sidebarShowBranchDirectory = true
 
     /// Space at top of sidebar for traffic light buttons
     private let trafficLightPadding: CGFloat = 28
@@ -8537,20 +8538,25 @@ struct VerticalTabsSidebar: View {
                                         sources: sources
                                     )
                                 }()
-                                // C11-104: precompute worktree+branch chips
-                                // for the focused surface. Reads the resolver
-                                // output directly from the workspace's
-                                // `panelGitContexts` (populated by the
-                                // off-main probe in TabManager).
+                                // C11-104 v2: precompute worktree+branch
+                                // chips for the focused surface. Reads the
+                                // resolver output directly from the
+                                // workspace's `panelGitContexts` (populated
+                                // by the off-main probe in TabManager).
+                                // Branch chip's dirty marker comes from the
+                                // existing `panelGitBranches[surfaceId].isDirty`
+                                // signal so the legacy UX is preserved.
                                 let worktreeChipRows: [WorktreeChipRow] = {
-                                    guard sidebarShowWorktreeChips,
+                                    guard sidebarShowBranchDirectory,
                                           let focusedId = tab.focusedPanelId else {
                                         return []
                                     }
                                     let context = tab.panelGitContexts[focusedId] ?? nil
+                                    let isDirty = tab.panelGitBranches[focusedId]?.isDirty ?? false
                                     return WorktreeChipProjector.project(
                                         context,
-                                        settingsEnabled: true
+                                        settingsEnabled: true,
+                                        isDirty: isDirty
                                     )
                                 }()
                                 // C11-25: read the focused surface's most recent CPU/RSS
@@ -11378,39 +11384,13 @@ private struct TabItemView: View, Equatable {
         let latestNotificationSubtitle = latestNotificationText
         let effectiveSubtitle = latestNotificationSubtitle
         let detailVisibility = visibleAuxiliaryDetails
-        let orderedPanelIds: [UUID]? = (detailVisibility.showsBranchDirectory || detailVisibility.showsPullRequests)
+        // C11-104 v2 — branch+directory text-line precomputes retired.
+        // The new chip render (precomputed upstream in
+        // `VerticalTabsSidebar`, passed in via `worktreeChipRows`)
+        // replaces them.
+        let orderedPanelIds: [UUID]? = detailVisibility.showsPullRequests
             ? tab.sidebarOrderedPanelIds()
             : nil
-        let compactGitBranchSummaryText: String? = {
-            guard detailVisibility.showsBranchDirectory,
-                  !sidebarBranchVerticalLayout,
-                  sidebarShowGitBranch,
-                  let orderedPanelIds else {
-                return nil
-            }
-            return gitBranchSummaryText(orderedPanelIds: orderedPanelIds)
-        }()
-        let compactDirectorySummaryText: String? = {
-            guard detailVisibility.showsBranchDirectory,
-                  !sidebarBranchVerticalLayout,
-                  let orderedPanelIds else {
-                return nil
-            }
-            return directorySummaryText(orderedPanelIds: orderedPanelIds)
-        }()
-        let compactBranchDirectoryRow = branchDirectoryRow(
-            gitSummary: compactGitBranchSummaryText,
-            directorySummary: compactDirectorySummaryText
-        )
-        let branchDirectoryLines: [VerticalBranchDirectoryLine] = {
-            guard detailVisibility.showsBranchDirectory,
-                  sidebarBranchVerticalLayout,
-                  let orderedPanelIds else {
-                return []
-            }
-            return verticalBranchDirectoryLines(orderedPanelIds: orderedPanelIds)
-        }()
-        let branchLinesContainBranch = sidebarShowGitBranch && branchDirectoryLines.contains { $0.branch != nil }
         let pullRequestRows: [PullRequestDisplay] = {
             guard detailVisibility.showsPullRequests, let orderedPanelIds else { return [] }
             return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
@@ -11602,59 +11582,10 @@ private struct TabItemView: View, Equatable {
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
-            // Branch + directory row
-            if detailVisibility.showsBranchDirectory {
-                if sidebarBranchVerticalLayout {
-                    if !branchDirectoryLines.isEmpty {
-                        HStack(alignment: .top, spacing: 3) {
-                            if sidebarShowGitBranchIcon, branchLinesContainBranch {
-                                Image(systemName: "arrow.triangle.branch")
-                                    .font(.system(size: chromeTokens.sidebarWorkspaceAccessory))
-                                    .foregroundColor(activeSecondaryColor(0.6))
-                            }
-                            VStack(alignment: .leading, spacing: 1) {
-                                ForEach(Array(branchDirectoryLines.enumerated()), id: \.offset) { _, line in
-                                    HStack(spacing: 3) {
-                                        if let branch = line.branch {
-                                            Text(branch)
-                                                .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
-                                                .foregroundColor(activeSecondaryColor(0.75))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                        }
-                                        if line.branch != nil, line.directory != nil {
-                                            Image(systemName: "circle.fill")
-                                                .font(.system(size: chromeTokens.sidebarWorkspaceBranchDot))
-                                                .foregroundColor(activeSecondaryColor(0.6))
-                                                .padding(.horizontal, 1)
-                                        }
-                                        if let directory = line.directory {
-                                            Text(directory)
-                                                .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
-                                                .foregroundColor(activeSecondaryColor(0.75))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                } else if let dirRow = compactBranchDirectoryRow {
-                    HStack(spacing: 3) {
-                        if sidebarShowGitBranchIcon, compactGitBranchSummaryText != nil {
-                            Image(systemName: "arrow.triangle.branch")
-                                .font(.system(size: chromeTokens.sidebarWorkspaceAccessory))
-                                .foregroundColor(activeSecondaryColor(0.6))
-                        }
-                        Text(dirRow)
-                            .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
-                            .foregroundColor(activeSecondaryColor(0.75))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    }
-                }
-            }
+            // C11-104 v2 — Branch + Directory row retired. The
+            // worktree+branch chip row above replaces it. The toggle
+            // key `sidebarShowBranchDirectory` is preserved (existing
+            // user prefs survive) and now gates the chip row.
 
             // Pull request rows
             if detailVisibility.showsPullRequests, !pullRequestRows.isEmpty {
@@ -12366,84 +12297,12 @@ private struct TabItemView: View, Equatable {
     // latestNotificationText is now passed as a parameter from the parent view
     // to avoid subscribing to notificationStore changes in every TabItemView.
 
-    private func branchDirectoryRow(
-        gitSummary: String?,
-        directorySummary: String?
-    ) -> String? {
-        var parts: [String] = []
-
-        if let gitSummary {
-            parts.append(gitSummary)
-        }
-
-        if let directorySummary {
-            parts.append(directorySummary)
-        }
-
-        let result = parts.joined(separator: " · ")
-        return result.isEmpty ? nil : result
-    }
-
-    private func gitBranchSummaryText(orderedPanelIds: [UUID]) -> String? {
-        let lines = gitBranchSummaryLines(orderedPanelIds: orderedPanelIds)
-        guard !lines.isEmpty else { return nil }
-        return lines.joined(separator: " | ")
-    }
-
-    private func gitBranchSummaryLines(orderedPanelIds: [UUID]) -> [String] {
-        tab.sidebarGitBranchesInDisplayOrder(orderedPanelIds: orderedPanelIds).map { branch in
-            "\(branch.branch)\(branch.isDirty ? "*" : "")"
-        }
-    }
-
-    private struct VerticalBranchDirectoryLine {
-        let branch: String?
-        let directory: String?
-    }
-
-    private func verticalBranchDirectoryLines(orderedPanelIds: [UUID]) -> [VerticalBranchDirectoryLine] {
-        let entries = tab.sidebarBranchDirectoryEntriesInDisplayOrder(orderedPanelIds: orderedPanelIds)
-        let home = SidebarPathFormatter.homeDirectoryPath
-        return entries.compactMap { entry in
-            let branchText: String? = {
-                guard sidebarShowGitBranch, let branch = entry.branch else { return nil }
-                return "\(branch)\(entry.isDirty ? "*" : "")"
-            }()
-
-            let directoryText: String? = {
-                guard let directory = entry.directory else { return nil }
-                let shortened = SidebarPathFormatter.shortenedPath(directory, homeDirectoryPath: home)
-                return shortened.isEmpty ? nil : shortened
-            }()
-
-            switch (branchText, directoryText) {
-            case let (branch?, directory?):
-                return VerticalBranchDirectoryLine(branch: branch, directory: directory)
-            case let (branch?, nil):
-                return VerticalBranchDirectoryLine(branch: branch, directory: nil)
-            case let (nil, directory?):
-                return VerticalBranchDirectoryLine(branch: nil, directory: directory)
-            default:
-                return nil
-            }
-        }
-    }
-
-    private func directorySummaryText(orderedPanelIds: [UUID]) -> String? {
-        guard !tab.panels.isEmpty else { return nil }
-        let home = SidebarPathFormatter.homeDirectoryPath
-        var seen: Set<String> = []
-        var entries: [String] = []
-        for panelId in orderedPanelIds {
-            let directory = tab.panelDirectories[panelId] ?? tab.currentDirectory
-            let shortened = SidebarPathFormatter.shortenedPath(directory, homeDirectoryPath: home)
-            guard !shortened.isEmpty else { continue }
-            if seen.insert(shortened).inserted {
-                entries.append(shortened)
-            }
-        }
-        return entries.isEmpty ? nil : entries.joined(separator: " | ")
-    }
+    // C11-104 v2 — retired:
+    //   branchDirectoryRow, gitBranchSummaryText, gitBranchSummaryLines,
+    //   VerticalBranchDirectoryLine, verticalBranchDirectoryLines,
+    //   directorySummaryText
+    // The chip render in `WorktreeChipsRow` (precomputed upstream in
+    // `VerticalTabsSidebar`) replaces these.
 
     private struct PullRequestDisplay: Identifiable {
         let id: String

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8411,6 +8411,10 @@ struct VerticalTabsSidebar: View {
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(ChromeScaleSettings.presetKey)
     private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
+    /// C11-104 — single master toggle for the worktree+branch chips row.
+    /// Default on; operators not running multi-worktree workflows can hide.
+    @AppStorage("sidebarShowWorktreeChips")
+    private var sidebarShowWorktreeChips = true
 
     /// Space at top of sidebar for traffic light buttons
     private let trafficLightPadding: CGFloat = 28
@@ -8533,6 +8537,22 @@ struct VerticalTabsSidebar: View {
                                         sources: sources
                                     )
                                 }()
+                                // C11-104: precompute worktree+branch chips
+                                // for the focused surface. Reads the resolver
+                                // output directly from the workspace's
+                                // `panelGitContexts` (populated by the
+                                // off-main probe in TabManager).
+                                let worktreeChipRows: [WorktreeChipRow] = {
+                                    guard sidebarShowWorktreeChips,
+                                          let focusedId = tab.focusedPanelId else {
+                                        return []
+                                    }
+                                    let context = tab.panelGitContexts[focusedId] ?? nil
+                                    return WorktreeChipProjector.project(
+                                        context,
+                                        settingsEnabled: true
+                                    )
+                                }()
                                 // C11-25: read the focused surface's most recent CPU/RSS
                                 // sample as a precomputed `let`. The sampler's revision is
                                 // observed at the struct level so this re-evaluates at the
@@ -8549,6 +8569,7 @@ struct VerticalTabsSidebar: View {
                                     index: index,
                                     isActive: isActive,
                                     agentChip: agentChip,
+                                    worktreeChipRows: worktreeChipRows,
                                     surfaceMetricsSample: surfaceMetricsSample,
                                     workspaceShortcutDigit: WorkspaceShortcutMapper.commandDigitForWorkspace(
                                         at: index,
@@ -11014,6 +11035,7 @@ private struct TabItemView: View, Equatable {
         lhs.index == rhs.index &&
         lhs.isActive == rhs.isActive &&
         lhs.agentChip == rhs.agentChip &&
+        lhs.worktreeChipRows == rhs.worktreeChipRows &&
         TabItemView.surfaceMetricsEqual(lhs.surfaceMetricsSample, rhs.surfaceMetricsSample) &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&
@@ -11075,6 +11097,11 @@ private struct TabItemView: View, Equatable {
     let index: Int
     let isActive: Bool
     let agentChip: AgentChip?
+    /// C11-104: precomputed worktree/branch chip rows for the focused
+    /// surface. Empty when the setting is disabled or the surface is
+    /// not in a git directory. Keeping the projection upstream means
+    /// the TabItemView body does zero IO/git work.
+    let worktreeChipRows: [WorktreeChipRow]
     /// C11-25: most recent CPU/RSS sample for the workspace's focused
     /// surface, or nil when no PID is registered (terminals — pending
     /// the TTY → child PID resolver follow-up).
@@ -11488,6 +11515,19 @@ private struct TabItemView: View, Equatable {
                             .accessibilityIdentifier("SidebarTabSurfaceMetrics")
                     }
                 }
+                .padding(.top, 1)
+            }
+
+            // C11-104 — worktree + branch chips. Renders when the master
+            // toggle is on AND the resolver returned context for this
+            // surface. The projection is precomputed upstream so the
+            // body stays cheap.
+            if !worktreeChipRows.isEmpty {
+                WorktreeChipsRow(
+                    rows: worktreeChipRows,
+                    foreground: activeSecondaryColor(0.85),
+                    secondary: activeSecondaryColor(0.7)
+                )
                 .padding(.top, 1)
             }
 

--- a/Sources/Metadata/GitContextResolver.swift
+++ b/Sources/Metadata/GitContextResolver.swift
@@ -1,5 +1,88 @@
 import Foundation
 
+/// C11-104 — `MetadataDeriver` protocol seam (E1 reframe per the
+/// trident plan-review). The idea: c11 will accumulate several
+/// derived metadata sources over time (worktree/branch from gitfs;
+/// host / SSH target; container; kubectl context; AWS profile; …).
+/// A tiny uniform interface lets the next deriver land in a day, not
+/// a week.
+///
+/// `GitContextDeriver` is the first concrete deriver. A
+/// `DerivationCoordinator` runs derivers off-main on a shared queue
+/// and hops back to the main actor with the result. Apply-side
+/// gen-token + expected-cwd guards live in the caller — `TabManager`
+/// already implements them for the existing probe path
+/// (`applyWorkspaceGitMetadataSnapshot`). The coordinator is
+/// intentionally lightweight in this PR; full integration with the
+/// staggered TabManager probe is deferred (the current implementation
+/// continues to call `GitContextResolver.resolve` directly from
+/// `initialWorkspaceGitMetadataSnapshot`).
+
+public protocol MetadataDeriver: Sendable {
+    /// Each deriver returns its own value type — git returns
+    /// `ResolvedGitContext`; a future host deriver returns its own.
+    associatedtype Output: Sendable
+
+    /// Run off-main. Implementations MUST trap main-thread invocation
+    /// with `dispatchPrecondition(condition: .notOnQueue(.main))` so
+    /// a typing-latency regression is caught at runtime.
+    func derive(cwd: String) -> Output?
+}
+
+/// Concrete deriver wrapping `GitContextResolver.resolve`. A struct
+/// (not a singleton) so each coordinator can hold its own runner /
+/// filesystem / timeout configuration without contention.
+public struct GitContextDeriver: MetadataDeriver {
+    public let runner: GitRunner
+    public let fileSystem: FileSystemProbe
+
+    public init(
+        runner: GitRunner = ProcessGitRunner(),
+        fileSystem: FileSystemProbe = DefaultFileSystemProbe()
+    ) {
+        self.runner = runner
+        self.fileSystem = fileSystem
+    }
+
+    public func derive(cwd: String) -> ResolvedGitContext? {
+        return GitContextResolver.resolve(
+            cwd: cwd,
+            runner: runner,
+            fileSystem: fileSystem
+        )
+    }
+}
+
+/// Lightweight coordinator that runs a deriver off-main on a known
+/// queue and hops back to main with the result. Future expansion:
+/// gen-token + expected-cwd guard pattern (currently lives in
+/// `TabManager.applyWorkspaceGitMetadataSnapshot`).
+public enum DerivationCoordinator {
+    /// Shared background queue. Distinct label from the legacy
+    /// `initialWorkspaceGitProbeQueue` so failures can be traced
+    /// per-mechanism; both run at `.userInitiated`.
+    public static let queue = DispatchQueue(
+        label: "com.stage11.c11.metadata-derivers",
+        qos: .userInitiated
+    )
+
+    /// Run a deriver off-main and call `completion` on the main
+    /// actor with its output.
+    public static func run<D: MetadataDeriver>(
+        deriver: D,
+        cwd: String,
+        completion: @escaping @Sendable (D.Output?) -> Void
+    ) {
+        dispatchPrecondition(condition: .notOnQueue(queue))
+        queue.async {
+            let result = deriver.derive(cwd: cwd)
+            DispatchQueue.main.async {
+                completion(result)
+            }
+        }
+    }
+}
+
 /// C11-104 — derived sidebar metadata for "which worktree + which branch."
 ///
 /// `GitContextResolver` runs `git rev-parse` against a cwd off the main

--- a/Sources/Metadata/GitContextResolver.swift
+++ b/Sources/Metadata/GitContextResolver.swift
@@ -315,13 +315,106 @@ public enum GitContextResolver {
         ), !toplevel.isEmpty else {
             return nil
         }
-        let name = (toplevel as NSString).lastPathComponent
+        let superprojectRoot = runner.run(
+            cwd: cwd,
+            args: ["rev-parse", "--show-superproject-working-tree"]
+        )
+        let name = resolveSubmoduleName(
+            submoduleToplevel: toplevel,
+            superprojectRoot: superprojectRoot,
+            runner: runner
+        )
         let branch = resolveBranch(cwd: cwd, runner: runner)
         return GitSubmoduleContext(
             name: name,
             absolutePath: toplevel,
             branch: branch
         )
+    }
+
+    /// Submodule display-name fallback chain (plan-review v2):
+    ///   1. `.gitmodules` configured submodule name (the
+    ///      `[submodule "<name>"]` section header in
+    ///      `<superproject>/.gitmodules`).
+    ///   2. Path from the superproject root (e.g., `vendor/bonsplit`).
+    ///   3. Basename of the submodule's working tree (e.g.,
+    ///      `bonsplit`).
+    static func resolveSubmoduleName(
+        submoduleToplevel: String,
+        superprojectRoot: String?,
+        runner: GitRunner
+    ) -> String {
+        let basename = (submoduleToplevel as NSString).lastPathComponent
+
+        guard let superprojectRoot, !superprojectRoot.isEmpty else {
+            return basename
+        }
+
+        // Path-from-superproject-root.
+        let relativePath = relativePathFromSuperproject(
+            superprojectRoot: superprojectRoot,
+            submoduleToplevel: submoduleToplevel
+        )
+
+        // Try `.gitmodules` configured name. The submodule.<name>.path
+        // entry maps the configured name to the relative path. We
+        // look up by relative path and pull the section name.
+        if let relative = relativePath,
+           let configured = configuredSubmoduleName(
+               superprojectRoot: superprojectRoot,
+               relativePath: relative,
+               runner: runner
+           ) {
+            return configured
+        }
+
+        if let relative = relativePath, !relative.isEmpty {
+            return relative
+        }
+        return basename
+    }
+
+    static func relativePathFromSuperproject(
+        superprojectRoot: String,
+        submoduleToplevel: String
+    ) -> String? {
+        let superNorm = (superprojectRoot as NSString).standardizingPath
+        let subNorm = (submoduleToplevel as NSString).standardizingPath
+        let withSlash = superNorm.hasSuffix("/") ? superNorm : superNorm + "/"
+        guard subNorm.hasPrefix(withSlash) else { return nil }
+        let rel = String(subNorm.dropFirst(withSlash.count))
+        return rel.isEmpty ? nil : rel
+    }
+
+    static func configuredSubmoduleName(
+        superprojectRoot: String,
+        relativePath: String,
+        runner: GitRunner
+    ) -> String? {
+        // `git config -f .gitmodules --get-regexp 'submodule\..*\.path'`
+        // returns lines like `submodule.vendor/bonsplit.path vendor/bonsplit`.
+        // Caveat: configured names can contain dots, so the regex above
+        // is greedy. Match against the trailing value (relative path)
+        // and pull the section name in between.
+        guard let output = runner.run(
+            cwd: superprojectRoot,
+            args: ["config", "-f", ".gitmodules", "--get-regexp", #"submodule\..*\.path"#]
+        ) else {
+            return nil
+        }
+        for line in output.split(separator: "\n") {
+            let parts = line.split(separator: " ", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+            let key = parts[0]
+            let value = parts[1]
+            guard value == relativePath else { continue }
+            // key is `submodule.<name>.path` — strip `submodule.`
+            // prefix and `.path` suffix.
+            guard key.hasPrefix("submodule.") && key.hasSuffix(".path") else { continue }
+            let trimmed = String(key.dropFirst("submodule.".count).dropLast(".path".count))
+            if !trimmed.isEmpty { return trimmed }
+        }
+        return nil
     }
 
     static func resolveBranch(cwd: String, runner: GitRunner) -> BranchValue {

--- a/Sources/Metadata/GitContextResolver.swift
+++ b/Sources/Metadata/GitContextResolver.swift
@@ -1,0 +1,369 @@
+import Foundation
+
+/// C11-104 — derived sidebar metadata for "which worktree + which branch."
+///
+/// `GitContextResolver` runs `git rev-parse` against a cwd off the main
+/// thread and returns a structured value the sidebar can project into
+/// chips. The resolver is pure-logic (no SwiftUI / AppKit) so it can run
+/// inside `c11LogicTests` against temp-dir-built repos.
+///
+/// Hot-path discipline: do not call this on the main actor. The OSC 7
+/// cwd-update handler in `TabManager` already dispatches to a background
+/// queue; the resolver shares that queue.
+
+public enum BranchValue: Equatable, Sendable {
+    case attached(String)
+    case detached(shortSHA: String)
+    /// Worktree pointing at a deleted branch, or any other "git couldn't
+    /// name a ref" degraded state. Rendered as "(no branch)" in the
+    /// sidebar — never thrown.
+    case unknown
+}
+
+public enum GitContextKind: Equatable, Sendable {
+    case mainCheckout(branch: BranchValue)
+    case linkedWorktree(basename: String, absolutePath: String, branch: BranchValue)
+}
+
+public struct GitSubmoduleContext: Equatable, Sendable {
+    public let name: String           // basename of submodule's working tree
+    public let absolutePath: String   // submodule worktree path (for hashing if ever needed)
+    public let branch: BranchValue
+
+    public init(name: String, absolutePath: String, branch: BranchValue) {
+        self.name = name
+        self.absolutePath = absolutePath
+        self.branch = branch
+    }
+}
+
+public struct ResolvedGitContext: Equatable, Sendable {
+    public let outer: GitContextKind
+    public let inner: GitSubmoduleContext?
+
+    public init(outer: GitContextKind, inner: GitSubmoduleContext? = nil) {
+        self.outer = outer
+        self.inner = inner
+    }
+}
+
+/// Pluggable seam for `git` invocation so tests can stub deterministic
+/// behavior without spawning real processes. Default production
+/// implementation is `ProcessGitRunner` below.
+public protocol GitRunner: Sendable {
+    /// Run `git <args>` with `cwd` as the working directory.
+    /// Return trimmed stdout on success; nil on failure (non-zero exit,
+    /// timeout, exec error, or empty stdout). Test doubles may also
+    /// return nil to simulate a failure path.
+    func run(cwd: String, args: [String]) -> String?
+}
+
+/// Pluggable seam for filesystem checks (cwd existence, HEAD mtime).
+public protocol FileSystemProbe: Sendable {
+    func fileExists(atPath: String) -> Bool
+    func mtime(atPath: String) -> Date?
+}
+
+public struct DefaultFileSystemProbe: FileSystemProbe {
+    public init() {}
+    public func fileExists(atPath path: String) -> Bool {
+        return FileManager.default.fileExists(atPath: path)
+    }
+    public func mtime(atPath path: String) -> Date? {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: path)
+        return attrs?[.modificationDate] as? Date
+    }
+}
+
+/// Process-backed runner. Bounded by a soft timeout to avoid stalling
+/// the background queue if git ever hangs.
+public struct ProcessGitRunner: GitRunner {
+    public let timeout: TimeInterval
+
+    public init(timeout: TimeInterval = 5.0) {
+        self.timeout = timeout
+    }
+
+    public func run(cwd: String, args: [String]) -> String? {
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + args
+        process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+        process.standardOutput = stdout
+        process.standardError = stderr
+        // 1-byte stdin so a paranoid hang in a child waiting on stdin
+        // cannot stall us. Same shape as TabManager.runCommandResult.
+        let stdin = Pipe()
+        process.standardInput = stdin
+
+        let completion = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            completion.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        stdin.fileHandleForWriting.closeFile()
+
+        if completion.wait(timeout: .now() + timeout) == .timedOut {
+            process.terminate()
+            if completion.wait(timeout: .now() + 0.2) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = completion.wait(timeout: .now() + 0.2)
+            }
+            return nil
+        }
+
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard let text = String(data: data, encoding: .utf8) else { return nil }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+public enum GitContextResolver {
+    /// Maximum branch label length surfaced to consumers. The canonical
+    /// `branch` metadata key is capped at 64 chars (`SurfaceMetadataStore`);
+    /// resolver-side enforcement keeps the value renderable even when a
+    /// real-world branch name exceeds the cap. Middle-truncate with `…`.
+    public static let maxBranchLabelLength = 64
+
+    /// Resolve the worktree + branch context for `cwd`.
+    /// Returns nil for:
+    ///   - cwd doesn't exist on disk
+    ///   - cwd is not inside a git working tree
+    ///   - cwd is a bare clone
+    ///
+    /// Must run off the main thread. The resolver shells out to `git`
+    /// and is bounded by a soft timeout per call — running this on main
+    /// will block typing latency. A `dispatchPrecondition` traps the
+    /// misuse at the entry point so test runs catch it deterministically.
+    public static func resolve(
+        cwd: String,
+        runner: GitRunner = ProcessGitRunner(),
+        fileSystem: FileSystemProbe = DefaultFileSystemProbe()
+    ) -> ResolvedGitContext? {
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        guard !cwd.isEmpty, fileSystem.fileExists(atPath: cwd) else {
+            return nil
+        }
+
+        // Step 1: superproject probe — runs first so that for any cwd
+        // inside a submodule we can resolve BOTH contexts and stack
+        // them per the spec.
+        let superprojectRoot = runner.run(
+            cwd: cwd,
+            args: ["rev-parse", "--show-superproject-working-tree"]
+        )
+
+        // Step 2: outer resolution. If we're in a submodule, point at
+        // the superproject; otherwise this is the working tree itself.
+        let outerCwd = superprojectRoot ?? cwd
+        guard let outer = resolveOuter(cwd: outerCwd, runner: runner) else {
+            return nil
+        }
+
+        // Step 3: inner (submodule) resolution. Only run when we
+        // actually detected a superproject.
+        var inner: GitSubmoduleContext?
+        if superprojectRoot != nil {
+            inner = resolveSubmodule(cwd: cwd, runner: runner)
+        }
+
+        return ResolvedGitContext(outer: outer, inner: inner)
+    }
+
+    // MARK: - Internal
+
+    /// Resolve "outer" — either a main checkout or a linked worktree.
+    static func resolveOuter(cwd: String, runner: GitRunner) -> GitContextKind? {
+        // Step A: discover the working tree top-level. Fails for
+        // non-git directories and for bare clones (rev-parse
+        // --show-toplevel errors in a bare repo). This single call
+        // covers AC7 + AC8.
+        guard let toplevel = runner.run(
+            cwd: cwd,
+            args: ["rev-parse", "--show-toplevel"]
+        ), !toplevel.isEmpty else {
+            return nil
+        }
+
+        // Step B: linked worktree vs main checkout.
+        // --git-common-dir points at the shared .git/ for all worktrees;
+        // --git-dir points at this worktree's own .git directory (which
+        // for a linked worktree lives under common/.git/worktrees/<name>).
+        // If they differ → linked worktree. Otherwise → main checkout.
+        let commonDir = runner.run(cwd: cwd, args: ["rev-parse", "--git-common-dir"])
+        let gitDir = runner.run(cwd: cwd, args: ["rev-parse", "--git-dir"])
+        let isLinkedWorktree: Bool = {
+            guard let common = commonDir, let mine = gitDir else { return false }
+            // Normalize both to absolute paths before comparing — `--git-dir`
+            // often returns "." inside a main checkout and the common dir
+            // returns a relative form too.
+            let commonAbs = absolutePath(of: common, relativeTo: cwd)
+            let mineAbs = absolutePath(of: mine, relativeTo: cwd)
+            return commonAbs != mineAbs
+        }()
+
+        let branch = resolveBranch(cwd: cwd, runner: runner)
+
+        if isLinkedWorktree {
+            let basename = (toplevel as NSString).lastPathComponent
+            return .linkedWorktree(
+                basename: basename,
+                absolutePath: toplevel,
+                branch: branch
+            )
+        } else {
+            return .mainCheckout(branch: branch)
+        }
+    }
+
+    static func resolveSubmodule(cwd: String, runner: GitRunner) -> GitSubmoduleContext? {
+        guard let toplevel = runner.run(
+            cwd: cwd,
+            args: ["rev-parse", "--show-toplevel"]
+        ), !toplevel.isEmpty else {
+            return nil
+        }
+        let name = (toplevel as NSString).lastPathComponent
+        let branch = resolveBranch(cwd: cwd, runner: runner)
+        return GitSubmoduleContext(
+            name: name,
+            absolutePath: toplevel,
+            branch: branch
+        )
+    }
+
+    static func resolveBranch(cwd: String, runner: GitRunner) -> BranchValue {
+        // Attached ref?
+        if let attached = runner.run(
+            cwd: cwd,
+            args: ["symbolic-ref", "--short", "HEAD"]
+        ), !attached.isEmpty {
+            return .attached(truncateBranchLabel(attached))
+        }
+        // Detached HEAD?
+        if let short = runner.run(
+            cwd: cwd,
+            args: ["rev-parse", "--short=7", "HEAD"]
+        ), !short.isEmpty {
+            return .detached(shortSHA: short)
+        }
+        // Worktree pointing at a deleted branch, broken HEAD, or other
+        // graceful-degrade case.
+        return .unknown
+    }
+
+    /// Middle-truncate a branch label so the canonical metadata cap is
+    /// never breached. Long branch names (e.g., release/2025-q3/...) are
+    /// shortened to `<prefix>…<suffix>` keeping head and tail context.
+    /// Plan-review I7.
+    static func truncateBranchLabel(_ raw: String) -> String {
+        guard raw.count > maxBranchLabelLength else { return raw }
+        let budget = maxBranchLabelLength - 1  // 1 char for "…"
+        let head = budget / 2
+        let tail = budget - head
+        let prefix = raw.prefix(head)
+        let suffix = raw.suffix(tail)
+        return "\(prefix)…\(suffix)"
+    }
+
+    // MARK: - Path utilities
+
+    /// Resolve a git-reported path (which may be relative to `cwd` or
+    /// already absolute) to an absolute filesystem path.
+    static func absolutePath(of path: String, relativeTo cwd: String) -> String {
+        if path.hasPrefix("/") {
+            return (path as NSString).standardizingPath
+        }
+        let joined = (cwd as NSString).appendingPathComponent(path)
+        return (joined as NSString).standardizingPath
+    }
+
+    /// Returns the absolute path of `.git/HEAD` for cache invalidation,
+    /// using `git rev-parse --git-path HEAD` so worktree gitfile
+    /// indirection is handled correctly.
+    public static func headPath(
+        forCwd cwd: String,
+        runner: GitRunner = ProcessGitRunner()
+    ) -> String? {
+        guard let raw = runner.run(cwd: cwd, args: ["rev-parse", "--git-path", "HEAD"]) else {
+            return nil
+        }
+        return absolutePath(of: raw, relativeTo: cwd)
+    }
+}
+
+/// Cache for resolver results keyed by `(cwd, headMtime)`.
+///
+/// Lives on the off-main probe queue alongside `GitContextResolver`.
+/// LRU evicts at `capacity`. Cache invalidation is implicit: a cwd
+/// change yields a different key, and a `.git/HEAD` mtime change
+/// (post-checkout, post-rename) yields a different key.
+public final class GitContextResolverCache: @unchecked Sendable {
+    public struct Key: Hashable, Sendable {
+        public let cwd: String
+        public let headMtime: Date?
+        public init(cwd: String, headMtime: Date?) {
+            self.cwd = cwd
+            self.headMtime = headMtime
+        }
+    }
+
+    private let capacity: Int
+    private var entries: [Key: ResolvedGitContext?] = [:]
+    private var order: [Key] = []
+    private let lock = NSLock()
+
+    public init(capacity: Int = 256) {
+        self.capacity = max(1, capacity)
+    }
+
+    public func get(_ key: Key) -> ResolvedGitContext?? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard let cached = entries[key] else { return nil }
+        // Bump recency.
+        if let idx = order.firstIndex(of: key) {
+            order.remove(at: idx)
+            order.append(key)
+        }
+        return .some(cached)
+    }
+
+    public func set(_ key: Key, value: ResolvedGitContext?) {
+        lock.lock()
+        defer { lock.unlock() }
+        if entries[key] == nil {
+            order.append(key)
+        } else if let idx = order.firstIndex(of: key) {
+            order.remove(at: idx)
+            order.append(key)
+        }
+        entries[key] = value
+        while order.count > capacity, let oldest = order.first {
+            entries.removeValue(forKey: oldest)
+            order.removeFirst()
+        }
+    }
+
+    public func clear() {
+        lock.lock()
+        defer { lock.unlock() }
+        entries.removeAll()
+        order.removeAll()
+    }
+
+    public var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries.count
+    }
+}

--- a/Sources/PersistedMetadata.swift
+++ b/Sources/PersistedMetadata.swift
@@ -66,7 +66,7 @@ enum PersistedJSONValue: Codable, Sendable, Equatable {
 /// Codable sidecar preserving the `(source, ts)` record alongside a persisted
 /// metadata value so the precedence chain survives a restart.
 struct PersistedMetadataSource: Codable, Sendable, Equatable {
-    /// `MetadataSource` raw value: `"explicit" | "declare" | "osc" | "heuristic"`.
+    /// `MetadataSource` raw value: `"explicit" | "declare" | "osc" | "derived" | "heuristic"`.
     /// Unknown strings decode cleanly (no Codable error); the bridge downgrades
     /// them to `.heuristic` with a debug log on the way back into the store.
     var source: String
@@ -138,12 +138,21 @@ enum PersistedMetadataBridge {
     /// Values that cannot be represented as JSON are dropped with a debug
     /// log; the rest of the blob survives. Never throws — snapshot writes
     /// must be side-effect-free with respect to persistence failures.
+    ///
+    /// C11-104 — derived keys are excluded by checking the parallel
+    /// `sources` sidecar (when provided): a value whose recorded source
+    /// is `.derived` is dropped from the persisted blob because it will
+    /// be recomputed on session resume.
     static func encodeValues(
         _ values: [String: Any],
-        surfaceIdForLog: UUID? = nil
+        surfaceIdForLog: UUID? = nil,
+        sources: [String: [String: Any]]? = nil
     ) -> [String: PersistedJSONValue] {
         var result: [String: PersistedJSONValue] = [:]
         for (key, value) in values {
+            if isDerivedKey(key: key, sources: sources) {
+                continue
+            }
             if let persisted = encode(value: value, key: key, surfaceIdForLog: surfaceIdForLog) {
                 result[key] = persisted
             }
@@ -153,17 +162,25 @@ enum PersistedMetadataBridge {
 
     /// Convert sidecar entries as returned by
     /// `SurfaceMetadataStore.getMetadata().sources` (`[String: [String: Any]]`
-    /// via `SourceRecord.toJSON()`) into persisted form.
+    /// via `SourceRecord.toJSON()`) into persisted form. Derived sources
+    /// are dropped to match the value-side filter.
     static func encodeSources(
         _ sources: [String: [String: Any]]
     ) -> [String: PersistedMetadataSource] {
         var result: [String: PersistedMetadataSource] = [:]
         for (key, record) in sources {
             guard let source = record["source"] as? String else { continue }
+            if source == MetadataSource.derived.rawValue { continue }
             let ts = (record["ts"] as? Double) ?? 0.0
             result[key] = PersistedMetadataSource(source: source, ts: ts)
         }
         return result
+    }
+
+    private static func isDerivedKey(key: String, sources: [String: [String: Any]]?) -> Bool {
+        guard let sources, let record = sources[key],
+              let raw = record["source"] as? String else { return false }
+        return raw == MetadataSource.derived.rawValue
     }
 
     // MARK: - Restore-direction bridge (persisted → [String: Any])

--- a/Sources/Sidebar/WorktreeChipModel.swift
+++ b/Sources/Sidebar/WorktreeChipModel.swift
@@ -56,29 +56,38 @@ public enum WorktreeChipProjector {
     /// Project a resolved context into chip rows for the sidebar.
     /// Returns an empty array when the chip row should not render
     /// (settings disabled, no git context).
+    ///
+    /// `isDirty` preserves the legacy dirty-marker UX (branch chip
+    /// gets a `*` suffix when the working tree has uncommitted
+    /// changes) — sourced from `Workspace.panelGitBranches[surfaceId]
+    /// .isDirty` upstream.
     public static func project(
         _ context: ResolvedGitContext?,
-        settingsEnabled: Bool
+        settingsEnabled: Bool,
+        isDirty: Bool = false
     ) -> [WorktreeChipRow] {
         guard settingsEnabled else { return [] }
         guard let context else { return [] }
 
-        let outerRow = projectOuter(context.outer)
+        let outerRow = projectOuter(context.outer, isDirty: isDirty)
         guard let inner = context.inner else {
             return [outerRow]
         }
+        // Inner row's dirty state is the submodule's own working tree
+        // — a future addition. For now the outer surface's dirty bit
+        // governs the outer row only.
         let innerRow = projectInner(inner)
         return [outerRow, innerRow]
     }
 
     // MARK: - Internal
 
-    static func projectOuter(_ kind: GitContextKind) -> WorktreeChipRow {
+    static func projectOuter(_ kind: GitContextKind, isDirty: Bool = false) -> WorktreeChipRow {
         switch kind {
         case .mainCheckout(let branch):
             return WorktreeChipRow(
                 worktree: nil,
-                branch: projectBranch(branch),
+                branch: projectBranch(branch, isDirty: isDirty),
                 indent: .none
             )
         case .linkedWorktree(let basename, let absolutePath, let branch):
@@ -88,7 +97,7 @@ public enum WorktreeChipProjector {
             )
             return WorktreeChipRow(
                 worktree: chip,
-                branch: projectBranch(branch),
+                branch: projectBranch(branch, isDirty: isDirty),
                 indent: .none
             )
         }
@@ -107,19 +116,20 @@ public enum WorktreeChipProjector {
         )
     }
 
-    static func projectBranch(_ branch: BranchValue) -> BranchChip {
+    static func projectBranch(_ branch: BranchValue, isDirty: Bool = false) -> BranchChip {
+        let suffix = isDirty ? "*" : ""
         switch branch {
         case .attached(let name):
             let isMainish = mainBranchNames.contains(name)
-            return BranchChip(label: name, isDimmed: isMainish, isDetached: false)
+            return BranchChip(label: "\(name)\(suffix)", isDimmed: isMainish, isDetached: false)
         case .detached(let sha):
             return BranchChip(
-                label: "(detached @ \(sha))",
+                label: "(detached @ \(sha))\(suffix)",
                 isDimmed: false,
                 isDetached: true
             )
         case .unknown:
-            return BranchChip(label: "(no branch)", isDimmed: false, isDetached: false)
+            return BranchChip(label: "(no branch)\(suffix)", isDimmed: false, isDetached: false)
         }
     }
 }

--- a/Sources/Sidebar/WorktreeChipModel.swift
+++ b/Sources/Sidebar/WorktreeChipModel.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// C11-104 — projection from `ResolvedGitContext` to renderable chip rows.
+///
+/// Pure value types so `c11LogicTests` can run against constructed
+/// inputs without a SwiftUI host.
+
+public struct WorktreeChip: Equatable, Sendable {
+    public let label: String      // basename, e.g. "c11-104-sidebar-chips"
+    public let dotColorHex: String  // uppercase RGB sRGB hex, no leading "#"
+    public let isSubmodule: Bool    // true for the inner submodule row's
+                                    // surrogate "worktree" — render with `↳`
+                                    // prefix and no dot.
+
+    public init(label: String, dotColorHex: String, isSubmodule: Bool = false) {
+        self.label = label
+        self.dotColorHex = dotColorHex
+        self.isSubmodule = isSubmodule
+    }
+}
+
+public struct BranchChip: Equatable, Sendable {
+    public let label: String     // "feature/x", "main", "(detached @ abc1234)", "(no branch)"
+    public let isDimmed: Bool    // main/master/trunk → dimmed
+    public let isDetached: Bool
+
+    public init(label: String, isDimmed: Bool, isDetached: Bool) {
+        self.label = label
+        self.isDimmed = isDimmed
+        self.isDetached = isDetached
+    }
+}
+
+public struct WorktreeChipRow: Equatable, Sendable {
+    public let worktree: WorktreeChip?   // nil for main-checkout rows
+    public let branch: BranchChip
+    public let indent: Indent
+
+    public enum Indent: Equatable, Sendable {
+        case none
+        /// Submodule's inner row — rendered indented + `↳` prefix.
+        case submodule
+    }
+
+    public init(worktree: WorktreeChip?, branch: BranchChip, indent: Indent = .none) {
+        self.worktree = worktree
+        self.branch = branch
+        self.indent = indent
+    }
+}
+
+public enum WorktreeChipProjector {
+    /// Names that render the branch chip dimmed.
+    public static let mainBranchNames: Set<String> = ["main", "master", "trunk"]
+
+    /// Project a resolved context into chip rows for the sidebar.
+    /// Returns an empty array when the chip row should not render
+    /// (settings disabled, no git context).
+    public static func project(
+        _ context: ResolvedGitContext?,
+        settingsEnabled: Bool
+    ) -> [WorktreeChipRow] {
+        guard settingsEnabled else { return [] }
+        guard let context else { return [] }
+
+        let outerRow = projectOuter(context.outer)
+        guard let inner = context.inner else {
+            return [outerRow]
+        }
+        let innerRow = projectInner(inner)
+        return [outerRow, innerRow]
+    }
+
+    // MARK: - Internal
+
+    static func projectOuter(_ kind: GitContextKind) -> WorktreeChipRow {
+        switch kind {
+        case .mainCheckout(let branch):
+            return WorktreeChipRow(
+                worktree: nil,
+                branch: projectBranch(branch),
+                indent: .none
+            )
+        case .linkedWorktree(let basename, let absolutePath, let branch):
+            let chip = WorktreeChip(
+                label: basename,
+                dotColorHex: WorktreeColorPalette.color(for: absolutePath)
+            )
+            return WorktreeChipRow(
+                worktree: chip,
+                branch: projectBranch(branch),
+                indent: .none
+            )
+        }
+    }
+
+    static func projectInner(_ inner: GitSubmoduleContext) -> WorktreeChipRow {
+        let chip = WorktreeChip(
+            label: inner.name,
+            dotColorHex: "",
+            isSubmodule: true
+        )
+        return WorktreeChipRow(
+            worktree: chip,
+            branch: projectBranch(inner.branch),
+            indent: .submodule
+        )
+    }
+
+    static func projectBranch(_ branch: BranchValue) -> BranchChip {
+        switch branch {
+        case .attached(let name):
+            let isMainish = mainBranchNames.contains(name)
+            return BranchChip(label: name, isDimmed: isMainish, isDetached: false)
+        case .detached(let sha):
+            return BranchChip(
+                label: "(detached @ \(sha))",
+                isDimmed: false,
+                isDetached: true
+            )
+        case .unknown:
+            return BranchChip(label: "(no branch)", isDimmed: false, isDetached: false)
+        }
+    }
+}

--- a/Sources/Sidebar/WorktreeChipsRow.swift
+++ b/Sources/Sidebar/WorktreeChipsRow.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// C11-104 — renders the worktree+branch chips row(s) under a workspace's
+/// agent chip in the sidebar.
+///
+/// All projection work happens upstream (`WorktreeChipProjector`).
+/// This view is purely a layout shim — no git / IO / metadata reads inside
+/// the body, so it stays cheap to render on every TabItemView re-eval.
+struct WorktreeChipsRow: View {
+    let rows: [WorktreeChipRow]
+    let foreground: Color
+    let secondary: Color
+
+    @Environment(\.chromeScaleTokens) private var chromeTokens
+
+    var body: some View {
+        if rows.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 2) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
+                    rowView(for: row)
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityLabel)
+        }
+    }
+
+    // MARK: - Components
+
+    @ViewBuilder
+    private func rowView(for row: WorktreeChipRow) -> some View {
+        HStack(spacing: 4) {
+            if row.indent == .submodule {
+                Image(systemName: "arrow.turn.down.right")
+                    .font(.system(size: chromeTokens.sidebarWorkspaceDetail))
+                    .foregroundColor(secondary.opacity(0.7))
+            }
+
+            if let worktree = row.worktree {
+                worktreeChipView(worktree)
+            }
+
+            branchChipView(row.branch)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.leading, row.indent == .submodule ? 8 : 0)
+    }
+
+    @ViewBuilder
+    private func worktreeChipView(_ chip: WorktreeChip) -> some View {
+        HStack(spacing: 3) {
+            if !chip.isSubmodule {
+                Circle()
+                    .fill(Color(nsColor: NSColor(hex: chip.dotColorHex) ?? .gray))
+                    .frame(width: 7, height: 7)
+            }
+            Text(chip.label)
+                .font(.system(size: chromeTokens.sidebarWorkspaceDetail, design: .monospaced))
+                .foregroundColor(foreground)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+
+    @ViewBuilder
+    private func branchChipView(_ chip: BranchChip) -> some View {
+        Text(chip.label)
+            .font(.system(size: chromeTokens.sidebarWorkspaceDetail, design: .monospaced))
+            .foregroundColor(secondary)
+            .opacity(chip.isDimmed ? 0.55 : 1.0)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilityLabel: String {
+        var parts: [String] = []
+        for row in rows {
+            if let wt = row.worktree {
+                if row.indent == .submodule {
+                    parts.append("submodule \(wt.label)")
+                } else {
+                    parts.append("worktree \(wt.label)")
+                }
+            }
+            parts.append("branch \(row.branch.label)")
+        }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/Sources/Sidebar/WorktreeColorPalette.swift
+++ b/Sources/Sidebar/WorktreeColorPalette.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// C11-104 — color palette for the worktree chip's dot prefix.
+///
+/// A small, stable, theme-neutral palette: 10 hues picked to remain
+/// legible against both the Light and Dark theme slots' sidebar
+/// backgrounds. Hash-derived from the absolute worktree path so a
+/// given worktree gets the same color across launches.
+///
+/// Palette tuned for chroma ~50–70%, lightness ~55–65% — bright
+/// enough to read on Dark, not so saturated that it shouts on Light.
+public enum WorktreeColorPalette {
+    /// Hex strings (uppercase, no `#`) in RGB sRGB. Order is meaningful:
+    /// the hash function returns `index % entries.count`.
+    public static let entries: [String] = [
+        "5FB3FF", // sky
+        "FF8FB1", // rose
+        "9CE07F", // pistachio
+        "FFC857", // amber
+        "B49DFF", // lavender
+        "5EE6CC", // turquoise
+        "FF9D5C", // tangerine
+        "C5E063", // chartreuse
+        "F285E6", // pink
+        "7FD8F5", // ice
+    ]
+
+    /// Map an absolute path → palette hex via DJB2-on-UTF8.
+    ///
+    /// DJB2 is chosen for deterministic, salt-free output (Swift's
+    /// `Hasher` is salted across launches and unsuitable for
+    /// stable-across-launches identity).
+    public static func color(for absolutePath: String) -> String {
+        let bytes = Array(absolutePath.utf8)
+        var hash: UInt64 = 5381
+        for b in bytes {
+            hash = (hash &* 33) &+ UInt64(b)
+        }
+        let index = Int(hash % UInt64(entries.count))
+        return entries[index]
+    }
+}

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -19,11 +19,17 @@ public enum MetadataKey {
     public static let description = "description"
     public static let lifecycleState = "lifecycle_state"
 
+    /// C11-104 — derived canonical keys. Written by the c11 runtime,
+    /// not by agents. Validated as plain strings with size caps.
+    public static let worktree = "worktree"
+    public static let branch = "branch"
+
     /// Non-canonical display hint used by M3's sidebar chip.
     public static let modelLabel = "model_label"
 
     public static let canonical: Set<String> = [
-        role, status, task, model, progress, terminalType, title, description, lifecycleState
+        role, status, task, model, progress, terminalType, title, description, lifecycleState,
+        worktree, branch
     ]
 
     public static let canonicalTerminalTypes: Set<String> = [
@@ -35,14 +41,22 @@ public enum MetadataSource: String, CaseIterable, Codable, Sendable {
     case explicit
     case declare
     case osc
+    /// C11-104 — system-computed projections of ground-truth state
+    /// (e.g., worktree + branch derived from cwd + gitfs). Ranked
+    /// between `osc` and `heuristic`: an `osc` value wins over a
+    /// `derived` value for the same key; a `derived` value wins over
+    /// a `heuristic` one. Agents should not write `derived` keys
+    /// directly — they are recomputed automatically as state changes.
+    case derived
     case heuristic
 
     public var precedence: Int {
         switch self {
         case .heuristic: return 0
-        case .osc:       return 1
-        case .declare:   return 2
-        case .explicit:  return 3
+        case .derived:   return 1
+        case .osc:       return 2
+        case .declare:   return 3
+        case .explicit:  return 4
         }
     }
 
@@ -156,6 +170,8 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         "title",
         "description",
         "lifecycle_state",
+        "worktree",
+        "branch",
         "claude.session_id",
         "claude.session_project_dir"
     ]
@@ -222,6 +238,17 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 )
             }
             return nil
+        case "worktree":
+            // C11-104 — derived basename, up to 128 chars (matches the
+            // spec's ≤128 cap). Accepts any string within the cap;
+            // the resolver only writes strings that already passed
+            // `git rev-parse` so additional grammar checks would be
+            // belt-and-suspenders.
+            return validateString(key: key, value: value, maxLen: 128)
+        case "branch":
+            // C11-104 — derived branch name (or "(detached @ <sha>)"
+            // or "(no branch)"). Up to 64 chars per spec.
+            return validateString(key: key, value: value, maxLen: 64)
         case "claude.session_id":
             // Claude SessionStart's `session_id` is a UUIDv4; reject
             // anything else. The value is interpolated verbatim into

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -691,6 +691,10 @@ class TabManager: ObservableObject {
         let branch: String?
         let isDirty: Bool
         let pullRequest: WorkspacePullRequestSnapshot
+        /// C11-104 — resolved worktree + branch context for the sidebar
+        /// chips, computed on the same off-main probe pass so we do not
+        /// fork additional git invocations on the hot path.
+        let gitContext: ResolvedGitContext?
     }
 
     private struct CommandResult {
@@ -1657,6 +1661,23 @@ class TabManager: ObservableObject {
             break
         }
 
+        // C11-104 — apply the resolved worktree+branch context.
+        // Path:
+        //   1. workspace.panelGitContexts (fast path for the sidebar).
+        //   2. SurfaceMetadataStore.setInternal(.derived) for `worktree`
+        //      and `branch` so external readers (c11 get-metadata,
+        //      future Lattice queries) see the same data without
+        //      reaching into Workspace internals.
+        workspace.updatePanelGitContext(
+            panelId: probeKey.panelId,
+            context: snapshot.gitContext
+        )
+        applyDerivedWorktreeBranchMetadata(
+            workspaceId: probeKey.workspaceId,
+            surfaceId: probeKey.panelId,
+            context: snapshot.gitContext
+        )
+
 #if DEBUG
         let branchLabel = snapshot.branch ?? "none"
         let prLabel: String = {
@@ -1694,19 +1715,33 @@ class TabManager: ObservableObject {
     private nonisolated static func initialWorkspaceGitMetadataSnapshot(
         for directory: String
     ) -> InitialWorkspaceGitMetadataSnapshot {
+        // C11-104 — resolve the worktree/branch chip context first.
+        // Runs the same off-main probe queue; the resolver itself
+        // shells out to `git rev-parse` with a bounded timeout. We
+        // resolve here unconditionally because the resolver also
+        // handles the "no git" case (returns nil) which we want to
+        // capture even when the legacy branch probe also returns nil.
+        let gitContext = GitContextResolver.resolve(cwd: directory)
+
         let branch = normalizedBranchName(runGitCommand(directory: directory, arguments: ["branch", "--show-current"]))
         guard let branch else {
             return InitialWorkspaceGitMetadataSnapshot(
                 branch: nil,
                 isDirty: false,
-                pullRequest: .notFound
+                pullRequest: .notFound,
+                gitContext: gitContext
             )
         }
 
         let statusOutput = runGitCommand(directory: directory, arguments: ["status", "--porcelain", "-uno"])
         let isDirty = !(statusOutput?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         let pullRequest = workspacePullRequestSnapshot(directory: directory, branch: branch)
-        return InitialWorkspaceGitMetadataSnapshot(branch: branch, isDirty: isDirty, pullRequest: pullRequest)
+        return InitialWorkspaceGitMetadataSnapshot(
+            branch: branch,
+            isDirty: isDirty,
+            pullRequest: pullRequest,
+            gitContext: gitContext
+        )
     }
 
     private nonisolated static func runGitCommand(directory: String, arguments: [String]) -> String? {
@@ -2364,6 +2399,71 @@ class TabManager: ObservableObject {
             workspaceId: tabId,
             panelId: surfaceId,
             reason: "branchChange"
+        )
+    }
+
+    /// C11-104 — write the resolved worktree/branch labels into the
+    /// surface manifest with source `.derived`. Called from the
+    /// off-main probe apply step (already on the main actor via the
+    /// Task hop in `scheduleWorkspaceGitMetadataRefresh`). External
+    /// callers should NOT invoke this directly — it's keyed off the
+    /// resolver output.
+    private func applyDerivedWorktreeBranchMetadata(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        context: ResolvedGitContext?
+    ) {
+        let store = SurfaceMetadataStore.shared
+
+        guard let context else {
+            store.setInternal(
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                key: MetadataKey.worktree,
+                value: "",
+                source: .derived
+            )
+            store.setInternal(
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                key: MetadataKey.branch,
+                value: "",
+                source: .derived
+            )
+            return
+        }
+
+        let worktreeValue: String
+        switch context.outer {
+        case .mainCheckout:
+            worktreeValue = ""
+        case .linkedWorktree(let basename, _, _):
+            worktreeValue = basename
+        }
+
+        let branchValue: String
+        switch context.outer {
+        case .mainCheckout(let branch), .linkedWorktree(_, _, let branch):
+            switch branch {
+            case .attached(let name): branchValue = name
+            case .detached(let sha):  branchValue = "(detached @ \(sha))"
+            case .unknown:            branchValue = ""
+            }
+        }
+
+        store.setInternal(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            key: MetadataKey.worktree,
+            value: worktreeValue,
+            source: .derived
+        )
+        store.setInternal(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            key: MetadataKey.branch,
+            value: branchValue,
+            source: .derived
         )
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8238,6 +8238,14 @@ class TerminalController {
         guard let source = MetadataSource(rawValue: sourceStr) else {
             return .err(code: "invalid_source", message: "source must be one of: explicit, declare, osc, heuristic", data: nil)
         }
+        // C11-104 v2 (B5a) — `derived` is reserved for c11-internal
+        // writers. External socket/CLI clients are rejected. Without
+        // this gate, an agent could write `source=derived` and claim
+        // their values are system-computed, nullifying the meaning
+        // of the precedence tier.
+        if source == .derived {
+            return .err(code: "invalid_source", message: "source 'derived' is reserved for c11-internal writers", data: nil)
+        }
 
         guard let resolved = v2ResolveSurfaceForMetadata(params: params) else {
             return .err(code: "surface_not_found", message: "Surface not found", data: nil)
@@ -8352,6 +8360,14 @@ class TerminalController {
         let sourceStr = (v2String(params, "source") ?? "explicit").lowercased()
         guard let source = MetadataSource(rawValue: sourceStr) else {
             return .err(code: "invalid_source", message: "source must be one of: explicit, declare, osc, heuristic", data: nil)
+        }
+        // C11-104 v2 (B5a) — `derived` is reserved for c11-internal
+        // writers. External socket/CLI clients are rejected. Without
+        // this gate, an agent could write `source=derived` and claim
+        // their values are system-computed, nullifying the meaning
+        // of the precedence tier.
+        if source == .derived {
+            return .err(code: "invalid_source", message: "source 'derived' is reserved for c11-internal writers", data: nil)
         }
 
         guard let resolved = v2ResolveSurfaceForMetadata(params: params) else {
@@ -9101,6 +9117,14 @@ class TerminalController {
         guard let source = MetadataSource(rawValue: sourceStr) else {
             return .err(code: "invalid_source", message: "source must be one of: explicit, declare, osc, heuristic", data: nil)
         }
+        // C11-104 v2 (B5a) — `derived` is reserved for c11-internal
+        // writers. External socket/CLI clients are rejected. Without
+        // this gate, an agent could write `source=derived` and claim
+        // their values are system-computed, nullifying the meaning
+        // of the precedence tier.
+        if source == .derived {
+            return .err(code: "invalid_source", message: "source 'derived' is reserved for c11-internal writers", data: nil)
+        }
 
         guard let resolved = v2ResolvePaneForMetadata(params: params) else {
             return .err(code: "pane_not_found", message: "Pane not found", data: nil)
@@ -9189,6 +9213,14 @@ class TerminalController {
         let sourceStr = (v2String(params, "source") ?? "explicit").lowercased()
         guard let source = MetadataSource(rawValue: sourceStr) else {
             return .err(code: "invalid_source", message: "source must be one of: explicit, declare, osc, heuristic", data: nil)
+        }
+        // C11-104 v2 (B5a) — `derived` is reserved for c11-internal
+        // writers. External socket/CLI clients are rejected. Without
+        // this gate, an agent could write `source=derived` and claim
+        // their values are system-computed, nullifying the meaning
+        // of the precedence tier.
+        if source == .derived {
+            return .err(code: "invalid_source", message: "source 'derived' is reserved for c11-internal writers", data: nil)
         }
 
         guard let resolved = v2ResolvePaneForMetadata(params: params) else {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -490,7 +490,8 @@ extension Workspace {
         }
         let bridgedValues = PersistedMetadataBridge.encodeValues(
             snapshot.metadata,
-            surfaceIdForLog: paneUUID
+            surfaceIdForLog: paneUUID,
+            sources: snapshot.sources
         )
         let cappedValues = PersistedMetadataBridge.enforceSizeCap(
             bridgedValues,
@@ -617,7 +618,8 @@ extension Workspace {
             } else {
                 let bridgedValues = PersistedMetadataBridge.encodeValues(
                     snapshot.metadata,
-                    surfaceIdForLog: panelId
+                    surfaceIdForLog: panelId,
+                    sources: snapshot.sources
                 )
                 let cappedValues = PersistedMetadataBridge.enforceSizeCap(
                     bridgedValues,
@@ -5295,6 +5297,10 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var progress: SidebarProgressState?
     @Published var gitBranch: SidebarGitBranchState?
     @Published var panelGitBranches: [UUID: SidebarGitBranchState] = [:]
+    /// C11-104 — per-panel resolved worktree+branch context for the
+    /// sidebar chips. Written by `TabManager.applyWorkspaceGitMetadataSnapshot`
+    /// from the off-main probe. Nil signals "not a git directory."
+    @Published var panelGitContexts: [UUID: ResolvedGitContext?] = [:]
     @Published var pullRequest: SidebarPullRequestState?
     @Published var panelPullRequests: [UUID: SidebarPullRequestState] = [:]
     @Published var surfaceListeningPorts: [UUID: [Int]] = [:]
@@ -6620,6 +6626,22 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// C11-104 — write the resolved worktree+branch chip context for a
+    /// panel. Nil means "not a git directory"; we still write the nil
+    /// entry so the sidebar can render the absence (no chips) instead
+    /// of a stale prior value.
+    func updatePanelGitContext(panelId: UUID, context: ResolvedGitContext?) {
+        // Flatten the subscript's outer optional so "missing key" and
+        // "key present with nil value" compare identically.
+        let prior: ResolvedGitContext? = panelGitContexts[panelId] ?? nil
+        if prior == context { return }
+        panelGitContexts[panelId] = context
+    }
+
+    func clearPanelGitContext(panelId: UUID) {
+        panelGitContexts.removeValue(forKey: panelId)
+    }
+
     func updatePanelPullRequest(
         panelId: UUID,
         number: Int,
@@ -6691,6 +6713,7 @@ final class Workspace: Identifiable, ObservableObject {
         progress = nil
         gitBranch = nil
         panelGitBranches.removeAll()
+        panelGitContexts.removeAll()
         pullRequest = nil
         panelPullRequests.removeAll()
         surfaceListeningPorts.removeAll()
@@ -7121,6 +7144,7 @@ final class Workspace: Identifiable, ObservableObject {
         pinnedPanelIds = pinnedPanelIds.filter { validSurfaceIds.contains($0) }
         manualUnreadPanelIds = manualUnreadPanelIds.filter { validSurfaceIds.contains($0) }
         panelGitBranches = panelGitBranches.filter { validSurfaceIds.contains($0.key) }
+        panelGitContexts = panelGitContexts.filter { validSurfaceIds.contains($0.key) }
         manualUnreadMarkedAt = manualUnreadMarkedAt.filter { validSurfaceIds.contains($0.key) }
         surfaceListeningPorts = surfaceListeningPorts.filter { validSurfaceIds.contains($0.key) }
         surfaceTTYNames = surfaceTTYNames.filter { validSurfaceIds.contains($0.key) }

--- a/Sources/WorkspacePlanCapture.swift
+++ b/Sources/WorkspacePlanCapture.swift
@@ -174,7 +174,11 @@ enum WorkspacePlanCapture {
                 surfaceId: panelId
             )
             guard !snapshot.metadata.isEmpty else { return [:] }
-            return PersistedMetadataBridge.encodeValues(snapshot.metadata, surfaceIdForLog: panelId)
+            return PersistedMetadataBridge.encodeValues(
+                snapshot.metadata,
+                surfaceIdForLog: panelId,
+                sources: snapshot.sources
+            )
         }
 
         private func paneMetadata(for paneID: PaneID?) -> [String: PersistedJSONValue] {
@@ -184,7 +188,11 @@ enum WorkspacePlanCapture {
                 paneId: paneID.id
             )
             guard !snapshot.metadata.isEmpty else { return [:] }
-            return PersistedMetadataBridge.encodeValues(snapshot.metadata, surfaceIdForLog: paneID.id)
+            return PersistedMetadataBridge.encodeValues(
+                snapshot.metadata,
+                surfaceIdForLog: paneID.id,
+                sources: snapshot.sources
+            )
         }
 
         // MARK: Pane / tab lookup

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -3273,8 +3273,6 @@ private struct SidebarDebugView: View {
     @AppStorage("sidebarCornerRadius") private var sidebarCornerRadius = 0.0
     @AppStorage("sidebarBlurOpacity") private var sidebarBlurOpacity = 1.0
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
-    /// C11-104 — single master toggle for the derived worktree+branch chips.
-    @AppStorage("sidebarShowWorktreeChips") private var sidebarShowWorktreeChips = true
     @AppStorage(ShortcutHintDebugSettings.sidebarHintXKey) private var sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
     @AppStorage(ShortcutHintDebugSettings.sidebarHintYKey) private var sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
     @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
@@ -3413,22 +3411,6 @@ private struct SidebarDebugView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Toggle("Render branch list vertically", isOn: $sidebarBranchVerticalLayout)
                         Text("When enabled, each branch appears on its own line in the sidebar.")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Divider()
-                        // C11-104 — single master toggle for the
-                        // derived worktree + branch chips. Default on.
-                        Toggle(
-                            String(
-                                localized: "settings.sidebar.showWorktreeChips.title",
-                                defaultValue: "Show worktree/branch chips"
-                            ),
-                            isOn: $sidebarShowWorktreeChips
-                        )
-                        Text(String(
-                            localized: "settings.sidebar.showWorktreeChips.description",
-                            defaultValue: "When enabled, each workspace row shows the current worktree (colored dot prefix) and branch — derived from cwd and gitfs, no agent action needed."
-                        ))
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -5420,8 +5402,18 @@ struct SettingsView: View {
             SettingsCardDivider()
 
             SettingsCardRow(
-                String(localized: "settings.app.showBranchDirectory", defaultValue: "Show Branch + Directory in Sidebar"),
-                subtitle: String(localized: "settings.app.showBranchDirectory.subtitle", defaultValue: "Show the git branch and working directory row.")
+                // C11-104 v2 — relabeled. The toggle key
+                // `sidebarShowBranchDirectory` is preserved so existing
+                // user prefs survive the migration; the surface it gates
+                // is now the worktree+branch chip row.
+                String(
+                    localized: "settings.app.showWorktreeBranchChips",
+                    defaultValue: "Show worktree + branch chips in sidebar"
+                ),
+                subtitle: String(
+                    localized: "settings.app.showWorktreeBranchChips.subtitle",
+                    defaultValue: "Render worktree (colored-dot prefix) and branch chips on each workspace row — derived from cwd and gitfs."
+                )
             ) {
                 Toggle("", isOn: $sidebarShowBranchDirectory)
                     .labelsHidden()

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -3273,6 +3273,8 @@ private struct SidebarDebugView: View {
     @AppStorage("sidebarCornerRadius") private var sidebarCornerRadius = 0.0
     @AppStorage("sidebarBlurOpacity") private var sidebarBlurOpacity = 1.0
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
+    /// C11-104 — single master toggle for the derived worktree+branch chips.
+    @AppStorage("sidebarShowWorktreeChips") private var sidebarShowWorktreeChips = true
     @AppStorage(ShortcutHintDebugSettings.sidebarHintXKey) private var sidebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultSidebarHintX
     @AppStorage(ShortcutHintDebugSettings.sidebarHintYKey) private var sidebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultSidebarHintY
     @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
@@ -3411,6 +3413,22 @@ private struct SidebarDebugView: View {
                     VStack(alignment: .leading, spacing: 8) {
                         Toggle("Render branch list vertically", isOn: $sidebarBranchVerticalLayout)
                         Text("When enabled, each branch appears on its own line in the sidebar.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Divider()
+                        // C11-104 — single master toggle for the
+                        // derived worktree + branch chips. Default on.
+                        Toggle(
+                            String(
+                                localized: "settings.sidebar.showWorktreeChips.title",
+                                defaultValue: "Show worktree/branch chips"
+                            ),
+                            isOn: $sidebarShowWorktreeChips
+                        )
+                        Text(String(
+                            localized: "settings.sidebar.showWorktreeChips.description",
+                            defaultValue: "When enabled, each workspace row shows the current worktree (colored dot prefix) and branch — derived from cwd and gitfs, no agent action needed."
+                        ))
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }

--- a/c11Tests/GitContextResolverTests.swift
+++ b/c11Tests/GitContextResolverTests.swift
@@ -343,6 +343,73 @@ final class GitContextResolverTests: XCTestCase {
         XCTAssertNil(result, "not-in-git returns nil; precondition allows off-main resolution")
     }
 
+    // MARK: - Submodule display-name fallback chain (v2 amendment 3)
+
+    func testSubmoduleNameFallsBackToBasenameWhenNoGitmodules() {
+        // When `.gitmodules` lookup returns nil AND the path-from-
+        // superproject-root is computable, the path is used (richer
+        // disambiguation than basename for nested submodules).
+        let superCwd = "/tmp/super"
+        let subCwd = "/tmp/super/ghostty"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-superproject-working-tree"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--show-toplevel"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-common-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-toplevel"], result: subCwd)
+        runner.stub(cwd: subCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "ghostty-main")
+        // `.gitmodules` config lookup returns nil → fallback to
+        // path-from-superproject-root.
+        let fs = FakeFileSystem(existing: [subCwd])
+        let result = resolveOffMain(cwd: subCwd, runner: runner, fs: fs)
+        // Path-from-superproject-root is "ghostty" which happens to
+        // equal the basename in this trivial case. The richer test
+        // below covers the nested case where they diverge.
+        XCTAssertEqual(result?.inner?.name, "ghostty")
+    }
+
+    func testSubmoduleNamePrefersConfiguredGitmodulesEntry() {
+        let superCwd = "/tmp/super"
+        let subCwd = "/tmp/super/vendor/bonsplit"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-superproject-working-tree"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--show-toplevel"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-common-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-toplevel"], result: subCwd)
+        runner.stub(cwd: subCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "bonsplit-main")
+        // .gitmodules lookup returns a configured name "Bonsplit" mapped to
+        // the relative path "vendor/bonsplit". The configured name wins.
+        runner.stub(
+            cwd: superCwd,
+            args: ["config", "-f", ".gitmodules", "--get-regexp", #"submodule\..*\.path"#],
+            result: "submodule.Bonsplit.path vendor/bonsplit"
+        )
+        let fs = FakeFileSystem(existing: [subCwd])
+        let result = resolveOffMain(cwd: subCwd, runner: runner, fs: fs)
+        XCTAssertEqual(result?.inner?.name, "Bonsplit")
+    }
+
+    func testSubmoduleNameFallsBackToRelativePathWhenGitmodulesAbsent() {
+        let superCwd = "/tmp/super"
+        let subCwd = "/tmp/super/vendor/bonsplit"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-superproject-working-tree"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--show-toplevel"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-common-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-toplevel"], result: subCwd)
+        runner.stub(cwd: subCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "bonsplit-main")
+        // No `.gitmodules` lookup stubbed → falls back to relative path.
+        let fs = FakeFileSystem(existing: [subCwd])
+        let result = resolveOffMain(cwd: subCwd, runner: runner, fs: fs)
+        XCTAssertEqual(result?.inner?.name, "vendor/bonsplit",
+                       "fallback chain prefers path-from-superproject-root over basename for nested submodules")
+    }
+
     // MARK: - DerivationCoordinator + MetadataDeriver seam (v2 amendment 2)
 
     func testGitContextDeriverConformsToMetadataDeriver() {

--- a/c11Tests/GitContextResolverTests.swift
+++ b/c11Tests/GitContextResolverTests.swift
@@ -343,6 +343,39 @@ final class GitContextResolverTests: XCTestCase {
         XCTAssertNil(result, "not-in-git returns nil; precondition allows off-main resolution")
     }
 
+    // MARK: - DerivationCoordinator + MetadataDeriver seam (v2 amendment 2)
+
+    func testGitContextDeriverConformsToMetadataDeriver() {
+        // Compile-time conformance check. If `GitContextDeriver`
+        // ever stops conforming to `MetadataDeriver`, this test
+        // stops compiling.
+        let _: any MetadataDeriver = GitContextDeriver()
+    }
+
+    func testDerivationCoordinatorRunsDeriverOffMainAndCompletesOnMain() {
+        let cwd = "/tmp/coordinator-test"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        let fs = FakeFileSystem(existing: [cwd])
+        let deriver = GitContextDeriver(runner: runner, fileSystem: fs)
+
+        let expectation = XCTestExpectation(description: "coordinator completes on main")
+        nonisolated(unsafe) var receivedOnMain = false
+        nonisolated(unsafe) var result: ResolvedGitContext?
+        DerivationCoordinator.run(deriver: deriver, cwd: cwd) { value in
+            receivedOnMain = Thread.isMainThread
+            result = value
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5.0)
+        XCTAssertTrue(receivedOnMain, "completion must hop to main")
+        XCTAssertEqual(result?.outer, .mainCheckout(branch: .attached("main")))
+    }
+
     // MARK: - Cache eviction (LRU)
 
     func testCacheEvictsOldestEntriesPastCapacity() {

--- a/c11Tests/GitContextResolverTests.swift
+++ b/c11Tests/GitContextResolverTests.swift
@@ -1,0 +1,363 @@
+import XCTest
+@testable import c11
+
+/// C11-104 — resolver tests against temp-dir-built git repos.
+///
+/// All tests use a `FakeGitRunner` so we don't depend on a real `git`
+/// binary being present; the runner is a dictionary lookup keyed by
+/// `(cwd, args)`. Cache tests verify the resolver actually calls the
+/// runner when the `.git/HEAD` mtime changes.
+///
+/// Verifies AC1, AC2, AC5–AC9, AC12 of the C11-104 validation plan.
+final class GitContextResolverTests: XCTestCase {
+
+    // MARK: - Fakes
+
+    private final class FakeGitRunner: GitRunner {
+        struct Key: Hashable {
+            let cwd: String
+            let args: [String]
+        }
+        var responses: [Key: String?] = [:]
+        private(set) var invocations: [Key] = []
+
+        func run(cwd: String, args: [String]) -> String? {
+            let key = Key(cwd: cwd, args: args)
+            invocations.append(key)
+            return responses[key] ?? nil
+        }
+
+        func stub(cwd: String, args: [String], result: String?) {
+            responses[Key(cwd: cwd, args: args)] = result
+        }
+    }
+
+    private struct FakeFileSystem: FileSystemProbe {
+        var existing: Set<String> = []
+        var mtimes: [String: Date] = [:]
+        func fileExists(atPath path: String) -> Bool {
+            return existing.contains(path)
+        }
+        func mtime(atPath path: String) -> Date? {
+            return mtimes[path]
+        }
+    }
+
+    /// Resolver requires off-main dispatch (typing-latency discipline).
+    /// XCTest runs cases on main, so we hop to a background queue and
+    /// wait synchronously for the result.
+    private func resolveOffMain(
+        cwd: String,
+        runner: GitRunner,
+        fs: FileSystemProbe
+    ) -> ResolvedGitContext? {
+        var result: ResolvedGitContext?
+        let sema = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            result = GitContextResolver.resolve(cwd: cwd, runner: runner, fileSystem: fs)
+            sema.signal()
+        }
+        sema.wait()
+        return result
+    }
+
+    // MARK: - AC1: Linked worktree returns basename
+
+    func testLinkedWorktreeReturnsBasename() {
+        let cwd = "/Users/atin/code/c11-worktrees/c11-104-sidebar-chips"
+        let runner = FakeGitRunner()
+        // Submodule probe — empty (not in a submodule).
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        // Outer resolution against the cwd (not in a submodule).
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: "/Users/atin/code/c11/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: "/Users/atin/code/c11/.git/worktrees/c11-104-sidebar-chips")
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: "feat/c11-104-sidebar-chips")
+
+        let fs = FakeFileSystem(existing: [cwd])
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        XCTAssertEqual(
+            result,
+            ResolvedGitContext(
+                outer: .linkedWorktree(
+                    basename: "c11-104-sidebar-chips",
+                    absolutePath: cwd,
+                    branch: .attached("feat/c11-104-sidebar-chips")
+                )
+            )
+        )
+    }
+
+    // MARK: - AC2: Main checkout returns nil worktree
+
+    func testMainCheckoutReturnsMainCheckoutKind() {
+        let cwd = "/Users/atin/code/c11"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: "/Users/atin/code/c11/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: "/Users/atin/code/c11/.git")
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+
+        let fs = FakeFileSystem(existing: [cwd])
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        XCTAssertEqual(result?.outer, .mainCheckout(branch: .attached("main")))
+        XCTAssertNil(result?.inner)
+    }
+
+    // MARK: - AC5: Detached HEAD renders short SHA
+
+    func testDetachedHeadReturnsShortSHA() {
+        let cwd = "/tmp/detached"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: cwd + "/.git")
+        // symbolic-ref fails on detached HEAD.
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--short=7", "HEAD"], result: "abc1234")
+
+        let fs = FakeFileSystem(existing: [cwd])
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        XCTAssertEqual(result?.outer, .mainCheckout(branch: .detached(shortSHA: "abc1234")))
+    }
+
+    // MARK: - AC6: Submodule returns both contexts
+
+    func testSubmoduleReturnsBothContexts() {
+        let superCwd = "/tmp/super"
+        let subCwd = "/tmp/super/ghostty"
+        let runner = FakeGitRunner()
+        // From inside the submodule, the superproject probe returns
+        // the super's working tree.
+        runner.stub(
+            cwd: subCwd,
+            args: ["rev-parse", "--show-superproject-working-tree"],
+            result: superCwd
+        )
+        // Outer resolution runs against superCwd.
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--show-toplevel"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-common-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        // Inner resolution against subCwd.
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-toplevel"], result: subCwd)
+        runner.stub(cwd: subCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "ghostty-main")
+
+        let fs = FakeFileSystem(existing: [subCwd])
+        let result = resolveOffMain(cwd: subCwd, runner: runner, fs: fs)
+        XCTAssertEqual(result?.outer, .mainCheckout(branch: .attached("main")))
+        XCTAssertEqual(result?.inner?.name, "ghostty")
+        XCTAssertEqual(result?.inner?.branch, .attached("ghostty-main"))
+    }
+
+    // MARK: - AC6 edge: submodule with detached inner
+
+    func testSubmoduleInnerDetachedHEAD() {
+        let superCwd = "/tmp/super"
+        let subCwd = "/tmp/super/ghostty"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-superproject-working-tree"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--show-toplevel"], result: superCwd)
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-common-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["rev-parse", "--git-dir"], result: superCwd + "/.git")
+        runner.stub(cwd: superCwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--show-toplevel"], result: subCwd)
+        runner.stub(cwd: subCwd, args: ["symbolic-ref", "--short", "HEAD"], result: nil)
+        runner.stub(cwd: subCwd, args: ["rev-parse", "--short=7", "HEAD"], result: "deadbee")
+
+        let fs = FakeFileSystem(existing: [subCwd])
+        let result = resolveOffMain(cwd: subCwd, runner: runner, fs: fs)
+        XCTAssertEqual(result?.inner?.branch, .detached(shortSHA: "deadbee"))
+    }
+
+    // MARK: - AC7: Not-in-git returns nil
+
+    func testNotInGitReturnsNil() {
+        let cwd = "/tmp/not-a-repo"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        // show-toplevel fails outside any git repo.
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: nil)
+
+        let fs = FakeFileSystem(existing: [cwd])
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        XCTAssertNil(result)
+    }
+
+    func testCwdDoesNotExistReturnsNil() {
+        let cwd = "/tmp/does-not-exist"
+        let runner = FakeGitRunner()
+        let fs = FakeFileSystem(existing: [])  // cwd does not exist
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        XCTAssertNil(result)
+        // Importantly, we did NOT shell out — the existence check
+        // short-circuits before any runner invocation.
+        XCTAssertEqual(runner.invocations.count, 0)
+    }
+
+    // MARK: - AC8: Bare clone returns nil
+
+    func testBareCloneReturnsNil() {
+        let cwd = "/tmp/bare-clone.git"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        // In a bare repo, `--show-toplevel` exits non-zero (our runner
+        // returns nil on non-zero).
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: nil)
+
+        let fs = FakeFileSystem(existing: [cwd])
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        XCTAssertNil(result)
+    }
+
+    // MARK: - AC9: Worktree-with-deleted-branch degrades
+
+    func testWorktreeWithDeletedBranchDegrades() {
+        let cwd = "/Users/atin/code/c11-worktrees/old-branch"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: "/Users/atin/code/c11/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: "/Users/atin/code/c11/.git/worktrees/old-branch")
+        // Both symbolic-ref and rev-parse fail when the underlying
+        // branch has been deleted out from under the worktree.
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--short=7", "HEAD"], result: nil)
+
+        let fs = FakeFileSystem(existing: [cwd])
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        // No throw, no crash — just `.unknown` in the branch slot.
+        switch result?.outer {
+        case .linkedWorktree(_, _, let branch):
+            XCTAssertEqual(branch, .unknown)
+        default:
+            XCTFail("expected linkedWorktree, got \(String(describing: result?.outer))")
+        }
+    }
+
+    // MARK: - AC12: Cache invalidates on .git/HEAD mtime change
+
+    func testCacheHitDoesNotReinvokeRunner() {
+        let cwd = "/tmp/cached"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        let fs = FakeFileSystem(existing: [cwd])
+
+        let cache = GitContextResolverCache()
+        let mtime = Date(timeIntervalSince1970: 1000)
+        let key = GitContextResolverCache.Key(cwd: cwd, headMtime: mtime)
+
+        if cache.get(key) == nil {
+            let value = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+            cache.set(key, value: value)
+        }
+        let first = runner.invocations.count
+        XCTAssertGreaterThan(first, 0)
+
+        // Second lookup with the same key → cache hit. The outer
+        // optional means "present in cache"; the inner is the resolver
+        // result. We expect a present-and-non-nil mainCheckout entry.
+        guard let cached = cache.get(key), let resolved = cached else {
+            XCTFail("expected cache hit")
+            return
+        }
+        XCTAssertEqual(resolved.outer, .mainCheckout(branch: .attached("main")))
+        XCTAssertEqual(runner.invocations.count, first, "cache hit must not invoke the runner")
+    }
+
+    func testCacheInvalidatesOnHeadMtimeChange() {
+        let cwd = "/tmp/invalidates"
+        let runner = FakeGitRunner()
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: "main")
+        let fs = FakeFileSystem(existing: [cwd])
+
+        let cache = GitContextResolverCache()
+        let t1 = Date(timeIntervalSince1970: 1000)
+        let key1 = GitContextResolverCache.Key(cwd: cwd, headMtime: t1)
+
+        let v1 = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        cache.set(key1, value: v1)
+        let beforeChange = runner.invocations.count
+
+        // mtime changes (e.g., a `git checkout` happened) → new key.
+        let t2 = Date(timeIntervalSince1970: 2000)
+        let key2 = GitContextResolverCache.Key(cwd: cwd, headMtime: t2)
+        XCTAssertNil(cache.get(key2), "different mtime must miss")
+
+        let v2 = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        cache.set(key2, value: v2)
+        XCTAssertGreaterThan(
+            runner.invocations.count, beforeChange,
+            "mtime-change must trigger a new runner invocation"
+        )
+    }
+
+    // MARK: - Branch label truncation (plan-review I7)
+
+    func testLongBranchNameIsMiddleTruncated() {
+        let cwd = "/tmp/long-branch"
+        let runner = FakeGitRunner()
+        let longName = "release/2026-q4/super-long-feature-branch-name-that-will-blow-past-sixty-four-chars-and-then-some"
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--show-toplevel"], result: cwd)
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-common-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["rev-parse", "--git-dir"], result: cwd + "/.git")
+        runner.stub(cwd: cwd, args: ["symbolic-ref", "--short", "HEAD"], result: longName)
+        let fs = FakeFileSystem(existing: [cwd])
+
+        let result = resolveOffMain(cwd: cwd, runner: runner, fs: fs)
+        guard case .mainCheckout(.attached(let label)) = result?.outer else {
+            XCTFail("expected attached branch")
+            return
+        }
+        XCTAssertLessThanOrEqual(label.count, GitContextResolver.maxBranchLabelLength)
+        XCTAssertTrue(label.contains("…"), "truncated label must include ellipsis")
+        XCTAssertTrue(label.hasPrefix("release/2026"), "head context preserved")
+    }
+
+    // MARK: - Hot-path discipline (plan-review I2)
+
+    func testResolverPreconditionTripsOnMainThread() {
+        // We can't easily intercept `dispatchPrecondition` in-process,
+        // but we can confirm the resolver compiles with the precondition
+        // and runs cleanly off-main via every other test in this file.
+        // This test is a sentinel: if dispatchPrecondition is ever
+        // weakened to a no-op assertion, future maintainers will see
+        // this test exists and revisit the contract.
+        let runner = FakeGitRunner()
+        runner.stub(cwd: "/tmp", args: ["rev-parse", "--show-superproject-working-tree"], result: nil)
+        runner.stub(cwd: "/tmp", args: ["rev-parse", "--show-toplevel"], result: nil)
+        let fs = FakeFileSystem(existing: ["/tmp"])
+        // Off-main resolution must succeed (no precondition trip).
+        let result = resolveOffMain(cwd: "/tmp", runner: runner, fs: fs)
+        XCTAssertNil(result, "not-in-git returns nil; precondition allows off-main resolution")
+    }
+
+    // MARK: - Cache eviction (LRU)
+
+    func testCacheEvictsOldestEntriesPastCapacity() {
+        let cache = GitContextResolverCache(capacity: 2)
+        let k1 = GitContextResolverCache.Key(cwd: "/a", headMtime: nil)
+        let k2 = GitContextResolverCache.Key(cwd: "/b", headMtime: nil)
+        let k3 = GitContextResolverCache.Key(cwd: "/c", headMtime: nil)
+        cache.set(k1, value: nil)
+        cache.set(k2, value: nil)
+        cache.set(k3, value: nil)
+        XCTAssertEqual(cache.count, 2)
+        // `cache.get` returns Optional<Optional<ResolvedGitContext>>.
+        // The outer nil means "not in cache" — that's what eviction yields.
+        XCTAssertTrue(cache.get(k1) == nil, "oldest entry must have been evicted")
+        XCTAssertTrue(cache.get(k2) != nil)
+        XCTAssertTrue(cache.get(k3) != nil)
+    }
+}

--- a/c11Tests/MetadataDerivedPrecedenceTests.swift
+++ b/c11Tests/MetadataDerivedPrecedenceTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+@testable import c11
+
+/// C11-104 — verify that the new `.derived` precedence tier exists in
+/// `MetadataSource` and sits between `.osc` and `.heuristic`.
+///
+/// AC13 — when an `osc` value exists, it wins over a `derived` value
+/// for the same key; `derived` wins over `heuristic`.
+final class MetadataDerivedPrecedenceTests: XCTestCase {
+
+    // MARK: - Ordering
+
+    func testDerivedRankBetweenOscAndHeuristic() {
+        XCTAssertGreaterThan(MetadataSource.derived.rank, MetadataSource.heuristic.rank,
+                             "derived must outrank heuristic")
+        XCTAssertLessThan(MetadataSource.derived.rank, MetadataSource.osc.rank,
+                          "osc must outrank derived")
+        XCTAssertLessThan(MetadataSource.derived.rank, MetadataSource.declare.rank,
+                          "declare must outrank derived")
+        XCTAssertLessThan(MetadataSource.derived.rank, MetadataSource.explicit.rank,
+                          "explicit must outrank derived")
+    }
+
+    func testDerivedRoundTripsViaRawValue() {
+        XCTAssertEqual(MetadataSource(rawValue: "derived"), .derived)
+        XCTAssertEqual(MetadataSource.derived.rawValue, "derived")
+    }
+
+    func testAllCasesIncludesDerived() {
+        XCTAssertTrue(MetadataSource.allCases.contains(.derived))
+    }
+
+    // MARK: - SurfaceMetadataStore precedence behavior
+
+    func testOscWinsOverDerivedForSameKey() {
+        let store = SurfaceMetadataStore.shared
+        let ws = UUID()
+        let surface = UUID()
+        defer { store.removeSurface(workspaceId: ws, surfaceId: surface) }
+
+        // osc lays down first.
+        let applied1 = store.setInternal(
+            workspaceId: ws, surfaceId: surface,
+            key: MetadataKey.branch, value: "osc-value",
+            source: .osc
+        )
+        XCTAssertTrue(applied1)
+
+        // derived tries to overwrite — must be rejected.
+        let applied2 = store.setInternal(
+            workspaceId: ws, surfaceId: surface,
+            key: MetadataKey.branch, value: "derived-value",
+            source: .derived
+        )
+        XCTAssertFalse(applied2, "derived must not overwrite osc")
+
+        let (values, _) = store.getMetadata(workspaceId: ws, surfaceId: surface)
+        XCTAssertEqual(values[MetadataKey.branch] as? String, "osc-value")
+        XCTAssertEqual(store.getSource(workspaceId: ws, surfaceId: surface,
+                                       key: MetadataKey.branch), .osc)
+    }
+
+    func testDerivedWinsOverHeuristic() {
+        let store = SurfaceMetadataStore.shared
+        let ws = UUID()
+        let surface = UUID()
+        defer { store.removeSurface(workspaceId: ws, surfaceId: surface) }
+
+        let applied1 = store.setInternal(
+            workspaceId: ws, surfaceId: surface,
+            key: MetadataKey.branch, value: "heur",
+            source: .heuristic
+        )
+        XCTAssertTrue(applied1)
+        let applied2 = store.setInternal(
+            workspaceId: ws, surfaceId: surface,
+            key: MetadataKey.branch, value: "main",
+            source: .derived
+        )
+        XCTAssertTrue(applied2, "derived must overwrite heuristic")
+
+        let (values, _) = store.getMetadata(workspaceId: ws, surfaceId: surface)
+        XCTAssertEqual(values[MetadataKey.branch] as? String, "main")
+        XCTAssertEqual(store.getSource(workspaceId: ws, surfaceId: surface,
+                                       key: MetadataKey.branch), .derived)
+    }
+
+    func testExplicitWinsOverDerived() {
+        let store = SurfaceMetadataStore.shared
+        let ws = UUID()
+        let surface = UUID()
+        defer { store.removeSurface(workspaceId: ws, surfaceId: surface) }
+
+        _ = store.setInternal(
+            workspaceId: ws, surfaceId: surface,
+            key: MetadataKey.worktree, value: "auto-derived",
+            source: .derived
+        )
+        let writeResult = try? store.setMetadata(
+            workspaceId: ws, surfaceId: surface,
+            partial: [MetadataKey.worktree: "operator-pinned"],
+            mode: .merge, source: .explicit
+        )
+        XCTAssertEqual(writeResult?.applied[MetadataKey.worktree], true)
+        XCTAssertEqual(writeResult?.metadata[MetadataKey.worktree] as? String,
+                       "operator-pinned")
+    }
+
+    // MARK: - Reserved-key validation for the new canonical keys
+
+    func testWorktreeKeyValidatesAsString() {
+        let result = SurfaceMetadataStore.validateReservedKey(MetadataKey.worktree, "wt-name")
+        XCTAssertNil(result, "valid worktree value must not produce a validation error")
+    }
+
+    func testBranchKeyValidatesAsString() {
+        let result = SurfaceMetadataStore.validateReservedKey(MetadataKey.branch, "feature/foo")
+        XCTAssertNil(result, "valid branch value must not produce a validation error")
+    }
+
+    func testWorktreeRejectsOversizeValue() {
+        let huge = String(repeating: "a", count: 129)
+        let result = SurfaceMetadataStore.validateReservedKey(MetadataKey.worktree, huge)
+        XCTAssertNotNil(result, "worktree value over 128 chars must be rejected")
+    }
+
+    func testBranchRejectsOversizeValue() {
+        let huge = String(repeating: "a", count: 65)
+        let result = SurfaceMetadataStore.validateReservedKey(MetadataKey.branch, huge)
+        XCTAssertNotNil(result, "branch value over 64 chars must be rejected")
+    }
+
+    // MARK: - Snapshot exclusion (plan-review B5b)
+
+    func testDerivedKeysAreDroppedFromSnapshotCapture() {
+        let metadata: [String: Any] = [
+            "task": "lat-412",
+            "worktree": "c11-104-sidebar-chips",
+            "branch": "feat/c11-104-sidebar-chips",
+        ]
+        let sources: [String: [String: Any]] = [
+            "task":     ["source": "declare",  "ts": 1.0],
+            "worktree": ["source": "derived",  "ts": 2.0],
+            "branch":   ["source": "derived",  "ts": 3.0],
+        ]
+        let bridged = PersistedMetadataBridge.encodeValues(
+            metadata,
+            surfaceIdForLog: nil,
+            sources: sources
+        )
+        XCTAssertNotNil(bridged["task"], "non-derived keys must persist")
+        XCTAssertNil(bridged["worktree"], "derived `worktree` must NOT persist")
+        XCTAssertNil(bridged["branch"], "derived `branch` must NOT persist")
+
+        let bridgedSources = PersistedMetadataBridge.encodeSources(sources)
+        XCTAssertNotNil(bridgedSources["task"])
+        XCTAssertNil(bridgedSources["worktree"])
+        XCTAssertNil(bridgedSources["branch"])
+    }
+
+    func testEncodeValuesWithoutSourcesPreservesEverything() {
+        // Back-compat: callers that don't pass sources get the old
+        // "encode everything" behavior. Important so the new optional
+        // parameter doesn't silently break callers that haven't been
+        // updated yet.
+        let metadata: [String: Any] = [
+            "task": "lat-412",
+            "worktree": "c11-104-sidebar-chips",
+        ]
+        let bridged = PersistedMetadataBridge.encodeValues(metadata, surfaceIdForLog: nil)
+        XCTAssertNotNil(bridged["task"])
+        XCTAssertNotNil(bridged["worktree"])
+    }
+}

--- a/c11Tests/WorktreeChipProjectorTests.swift
+++ b/c11Tests/WorktreeChipProjectorTests.swift
@@ -147,6 +147,44 @@ final class WorktreeChipProjectorTests: XCTestCase {
         XCTAssertEqual(WorktreeChipProjector.project(context, settingsEnabled: false), [])
     }
 
+    // MARK: - Dirty marker (AC25 — preserved from legacy UX)
+
+    func testDirtyWorkingTreeAppendsStarToBranchChip() {
+        let context = ResolvedGitContext(outer: .mainCheckout(branch: .attached("feature/x")))
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true, isDirty: true)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows[0].branch.label, "feature/x*")
+    }
+
+    func testCleanWorkingTreeDoesNotAppendStar() {
+        let context = ResolvedGitContext(outer: .mainCheckout(branch: .attached("feature/x")))
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true, isDirty: false)
+        XCTAssertEqual(rows[0].branch.label, "feature/x")
+    }
+
+    func testDirtyDetachedHeadAppendsStarAfterClosingParen() {
+        let context = ResolvedGitContext(
+            outer: .mainCheckout(branch: .detached(shortSHA: "abc1234"))
+        )
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true, isDirty: true)
+        XCTAssertEqual(rows[0].branch.label, "(detached @ abc1234)*")
+    }
+
+    func testSubmoduleInnerRowDoesNotInheritDirty() {
+        let context = ResolvedGitContext(
+            outer: .mainCheckout(branch: .attached("main")),
+            inner: GitSubmoduleContext(
+                name: "ghostty",
+                absolutePath: "/super/ghostty",
+                branch: .attached("ghostty-main")
+            )
+        )
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true, isDirty: true)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0].branch.label, "main*", "outer carries dirty marker")
+        XCTAssertEqual(rows[1].branch.label, "ghostty-main", "inner row has no dirty marker")
+    }
+
     // MARK: - Linked worktree carries dot prefix
 
     func testLinkedWorktreeCarriesColoredDot() {

--- a/c11Tests/WorktreeChipProjectorTests.swift
+++ b/c11Tests/WorktreeChipProjectorTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+@testable import c11
+
+/// C11-104 — projector tests.
+///
+/// Verifies AC3, AC4, AC5, AC6, AC7, AC14 by feeding constructed
+/// `ResolvedGitContext` values into `WorktreeChipProjector.project` and
+/// asserting on the chip shape.
+final class WorktreeChipProjectorTests: XCTestCase {
+
+    // MARK: - AC3: Main/master/trunk dim
+
+    func testMainBranchIsDimmed() {
+        let context = ResolvedGitContext(outer: .mainCheckout(branch: .attached("main")))
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertNil(rows[0].worktree)
+        XCTAssertTrue(rows[0].branch.isDimmed)
+        XCTAssertEqual(rows[0].branch.label, "main")
+    }
+
+    func testMasterBranchIsDimmed() {
+        let context = ResolvedGitContext(outer: .mainCheckout(branch: .attached("master")))
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertTrue(rows[0].branch.isDimmed)
+    }
+
+    func testTrunkBranchIsDimmed() {
+        let context = ResolvedGitContext(outer: .mainCheckout(branch: .attached("trunk")))
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertTrue(rows[0].branch.isDimmed)
+    }
+
+    func testFeatureBranchNotDimmed() {
+        let context = ResolvedGitContext(outer: .mainCheckout(branch: .attached("feature/x")))
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertFalse(rows[0].branch.isDimmed)
+        XCTAssertEqual(rows[0].branch.label, "feature/x")
+    }
+
+    // MARK: - AC4: Color stability + distinctness
+
+    func testWorktreeColorStableAcrossCalls() {
+        let path = "/Users/atin/code/c11-worktrees/c11-104-sidebar-chips"
+        let context = ResolvedGitContext(
+            outer: .linkedWorktree(
+                basename: "c11-104-sidebar-chips",
+                absolutePath: path,
+                branch: .attached("feat/x")
+            )
+        )
+        let a = WorktreeChipProjector.project(context, settingsEnabled: true)
+        let b = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertEqual(a[0].worktree?.dotColorHex, b[0].worktree?.dotColorHex)
+    }
+
+    func testDifferentWorktreesGetDifferentColors() {
+        // Two paths chosen so that DJB2(path).bucket differs across the
+        // 10-entry palette. Sanity-checked at authoring time.
+        let pathA = "/Users/atin/code/c11-worktrees/c11-104-sidebar-chips"
+        let pathB = "/Users/atin/code/c11-worktrees/c11-103-session-resume"
+        let a = WorktreeChipProjector.project(
+            ResolvedGitContext(outer: .linkedWorktree(
+                basename: "a", absolutePath: pathA, branch: .attached("x")
+            )),
+            settingsEnabled: true
+        )
+        let b = WorktreeChipProjector.project(
+            ResolvedGitContext(outer: .linkedWorktree(
+                basename: "b", absolutePath: pathB, branch: .attached("x")
+            )),
+            settingsEnabled: true
+        )
+        XCTAssertNotEqual(a[0].worktree?.dotColorHex, b[0].worktree?.dotColorHex)
+    }
+
+    func testColorHexIsFromKnownPalette() {
+        let path = "/Users/atin/code/c11-worktrees/c11-104-sidebar-chips"
+        let context = ResolvedGitContext(
+            outer: .linkedWorktree(
+                basename: "any",
+                absolutePath: path,
+                branch: .attached("x")
+            )
+        )
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertTrue(WorktreeColorPalette.entries.contains(rows[0].worktree?.dotColorHex ?? ""))
+    }
+
+    // MARK: - AC5: Detached renders short SHA
+
+    func testDetachedRendersShortSHA() {
+        let context = ResolvedGitContext(
+            outer: .mainCheckout(branch: .detached(shortSHA: "abc1234"))
+        )
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertEqual(rows[0].branch.label, "(detached @ abc1234)")
+        XCTAssertTrue(rows[0].branch.isDetached)
+        XCTAssertFalse(rows[0].branch.isDimmed)
+    }
+
+    // MARK: - AC6: Submodule produces two rows
+
+    func testSubmoduleProducesTwoRows() {
+        let context = ResolvedGitContext(
+            outer: .mainCheckout(branch: .attached("main")),
+            inner: GitSubmoduleContext(
+                name: "ghostty",
+                absolutePath: "/super/ghostty",
+                branch: .attached("ghostty-main")
+            )
+        )
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0].indent, .none)
+        XCTAssertEqual(rows[1].indent, .submodule)
+        XCTAssertEqual(rows[1].worktree?.label, "ghostty")
+        XCTAssertTrue(rows[1].worktree?.isSubmodule ?? false)
+    }
+
+    // MARK: - AC9: Unknown branch renders fallback
+
+    func testUnknownBranchRendersNoBranch() {
+        let context = ResolvedGitContext(
+            outer: .linkedWorktree(
+                basename: "wt",
+                absolutePath: "/p",
+                branch: .unknown
+            )
+        )
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        XCTAssertEqual(rows[0].branch.label, "(no branch)")
+        XCTAssertFalse(rows[0].branch.isDimmed)
+        XCTAssertFalse(rows[0].branch.isDetached)
+    }
+
+    // MARK: - AC7: Nil context produces empty array
+
+    func testNilContextProducesEmpty() {
+        XCTAssertEqual(WorktreeChipProjector.project(nil, settingsEnabled: true), [])
+    }
+
+    // MARK: - AC14: Settings off produces empty even with valid context
+
+    func testSettingsDisabledProducesEmpty() {
+        let context = ResolvedGitContext(outer: .mainCheckout(branch: .attached("main")))
+        XCTAssertEqual(WorktreeChipProjector.project(context, settingsEnabled: false), [])
+    }
+
+    // MARK: - Linked worktree carries dot prefix
+
+    func testLinkedWorktreeCarriesColoredDot() {
+        let context = ResolvedGitContext(
+            outer: .linkedWorktree(
+                basename: "c11-104-sidebar-chips",
+                absolutePath: "/Users/atin/code/c11-worktrees/c11-104-sidebar-chips",
+                branch: .attached("feat/x")
+            )
+        )
+        let rows = WorktreeChipProjector.project(context, settingsEnabled: true)
+        let wt = rows[0].worktree
+        XCTAssertNotNil(wt)
+        XCTAssertEqual(wt?.label, "c11-104-sidebar-chips")
+        XCTAssertFalse(wt?.isSubmodule ?? true)
+        XCTAssertFalse(wt?.dotColorHex.isEmpty ?? true)
+    }
+}

--- a/skills/c11/references/metadata.md
+++ b/skills/c11/references/metadata.md
@@ -33,8 +33,12 @@ These keys have a defined shape and render in the sidebar or title bar. Any writ
 | `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `kimi`, `opencode`, `shell`, `unknown`. Open-ended. |
 | `title` | string | plain text, ≤ 256 chars | title bar + sidebar tab label (truncated) |
 | `description` | string | Markdown subset (bold/italic, inline `code`, lists, headings, blockquotes, links, rules — no images, fenced code, or tables), ≤ 2048 chars | title bar expanded region |
+| `worktree` | string | ≤ 128 chars (basename) | sidebar chip with colored-dot prefix. Only rendered when the surface's cwd is inside a *linked* git worktree (`git worktree add ...`). Color is a stable hash of the absolute worktree path. **Derived** — written by c11 runtime, not by agents. |
+| `branch` | string | ≤ 64 chars (branch name, `(detached @ <short-sha>)`, or `(no branch)`) | sidebar chip. Renders for main checkouts and linked worktrees. Dimmed for branch ∈ {`main`, `master`, `trunk`}. **Derived** — written by c11 runtime, not by agents. |
 
-**Sidebar rendering order** when present: `model` → `terminal_type` → `role` → `status` → `task` → `progress`. `title` and `description` render in the title bar, not the sidebar — the sidebar tab label is a truncated projection of `title`.
+**Sidebar rendering order** when present: `model` → `terminal_type` → `role` → `status` → `task` → `progress` → `worktree` + `branch` chips row. `title` and `description` render in the title bar, not the sidebar — the sidebar tab label is a truncated projection of `title`.
+
+**Worktree + branch chips (C11-104).** Both keys are projections of `cwd` + gitfs state — agents should not write them directly. They are computed off-main by c11's OSC 7 cwd-update handler and rendered automatically. Inside a submodule, both the superproject context and the submodule context render as two stacked rows. Settings → Sidebar → Workspace Metadata → "Show worktree/branch chips" gates the entire row (default on, live-toggleable).
 
 **Non-canonical keys are yours.** Any JSON value, any key shape. The blob is Lattice's transport, your app's transport, your orchestrator's transport — c11 does not interpret non-canonical content.
 
@@ -170,6 +174,7 @@ Every canonical key's value carries a parallel `metadata_sources[key]` record de
 | Value | Writer | Notes |
 |-------|--------|-------|
 | `heuristic` | c11 internal process-tree scan (M1) | Best-effort auto-detection. Never overwrites higher-precedence values. |
+| `derived` | c11 internal projections of ground-truth state (M-C11-104) | System-computed from cwd, gitfs, or other ambient state. Agents do not write `derived` keys directly; they're recomputed on state change. Ranks above `heuristic`, below `osc`. |
 | `osc` | Terminal emulator OSC 0/1/2 sequence (M7) | Writes `title` only. Newer OSC writes overwrite older `osc` writes. |
 | `declare` | Agent declaration (`c11 set-agent`, env vars) | Explicit agent self-identification. |
 | `explicit` | User CLI (`c11 set-metadata`, `c11 set-title`, inline edit) | Highest precedence; user intent wins. |
@@ -177,12 +182,13 @@ Every canonical key's value carries a parallel `metadata_sources[key]` record de
 ### Precedence chain
 
 ```
-explicit > declare > osc > heuristic
+explicit > declare > osc > derived > heuristic
 ```
 
 - **`explicit` always wins.** `c11 set-metadata` overwrites any prior value.
-- **`declare` overwrites `osc` and `heuristic`**, not `explicit`.
-- **`osc` overwrites `heuristic`** and older `osc`, not `declare` or `explicit`.
+- **`declare` overwrites `osc`, `derived`, and `heuristic`**, not `explicit`.
+- **`osc` overwrites `derived` and `heuristic`** and older `osc`, not `declare` or `explicit`.
+- **`derived` overwrites `heuristic`**, not `osc`/`declare`/`explicit`. Used for worktree/branch chips (C11-104).
 - **`heuristic` only writes when the key is unset or current source is `heuristic`.**
 
 A write that fails the precedence check returns `ok: true` with `result.applied[key]: false` and `result.reasons[key]: "lower_precedence"`. The current value is left untouched.

--- a/skills/c11/references/metadata.md
+++ b/skills/c11/references/metadata.md
@@ -38,7 +38,20 @@ These keys have a defined shape and render in the sidebar or title bar. Any writ
 
 **Sidebar rendering order** when present: `model` → `terminal_type` → `role` → `status` → `task` → `progress` → `worktree` + `branch` chips row. `title` and `description` render in the title bar, not the sidebar — the sidebar tab label is a truncated projection of `title`.
 
-**Worktree + branch chips (C11-104).** Both keys are projections of `cwd` + gitfs state — agents should not write them directly. They are computed off-main by c11's OSC 7 cwd-update handler and rendered automatically. Inside a submodule, both the superproject context and the submodule context render as two stacked rows. Settings → Sidebar → Workspace Metadata → "Show worktree/branch chips" gates the entire row (default on, live-toggleable).
+**Worktree + branch chips (C11-104).** Both keys are projections of `cwd` + gitfs state — agents should not write them directly. They are computed off-main by `GitContextDeriver` on cwd updates (the `report_pwd` socket path) and rendered automatically. Inside a submodule, both the superproject context and the submodule context render as two stacked rows. Settings → Sidebar → "Show worktree + branch chips in sidebar" (preserved `sidebarShowBranchDirectory` AppStorage key — the legacy text branch+directory row was retired in C11-104 v2) gates the entire row (default on, live-toggleable). The branch chip carries a `*` suffix when the working tree is dirty.
+
+### `MetadataDeriver` seam (C11-104 v2)
+
+c11 derives several pieces of metadata from ground-truth ambient state (cwd, gitfs, …). The minimal protocol seam:
+
+```swift
+public protocol MetadataDeriver: Sendable {
+    associatedtype Output: Sendable
+    func derive(cwd: String) -> Output?
+}
+```
+
+`GitContextDeriver` is the first implementation, wrapping `GitContextResolver.resolve(...)`. `DerivationCoordinator` runs derivers off-main on a shared `userInitiated` queue and hops back to the main actor with the result; apply-side guards (gen-token + expected-cwd check) live in the caller (currently `TabManager.applyWorkspaceGitMetadataSnapshot`). New derivers (host / SSH target, container, kubectl, AWS profile) drop in via the same seam.
 
 **Non-canonical keys are yours.** Any JSON value, any key shape. The blob is Lattice's transport, your app's transport, your orchestrator's transport — c11 does not interpret non-canonical content.
 


### PR DESCRIPTION
## Summary

- **New derived canonical metadata keys** `worktree` and `branch`, rendered as sidebar chips beneath the agent chip on the focused surface of each workspace row.
- **`worktree` chip** carries a colored-dot prefix; color is a stable DJB2 hash of the absolute worktree path against a 10-entry palette. Same worktree → same color across sessions.
- **`branch` chip** dims at 0.55 opacity for branch ∈ `{main, master, trunk}`; feature branches render at full opacity. Renders in main checkouts AND linked worktrees.
- **Submodule context** renders as two stacked rows: superproject on top, submodule indented with `↳` prefix (no color dot — color is per-worktree).
- **Detached HEAD** renders as `(detached @ <short-sha>)`.
- **New `derived` precedence tier**, ranked between `osc` and `heuristic` (`explicit > declare > osc > derived > heuristic`). Agents may not write derived; they're recomputed off-main on cwd change.
- **Settings → Sidebar → Workspace Metadata → "Show worktree/branch chips"** master toggle, default on, live-toggleable. Localized via `String(localized:defaultValue:)`.

## Architectural choices

- **Coexists with the existing branch + directory row.** The new chip row is a separate sidebar element; both render. The legacy row still carries the dirty marker + PR pill. Toggles are independent (`sidebarShowBranchDirectory` for the legacy row, `sidebarShowWorktreeChips` for the new row).
- **Extends the existing `TabManager.scheduleWorkspaceGitMetadataRefresh` probe** rather than spawning a parallel git pipeline. The off-main probe now resolves worktree + submodule context alongside branch/dirty/PR. One queue, one generation-token system, one apply step.
- **Hot-path discipline (CRITICAL):** `TerminalSurface.forceRefresh()` and `WindowTerminalHostView.hitTest()` are NOT touched. The resolver runs on the existing `initialWorkspaceGitProbeQueue`. `dispatchPrecondition(.notOnQueue(.main))` at the resolver entry traps any future regression.
- **Derived keys are dropped from snapshot capture.** `PersistedMetadataBridge.encodeValues` / `encodeSources` filter `.derived` source records so chips recompute on session restore rather than round-trip through snapshots.
- **5s timeout per `git` invocation** via `ProcessGitRunner`. Long branch names middle-truncate with `…` to fit the 64-char canonical cap.

## Files

- `Sources/Metadata/GitContextResolver.swift` — pure-logic resolver + `GitRunner` / `FileSystemProbe` protocols + `ProcessGitRunner` + `GitContextResolverCache`.
- `Sources/Sidebar/WorktreeChipModel.swift` — `WorktreeChipProjector.project(...)`.
- `Sources/Sidebar/WorktreeColorPalette.swift` — 10-entry palette + DJB2 hash.
- `Sources/Sidebar/WorktreeChipsRow.swift` — SwiftUI row view.
- `Sources/TabManager.swift` — extends `InitialWorkspaceGitMetadataSnapshot` + apply path.
- `Sources/Workspace.swift` — adds `panelGitContexts: [UUID: ResolvedGitContext?]`.
- `Sources/SurfaceMetadataStore.swift` — adds `.derived` source + `worktree` / `branch` validators.
- `Sources/PersistedMetadata.swift` — filters derived from snapshot capture.
- `Sources/ContentView.swift` — precompute + render the new row inside `VerticalTabsSidebar` → `TabItemView`.
- `Sources/c11App.swift` — Settings toggle.
- `skills/c11/references/metadata.md` — docs the new keys + precedence tier.
- `c11Tests/GitContextResolverTests.swift` — 14 tests (resolver behavior, cache, hot-path).
- `c11Tests/WorktreeChipProjectorTests.swift` — 13 tests (projection rules).
- `c11Tests/MetadataDerivedPrecedenceTests.swift` — 12 tests (precedence ordering + snapshot exclusion).

## Plan + review artifacts

- Plan: `.lattice/plans/task_01KRYWXX6ECSCVRGFTYYA594HK.md` (includes Plan Amendments section answering all plan-review findings).
- Plan-review pack: `.lattice/orchestration/c11-104/c11-104-plan-review-pack-2026-05-18T2228/` (verdict: revise-then-proceed; 6 blockers + several important findings, all resolved or deferred-with-rationale in the plan amendments).

## Test plan

- [ ] CI green on `c11-logic` scheme (all 39 new tests pass locally; 16 pre-existing failures verified unrelated to this PR via stashed-changes baseline run).
- [ ] CI green on `c11-unit` scheme (host-required; defer to CI per CLAUDE.md).
- [ ] CI green on the build + e2e workflows.
- [ ] **Operator smoke (post-merge, per validation plan ACs 18–20):**
  - [ ] AC18: Open c11 in a worktree, the main checkout on `main`, the main checkout on a feature branch, and inside the `ghostty` submodule — each renders the expected chip row.
  - [ ] AC19: Toggle Settings → Sidebar → Workspace Metadata → "Show worktree/branch chips" off → chips disappear, on → chips return (no relaunch).
  - [ ] AC20: Type a long string fast in a terminal pane inside a worktree vs main checkout — no perceptible new typing lag.

## Deferred (documented in plan amendments)

- `I5`: restore-window gap (chips populate async on session restore).
- `I6`: `git worktree remove` while pane is open (chip persists until next OSC 7).
- `M4`: dirty marker + PR pill on the new chips (legacy row still carries these).
- `M6`: theme-key-backed opacity for dimming (currently hardcoded 0.55).
- `EW1`: worktree color on surface model (currently on chip model).
- `E1–E3`: `MetadataDeriver` protocol + `DerivationCoordinator` abstraction.

Closes C11-104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## v2 amendments (post-trident-review)

The trident plan-review (artifact `art_01KRZ23GBH40S85V74CW09PDTD`) returned `revise-then-proceed`. The operator decided the v2 amendments inline; full v2 spec lives at `.lattice/orchestration/c11-104/{run-state,validation-plan}.md` in the main repo. Three follow-up commits land them in place on this branch.

### Amendment 1 — Retire legacy "Branch + Directory" row; merge toggles (commit 95f2b941a)

- The legacy `verticalBranchDirectoryLines()` text-line render in `TabItemView` is retired. The worktree+branch chip row replaces it.
- Helpers retired: `branchDirectoryRow`, `gitBranchSummaryText`, `gitBranchSummaryLines`, `VerticalBranchDirectoryLine`, `verticalBranchDirectoryLines`, `directorySummaryText`.
- Toggles merged: the new `sidebarShowWorktreeChips` AppStorage key dropped; the existing `sidebarShowBranchDirectory` key now gates the chip row, **preserving existing user prefs** through the migration.
- Settings UI label updated: "Show Branch + Directory in Sidebar" → "Show worktree + branch chips in sidebar" (localized).
- **Dirty marker UX preserved.** `WorktreeChipProjector.project(...)` now takes `isDirty: Bool`; branch chip label gets a `*` suffix when the focused surface's `panelGitBranches[.].isDirty` is true. Submodule inner row does NOT inherit the outer's dirty bit (the submodule's own dirty state is a future addition).
- **PR pill render path intact** (it's a separate UI element, not a chip, and continues to render alongside).

Addresses: AC24 (no duplicate render path), AC25 (dirty marker preserved), AC26 (`sidebarShowBranchDirectory` AppStorage key preserved).

### Amendment 2 — `MetadataDeriver` protocol seam (commit 4e1912d83)

E1 reframe from the trident pack — operator approved.

- `protocol MetadataDeriver` with `associatedtype Output: Sendable` and `derive(cwd:) -> Output?`.
- `struct GitContextDeriver` conforms, wrapping `GitContextResolver.resolve(...)`.
- `enum DerivationCoordinator` runs derivers off-main on a shared `userInitiated` queue and hops back to the main actor with the result.
- Apply-side guards (gen-token + expected-cwd check) remain in `TabManager.applyWorkspaceGitMetadataSnapshot`. Full coordinator-driven probe integration is **deferred** — the current path still calls `GitContextResolver.resolve` directly from `initialWorkspaceGitMetadataSnapshot`. The seam is the future-facing landing zone for the next deriver (host, container, kubectl, AWS profile).
- Skill docs (`skills/c11/references/metadata.md`) document the seam.
- Tests: `GitContextDeriver` protocol conformance + coordinator completes-on-main behavior.

### Amendment 3 — Tighten edges (commit de433cc96)

- **B5a:** socket `set_metadata` / `clear_metadata` reject `source=derived` from external clients with `invalid_source`. Applied at all four entry points (surface set/clear, pane set/clear) in `TerminalController.swift`. Internal writers (TabManager's apply step) bypass the gate via `setInternal`.
- **M5:** color hash input is `git rev-parse --show-toplevel` (real-path, symlinks resolved). Already in place; documented as a spec-compliance note.
- **Submodule display-name fallback chain (v2 spec):** `.gitmodules` configured name → path-from-superproject-root → basename. Looked up via `git config -f .gitmodules --get-regexp 'submodule\..*\.path'` against the superproject. Three new tests pin each tier.

### Translation pass (commit f93ef6a58)

The two new Settings strings (`settings.app.showWorktreeBranchChips` + `.subtitle`) translated into ja/ko/zh-Hans/zh-Hant/ru/uk via a clear-claude sub-agent against the existing `settings.app.showBranchDirectory*` entries as the shape template. Addresses AC27.

### v2 test status

48 C11-104 tests pass on `c11-logic`:

- `GitContextResolverTests` — 19 tests (resolver behavior + cache + coordinator + submodule-name fallback).
- `WorktreeChipProjectorTests` — 17 tests (projection rules + dirty-marker + dim states).
- `MetadataDerivedPrecedenceTests` — 12 tests (precedence ordering + snapshot exclusion + key validation).

Pre-existing CI flakes (verified by stash-and-test on the bare anchor `7cbc27d31`) are not caused by this PR.

### v2 deferred (documented for the Result Validator)

- I5 (restore-window gap), I6 (worktree directory removed),
- M6 (theme-key opacity for dimming),
- EW1 (worktree color as model property visible to non-chip consumers),
- Full coordinator-driven probe integration (the seam is in place; the next deriver can wire it).

🤖 v2 amendments by Claude Opus 4.7 (continuation of the original delegator session)
