### PR TITLE
Staging build perf: arm64-only + shared derived-data + no index store + incremental swift

### DIFF
--- a/.lattice/plans/task_01KS0CN5A0K2WSVF6BB4JH9HHF.md
+++ b/.lattice/plans/task_01KS0CN5A0K2WSVF6BB4JH9HHF.md
@@ -1,0 +1,88 @@
+# C11-110 — Staging build perf plan
+
+Apply four xcodebuild improvements to `scripts/reloads.sh` (staging Release build) on M-series Macs. Item 3 from the original spec (skipPackagePluginValidation + skipMacroValidation) was dropped by the operator. CI's `release.yml` and `nightly.yml` are untouched.
+
+## Files affected
+
+- `scripts/reloads.sh` (primary)
+- `scripts/reload.sh` (Debug script): not touched in this PR. Same improvements can apply but are out of scope per the prompt — surface as follow-up at the end.
+
+## Decisions
+
+### Flag names
+
+| Flag | Default behavior | Effect when passed |
+|------|------------------|--------------------|
+| `--universal` | arm64-only | adds `x86_64` back: drops `ARCHS=` / `ONLY_ACTIVE_ARCH=YES` overrides so the project's `ONLY_ACTIVE_ARCH=NO` Release setting takes hold |
+| `--clean` | reuse derived-data | nuke derived-data dir before build |
+| `--wmo` | `SWIFT_COMPILATION_MODE=incremental` | drop the override so the project's `wholemodule` Release setting takes hold |
+
+Chose `--wmo` over `--release-mode` because the only thing we're actually toggling is the Swift compilation mode. "Release mode" reads as "switch to Release config," which is misleading (we're already in Release config).
+
+### Derived-data family path
+
+Default per-tag path today: `/tmp/c11-staging-<tag-slug>/`.
+New default: `/tmp/c11-staging-<family>/`, where `<family>` is derived from `<tag-slug>` as the segment up to the first hyphen:
+
+| Tag | Sanitized slug | Family | Derived-data |
+|-----|----------------|--------|--------------|
+| `release/v0.49.0` | `release-v0-49-0` | `release` | `/tmp/c11-staging-release/` |
+| `c11-110-build-perf` | `c11-110-build-perf` | `c11` | `/tmp/c11-staging-c11/` |
+| `feat/foo-bar` | `feat-foo-bar` | `feat` | `/tmp/c11-staging-feat/` |
+| (no tag) | n/a | n/a | (unchanged: no derived-data override) |
+
+Explicit `--derived-data` overrides keep working untouched. `--clean` wipes whichever directory is selected.
+
+### HEAD sanity check
+
+On entry (after path is chosen, before xcodebuild runs):
+
+1. If the derived-data dir exists, read `<derived-data>/.last-sha` and `<derived-data>/.last-tag`. Print both alongside current `git rev-parse --short HEAD` and current tag — one stdout line, not a prompt.
+2. After successful xcodebuild, write current short SHA + tag to those files.
+3. No blocking, no interactive prompt. The point is "leave a breadcrumb so the operator can decide whether to pass `--clean` next time." Forcing a prompt would break unattended runs.
+
+### Universal flag interaction with WMO
+
+`--universal --wmo` is the closest-to-prod-parity validation mode. Document that combo explicitly in the help text — it's the "right before tag push" recipe.
+
+## What stays the same
+
+- `xcodebuild -configuration Release` (Release config still controls codesign/optimizations/etc. on the project side).
+- App-bundle copying, PlistBuddy injections, codesign, socket isolation, c11d zig build, `open -g`.
+- The `--tag`/`--name`/`--bundle-id`/`--derived-data` flags retain their existing meanings.
+
+## Implementation order
+
+1. **Items 4 and 5** (smallest, no flag plumbing): add `COMPILER_INDEX_STORE_ENABLE=NO` and `SWIFT_COMPILATION_MODE=incremental` unconditionally. *Then* refactor to honor `--wmo`. Separate commits.
+2. **Item 1**: add arm64-only by default with `--universal` opt-out. One commit.
+3. **Item 2**: switch default derived-data path to family-keyed, add `--clean`, add HEAD sanity check. One commit.
+4. Update `--help` text to document all new flags + new defaults.
+
+Each step is its own commit on `c11-110/staging-build-perf`. One PR against `main`.
+
+## Validation
+
+Run from this worktree, with `--tag c11-110-perf-test` so a stray staging app doesn't collide with the operator's live `release/v0.49.0` staging build.
+
+| Scenario | Command | Expected |
+|----------|---------|----------|
+| Cold build (default) | `./scripts/reloads.sh --tag c11-110-perf-test --clean` | arm64-only, incremental; wall-clock vs. universal+wmo baseline |
+| Warm rebuild | `./scripts/reloads.sh --tag c11-110-perf-test` | sub-minute incremental |
+| Universal opt-out | `./scripts/reloads.sh --tag c11-110-perf-test --clean --universal` | universal binary in `Build/Products/Release/c11.app/Contents/MacOS/c11` (`lipo -info` shows arm64 + x86_64) |
+| Clean wipe | `./scripts/reloads.sh --tag c11-110-perf-test --clean` | derived-data dir absent before build (verified by adding a stray file and watching it disappear) |
+| WMO opt-out | `./scripts/reloads.sh --tag c11-110-perf-test --clean --wmo` | wall-clock longer than incremental; verify Swift driver invocations show `-whole-module-optimization` |
+| App launches | after each successful build | staging app comes up, sidebar visible, terminal pane opens |
+
+Capture wall-clock numbers for the PR body. Cold-vs-warm is the headline.
+
+## Out of scope
+
+- `scripts/reload.sh` (Debug script): same improvements would help but the prompt scopes this PR to `reloads.sh`. Flag as follow-up in PR description.
+- No version bump, no CHANGELOG entry.
+- No new tests. c11 test-quality policy: build-script behavior verified by running the script, not by source-text assertions.
+
+## Risks
+
+- Project-level `ARCHS = "arm64 x86_64"` could be referenced from elsewhere (Run Script phases, packaging). Worth a grep before shipping.
+- `SWIFT_COMPILATION_MODE` interaction with module-emit or LTO settings is generally fine for Release+incremental, but the 0.47.0 New Workspace dialog regression was a WMO-only bug. The `--wmo` flag is the escape hatch for the "validate before tag push" case where that matters.
+- Family extraction prefix-up-to-first-hyphen is dumb-simple by design. If a future tag style breaks it (e.g. `releaseV050`), the `--derived-data` override is still there as a manual fallback.

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -10,6 +10,7 @@ NAME_SET=0
 BUNDLE_SET=0
 DERIVED_SET=0
 TAG=""
+WMO=0
 LAST_SOCKET_PATH_DIR="$HOME/Library/Application Support/c11"
 LAST_SOCKET_PATH_FILE="${LAST_SOCKET_PATH_DIR}/last-socket-path"
 
@@ -33,6 +34,9 @@ Options:
   --name <app name>      Override app display/bundle name.
   --bundle-id <id>       Override bundle identifier.
   --derived-data <path>  Override derived data path.
+  --wmo                  Use wholemodule Swift compilation (prod parity).
+                         Default is incremental for faster local iteration.
+                         Recommended before tag push to catch WMO-only bugs.
   -h, --help             Show this help.
 EOF
 }
@@ -94,6 +98,10 @@ while [[ $# -gt 0 ]]; do
       DERIVED_SET=1
       shift 2
       ;;
+    --wmo)
+      WMO=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -139,6 +147,14 @@ fi
 # Staging is built for running, not for IDE navigation; the indexer output
 # would only be useful if we ever edited against this build in Xcode.
 XCODEBUILD_ARGS+=(COMPILER_INDEX_STORE_ENABLE=NO)
+# Default to incremental Swift compilation. Wholemodule is faster for a
+# single binary's runtime perf but slower to compile on each iteration.
+# Pass --wmo for the rare staging build that needs prod parity (e.g. the
+# build right before a tag push, to catch WMO-only regressions like the
+# 0.47.0 New Workspace dialog issue).
+if [[ "$WMO" -eq 0 ]]; then
+  XCODEBUILD_ARGS+=(SWIFT_COMPILATION_MODE=incremental)
+fi
 XCODEBUILD_ARGS+=(build)
 
 xcodebuild "${XCODEBUILD_ARGS[@]}"

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -228,6 +228,7 @@ if [[ "$WMO" -eq 0 ]]; then
 fi
 XCODEBUILD_ARGS+=(build)
 
+echo "[reloads.sh] xcodebuild ${XCODEBUILD_ARGS[*]}"
 xcodebuild "${XCODEBUILD_ARGS[@]}"
 sleep 0.2
 

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -11,6 +11,7 @@ BUNDLE_SET=0
 DERIVED_SET=0
 TAG=""
 WMO=0
+UNIVERSAL=0
 LAST_SOCKET_PATH_DIR="$HOME/Library/Application Support/c11"
 LAST_SOCKET_PATH_FILE="${LAST_SOCKET_PATH_DIR}/last-socket-path"
 
@@ -34,6 +35,10 @@ Options:
   --name <app name>      Override app display/bundle name.
   --bundle-id <id>       Override bundle identifier.
   --derived-data <path>  Override derived data path.
+  --universal            Build a universal (arm64 + x86_64) binary.
+                         Default is arm64-only for faster local iteration.
+                         Use this for x86_64-specific checks; combine with
+                         --wmo for full prod parity before a tag push.
   --wmo                  Use wholemodule Swift compilation (prod parity).
                          Default is incremental for faster local iteration.
                          Recommended before tag push to catch WMO-only bugs.
@@ -102,6 +107,10 @@ while [[ $# -gt 0 ]]; do
       WMO=1
       shift
       ;;
+    --universal)
+      UNIVERSAL=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -143,6 +152,13 @@ if [[ -z "$TAG" ]]; then
     INFOPLIST_KEY_CFBundleDisplayName="$APP_NAME"
     PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID"
   )
+fi
+# On Apple Silicon the x86_64 slice of a universal build is dead weight at
+# iteration time and roughly doubles the Swift compile cost. CI's release.yml
+# still produces universal because it invokes xcodebuild without these
+# overrides; pass --universal here to catch x86_64-only issues locally.
+if [[ "$UNIVERSAL" -eq 0 ]]; then
+  XCODEBUILD_ARGS+=(ARCHS=arm64 ONLY_ACTIVE_ARCH=YES)
 fi
 # Staging is built for running, not for IDE navigation; the indexer output
 # would only be useful if we ever edited against this build in Xcode.

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -12,6 +12,7 @@ DERIVED_SET=0
 TAG=""
 WMO=0
 UNIVERSAL=0
+CLEAN=0
 LAST_SOCKET_PATH_DIR="$HOME/Library/Application Support/c11"
 LAST_SOCKET_PATH_FILE="${LAST_SOCKET_PATH_DIR}/last-socket-path"
 
@@ -35,6 +36,7 @@ Options:
   --name <app name>      Override app display/bundle name.
   --bundle-id <id>       Override bundle identifier.
   --derived-data <path>  Override derived data path.
+  --clean                Wipe the derived-data dir before building.
   --universal            Build a universal (arm64 + x86_64) binary.
                          Default is arm64-only for faster local iteration.
                          Use this for x86_64-specific checks; combine with
@@ -43,6 +45,17 @@ Options:
                          Default is incremental for faster local iteration.
                          Recommended before tag push to catch WMO-only bugs.
   -h, --help             Show this help.
+
+The default derived-data path keys on the tag *family* (the prefix up to
+the first hyphen of the sanitized tag), so related tags share an
+incremental build cache:
+
+  --tag release/v0.49.0   -> /tmp/c11-staging-release/
+  --tag c11-110-build     -> /tmp/c11-staging-c11/
+  --tag feat-foo-bar      -> /tmp/c11-staging-feat/
+
+The script prints the last tag/SHA built into the shared dir on reuse;
+pass --clean (or --derived-data <path>) to override.
 EOF
 }
 
@@ -64,6 +77,19 @@ sanitize_path() {
     cleaned="agent"
   fi
   echo "$cleaned"
+}
+
+# Family extraction: prefix-up-to-first-hyphen of the sanitized tag slug.
+# release-v0-49-0 -> release; c11-110-build-perf -> c11; feat-foo -> feat.
+# Lets related tags (release/v0.49.0, release/v0.50.0; c11-108, c11-109)
+# share a derived-data dir for incremental rebuilds across branches.
+family_for_slug() {
+  local slug="$1"
+  local family="${slug%%-*}"
+  if [[ -z "$family" ]]; then
+    family="default"
+  fi
+  echo "$family"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -111,6 +137,10 @@ while [[ $# -gt 0 ]]; do
       UNIVERSAL=1
       shift
       ;;
+    --clean)
+      CLEAN=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -126,6 +156,7 @@ done
 if [[ -n "$TAG" ]]; then
   TAG_ID="$(sanitize_bundle "$TAG")"
   TAG_SLUG="$(sanitize_path "$TAG")"
+  TAG_FAMILY="$(family_for_slug "$TAG_SLUG")"
   if [[ "$NAME_SET" -eq 0 ]]; then
     APP_NAME="c11 STAGING ${TAG}"
   fi
@@ -133,7 +164,31 @@ if [[ -n "$TAG" ]]; then
     BUNDLE_ID="com.stage11.c11.staging.${TAG_ID}"
   fi
   if [[ "$DERIVED_SET" -eq 0 ]]; then
-    DERIVED_DATA="/tmp/c11-staging-${TAG_SLUG}"
+    DERIVED_DATA="/tmp/c11-staging-${TAG_FAMILY}"
+  fi
+fi
+
+# Optional cold-build: wipe the derived-data dir before building.
+# Mirrors the old per-tag "always clean" behavior for callers that need it.
+if [[ "$CLEAN" -eq 1 && -n "$DERIVED_DATA" && -d "$DERIVED_DATA" ]]; then
+  echo "[reloads.sh] --clean: removing $DERIVED_DATA"
+  rm -rf "$DERIVED_DATA"
+fi
+
+# Breadcrumb for shared derived-data reuse. Reports what was last built
+# in this dir alongside the current HEAD/tag so the operator can decide
+# whether to pass --clean next time.
+LAST_SHA_FILE=""
+LAST_TAG_FILE=""
+if [[ -n "$DERIVED_DATA" ]]; then
+  LAST_SHA_FILE="${DERIVED_DATA}/.last-sha"
+  LAST_TAG_FILE="${DERIVED_DATA}/.last-tag"
+  CUR_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  if [[ -f "$LAST_SHA_FILE" || -f "$LAST_TAG_FILE" ]]; then
+    PREV_SHA="$(cat "$LAST_SHA_FILE" 2>/dev/null || echo unknown)"
+    PREV_TAG="$(cat "$LAST_TAG_FILE" 2>/dev/null || echo unknown)"
+    echo "[reloads.sh] reusing $DERIVED_DATA (last: tag=$PREV_TAG sha=$PREV_SHA; now: tag=${TAG:-none} sha=$CUR_SHA)"
+    echo "             pass --clean to force a cold build"
   fi
 fi
 
@@ -175,6 +230,13 @@ XCODEBUILD_ARGS+=(build)
 
 xcodebuild "${XCODEBUILD_ARGS[@]}"
 sleep 0.2
+
+# Successful build: record the breadcrumb for the next reuse.
+if [[ -n "$DERIVED_DATA" && -d "$DERIVED_DATA" ]]; then
+  CUR_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+  printf '%s\n' "$CUR_SHA" > "$LAST_SHA_FILE" 2>/dev/null || true
+  printf '%s\n' "${TAG:-none}" > "$LAST_TAG_FILE" 2>/dev/null || true
+fi
 
 FALLBACK_APP_NAME="$BASE_APP_NAME"
 SEARCH_APP_NAME="$APP_NAME"

--- a/scripts/reloads.sh
+++ b/scripts/reloads.sh
@@ -136,6 +136,9 @@ if [[ -z "$TAG" ]]; then
     PRODUCT_BUNDLE_IDENTIFIER="$BUNDLE_ID"
   )
 fi
+# Staging is built for running, not for IDE navigation; the indexer output
+# would only be useful if we ever edited against this build in Xcode.
+XCODEBUILD_ARGS+=(COMPILER_INDEX_STORE_ENABLE=NO)
 XCODEBUILD_ARGS+=(build)
 
 xcodebuild "${XCODEBUILD_ARGS[@]}"


### PR DESCRIPTION
## Summary

Four `scripts/reloads.sh` improvements that cut local staging build time on Apple Silicon. CI's `release.yml` and `nightly.yml` are untouched — they invoke xcodebuild without these overrides and continue to produce universal + wholemodule binaries.

- **Item 1** — arm64-only by default, `--universal` opt-out. Skips the dead-weight x86_64 slice for local iteration. (Pass `--universal` for x86_64-specific checks; combine with `--wmo` for full prod parity before a tag push.)
- **Item 2** — derived-data path now keys on tag *family* (prefix-up-to-first-hyphen), so related tags share an incremental cache. `release/*` tags share `/tmp/c11-staging-release/`; `c11-*` share `/tmp/c11-staging-c11/`; etc. Adds `--clean` to wipe before building, and a breadcrumb at `<derived-data>/.last-sha` + `.last-tag` printed on reuse so the operator knows whose build is in there.
- **Item 4** — `COMPILER_INDEX_STORE_ENABLE=NO`. Staging is for running, not for IDE navigation.
- **Item 5** — `SWIFT_COMPILATION_MODE=incremental` by default with `--wmo` opt-out. Wholemodule is prod's speed-of-binary play; incremental is the right mode for iterative recompiles.

Item 3 from the original spec (`-skipPackagePluginValidation -skipMacroValidation`) was deliberately dropped by the operator.

## Wall-clock results (M4 Max, this branch)

| Scenario | Command | Time |
|---|---|---|
| Cold build, default (first build with the family path) | `reloads.sh --tag c11-110-perf` (empty derived-data dir) | **6m 3s** |
| Warm rebuild, no source changes | `reloads.sh --tag c11-110-perf` (immediately after) | **15s** |
| Cold-after-clean (derived-data wiped, global caches retained) | `reloads.sh --tag c11-110-perf --clean` | **2m 45s** |

The headline win is the warm rebuild: under the old per-tag default, every new tag was a fresh `/tmp/c11-staging-<slug>/` and got a cold ~6min build. Family-keyed reuse makes the second-and-onwards build incremental.

The cold-after-clean number (2m 45s vs. 6m 3s first-cold) shows how much of the cold cost lives in global Xcode/Swift caches outside the per-build derived-data dir, and how much we recover when we keep those caches warm across tags.

`--universal` and `--wmo` were validated via dry-run (mocked xcodebuild echoing the args). Full builds for those modes were skipped to avoid extended foreground/focus churn while a separate staging app was being hand-tested. The xcodebuild invocations are echoed by the script now, so re-validating either path is one line in the operator's build log:

```
[reloads.sh] xcodebuild -project ... ARCHS=arm64 ONLY_ACTIVE_ARCH=YES COMPILER_INDEX_STORE_ENABLE=NO SWIFT_COMPILATION_MODE=incremental build   # default
[reloads.sh] xcodebuild -project ... COMPILER_INDEX_STORE_ENABLE=NO SWIFT_COMPILATION_MODE=incremental build                                    # --universal
[reloads.sh] xcodebuild -project ... ARCHS=arm64 ONLY_ACTIVE_ARCH=YES COMPILER_INDEX_STORE_ENABLE=NO build                                      # --wmo
[reloads.sh] xcodebuild -project ... COMPILER_INDEX_STORE_ENABLE=NO build                                                                       # --universal --wmo (prod parity)
```

## Acceptance criteria

- [x] No-flag build defaults to arm64-only + incremental + no-index-store + family derived-data
- [x] `--universal` opts back into universal binary (dry-run confirmed; arm64-only result confirmed via `lipo -info`)
- [x] `--clean` wipes the derived-data dir (verified by planting a stray file)
- [x] `--wmo` opts back into wholemodule (dry-run confirmed)
- [x] Resulting `c11 STAGING` app launches (PID alive, registered as foreground app via `lsappinfo`)
- [x] `release.yml` and `nightly.yml` untouched

## Test plan

No automated tests for build-script changes — per c11's [test-quality policy](https://github.com/Stage-11-Agentics/c11/blob/main/CLAUDE.md#test-quality-policy), source-text assertions against shell scripts aren't useful and there's no runtime seam to test through. Validation is by running the script in the four modes documented above.

- [ ] Reviewer: run `./scripts/reloads.sh --tag <your-tag>` and confirm the echoed xcodebuild invocation matches expectations for your flag combo.
- [ ] Reviewer: confirm warm rebuild under the same tag is sub-minute.

## Not in this PR

- `scripts/reload.sh` (Debug script) — same wins would apply but the prompt scoped this to `reloads.sh`. Easy follow-up: lift the same flag plumbing + family-keyed `tagged_derived_data_path` over.
- Version bump / CHANGELOG entry — post-release tooling, ships whenever it lands.

Closes Lattice C11-110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)