### PR TITLE
fix Text + Text recursion that blew the render-thread stack (C11-26)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4669,9 +4669,14 @@ struct ContentView: View {
             return Text(title).foregroundColor(.primary)
         }
 
+        // Build a flat AttributedString rather than accumulating Text + Text.
+        // Repeated `result = result + Text(...)` produces a recursive
+        // ConcatenatedTextStorage tree whose `resolve` is depth-N recursive;
+        // a highly fragmented match pattern (long title, alternating runs)
+        // blows the render-thread stack at SwiftUI resolve time (C11-26).
         let chars = Array(title)
         var index = 0
-        var result = Text("")
+        var attributed = AttributedString()
 
         while index < chars.count {
             let isMatched = matchedIndices.contains(index)
@@ -4680,16 +4685,13 @@ struct ContentView: View {
                 end += 1
             }
 
-            let segment = String(chars[index..<end])
-            if isMatched {
-                result = result + Text(segment).foregroundColor(.blue)
-            } else {
-                result = result + Text(segment).foregroundColor(.primary)
-            }
+            var run = AttributedString(String(chars[index..<end]))
+            run.foregroundColor = isMatched ? .blue : .primary
+            attributed.append(run)
             index = end
         }
 
-        return result
+        return Text(attributed)
     }
 
     private func commandPaletteTrailingLabel(for command: CommandPaletteCommand) -> CommandPaletteTrailingLabel? {

--- a/Sources/Panels/PaneInteractionCardView.swift
+++ b/Sources/Panels/PaneInteractionCardView.swift
@@ -208,22 +208,26 @@ private struct ConfirmCard: View {
         let matches = regex.matches(in: string, range: fullRange)
         guard !matches.isEmpty else { return Text(string) }
 
+        // Build a flat AttributedString instead of `Text + Text` accumulation —
+        // see commandPaletteHighlightedTitleText for the recursion hazard (C11-26).
         var cursor = 0
-        var result = Text("")
+        var attributed = AttributedString()
         for match in matches {
             if match.range.location > cursor {
                 let plainRange = NSRange(location: cursor, length: match.range.location - cursor)
-                result = result + Text(nsString.substring(with: plainRange))
+                attributed.append(AttributedString(nsString.substring(with: plainRange)))
             }
-            let emphasized = nsString.substring(with: match.range)
-            result = result + Text(emphasized).underline().bold()
+            var emphasized = AttributedString(nsString.substring(with: match.range))
+            emphasized.inlinePresentationIntent = .stronglyEmphasized
+            emphasized.underlineStyle = .single
+            attributed.append(emphasized)
             cursor = match.range.location + match.range.length
         }
         if cursor < nsString.length {
             let tailRange = NSRange(location: cursor, length: nsString.length - cursor)
-            result = result + Text(nsString.substring(with: tailRange))
+            attributed.append(AttributedString(nsString.substring(with: tailRange)))
         }
-        return result
+        return Text(attributed)
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `result = result + Text(...)` accumulation in two helpers with a flat `AttributedString` build, then a single `Text(attributedString)` wrap.
- Eliminates the recursive `ConcatenatedTextStorage` tree whose depth-N `resolve` blew the render-thread stack on macOS 26 production users (C11-26 in Sentry, 1 event so far on 0.48.0+102, expected to recur as command palette queries fragment titles more aggressively).

## Why this matters

SwiftUI's `Text + Text` builds a binary tree of `ConcatenatedTextStorage`. Each call to `.resolve` walks that tree recursively. A long command palette title with many alternating matched/unmatched runs produces a deep tree; SwiftUI's resolve recursion overflows the stack guard page (`___chkstk_darwin`) ~90 frames deep. The Sentry stack is unambiguous:

```
Text.Storage.resolve → ConcatenatedTextStorage.resolve → Text.resolve → ...
(repeated 90+ times) → ___chkstk_darwin
```

`AttributedString` uses flat run-based storage, so `Text(attributedString)` resolve depth is O(1) regardless of run count. Pattern already established in `TCCPrimerView.sayNoAttributed`.

## Sites changed

- `Sources/ContentView.swift` — `commandPaletteHighlightedTitleText` (the likely trigger; titles with fragmented fuzzy matches)
- `Sources/Panels/PaneInteractionCardView.swift` — `emphasizedText` (lower risk in practice — regex on "entire" — but same hazardous pattern, converted defensively)

## Test plan

- [ ] Build the project (verified locally: `xcodebuild -scheme c11 build` succeeded)
- [ ] Tagged build smoke: open the command palette, type a query that produces highly fragmented matches in a long title (e.g. `cww` against `command palette switch workspace`) — should render highlights without hanging or crashing
- [ ] Tagged build smoke: trigger the "close entire pane" confirm dialog — the word "entire" should still be underlined and bold
- [ ] After merge, confirm C11-26 stops recurring in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)