### PR TITLE
Release v0.49.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.49.1] - 2026-05-19
+
+Patch release. Two correctness follow-ups to v0.49.0: a SwiftUI render-thread crash from a `Text + Text` concat path in the workspace chrome, and a restored-session execution bug where `c11 restore` typed the resume command into the recipient surface's prompt but never submitted it.
+
+### Fixed
+
+- **`Text + Text` recursion no longer blows the render-thread stack.** A concat path in the workspace chrome (sidebar + pane interaction card) recursed through SwiftUI's `Text + Text` operator deeply enough to overflow the render thread on some configurations, taking the window down. Switched the construction to a flattened form. ([#195](https://github.com/Stage-11-Agentics/c11/pull/195))
+- **`c11 restore` now actually executes the resume command on restored surfaces.** `TerminalSurface.sendText` wraps every write in bracketed-paste markers (`ESC[200~ … ESC[201~`), so any embedded `\n` or `\r` is treated as data by zsh ZLE / bash readline / TUI raw-mode handlers and never submits. Session restore was typing the `claude --resume <id>` command into the prompt and then leaving it stranded — every restored Claude Code surface came up showing the resume line waiting for the operator to press Enter. The restart-registry executor now dispatches a real Return outside the bracketed-paste sequence so the command actually runs. ([7cb87a5e6](https://github.com/Stage-11-Agentics/c11/commit/7cb87a5e6))
+
+### Built and shipped by
+
+Stage 11 Agentics. Operator:agent, fused.
+
 ## [0.49.0] - 2026-05-19
 
 Stability + ergonomics release. Headline: **worktree and branch chips on every workspace's sidebar row** make git context visible at a glance — the operator running parallel worktrees never has to read `cwd` to know which workspace is on which branch. Underneath, the long-running C11-105 mystery is closed out: the c11 CLI socket no longer goes unreachable while the app is alive. State-directory migration from c11mux gets a per-entry merge so mixed-state homes survive. `c11 send` learns to submit by default — agents that drop the `send-key enter` follow-up no longer leave messages stranded in the recipient's input box. Workspace snapshots now persist browser surface URLs across restore. Terminal links pick up an Opt+click escape hatch to the system browser. Update pill opens its popover on the first click. And the close-workspace confirm overlay actually shows up when the target workspace is off-screen.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -1649,10 +1649,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1730,7 +1730,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1740,7 +1740,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1771,7 +1771,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1781,7 +1781,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -1849,10 +1849,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1867,14 +1867,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1889,14 +1889,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1912,10 +1912,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1931,10 +1931,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.0;
+				MARKETING_VERSION = 0.49.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Summary

Patch release. Two correctness follow-ups to v0.49.0.

- Fixed: `Text + Text` recursion no longer blows the render-thread stack (#195) — flattens a SwiftUI concat path in the workspace chrome that was deep enough to overflow on some configurations.
- Fixed: `c11 restore` now actually executes the resume command on restored surfaces (7cb87a5e6) — the restart-registry executor dispatches a real Return outside the bracketed-paste sequence so the `claude --resume <id>` command runs instead of sitting unsubmitted at the prompt.

## Version

`0.49.0` → `0.49.1`. Build `103` → `104`.

## Test plan

- [ ] Operator smokes `c11 STAGING rel-v0.49.1.app` (built locally from this branch)
- [ ] Smoke: workspace renders without crash (Text+Text path exercised across sidebar + pane interaction card)
- [ ] Smoke: `c11 snapshot` → quit → relaunch → `C11_SESSION_RESUME=1 c11 restore <id>` — restored Claude surfaces actually start their session, not sit at the prompt
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)