### PR TITLE
Fix Japanese/Chinese IME Enter leak into TUI (#147)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5831,7 +5831,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     private func shouldSendCommittedIMEConfirmKey(event: NSEvent, markedTextBefore: Bool) -> Bool {
         guard markedTextBefore, markedText.length == 0 else { return false }
-        return event.keyCode == 36 || event.keyCode == 76
+        guard event.keyCode == 36 || event.keyCode == 76 else { return false }
+        // Korean IME: Enter commits the syllable AND executes the command (single step).
+        // Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
+        // Only send the extra Return key for Korean input sources.
+        guard let sourceId = KeyboardLayout.id else { return false }
+        return sourceId.range(of: "korean", options: .caseInsensitive) != nil
     }
 
     private func ghosttyKeyEvent(for event: NSEvent, surface: ghostty_surface_t) -> ghostty_input_key_s {


### PR DESCRIPTION
## Summary

- Closes #147 (reporter: @hummer98).
- `shouldSendCommittedIMEConfirmKey` now gates the post-composition Return on a Korean-only input-source check — mirrors upstream cmux. Japanese/Chinese IMEs no longer get their conversion-confirm Enter forwarded to the TUI.

## What was broken

On c11 0.46.0 (still present on `main` at 0.49.1), pressing Enter to confirm a Japanese IME conversion inside any TUI submits the line. With Claude Code that meant every kanji conversion submitted the message half-typed. Reproduces 100% with macOS Hiragana per the report.

The actual root cause is much narrower than the reporter's diff suggested. `shouldSendCommittedIMEConfirmKey` (`Sources/GhosttyTerminalView.swift:5849`) returned `true` for any Return/NumpadEnter that landed after composition just emptied. Upstream cmux's version of the same function adds a Korean-only gate, because:

- **Korean** IME commits the syllable AND executes the command in a single Enter press, so the extra Return is correct.
- **Japanese/Chinese** IME's Enter is conversion-confirm only; a second Enter executes.

c11 was dispatching the second Return unconditionally.

## The fix

Five lines inside `shouldSendCommittedIMEConfirmKey` to mirror the upstream gate:

```swift
guard event.keyCode == 36 || event.keyCode == 76 else { return false }
// Korean IME: Enter commits the syllable AND executes the command (single step).
// Japanese/Chinese IME: Enter only confirms the conversion; a second Enter executes.
// Only send the extra Return key for Korean input sources.
guard let sourceId = KeyboardLayout.id else { return false }
return sourceId.range(of: "korean", options: .caseInsensitive) != nil
```

Korean two-set behaviour is preserved — the gate now matches upstream verbatim.

## Why not the full IME state-machine sweep

The issue reporter pointed at `suppressComposingFallbackText = keyEvent.composing` and several other upstream guards as missing. They are missing — but they guard against **other** IME edge cases (Korean arrow-key navigation through candidates, Bopomofo/Zhuyin preedit handling, AX/dictation sanitization paths, deferred numpad commits). They are not what causes the reported Enter leak. Bundling them into this PR would balloon the diff on a typing-latency hot path for fixes that need their own targeted validation against Traditional Chinese / Korean two-set / AppleScript dictation. Filing a follow-up to track the broader sweep separately.

## Test plan

- [x] `./scripts/reload.sh --tag issue-147-ime` — `** BUILD SUCCEEDED **`.
- [ ] CI: full c11-unit + c11-logic suites (existing `c11Tests/CJKIMEInputTests.swift` covers `performKeyEquivalent` non-consumption during composition; should be unaffected — no behaviour changed in that path).
- [ ] Reporter validation requested: install the tagged build, set macOS input source to Japanese (Hiragana), launch `claude` inside a c11 surface (TextBox NOT enabled), type `nihongo`, press Enter — the conversion should confirm only, with Claude Code receiving no submit; a second Enter then submits.
- [ ] Korean regression check: same flow with Korean 2-Set, type `안녕` (or any syllable), press Enter — should still both commit the syllable AND submit the line (the established single-step behaviour).
- [ ] Chinese regression check: Pinyin/Simplified, type `nihao`, press Enter — should confirm conversion only; second Enter submits.