### PR TITLE
C11-109: skip 7 flaky host-bound test classes to recover ~5min/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,18 +199,29 @@ jobs:
 
       - name: Host-bound unit tests (advisory)
         # Advisory while C11-99 Area C stabilizes the 32 expectation-timeout
-        # failures clustered in host-bound classes (AppDelegateShortcutRouting,
-        # GhosttyConfig, NotificationBurstCoalescer, TabManagerReopenClosedBrowserFocus,
-        # TerminalNotificationDirectInteraction, BrowserDeveloperToolsVisibilityPersistence,
-        # BrowserPanelHostContainerView). Failures still surface in the run
-        # log; they just don't gate merges. Flip back to hard-fail once C11-99
-        # Area C lands 5+ consecutive green runs.
+        # failures clustered in 7 host-bound classes. Failures still surface
+        # in the run log; they just don't gate merges. Flip back to hard-fail
+        # once C11-99 Area C lands 5+ consecutive green runs.
+        #
+        # C11-109: the 7 flaky classes are explicitly -skip-testing'd below.
+        # Each expectation timeout is ~10s; 32 timeouts dominated the ~6 min
+        # wall time even though `continue-on-error: true` made them advisory.
+        # Skipping recovers ~5 min per build while the remaining ~20 c11Tests
+        # still provide host-runtime signal (AppKit, Ghostty, WKWebView,
+        # UNNotificationCenter). Remove the skip flags when Area C lands.
         continue-on-error: true
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
           xcodebuild -project GhosttyTabs.xcodeproj -scheme c11-unit -configuration Debug \
             -only-testing:c11Tests \
+            -skip-testing:c11Tests/AppDelegateShortcutRoutingTests \
+            -skip-testing:c11Tests/GhosttyConfigTests \
+            -skip-testing:c11Tests/NotificationBurstCoalescerTests \
+            -skip-testing:c11Tests/TabManagerReopenClosedBrowserFocusTests \
+            -skip-testing:c11Tests/TerminalNotificationDirectInteractionTests \
+            -skip-testing:c11Tests/BrowserDeveloperToolsVisibilityPersistenceTests \
+            -skip-testing:c11Tests/BrowserPanelHostContainerViewTests \
             -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
             -disableAutomaticPackageResolution \
             -destination "platform=macOS" \


### PR DESCRIPTION
## Summary

The advisory `Host-bound unit tests` CI step runs for ~6 min, dominated by 32 expectation-timeout failures (~10s each) clustered in 7 named classes that C11-99 Area C will stabilize. The step is already `continue-on-error: true`, so those failures contribute zero merge signal — they just burn build minutes and make PRs feel sticky.

This PR adds `-skip-testing:` for each of the 7 classes. Expected wall-time drop: **6 min → <90s** per build. The remaining ~20 c11Tests still run and still exercise the AppKit responder chain, Ghostty surface, WKWebView, and UNNotificationCenter — so the host-runtime regression signal we actually get value from today is preserved.

Tracking: C11-109. Scaffolding: remove when C11-99 Area C lands 5+ consecutive green runs (inline comment names that trigger explicitly).

## What changed

`.github/workflows/ci.yml` — added 7 `-skip-testing:c11Tests/<ClassName>` flags to the `Host-bound unit tests (advisory)` step:

- `AppDelegateShortcutRoutingTests`
- `GhosttyConfigTests`
- `NotificationBurstCoalescerTests`
- `TabManagerReopenClosedBrowserFocusTests`
- `TerminalNotificationDirectInteractionTests`
- `BrowserDeveloperToolsVisibilityPersistenceTests`
- `BrowserPanelHostContainerViewTests`

Comment block on the step refreshed to point at C11-109 and explicitly state the removal trigger.

## Why these 7 specifically

The comment block already on this step named all 7 — they're the C11-99 Area C cluster. Each class name was verified against `c11Tests/` source.

## Out of scope

- **Splitting the advisory step into its own job.** Would surface the merge-gate conclusion faster on the PR UI but doesn't save wall time. Separate ticket if it's worth doing.
- **Parallelization (`-parallel-testing-enabled YES`).** Risky given shared state in c11Tests (sockets, NSWorkspace, NotificationCenter). Would need empirical validation per-class.
- **Fixing the 7 flaky classes.** That's C11-99 Area C.

## Reverse path

When C11-99 Area C lands 5+ consecutive green runs:
1. Drop all 7 `-skip-testing:` lines.
2. Flip `continue-on-error: true` → `false` (per the still-relevant outer comment).
3. The C11-109 block of comment becomes obsolete; drop it.

## Test plan

- [ ] CI on this PR shows the `Host-bound unit tests (advisory)` step completing in well under 90s
- [ ] The 7 skipped classes do not appear in the test report
- [ ] The remaining ~20 host-bound tests still run and report (green or otherwise)
- [ ] Merge gate (`Logic tests (gate)`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)