### PR TITLE
Release v0.49.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.49.2] - 2026-05-21
+
+Single-fix patch release for a Japanese / Chinese IME regression reported against 0.49.x. Korean IME behaviour is unchanged.
+
+### Fixed
+
+- **Japanese / Chinese IME Enter no longer leaks into the underlying TUI.** Confirming a Japanese (Hiragana) or Chinese (Pinyin) IME conversion with Return was forwarding a second Return into the terminal surface, so TUIs like Claude Code interpreted the conversion-confirm as a submit. Root cause: `shouldSendCommittedIMEConfirmKey` was returning `true` for any post-composition Return; it now matches upstream cmux by gating the extra Return on a Korean-only input-source check (Korean two-set IMEs commit+execute in a single Enter; Japanese / Chinese require a second Enter). ([#197](https://github.com/Stage-11-Agentics/c11/pull/197) — thanks [@hummer98](https://github.com/hummer98) for the report and the upstream diff bisection!)
+
+### Thanks to 2 contributors!
+
+- [@BenevolentFutures](https://github.com/BenevolentFutures)
+- [@hummer98](https://github.com/hummer98)
+
+### Built and shipped by
+
+Stage 11 Agentics. Operator:agent, fused.
+
 ## [0.49.1] - 2026-05-19
 
 Patch release. Two correctness follow-ups to v0.49.0: a SwiftUI render-thread crash from a `Text + Text` concat path in the workspace chrome, and a restored-session execution bug where `c11 restore` typed the resume command into the recipient surface's prompt but never submitted it.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -1649,10 +1649,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1730,7 +1730,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1740,7 +1740,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1771,7 +1771,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1781,7 +1781,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -1849,10 +1849,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1867,14 +1867,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1889,14 +1889,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1912,10 +1912,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1931,10 +1931,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 104;
+				CURRENT_PROJECT_VERSION = 105;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.1;
+				MARKETING_VERSION = 0.49.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Single-fix patch release for #147.

## Summary

Bumps to **v0.49.2**. Closes #147 (Japanese / Chinese IME Enter leaking into TUI). Korean two-set IME behaviour unchanged.

## Changelog

### Fixed

- **Japanese / Chinese IME Enter no longer leaks into the underlying TUI.** Confirming a Japanese (Hiragana) or Chinese (Pinyin) IME conversion with Return was forwarding a second Return into the terminal surface, so TUIs like Claude Code interpreted the conversion-confirm as a submit. Root cause: `shouldSendCommittedIMEConfirmKey` was returning `true` for any post-composition Return; it now matches upstream cmux by gating the extra Return on a Korean-only input-source check. (#197 — thanks @hummer98 for the report and the upstream diff bisection!)

## Test plan

- [x] `./scripts/reload.sh --tag issue-147-ime` — `** BUILD SUCCEEDED **`, validated locally on a tagged DEV build.
- [x] @hummer98's reproduction (Japanese Hiragana → `nihongo` → Enter) no longer submits in Claude Code; second Enter submits as expected.
- [ ] CI: full suite must pass on this PR before merge.
- [ ] Korean two-set regression check: existing `c11Tests/CJKIMEInputTests.swift` covers `performKeyEquivalent` non-consumption; no behavioural change in that path.