### PR TITLE
Release v0.49.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.49.3] - 2026-05-22
+
+Single-fix patch release: offscreen helper surfaces created via `c11 new-surface --no-focus` now actually start a PTY, instead of silently producing a zombie surface that swallows every `c11 send` byte.
+
+### Fixed
+
+- **`c11 new-surface --no-focus` no longer produces a zombie surface that swallows `c11 send` bytes.** `surface.create` was missing from `focusIntentV2Methods`, so `v2FocusAllowed` clamped `focus` to `false` regardless of the `--no-focus` flag's intent. The tab landed without selection, SwiftUI never mounted the cell, AppKit never moved the view into a window, and `attachToView`'s `view.window != nil` guard kept `ghostty_surface_t` nil — every subsequent `c11 send` queued bytes that never reached a shell. The fix is a minimal port of upstream cmux PR #4233 (`5cb4715a8`): install the view in a borderless, alpha-zero, mouse-ignoring helper window long enough for `ghostty_surface_new` to succeed, then swap to the real portal window when AppKit eventually mounts the view. Unblocks every lattice-orchestrator pattern and every socket-driven script that creates offscreen surfaces. ([#199](https://github.com/Stage-11-Agentics/c11/pull/199))
+
+### Built and shipped by
+
+Stage 11 Agentics. Operator:agent, fused.
+
 ## [0.49.2] - 2026-05-21
 
 Single-fix patch release for a Japanese / Chinese IME regression reported against 0.49.x. Korean IME behaviour is unchanged.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -1649,10 +1649,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1730,7 +1730,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1740,7 +1740,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1771,7 +1771,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1781,7 +1781,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -1849,10 +1849,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1867,14 +1867,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1889,14 +1889,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1912,10 +1912,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1931,10 +1931,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 105;
+				CURRENT_PROJECT_VERSION = 106;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.49.2;
+				MARKETING_VERSION = 0.49.3;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Single-fix patch release for #199.

## Summary

Bumps to **v0.49.3**. Lands the offscreen-helper PTY startup fix on top of v0.49.2.

## Changelog

### Fixed

- **`c11 new-surface --no-focus` no longer produces a zombie surface that swallows `c11 send` bytes.** `surface.create` was missing from `focusIntentV2Methods`, so `v2FocusAllowed` clamped `focus` to `false` regardless of intent. The tab landed without selection, SwiftUI never mounted the cell, AppKit never moved the view into a window, and `attachToView`'s `view.window != nil` guard kept `ghostty_surface_t` nil — every subsequent `c11 send` queued bytes that never reached a shell. Minimal port of upstream cmux PR #4233 (`5cb4715a8`): install the view in a borderless, alpha-zero, mouse-ignoring helper window long enough for `ghostty_surface_new` to succeed, then swap to the real portal window when AppKit eventually mounts the view. Unblocks every lattice-orchestrator pattern and every socket-driven script that creates offscreen surfaces. (#199)

## Test plan

- [ ] CI: full suite must pass on this PR before merge.
- [ ] Verify the fix end-to-end: from one c11 surface, `c11 new-surface --no-focus` into another workspace, then `c11 send --surface <new> "echo ok"` — the receiving surface should show the echo within a heartbeat, not queue bytes silently.

## Security threat-model recheck

`AppDelegate.swift` is in the monitored surface list; the diff is a `hostedView.window != nil` → `terminalPanel.surface.isViewInWindow` accessor swap at two existing call sites — part of the #199 helper-window abstraction, not new attack surface. URL handler (`application(_:open:)`), WebKit configuration, socket settings, entitlements, sdef: untouched.