### PR TITLE
C11-99 Area C: AAR

### DIFF
--- a/notes/c11-99-area-c-aar-2026-05-19.md
+++ b/notes/c11-99-area-c-aar-2026-05-19.md
@@ -1,0 +1,173 @@
+# C11-99 Area C: After-Action Review
+
+**Date.** 2026-05-19.
+**Scope.** Area C of the C11-99 orchestration: c11Tests + c11LogicTests stabilization, including the named 104-second slow test and the cluster of failures the v0.48.0 audit attributed to expectation-timeout races.
+**Author.** Claude (Opus 4.7) writing as `agent:claude-c11-99-d3-aar` over the work shipped by `agent:claude-c11-99-d2`.
+**Source material.** `notes/build-test-pipeline-audit-2026-05-18.md`, the C11-99 ticket on Lattice (Delegator 2's comment chain carries the running diagnosis), and PRs #174, #175, #176, #177, #182.
+
+The C11-99-specific delta lives in the merged PRs and the Lattice timeline; what follows is the portable part: what to do when the next "CI is mysteriously red" arrives.
+
+---
+
+## 1. Headline: the audit's framing was substantively wrong
+
+The audit (committed at `3246d82bf` as `notes/build-test-pipeline-audit-2026-05-18.md`) made two framing errors that shaped how the work was scoped. Both were corrected during execution. State them up front because they are the single highest-leverage takeaway.
+
+**1a. "32 expectation timeouts in c11Tests" was both an undercount and a misclassification.**
+
+Actual c11Tests state at v0.48.0 (run `26056033436`): 67 unique failing test methods, not 32. The "32" the audit footer reported was an XCAssert-level count from `c11LogicTests` (one method fails three asserts and the footer counts each); the suite-footer field the audit read belonged to a different suite. The 67 unique c11Tests failures broke down as:
+
+- **8** were `XCTestExpectation` 1-second-timeout failures (the audit's named class).
+- **~10** were stale string/path fixtures left behind by PR #164's cmux→c11 rename.
+- **~50** were a mix of real product and test-environment bugs: TabManager-init assumptions, `addWorkspace` ordering under `WorkspacePlacementSettings.afterCurrent`, `SurfaceSpec.id` re-minted at capture time, `[.skipsHiddenFiles]` excluding `.json` fixtures on Unix, the macOS `/var` → `/private/var` symlink not resolving through `URL.resolvingSymlinksInPath()`, one genuine browser-url drop in `WorkspacePlanCapture`, and a long tail of AppDelegate / browser DevTools / browser-panel-host clusters.
+
+**1b. "c11LogicTests had 0 unexpected failures" at v0.48.0 was wrong.** The same run had 32 XCAssert-level errors across 17 unique test methods in c11-logic. The audit's footer-reading was off by one suite. c11-logic had been latently red for a while; operationally it was invisible because the combined `c11-unit` scheme step always failed on c11Tests first and CI buried the c11LogicTests output below the truncation line. Area A's scheme split (PR #174) surfaced it.
+
+**Why this matters for the next reader.** If you take the audit's count at face value, you scope Area C as "bump eight timeouts to 5s and merge." That clears 7 of 67. The actual fix surface is mechanical fixture cleanup plus a class of test-environment assumptions. CI footer counts are summed at the XCAssert level, not the test-method level, and that summing is mixed across suites if you read the footer of the wrong block. Always re-derive the unique-method count from the xcresult before you scope.
+
+---
+
+## 2. The Bonsplit UTType cascade (the single biggest insight)
+
+The audit named `testMinimalModeUsesZeroTopSafeAreaForMainWindowContentView` (`c11Tests/AppDelegateShortcutRoutingTests.swift:878-912`) as a 104-123s outlier, 22% of total c11Tests wall time, and hypothesized that 100+ seconds of cost lived inside `appDelegate.createMainWindow()` (`Sources/AppDelegate.swift:6269`), likely SwiftUI scene-graph mount plus responder swizzles. The prescription was to profile with `sample(1)` and fix whatever showed up.
+
+**That diagnosis was wrong.** Local profile of the same test on Apple Silicon: 2.52 seconds. The slowness is CI-environment-specific.
+
+The xcresult activity log for one CI run of that test captured 1003 runtime activities:
+
+| Activity class | Count |
+|---|---|
+| `Type '<id>' was expected to be declared and exported in the Info.plist of c11 DEV.app, but it was not found` (UTType) | 375 |
+| `Publishing changes from within view updates is not allowed, this will cause undefined behavior` (SwiftUI) | 125 |
+| `NSAutoresizingMaskLayoutConstraint` conflict (titlebar accessory hosting in minimal mode) | 1 |
+| Other | ~500 |
+
+The UTType warnings originated in `vendor/bonsplit/Sources/Bonsplit/Internal/Models/TabItem.swift:8,12`, which constructs:
+
+```swift
+UTType(exportedAs: "com.splittabbar.tabitem")
+UTType(exportedAs: "com.splittabbar.tabtransfer", conformingTo: .data)
+```
+
+Neither identifier had a matching `UTExportedTypeDeclarations` entry in `Resources/Info.plist`. Only the c11-specific siblings (`com.stage11.c11.tabtransfer`, `com.stage11.c11.sidebar-tab-reorder`) were declared. The SwiftUI scene graph mounted inside `createMainWindow` constructs the Bonsplit UTTypes many times; every construction fires the runtime warning. The 125 "Publishing changes from within view updates" warnings cascaded from the UTType failures (they vanished entirely once the UTTypes were declared).
+
+PR #182's per-test xcresult diff after declaring both identifiers in `Resources/Info.plist`:
+
+| Metric | Pre-fix | Post-fix |
+|---|---|---|
+| Total runtime activities | 1003 | 2 |
+| UTType "not declared" warnings | 375 | 0 |
+| SwiftUI "Publishing changes" warnings | 125 | 0 |
+| AutoLayout conflicts | 1 | 1 (separate, follow-up) |
+| Per-test wall time (Apple Silicon) | 2.52s | 1.57s |
+
+**Why the cost was invisible locally and crushing on CI.** On Apple Silicon, XCTest's runtime-issue recording path is microsecond-cheap; 500 warnings cost roughly 25ms total. On shared-tenant `macos-15-xlarge` runners the same code path is closer to ~200ms per warning (more state written per warning, contention from co-tenants on the same physical host). 500 × ~200ms ≈ 100s, which matches the observed CI wall time exactly.
+
+**Portable lesson.** When a SwiftUI/AppKit test on shared-tenant CI is dramatically slower than locally, check the xcresult activity log for unresolved runtime warnings before profiling the application code. The hot path may not be in your code; it may be in Apple's runtime-issue framework. The mechanical recipe:
+
+```bash
+xcrun xcresulttool get test-results activities --path <bundle> --test-id <id>
+```
+
+If the activity count is in the hundreds or thousands, you have a warning cascade. Fix the warnings, then re-measure before profiling. This also explains a class of "slow test" complaints that profilers struggle with: `sample(1)` shows a sampled stack inside the runtime-issue recording machinery, but the machinery is generic and points at no production culprit. The culprit is the warning's origin, which the activity log surfaces directly.
+
+---
+
+## 3. The cmux→c11 rename was incomplete in test fixtures
+
+PR #164 ("Drop c11mux from active code paths", 2026-05-15) shipped the production rename but missed a batch of test fixtures. Each was a one-line update; together they accounted for the bulk of the stale-fixture cluster:
+
+- `MenuBarBuildHintFormatterTests`: `appName` fixtures `"cmux DEV..."` swapped to `"c11 DEV..."`. The formatter at `Sources/AppDelegate.swift:12737` hard-checks `hasPrefix("c11 DEV")`, so the cmux-prefixed fixtures returned the untagged path.
+- `SocketControlSettingsTests.testDefaultSocketPathByChannel`: bundle ids had `.tag` suffixes that exercise the per-tag isolation branches (`Sources/SocketControlSettings.swift:537-566`) added in PR #164, not the channel-default branches the test name implies. Dropping the `.tag` suffix put the test on the right code path.
+- `BrowserImportOutcomeFormatter`: expected string still said `cmux`.
+- Five workspace-snapshot JSON fixtures stored metadata as `{ "string": "X" }`, but `PersistedJSONValue` (`Sources/PersistedMetadata.swift:35-38`) decodes plain `"X"` natively as `.string("X")`. The wrapped form decodes as `.object([...])` and never matches the `.string("X")` form the tests assert. Production never emits the wrapped form; the fixtures were hand-authored under the wrong assumption.
+
+**Portable lesson.** When you do a project-wide rename, grep the test fixtures for the old term in the same change set, not as a follow-up. The fixtures don't trip the compiler. Once you've allowed a window of red CI, mechanical fixture drift accumulates undetected and later looks like a different problem class.
+
+---
+
+## 4. The 1-second `XCTestExpectation` class
+
+Eight tests were genuinely flaky-by-budget on shared-tenant CI. Bumping all `wait(for:..., timeout: 1.0)` to `5.0` across c11Tests (30 sites total) cleared 7 of them with no production impact and no observable runtime change on happy paths. The remaining one (`AppDelegateShortcutRoutingTests.testArrowNavigationRoutesWhileCommandPaletteOverlayIsInteractiveBeforeVisibilitySync`) waits 1s then asserts non-timing things (window number, delta) that still fail post-bump; it's separate residual work.
+
+**Portable.** `XCTWaiter.wait(for:)` returns the moment the expectation fulfills. The timeout value is an upper bound on the failure path only; happy paths get the same wall-clock cost regardless of whether you pass 1.0 or 60.0. For shared-tenant CI runners, always pick the larger bound when authoring new tests. There is no "you'll slow down the suite" tradeoff at the happy-path level; you only buy headroom against contention spikes.
+
+---
+
+## 5. macOS `/var` → `/private/var`: only `realpath(3)` resolves it
+
+macOS has a top-level symlink `/var` → `/private/var`. `FileManager.default.temporaryDirectory` returns `/var/folders/...`; `FileManager.contentsOfDirectory(at:)` returns `/private/var/folders/...` because the kernel resolves the symlink during enumeration. Path-equality checks across the two surfaces fail.
+
+You'd expect Foundation's symlink-resolving APIs to fix this. They do not:
+
+- `URL.resolvingSymlinksInPath()`: does not resolve the `/var` → `/private/var` symlink for this case.
+- `(string as NSString).resolvingSymlinksInPath`: same.
+
+Both APIs operate on path components and leave the top-level `/var` symlink unresolved here. The only thing that resolves it correctly in tests is libc's `realpath(3)`, called via a small Swift helper.
+
+This affected:
+- `WorkspaceSnapshotCaptureTests.makeTempDirectory` (1 test method).
+- `CLIHealthRuntimeTests.makeTempHome` (1 method, 8 XCAssert errors; each call to `redactHomePath(_:home:)` failed to redact because `home` was unresolved and the event paths were resolved).
+
+**Portable lesson.** When you need real filesystem-level canonical paths in tests or production on macOS, reach for `realpath(3)` via libc. Do not trust Foundation's `resolvingSymlinksInPath` methods to handle top-level system symlinks. If correctness depends on path-equality between two surfaces and one of them passes through the kernel's enumeration paths, write the test against the resolved form and canonicalize with `realpath`.
+
+---
+
+## 6. Test-design landmines worth naming
+
+Three patterns showed up across multiple c11LogicTests failures. They are class-of-bug things future readers should know about before writing tests against `TabManager` and `WorkspaceSnapshotCapture`.
+
+**6a. `TabManager()` auto-adds a workspace on init** (`Sources/TabManager.swift:1069-1070`). The intuitive read of `let m = TabManager()` is that `m.tabs` is empty. It is not: init creates a default workspace and assigns it as `selectedWorkspace`. Tests that call `m.addWorkspace()` once expecting a one-workspace result get two, and the rest of the assertions cascade off. Fix shape: replace `let ws = tabManager.addWorkspace()` with `let ws = try XCTUnwrap(tabManager.selectedWorkspace)` for the first workspace. `WorkspaceLayoutExecutorAcceptanceTests` had four tests written under this assumption.
+
+**6b. `addWorkspace` honors `WorkspacePlacementSettings.current()`.** The default policy is `.afterCurrent`, which inserts each new workspace right after the currently-selected one. Tests that do `addWorkspace(select: true)` twice and expect append-to-end ordering get Second, First, Third instead of First, Second, Third. Pass `placementOverride: .end` in tests that depend on order. `WorkspaceIdentityRestoreTests.testMultipleWorkspaceIdsSurviveRoundTripWithoutCollisionOrSwap` was the smoking gun.
+
+**6c. `SurfaceSpec.id` is re-minted at capture time** (`Sources/WorkspaceSnapshotCapture.swift:39-41`, documented invariant). Tests that load a fixture, apply it, then `capture()` and look up surfaces by the fixture's `id` will fail because the captured plan has surfaces with `id` values `s1`, `s2`, ... (newly minted), not the fixture's identifiers. Fix shape: look up by `kind` plus a distinguishing property (URL for browsers, path for markdown), not by `id`. `WorkspaceSnapshotRoundTripAcceptanceTests` failed because three tests assumed id-stability across capture.
+
+**Portable.** These three patterns are intentional behavior, not bugs. The lesson is that intuitive test setup against a system with non-trivial init semantics will silently produce wrong assertions. When writing a test against a model object with a complex init, dump the post-init state once and verify your assumptions before writing the test body.
+
+---
+
+## 7. The merge-sequencing trap (process insight)
+
+The original `ci.yml` build-job `timeout-minutes: 15` was the proximate cause of the "hang" framing. Today's runtime is 14-16 minutes; the 15-minute ceiling cut tests off mid-suite or just after they reported failures. Every C11-99 PR (A, B, C, D) plus the parallel work on `c11-99-c` got timeout-cancelled and was un-mergeable through the normal CI flow.
+
+**The trap.** Area A's prescription (bump the timeout to 25 minutes, split the scheme, quarantine the slow test) was itself blocked from merging by the very CI bottleneck it was meant to fix. The queue stalled.
+
+**The unstick.** Admin-merging Area A directly to `main` unblocked everything else. After Area A landed, Area D landed cleanly (also admin), Area B was admin-merged (the socket-isolation guard plus wrapper script were equally low-risk), and Area C rebased onto the new main with the 25-minute ceiling and the c11-logic gate, then merged through normal CI as the first natural-merge green build since v0.48.0.
+
+**Portable lesson.** When a CI bottleneck is the gate to fixing the CI bottleneck, admin-merge is the right tool, but only if the admin-merged change is itself low-risk and tightly scoped. Area A's diff was three mechanical edits plus a scheme split with no production behavior change; that is the bar. Do not admin-merge product-behavior changes to break a CI loop. Admin-merge mechanical infrastructure changes, then rebase product changes through the unstuck pipeline.
+
+A related insight: when scoping an "unblock CI" PR, deliberately keep it as low-risk as you can. The admin-merge calculus depends on the diff being a thing the operator can read in 30 seconds. The four C11-99 PRs landed in this order: A (admin), D (admin), C (normal CI green), B (admin). Three of four were admin merges; that ratio is high because the audit was load-bearing and each PR's diff stayed inside its lane.
+
+---
+
+## 8. What was scoped out / still TODO
+
+For completeness, since this AAR is the durable handoff for the next reader picking up C11-99-adjacent work:
+
+- **`WorkspacePlanCapture` browser-url drop** (`testCaptureAndRestoreBrowserFirstLayout`). Real product bug. Capture path drops `SurfaceSpec.url` for browser surfaces. XCTSkip'd in PR #176; fix in flight as sibling delegator #4 on branch `c11-99-browser-url`.
+- **Single remaining AutoLayout constraint conflict** (titlebar accessory hosting in minimal mode). Unrelated to the UTType cascade.
+- **`CommandPaletteSearchEngine` single-omission scoring regression.** Fuzzy matcher picked `command.find` over `command.finder`. XCTSkip'd; needs algorithm-side fix.
+- **The ~50 host-bound c11Tests advisory failures.** Cluster-by-cluster: Browser DevTools visibility (×8), browser-panel host hit-test (×6), AppDelegate shortcut routing non-timeout (×10), browser portal lifecycle (×4), AppDelegate orphan-context (×6), tail.
+- **Flip `c11-unit` back to hard-fail** after 5+ consecutive green main runs and the slow test re-enabled.
+
+---
+
+## 9. Quick reference: portable lessons extracted
+
+For an engineer or agent landing on a future CI/test problem that is not C11-99-specific:
+
+1. Re-derive unique-failing-method counts from the xcresult before scoping. CI footer counts are XCAssert-level and easy to mis-attribute across suites.
+2. A slow SwiftUI/AppKit test on shared-tenant CI that runs fast locally is almost always a runtime-warning cascade, not a production hot path. Check `xcrun xcresulttool get test-results activities` first.
+3. Undeclared `UTType(exportedAs:)` identifiers fire a per-construction runtime warning that is microsecond-cheap on Apple Silicon and ~200ms-each on shared-tenant CI. Cost compounds linearly with construction count.
+4. `XCTestExpectation` 1-second timeouts are tight on shared-tenant CI. 5s is a free upgrade; the happy path doesn't pay for it.
+5. Foundation's `resolvingSymlinksInPath` does not resolve macOS's top-level `/var` → `/private/var` symlink for the temp-dir-vs-enumeration case. Use `realpath(3)` via libc.
+6. When you do a project-wide rename, sweep test fixtures in the same change set. A long window of red CI hides accumulating fixture drift.
+7. `TabManager()` starts non-empty. `addWorkspace()` honors `WorkspacePlacementSettings.current()` placement. `SurfaceSpec.id` is re-minted at capture. Three places where intuitive test setup silently produces wrong assertions.
+8. When a CI bottleneck is the gate to fixing the CI bottleneck, admin-merge low-risk infrastructure changes and rebase product changes through the unstuck pipeline. Do not admin-merge product behavior to break a CI loop.
+9. Local test-runnability tooling is on the critical path for diagnosis. If `xcodebuild test` stomps the developer's running app, fix that before trying to diagnose subtle test behavior.
+10. Fixture-form decoding behavior is invisible to the compiler. A hand-authored JSON fixture that "looks right" can decode into the wrong variant of an enum-with-payload type. Round-trip your fixtures through the decoder once before relying on them.
+
+---
+
+*Produced 2026-05-19 by `agent:claude-c11-99-d3-aar` (Claude Opus 4.7) from the C11-99 Area C work shipped by `agent:claude-c11-99-d2`. This file is the durable archive in `notes/`; the Lattice comment on C11-99 is the discovery surface. Both contain the same content.*


### PR DESCRIPTION
## Summary

After-Action Review for C11-99 Area C (c11Tests + c11LogicTests stabilization), checked in as the durable `notes/` archive alongside the Lattice comment on **C11-99**. Same content in both places; the file is the archive, the Lattice comment is the discovery surface.

## Headline insights

- **The audit's "32 expectation timeouts" was wrong on two axes.** Actual c11Tests had 67 unique failing methods (only 8 were 1s-timeout, ~10 were stale cmux→c11 fixtures, ~50 were product/test-environment bugs). c11LogicTests was *also* red (17 methods, 32 XCAsserts), not "0 unexpected failures."
- **The 104s slow test was an XCTest runtime-warning cascade, not a `createMainWindow` hot path.** `vendor/bonsplit/Sources/Bonsplit/Internal/Models/TabItem.swift` constructs `UTType(exportedAs:)` for two identifiers that had no `UTExportedTypeDeclarations` entry in `Resources/Info.plist`. 375 warnings → 125 cascading SwiftUI warnings → ~200ms each on shared-tenant `macos-15-xlarge` → 100s wall. Declaring the UTTypes in Info.plist (PR #182) dropped activity count from 1003 → 2.
- **Foundation's `resolvingSymlinksInPath` does not resolve macOS's `/var` → `/private/var` symlink** for the temp-dir-vs-enumeration case. Only `realpath(3)` via libc does.
- **`TabManager()` starts non-empty, `addWorkspace()` honors `WorkspacePlacementSettings.afterCurrent`, and `SurfaceSpec.id` is re-minted at capture time.** Three places where intuitive test setup silently produces wrong assertions.
- **When a CI bottleneck is the gate to fixing the CI bottleneck, admin-merge low-risk infrastructure changes.** Three of four C11-99 PRs went in via admin merge; Area C then rebased and merged through normal CI as the first natural-merge green build since v0.48.0.

Full text in `notes/c11-99-area-c-aar-2026-05-19.md`.

## Test plan

- [x] AAR posted as a comment on Lattice ticket C11-99 (role: review).
- [x] Same content checked in as `notes/c11-99-area-c-aar-2026-05-19.md`.
- [ ] CI on this branch is green (text-only addition; should not affect builds or tests).

Lattice ticket: **C11-99** Area C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)