### PR TITLE
Fix offscreen terminal helper PTY startup (C11-114)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7512,7 +7512,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 let hostedView = terminalPanel.hostedView
                 let shouldReconcileVisibleSelection =
                     target.workspace.id == selectedWorkspaceId &&
-                    hostedView.window != nil &&
+                    terminalPanel.surface.isViewInWindow &&
                     hostedView.superview != nil
 
                 if shouldReconcileVisibleSelection {
@@ -10666,7 +10666,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let hostedView = terminalPanel.hostedView
         let hostedSize = hostedView.bounds.size
         let hostedHiddenInHierarchy = hostedView.isHiddenOrHasHiddenAncestor
-        let hostedAttachedToWindow = hostedView.window != nil
+        let hostedAttachedToWindow = terminalPanel.surface.isViewInWindow
         let firstResponderIsWindow = NSApp.keyWindow?.firstResponder is NSWindow
 
         let shouldSuppress = shouldSuppressSplitShortcutForTransientTerminalFocusInputs(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2568,12 +2568,31 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     private(set) var surface: ghostty_surface_t?
     private weak var attachedView: GhosttyNSView?
-    /// Whether the terminal surface view is currently attached to a window.
+    /// The user-facing window backing the hosted view. Returns `nil` when the view is
+    /// only parented to the internal headless bootstrap window used to start a Ghostty
+    /// surface ahead of the real portal. Callers that want "is this visible/focusable
+    /// to the operator" should use this instead of `hostedView.window` directly.
+    var uiWindow: NSWindow? {
+        guard let window = hostedView.window else { return nil }
+        if let headlessStartupWindow, window === headlessStartupWindow {
+            return nil
+        }
+        return window
+    }
+
+    /// Whether the terminal surface view is currently attached to a user-visible window.
     ///
     /// Use the hosted view rather than the inner surface view, since the surface can be
     /// temporarily unattached (surface not yet created / reparenting) even while the panel
-    /// is already in the window.
-    var isViewInWindow: Bool { hostedView.window != nil }
+    /// is already in the window. The headless bootstrap window does not count.
+    var isViewInWindow: Bool { uiWindow != nil }
+
+    /// True when `window` is the internal headless bootstrap window used to start the
+    /// Ghostty runtime before AppKit moves the view into a real window.
+    func isHeadlessStartupWindow(_ window: NSWindow?) -> Bool {
+        guard let window, let headlessStartupWindow else { return false }
+        return window === headlessStartupWindow
+    }
     let id: UUID
     private(set) var tabId: UUID
     /// Port ordinal for CMUX_PORT range assignment
@@ -2615,6 +2634,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
     /// submits the typed line on cold start.
     private var pendingSubmitOnFlush: Bool = false
     private var backgroundSurfaceStartQueued = false
+    /// Borderless, off-screen `NSWindow` used to bootstrap Ghostty's runtime surface
+    /// before AppKit moves the view into a real portal-backed window. Required because
+    /// `ghostty_surface_new` (via `attachToView`) gates on `view.window != nil`; for
+    /// offscreen surfaces (e.g. `c11 new-surface --no-focus`) the real window never
+    /// arrives until the user selects the tab. We attach into this window, let the
+    /// PTY spawn, and release it when the real window arrives (`reconcileAttachedWindowIfNeeded`).
+    private var headlessStartupWindow: NSWindow?
     private var surfaceCallbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
     /// Tracks the last focus state to avoid sending redundant focus events.
     /// This prevents prompt redraw issues with zsh themes like Powerlevel10k.
@@ -2719,6 +2745,17 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // Surface is created when attached to a view
         hostedView.attachSurface(self)
         TerminalSurfaceRegistry.shared.register(self)
+
+        // Surfaces with startup work (`initialCommand`) must spawn their PTY before
+        // the user focuses the workspace; otherwise the agent restore / cold-boot
+        // path stalls until the operator selects the tab. Ghostty's surface creation
+        // expects a non-nil `view.window`, so we install the view in a hidden
+        // bootstrap window now and swap to the real window when AppKit moves it there.
+        if self.initialCommand != nil {
+            MainActor.assumeIsolated {
+                scheduleHeadlessRuntimeStartIfNeeded(reason: "startup")
+            }
+        }
     }
 
 
@@ -2726,6 +2763,113 @@ final class TerminalSurface: Identifiable, ObservableObject {
         tabId = newTabId
         attachedView?.tabId = newTabId
         surfaceView.tabId = newTabId
+    }
+
+    // MARK: - Headless startup window
+    //
+    // Ghostty's surface creation gates on `view.window != nil` so that constructing
+    // a `TerminalSurface` (e.g. for a model-only restore, a unit test, or a
+    // background workspace) does not spawn a PTY. The trouble is real surfaces
+    // created via `c11 new-surface --no-focus` are also off-window — SwiftUI never
+    // mounts an unselected tab's view, so `attachToView` defers indefinitely and
+    // `c11 send` quietly queues into oblivion.
+    //
+    // The fix (mirrored from manaflow-ai/cmux PR #4233) is to install the view in
+    // a borderless, off-screen `NSWindow` long enough for `ghostty_surface_new` to
+    // succeed, then swap to the real window when AppKit eventually mounts the view
+    // for real. The headless window is invisible to the operator (`alphaValue = 0`,
+    // `.ignoresMouseEvents`, excluded from the windows menu) and is released as
+    // soon as `attachToView` fires for the real portal window.
+    @MainActor
+    private func scheduleHeadlessRuntimeStartIfNeeded(reason: String) {
+        startRuntimeUsingHeadlessWindowIfNeeded(reason: reason)
+    }
+
+    @MainActor
+    private func startRuntimeUsingHeadlessWindowIfNeeded(reason: String) {
+        guard surface == nil else { return }
+        ensureHeadlessStartupWindowIfNeeded(reason: reason)
+        hostedView.attachSurface(self)
+    }
+
+    @MainActor
+    private func ensureHeadlessStartupWindowIfNeeded(reason: String) {
+        guard headlessStartupWindow == nil else { return }
+        guard hostedView.window == nil else { return }
+
+        let width = max(surfaceView.bounds.width, CGFloat(800))
+        let height = max(surfaceView.bounds.height, CGFloat(600))
+        let frame = NSRect(x: 0, y: 0, width: width, height: height)
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.hasShadow = false
+        window.alphaValue = 0
+        window.ignoresMouseEvents = true
+        window.collectionBehavior = [.transient, .ignoresCycle, .stationary]
+        window.isExcludedFromWindowsMenu = true
+
+        let contentView = NSView(frame: frame)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+        window.contentView = contentView
+        headlessStartupWindow = window
+        hostedView.setVisibleInUI(false)
+        hostedView.setActive(false)
+
+#if DEBUG
+        dlog(
+            "surface.headless_window.create surface=\(id.uuidString.prefix(8)) " +
+            "reason=\(reason) window=\(ObjectIdentifier(window))"
+        )
+#endif
+    }
+
+    @MainActor
+    private func releaseHeadlessStartupWindowIfNeeded(for view: GhosttyNSView) {
+        guard let window = headlessStartupWindow else { return }
+        guard let currentWindow = view.window, currentWindow !== window else { return }
+        headlessStartupWindow = nil
+        window.contentView = nil
+        window.close()
+#if DEBUG
+        dlog(
+            "surface.headless_window.release surface=\(id.uuidString.prefix(8)) " +
+            "realWindow=\(ObjectIdentifier(currentWindow))"
+        )
+#endif
+    }
+
+    private func closeHeadlessStartupWindowIfNeeded() {
+        let startupWindow = headlessStartupWindow
+        headlessStartupWindow = nil
+        guard let startupWindow else { return }
+
+        let closeStartupWindow = {
+            startupWindow.contentView = nil
+            startupWindow.close()
+        }
+        if Thread.isMainThread {
+            closeStartupWindow()
+        } else {
+            DispatchQueue.main.async(execute: closeStartupWindow)
+        }
+    }
+
+    @MainActor
+    func reconcileAttachedWindowIfNeeded(for view: GhosttyNSView) {
+        guard attachedView === view else { return }
+        releaseHeadlessStartupWindowIfNeeded(for: view)
+        guard let screen = view.window?.screen ?? NSScreen.main,
+              let displayID = screen.displayID,
+              displayID != 0 else { return }
+        guard let s = self.surface else { return }
+        ghostty_surface_set_display_id(s, displayID)
     }
 
     private static func mergedNormalizedEnvironment(
@@ -2963,6 +3107,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     func teardownSurface() {
         recordTeardownRequest(reason: "surface.teardown")
         markPortalLifecycleClosed(reason: "teardown")
+        closeHeadlessStartupWindowIfNeeded()
 
         let callbackContext = surfaceCallbackContext
         surfaceCallbackContext = nil
@@ -3061,6 +3206,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // markers, visibility flags), so avoid forcing a geometry refresh when the attachment
         // itself is unchanged.
         if attachedView === view && surface != nil {
+            MainActor.assumeIsolated {
+                releaseHeadlessStartupWindowIfNeeded(for: view)
+            }
 #if DEBUG
             dlog("surface.attach.reuse surface=\(id.uuidString.prefix(5)) view=\(Unmanaged.passUnretained(view).toOpaque())")
 #endif
@@ -3084,9 +3232,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 
         attachedView = view
+        MainActor.assumeIsolated {
+            releaseHeadlessStartupWindowIfNeeded(for: view)
+        }
 
         // If surface doesn't exist yet, create it once the view is in a real window so
         // content scale and pixel geometry are derived from the actual backing context.
+        // Off-window panels (model-only restore, background workspace tabs) stay
+        // deferred; the headless bootstrap path above handles the offscreen-but-must-spawn
+        // case explicitly via `scheduleHeadlessRuntimeStartIfNeeded`.
         if surface == nil {
             guard view.window != nil else {
 #if DEBUG
@@ -3506,23 +3660,26 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     /// Force a full size recalculation and surface redraw.
+    ///
+    /// `uiWindow` is used instead of `view.window` so the headless bootstrap window
+    /// does not trigger refresh work — that window is invisible and unfocusable, so
+    /// draws into it are wasted wakeups on the typing hot path.
     func forceRefresh(reason: String = "unspecified") {
+#if DEBUG
         let hasSurface = surface != nil
         let viewState: String
         if let view = attachedView {
-            let inWindow = view.window != nil
+            let inWindow = uiWindow != nil
             let bounds = view.bounds
             let metalOK = (view.layer as? CAMetalLayer) != nil
             viewState = "inWindow=\(inWindow) bounds=\(bounds) metalOK=\(metalOK) hasSurface=\(hasSurface)"
         } else {
             viewState = "NO_ATTACHED_VIEW hasSurface=\(hasSurface)"
         }
-        #if DEBUG
         dlog("forceRefresh: \(id) reason=\(reason) \(viewState)")
-        #endif
+#endif
         guard let view = attachedView,
-              let surface,
-              view.window != nil,
+              let window = uiWindow,
               view.bounds.width > 0,
               view.bounds.height > 0 else {
             return
@@ -3537,7 +3694,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // Reassert display id on topology churn (split close/reparent) before forcing a refresh.
         // This avoids a first-run stuck-vsync state where Ghostty believes vsync is active
         // but callbacks have not resumed for the current display.
-        if let displayID = (view.window?.screen ?? NSScreen.main)?.displayID,
+        if let displayID = (window.screen ?? NSScreen.main)?.displayID,
            displayID != 0 {
             ghostty_surface_set_display_id(currentSurface, displayID)
         }
@@ -3713,6 +3870,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
         _ = performBindingAction("scroll_to_row:\(row)")
     }
 
+    // Socket / API operations are an explicit runtime demand: they must be able to
+    // start a terminal in a background workspace without selecting that workspace.
+    // When there is no real window yet, bootstrap Ghostty in a hidden window and
+    // reconcile display/window state when the terminal is later presented for real.
     func requestBackgroundSurfaceStartIfNeeded() {
         if !Thread.isMainThread {
             DispatchQueue.main.async { [weak self] in
@@ -3721,24 +3882,35 @@ final class TerminalSurface: Identifiable, ObservableObject {
             return
         }
 
-        guard surface == nil, attachedView != nil else { return }
+        guard surface == nil else { return }
         guard !backgroundSurfaceStartQueued else { return }
         backgroundSurfaceStartQueued = true
 
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            self.backgroundSurfaceStartQueued = false
-            guard self.surface == nil, let view = self.attachedView else { return }
-            #if DEBUG
-            let startedAt = ProcessInfo.processInfo.systemUptime
-            #endif
-            self.createSurface(for: view)
-            #if DEBUG
-            let elapsedMs = (ProcessInfo.processInfo.systemUptime - startedAt) * 1000.0
-            dlog(
-                "surface.background_start surface=\(self.id.uuidString.prefix(8)) inWindow=\(view.window != nil ? 1 : 0) ready=\(self.surface != nil ? 1 : 0) ms=\(String(format: "%.2f", elapsedMs))"
-            )
-            #endif
+            MainActor.assumeIsolated {
+                self.backgroundSurfaceStartQueued = false
+                guard self.surface == nil else { return }
+                #if DEBUG
+                let startedAt = ProcessInfo.processInfo.systemUptime
+                #endif
+                if let view = self.attachedView, view.window != nil {
+                    // The view is in a real window already — straightforward create.
+                    self.createSurface(for: view)
+                } else {
+                    // Offscreen surface. Install the view in a hidden bootstrap window
+                    // so `ghostty_surface_new` has a non-nil `view.window`; the real
+                    // window will swap in via `reconcileAttachedWindowIfNeeded`.
+                    self.scheduleHeadlessRuntimeStartIfNeeded(reason: "background-input")
+                }
+                #if DEBUG
+                let elapsedMs = (ProcessInfo.processInfo.systemUptime - startedAt) * 1000.0
+                let inWindow = (self.attachedView?.window != nil) ? 1 : 0
+                dlog(
+                    "surface.background_start surface=\(self.id.uuidString.prefix(8)) inWindow=\(inWindow) ready=\(self.surface != nil ? 1 : 0) ms=\(String(format: "%.2f", elapsedMs))"
+                )
+                #endif
+            }
         }
     }
 
@@ -3850,6 +4022,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     deinit {
         markPortalLifecycleClosed(reason: "deinit")
+        closeHeadlessStartupWindowIfNeeded()
 
         let callbackContext = surfaceCallbackContext
         surfaceCallbackContext = nil
@@ -4156,6 +4329,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         tabId = surface.tabId
         if !isAlreadyAttached {
             surface.attachToView(self)
+        } else {
+            // The surface is already attached (typically created in the headless
+            // bootstrap window). The view is now being mounted into the real
+            // portal; swap windows and re-assert display id so vsync resumes on
+            // the correct screen.
+            surface.reconcileAttachedWindowIfNeeded(for: self)
         }
         surface.setKeyboardCopyModeActive(keyboardCopyModeActive)
         if !isAlreadyAttached {
@@ -6517,6 +6696,16 @@ final class GhosttySurfaceScrollView: NSView {
     private var userScrolledAwayFromBottom = false
     /// [TextBox] Read-only accessor used by `TerminalSurface.isScrolledUp`.
     var isUserScrolledAwayFromBottom: Bool { userScrolledAwayFromBottom }
+
+    /// The user-facing window backing this scroll view, treating the headless
+    /// startup window as "not in a window" so focus and visibility logic does
+    /// not run against the invisible bootstrap surface.
+    var uiWindow: NSWindow? {
+        if let terminalSurface = surfaceView.terminalSurface {
+            return terminalSurface.uiWindow
+        }
+        return window
+    }
     /// [TextBox] Read-only accessor used by `TerminalSurface.scrollbarOffset`.
     var currentScrollbarOffset: UInt64? { surfaceView.scrollbar?.offset }
     /// Threshold in points from bottom to consider "at bottom" (allows for minor float drift)
@@ -7785,7 +7974,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     var debugPortalFrameInWindow: CGRect {
-        guard window != nil else { return .zero }
+        guard uiWindow != nil else { return .zero }
         return convert(bounds, to: nil)
     }
 
@@ -8168,9 +8357,10 @@ final class GhosttySurfaceScrollView: NSView {
 
     /// Returns true if the terminal's actual Ghostty surface view is (or contains) the window first responder.
     /// This is stricter than checking `hostedView` descendants, since the scroll view can sometimes become
-    /// first responder transiently while focus is being applied.
+    /// first responder transiently while focus is being applied. Uses `uiWindow` so the headless bootstrap
+    /// window — which has no real first responder of interest — does not produce phantom matches.
     func isSurfaceViewFirstResponder() -> Bool {
-        guard let window, let fr = window.firstResponder as? NSView else { return false }
+        guard let window = uiWindow, let fr = window.firstResponder as? NSView else { return false }
         return fr === surfaceView || fr.isDescendant(of: surfaceView)
     }
 
@@ -8206,7 +8396,7 @@ final class GhosttySurfaceScrollView: NSView {
     private func refreshSurfaceAfterFocusIfNeeded(reason: String) {
         guard let terminalSurface = surfaceView.terminalSurface,
               isActive,
-              let window,
+              let window = uiWindow,
               window.isKeyWindow,
               surfaceView.isVisibleInUI else { return }
 

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -250,7 +250,7 @@ final class TerminalPanel: Panel, ObservableObject {
         dlog(
             "surface.panel.close.begin panel=\(id.uuidString.prefix(5)) " +
             "workspace=\(workspaceId.uuidString.prefix(5)) runtimeSurface=\(surface.surface != nil ? 1 : 0) " +
-            "inWindow=\(hostedView.window != nil ? 1 : 0) hasSuperview=\(hostedView.superview != nil ? 1 : 0) " +
+            "inWindow=\(surface.isViewInWindow ? 1 : 0) hasSuperview=\(hostedView.superview != nil ? 1 : 0) " +
             "hidden=\(hostedView.isHidden ? 1 : 0) frame=\(frame) bounds=\(bounds)"
         )
 #endif
@@ -261,7 +261,7 @@ final class TerminalPanel: Panel, ObservableObject {
 #if DEBUG
         dlog(
             "surface.panel.close.end panel=\(id.uuidString.prefix(5)) " +
-            "inWindow=\(hostedView.window != nil ? 1 : 0) hasSuperview=\(hostedView.superview != nil ? 1 : 0) " +
+            "inWindow=\(surface.isViewInWindow ? 1 : 0) hasSuperview=\(hostedView.superview != nil ? 1 : 0) " +
             "hidden=\(hostedView.isHidden ? 1 : 0)"
         )
 #endif

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1254,7 +1254,7 @@ class TabManager: ObservableObject {
                 "find.startSearch workspace=\(panel.workspaceId.uuidString.prefix(5)) " +
                 "panel=\(panel.id.uuidString.prefix(5)) existing=\(hadExistingSearch ? "yes" : "no") " +
                 "handled=\(handled ? 1 : 0) " +
-                "firstResponder=\(String(describing: panel.surface.hostedView.window?.firstResponder))"
+                "firstResponder=\(String(describing: panel.surface.uiWindow?.firstResponder))"
             )
 #endif
             return
@@ -4370,7 +4370,7 @@ class TabManager: ObservableObject {
             timeoutSeconds: timeoutSeconds
         ) { panel in
             panel.surface.requestBackgroundSurfaceStartIfNeeded()
-            attached = panel.hostedView.window != nil
+            attached = panel.surface.isViewInWindow
             hasSurface = panel.surface.surface != nil
             firstResponder = panel.hostedView.isSurfaceViewFirstResponder()
             return attached && hasSurface
@@ -4540,7 +4540,7 @@ class TabManager: ObservableObject {
                         }
                         if let terminal = panel as? TerminalPanel {
                             selectedTerminalCount += 1
-                            if terminal.hostedView.window != nil {
+                            if terminal.surface.isViewInWindow {
                                 selectedTerminalAttachedCount += 1
                             }
                             let size = terminal.hostedView.bounds.size
@@ -5008,7 +5008,7 @@ class TabManager: ObservableObject {
                     panelId: rightPanel.id,
                     timeoutSeconds: 2.0
                 ) { panel in
-                    panel.hostedView.window != nil && panel.surface.surface != nil
+                    panel.surface.isViewInWindow && panel.surface.surface != nil
                 }
                 // Use an explicit shell exit command for deterministic child-exit behavior across
                 // startup timing variance; this still exercises the same SHOW_CHILD_EXITED path.
@@ -5252,7 +5252,7 @@ class TabManager: ObservableObject {
                 }
                 self.ensureFocusedTerminalFirstResponder()
             } else if let exitPanel = tab.terminalPanel(for: exitPanelId) {
-                exitPanelAttachedBeforeCtrlD = exitPanel.hostedView.window != nil
+                exitPanelAttachedBeforeCtrlD = exitPanel.surface.isViewInWindow
                 exitPanelHasSurfaceBeforeCtrlD = exitPanel.surface.surface != nil
             }
 
@@ -5373,7 +5373,7 @@ class TabManager: ObservableObject {
                             panelId: exitPanelId,
                             timeoutSeconds: 5.0
                         ) { panel in
-                            attachedBeforeTrigger = panel.hostedView.window != nil
+                            attachedBeforeTrigger = panel.surface.isViewInWindow
                             hasSurfaceBeforeTrigger = panel.surface.surface != nil
                             return attachedBeforeTrigger && hasSurfaceBeforeTrigger
                         }
@@ -5383,7 +5383,7 @@ class TabManager: ObservableObject {
                             return
                         }
                     } else if let panel = tab.terminalPanel(for: exitPanelId) {
-                        attachedBeforeTrigger = panel.hostedView.window != nil
+                        attachedBeforeTrigger = panel.surface.isViewInWindow
                         hasSurfaceBeforeTrigger = panel.surface.surface != nil
                     }
                     write([

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7324,7 +7324,7 @@ class TerminalController {
             let terminals: [[String: Any]] = surfaces.enumerated().map { index, terminalSurface in
                 let mapped = mappedLocations[ObjectIdentifier(terminalSurface)]
                 let hostedView = terminalSurface.hostedView
-                let hostedWindow = mapped?.window ?? hostedView.window
+                let hostedWindow = mapped?.window ?? terminalSurface.uiWindow
                 let fallbackWindowMetadata = resolvedWindowMetadata(for: hostedWindow)
                 let resolvedWindowId = mapped?.windowId ?? fallbackWindowMetadata.windowId
                 let resolvedWindowIndex = mapped?.windowIndex ?? fallbackWindowMetadata.windowIndex
@@ -7388,7 +7388,8 @@ class TerminalController {
                     "runtime_surface_ready": terminalSurface.surface != nil,
                     "hosted_view_ptr": objectPointerString(hostedView),
                     "hosted_view_class": className(hostedView) ?? "nil",
-                    "hosted_view_in_window": hostedView.window != nil,
+                    "hosted_view_in_window": terminalSurface.isViewInWindow,
+                    "hosted_view_in_headless_bootstrap_window": terminalSurface.isHeadlessStartupWindow(hostedView.window),
                     "hosted_view_has_superview": hostedView.superview != nil,
                     "hosted_view_hidden": hostedView.isHidden,
                     "hosted_view_hidden_or_ancestor_hidden": hostedView.isHiddenOrHasHiddenAncestor,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6317,7 +6317,7 @@ final class Workspace: Identifiable, ObservableObject {
         let isVisibleSelection =
             bonsplitController.focusedPaneId == paneId &&
             bonsplitController.selectedTab(inPane: paneId)?.id == tabId &&
-            terminalPanel.hostedView.window != nil &&
+            terminalPanel.surface.isViewInWindow &&
             terminalPanel.hostedView.superview != nil
 
         if isVisibleSelection {
@@ -9710,7 +9710,7 @@ final class Workspace: Identifiable, ObservableObject {
             let hostedView = terminalPanel.hostedView
             let hasUsableBounds = hostedView.bounds.width > 1 && hostedView.bounds.height > 1
             let hasSurface = terminalPanel.surface.surface != nil
-            let isAttached = hostedView.window != nil && hostedView.superview != nil
+            let isAttached = terminalPanel.surface.isViewInWindow && hostedView.superview != nil
 
             // Split close/reparent churn can transiently detach a surviving terminal view.
             // Force one SwiftUI representable update so the portal binding reattaches it.
@@ -9821,7 +9821,7 @@ final class Workspace: Identifiable, ObservableObject {
             let hostedView = terminalPanel.hostedView
 
             if shouldBeVisible {
-                if hostedView.isHidden || hostedView.window == nil || hostedView.superview == nil {
+                if hostedView.isHidden || !terminalPanel.surface.isViewInWindow || hostedView.superview == nil {
                     return true
                 }
             } else if !hostedView.isHidden {
@@ -10650,7 +10650,7 @@ extension Workspace: BonsplitDelegate {
 
     private func activationWindow(for panel: any Panel) -> NSWindow? {
         if let terminalPanel = panel as? TerminalPanel {
-            return terminalPanel.hostedView.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+            return terminalPanel.surface.uiWindow ?? NSApp.keyWindow ?? NSApp.mainWindow
         }
         if let browserPanel = panel as? BrowserPanel {
             return browserPanel.webView.window ?? browserPanel.portalAnchorView.window ?? NSApp.keyWindow ?? NSApp.mainWindow

--- a/tests_v2/test_cli_background_terminal_helpers_start_pty.py
+++ b/tests_v2/test_cli_background_terminal_helpers_start_pty.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Regression: CLI-created background terminal helpers should start a PTY.
+
+Ported from manaflow-ai/cmux PR #4233 (commit 5cb4715a8). Exercises the
+orchestrator pattern (`c11 new-surface --no-focus` then `c11 send`) against a
+background workspace. The pre-fix wedge was that offscreen surfaces never
+called `ghostty_surface_new` (their `view.window` stayed nil), so `c11 send`
+silently queued bytes into `pendingTextQueue` that would never flush. This
+test asserts that an echo sentinel actually reaches the helper terminal.
+
+Run against a tagged dev build's socket:
+    CMUX_SOCKET=/tmp/c11-debug-<tag>.sock \\
+    CMUXTERM_CLI=/path/to/c11 \\
+        python3 tests_v2/test_cli_background_terminal_helpers_start_pty.py
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import List, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = (
+    os.environ.get("C11_SOCKET_PATH")
+    or os.environ.get("C11_SOCKET")
+    or os.environ.get("CMUX_SOCKET_PATH")
+    or os.environ.get("CMUX_SOCKET")
+    or "/tmp/c11-debug.sock"
+)
+
+
+class c11Skip(Exception):
+    pass
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli_binary() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI") or os.environ.get("C11_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+
+    fixed_candidates = [
+        os.path.expanduser("~/Library/Developer/Xcode/DerivedData/c11-tests-v2/Build/Products/Debug/c11"),
+        os.path.expanduser("~/Library/Developer/Xcode/DerivedData/GhosttyTabs-*/Build/Products/Debug/c11"),
+    ]
+    for pattern in fixed_candidates:
+        for match in glob.glob(pattern):
+            if os.path.isfile(match) and os.access(match, os.X_OK):
+                return match
+
+    candidates = glob.glob(os.path.expanduser("~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/c11"), recursive=True)
+    candidates += glob.glob("/tmp/c11-*/Build/Products/Debug/c11")
+    candidates += glob.glob("/tmp/cmux-*/Build/Products/Debug/c11")
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate c11 CLI binary; set CMUXTERM_CLI or C11_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _run_cli(cli: str, args: List[str], check: bool = True) -> Tuple[int, str]:
+    env = dict(os.environ)
+    for key in (
+        "CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_TAB_ID",
+        "C11_WORKSPACE_ID", "C11_SURFACE_ID", "C11_TAB_ID",
+    ):
+        env.pop(key, None)
+
+    cmd = [cli, "--socket", SOCKET_PATH] + args
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+    merged = f"{proc.stdout}\n{proc.stderr}".strip()
+    if check and proc.returncode != 0:
+        raise cmuxError(f"CLI failed ({' '.join(cmd)}): {merged}")
+    return proc.returncode, proc.stdout.strip() if proc.returncode == 0 else merged
+
+
+def _extract_ref(output: str, kind: str) -> str:
+    match = re.search(rf"\b{kind}:\d+\b", output)
+    if not match:
+        raise cmuxError(f"Could not find {kind} ref in CLI output: {output!r}")
+    return match.group(0)
+
+
+def _wait_for_read_screen(cli: str, workspace_ref: str, surface_ref: str, token: str) -> str:
+    deadline = time.time() + 8.0
+    last_output = ""
+    while time.time() < deadline:
+        code, output = _run_cli(
+            cli,
+            [
+                "read-screen",
+                "--workspace",
+                workspace_ref,
+                "--surface",
+                surface_ref,
+                "--scrollback",
+                "--lines",
+                "80",
+            ],
+            check=False,
+        )
+        last_output = output
+        if code == 0 and token in output:
+            return output
+        time.sleep(0.1)
+    raise cmuxError(f"read-screen never observed {token!r} for {surface_ref}: {last_output!r}")
+
+
+def _exercise_helper(cli: str, workspace_ref: str, surface_ref: str, label: str) -> None:
+    token = f"C11_HELPER_PTY_{label}_{int(time.time() * 1000)}"
+    _run_cli(
+        cli,
+        [
+            "send",
+            "--workspace",
+            workspace_ref,
+            "--surface",
+            surface_ref,
+            "--",
+            f"echo {token}\\n",
+        ],
+    )
+    text = _wait_for_read_screen(cli, workspace_ref, surface_ref, token)
+    _must(token in text, f"helper terminal output missing {token!r}: {text!r}")
+
+
+def _create_background_workspace(cli: str) -> str:
+    _, output = _run_cli(cli, ["new-workspace", "--focus", "false"])
+    workspace_ref = output.removeprefix("OK ").strip()
+    _must(bool(workspace_ref), f"new-workspace returned no workspace ref: {output!r}")
+    return workspace_ref
+
+
+def _find_unhosted_background_workspace(c: cmux, cli: str, baseline_ws: str) -> Tuple[str, List[str]]:
+    created_workspaces: List[str] = []
+    try:
+        for _ in range(16):
+            workspace_ref = _create_background_workspace(cli)
+            created_workspaces.append(workspace_ref)
+            _run_cli(cli, ["select-workspace", "--workspace", baseline_ws])
+
+            health = c._call("surface.health", {"workspace_id": workspace_ref}) or {}
+            surfaces = health.get("surfaces") or []
+            if any(row.get("type") == "terminal" and row.get("in_window") is False for row in surfaces):
+                created_workspaces.remove(workspace_ref)
+                return workspace_ref, created_workspaces
+
+        raise c11Skip("could not create an unhosted background workspace for helper terminal regression")
+    except Exception:
+        for workspace_ref in created_workspaces:
+            try:
+                c.close_workspace(workspace_ref)
+            except Exception:
+                pass
+        raise
+
+
+def main() -> int:
+    cli = _find_cli_binary()
+
+    with cmux(SOCKET_PATH) as c:
+        baseline = c._call("workspace.current") or {}
+        baseline_ws = str(baseline.get("workspace_ref") or baseline.get("workspace_id") or "")
+        _must(bool(baseline_ws), f"workspace.current returned no workspace_id: {baseline}")
+
+        workspace_ref = ""
+        cleanup_workspaces: List[str] = []
+
+        try:
+            try:
+                workspace_ref, cleanup_workspaces = _find_unhosted_background_workspace(c, cli, baseline_ws)
+            except c11Skip as exc:
+                print(f"SKIP: {exc}")
+                return 0
+            panes = c._call("pane.list", {"workspace_id": workspace_ref}) or {}
+            pane_rows = panes.get("panes") or []
+            _must(bool(pane_rows), f"pane.list returned no panes for background workspace: {panes}")
+            pane_ref = str(pane_rows[0].get("ref") or pane_rows[0].get("id") or "")
+            _must(bool(pane_ref), f"pane.list returned pane without ref/id: {panes}")
+
+            _, surface_output = _run_cli(
+                cli,
+                [
+                    "new-surface",
+                    "--workspace",
+                    workspace_ref,
+                    "--pane",
+                    pane_ref,
+                    "--type",
+                    "terminal",
+                    "--focus",
+                    "false",
+                ],
+            )
+            helper_surface_ref = _extract_ref(surface_output, "surface")
+            _exercise_helper(cli, workspace_ref, helper_surface_ref, "surface")
+
+            _, pane_output = _run_cli(
+                cli,
+                [
+                    "new-pane",
+                    "--workspace",
+                    workspace_ref,
+                    "--type",
+                    "terminal",
+                    "--direction",
+                    "right",
+                    "--focus",
+                    "false",
+                ],
+            )
+            helper_pane_surface_ref = _extract_ref(pane_output, "surface")
+            _exercise_helper(cli, workspace_ref, helper_pane_surface_ref, "pane")
+
+            current = c._call("workspace.current") or {}
+            _must(
+                str(current.get("workspace_ref") or current.get("workspace_id") or "") == baseline_ws,
+                f"helper creation should not switch selected workspace: {current}",
+            )
+        finally:
+            for cleanup_workspace in cleanup_workspaces:
+                try:
+                    c.close_workspace(cleanup_workspace)
+                except Exception:
+                    pass
+            try:
+                if workspace_ref:
+                    c.close_workspace(workspace_ref)
+            except Exception:
+                pass
+
+    print("PASS: CLI-created background terminal helpers start a PTY")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fixes the PTY wedge where `c11 new-surface --no-focus` produces zombie surfaces — the panel exists but `ghostty_surface_t` is never created, so `c11 send` silently queues bytes that never reach a shell. Breaks the lattice-orchestrator pattern and every socket-driven script that creates offscreen surfaces.

**Root cause:** `surface.create` is not in `focusIntentV2Methods`, so `v2FocusAllowed` clamps `focus` to `false` regardless of CLI flag. The tab is added without selection, SwiftUI never mounts the cell, AppKit never moves the view into a window, and `attachToView`'s `view.window != nil` guard keeps `ghostty_surface_t` nil. c11's pre-existing recovery hook (`waitForTerminalSurfaceOffMain` → `requestBackgroundSurfaceStartIfNeeded` → `createSurface(for: view)` on an *off-window* view) is the path upstream concluded is unreliable and retreated from.

**Fix (minimal port of manaflow-ai/cmux PR #4233, commit `5cb4715a8`):** install the view in a borderless, alpha-zero, mouse-ignoring `NSWindow` long enough for `ghostty_surface_new` to succeed, then swap to the real portal window when AppKit eventually mounts the view for real. The headless window is invisible, never key/focus, excluded from the windows menu, and released by `attachToView` / `reconcileAttachedWindowIfNeeded` the moment the real window arrives.

### Why "minimal port"

c11 lacks several pre-PR scaffolding pieces upstream had before #4233 (`PendingKeyEvent`, `PendingSocketInput`-with-keys, `sendNamedKey` on `TerminalSurface`, `liveSurfaceForGhosttyAccess`). A full verbatim port would require backfilling 200-300 lines of pre-PR machinery before applying the fix. This PR adopts only the headless-window architectural fix that solves the wedge symptom. The enum-returning send-result contract and localized error strings can be picked up in a follow-on ticket if we want them.

### What changed

- `TerminalSurface`: new `uiWindow` (returns user-facing window, nil for headless), rewritten `isViewInWindow`, new `isHeadlessStartupWindow(_:)`. New `headlessStartupWindow` storage and six helper methods (schedule/start/ensure/release/close/reconcile).
- `TerminalSurface.init`: schedules the headless bootstrap eagerly when `initialCommand != nil` so agent restore paths spawn their PTY before the operator focuses the workspace.
- `requestBackgroundSurfaceStartIfNeeded`: retreats from the broken off-window `createSurface(for: view)` path. If view has a real window, create as before; otherwise delegate to `scheduleHeadlessRuntimeStartIfNeeded`.
- `attachToView`: releases the headless window at both reuse and new-attach paths.
- `forceRefresh`: uses `uiWindow` instead of `view.window` so headless window does not trigger refresh wakeups on the typing hot path.
- `teardownSurface` / `deinit`: close the headless window if still open.
- `GhosttySurfaceScrollView`: new `uiWindow` computed; `debugPortalFrameInWindow`, `isSurfaceViewFirstResponder`, and `refreshSurfaceAfterFocusIfNeeded` updated.
- `GhosttyNSView.attachSurface`: when the surface is already attached, call `reconcileAttachedWindowIfNeeded` so the runtime swaps from headless to real window and re-asserts display id.
- Callers in `AppDelegate`, `Workspace`, `TabManager`, `Panels/TerminalPanel`, `TerminalController`: `hostedView.window != nil` visibility checks → `surface.isViewInWindow`; window-resolution lookups → `surface.uiWindow`.
- Ported upstream regression test to `tests_v2/test_cli_background_terminal_helpers_start_pty.py`.

Provenance: refs `manaflow-ai/cmux` PR #4233 (commit `5cb4715a8`), issues #4187 and #4192. Tracking ticket: Lattice C11-114.

## Test plan

- [x] `xcodebuild -scheme c11 build` clean (worktree + tagged dev build)
- [x] `xcodebuild -scheme c11-logic test` — 870 tests, 3 skipped, 0 failures
- [x] Manual wedge repro against tagged build (`scripts/reload.sh --tag c11-114-pty`): single offscreen surface materializes its PTY immediately; `c11 send` "echo TOKEN" + `c11 read-screen` shows TOKEN
- [x] Stress repro: 30 offscreen surfaces in a loop, every one materializes and echoes its TOKEN (30/30 PASS)
- [x] Sanity: focused `new-pane` still works normally
- [ ] CI: full host-bound `c11Tests` (Xcode tests on the host scheme — left to CI, never run locally per CLAUDE.md)
- [ ] Ported regression test `tests_v2/test_cli_background_terminal_helpers_start_pty.py` run against a tagged build socket
- [ ] Dogfood for typing-latency regression — `forceRefresh` now reads `uiWindow` instead of `view.window`; equivalent cost for non-headless paths but worth a watch

## Out of scope (future tickets if pursued)

- Adopt upstream's enum-returning send-result API (`sendInputResult`, `NamedKeySendResult`) and localized error strings — gains us "honest error" reporting when a surface genuinely can't materialize
- Move `sendNamedKey` from a private `TerminalController` helper up to `TerminalSurface` to match upstream layout
- Refactor `pendingTextQueue` to `pendingSocketInputQueue` (with key events) and adopt upstream's hard-reject-over-cap policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)