### PR TITLE
C11-117: focus tab before showing close-confirm overlay

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2862,6 +2862,15 @@ class TabManager: ObservableObject {
                 defaultValue: "This will close the workspace \u{201C}%@\u{201D} and all of its panes."
             )
             let message = String(format: format, locale: .current, displayName)
+            // Off-screen workspaces are isHidden=true (perf #127), so their anchor
+            // view doesn't report a window-coord frame and the overlay would bail
+            // on `guard let anchor`. When the operator clicks the X on a background
+            // tab we first switch selection to that workspace so it becomes the
+            // visible one; the confirm card then mounts on the workspace being
+            // closed, matching what the dialog references. (C11-117)
+            if selectedTabId != workspace.id {
+                selectWorkspace(workspace)
+            }
             // Test seam: synchronous handler short-circuits the overlay flow so
             // unit tests can exercise the close path without a window.
             if let handler = workspaceCloseConfirmationHandler {
@@ -2873,17 +2882,9 @@ class TabManager: ObservableObject {
             // content area only, with a centered confirm/cancel card. Lands above
             // portal-hosted terminal/browser content via themeFrame mount. Sidebar
             // stays visible. Plan §3.1, §3.3.
-            //
-            // Host vs target: off-screen workspaces are isHidden=true (perf #127),
-            // so their anchor view doesn't report a window-coord frame and the
-            // overlay controller bails on `guard let anchor`. Mounting on the
-            // currently-selected workspace guarantees the card is visible; the
-            // dialog message already names the workspace being closed, so the
-            // operator still knows what they're confirming.
-            let host = selectedWorkspace ?? workspace
-            Task { @MainActor [weak self, weak workspace, weak host] in
-                guard let self, let workspace, let host else { return }
-                let accepted = await host.presentConfirmCloseWorkspace(
+            Task { @MainActor [weak self, weak workspace] in
+                guard let self, let workspace else { return }
+                let accepted = await workspace.presentConfirmCloseWorkspace(
                     title: title,
                     message: message,
                     source: .local

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10835,6 +10835,16 @@ extension Workspace: BonsplitDelegate {
                     // If the tab disappeared while we were scheduling, do nothing.
                     guard self.panelIdFromSurfaceId(tabId) != nil else { return }
 
+                    // C11-117: clicking X on a background pane-tab anchors the
+                    // confirm overlay on a panel that isn't on-screen (the pane
+                    // only renders the selected tab's panel), so the operator
+                    // doesn't see the dialog until they manually click the tab.
+                    // Bring the tab to the front first so the overlay mounts
+                    // where the operator is looking.
+                    if self.bonsplitController.selectedTab(inPane: pane)?.id != tabId {
+                        self.bonsplitController.selectTab(tabId)
+                    }
+
                     let confirmed = await self.confirmClosePanel(for: tabId)
                     guard confirmed else { return }
 

--- a/c11Tests/TabManagerUnitTests.swift
+++ b/c11Tests/TabManagerUnitTests.swift
@@ -189,6 +189,66 @@ final class TabManagerCloseWorkspacesWithConfirmationTests: XCTestCase {
         XCTAssertEqual(manager.tabs.map(\.title), ["Alpha", "Beta"])
     }
 
+    func testCloseWorkspaceWithConfirmationOnBackgroundTabFocusesItBeforePrompting() {
+        // C11-117: clicking the X on a background sidebar tab must select that
+        // workspace before the close-confirm overlay is shown, so the dialog
+        // mounts on the workspace being closed rather than the previously-visible
+        // one.
+        let envKey = "CMUX_UI_TEST_FORCE_CONFIRM_CLOSE_WORKSPACE"
+        setenv(envKey, "1", 1)
+        defer { unsetenv(envKey) }
+
+        let manager = TabManager()
+        let foreground = manager.tabs[0]
+        let background = manager.addWorkspace()
+        manager.selectWorkspace(foreground)
+        XCTAssertEqual(manager.selectedTabId, foreground.id)
+
+        var selectedTabIdWhenPrompted: UUID?
+        manager.workspaceCloseConfirmationHandler = { [weak manager] _, _ in
+            selectedTabIdWhenPrompted = manager?.selectedTabId
+            return false
+        }
+
+        manager.closeWorkspaceWithConfirmation(background)
+
+        XCTAssertEqual(
+            selectedTabIdWhenPrompted,
+            background.id,
+            "Expected the background tab to be selected before the confirmation prompt fires"
+        )
+        XCTAssertEqual(manager.selectedTabId, background.id)
+        XCTAssertEqual(
+            manager.tabs.map(\.id),
+            [foreground.id, background.id],
+            "Both workspaces remain because the operator cancelled"
+        )
+    }
+
+    func testCloseWorkspaceWithConfirmationOnForegroundTabKeepsSelection() {
+        // The foreground-tab case is the no-op: selection already matches, the
+        // confirm prompt fires once, and selection stays unchanged.
+        let envKey = "CMUX_UI_TEST_FORCE_CONFIRM_CLOSE_WORKSPACE"
+        setenv(envKey, "1", 1)
+        defer { unsetenv(envKey) }
+
+        let manager = TabManager()
+        let foreground = manager.tabs[0]
+        _ = manager.addWorkspace()
+        XCTAssertEqual(manager.selectedTabId, foreground.id)
+
+        var promptCount = 0
+        manager.workspaceCloseConfirmationHandler = { _, _ in
+            promptCount += 1
+            return false
+        }
+
+        manager.closeWorkspaceWithConfirmation(foreground)
+
+        XCTAssertEqual(promptCount, 1)
+        XCTAssertEqual(manager.selectedTabId, foreground.id)
+    }
+
     func testCloseCurrentWorkspaceWithConfirmationUsesSidebarMultiSelection() {
         let manager = TabManager()
         let second = manager.addWorkspace()


### PR DESCRIPTION
## Summary

Clicking the X on a background tab — either a sidebar workspace tab or a Bonsplit pane-tab — used to anchor the close-confirm dialog somewhere the operator wasn't looking. The fix selects the target tab first so the overlay mounts where the operator's eyes are.

Two close-confirm code paths were affected, fixed independently:

1. **Sidebar workspace tab X** (`Sources/TabManager.swift` `closeWorkspaceIfRunningProcess`). Off-screen workspaces are `isHidden=true` (perf #127); their anchor view reports no window-coord frame, so the previous code anchored on `selectedWorkspace ?? workspace` and kept the dialog on whatever workspace was already visible. Switch selection to the target first, then mount the overlay on it. The previous `host = selectedWorkspace ?? workspace` indirection collapses away.
2. **Bonsplit pane-tab X** (`Sources/Workspace.swift` `splitTabBar(_:shouldCloseTab:inPane:)`). A pane only renders its currently-selected tab's panel; clicking X on a background tab anchored the confirm overlay on a panel that wasn't being rendered, so the dialog was invisible until the operator manually switched. Switch the pane's selected tab to the close target before presenting the overlay.

Out of scope: the multi-close summary path (multiple sidebar selection or Cmd+Shift+W with multi-select) intentionally still anchors on `selectedWorkspace ?? workspaces.first` — selecting one of several would be arbitrary.

## Test plan

- [x] `xcodebuild -scheme c11-logic test` — 899/899 passing, no regressions.
- [x] `xcodebuild -scheme c11-unit build-for-testing` — c11Tests + c11LogicTests both compile clean.
- [x] New unit tests in `c11Tests/TabManagerUnitTests.swift` (host-bound, validated in CI per local-test policy):
  - `testCloseWorkspaceWithConfirmationOnBackgroundTabFocusesItBeforePrompting`: clicking X on a background workspace selects it before the confirm handler fires.
  - `testCloseWorkspaceWithConfirmationOnForegroundTabKeepsSelection`: foreground workspace case prompts once, selection stays.
- [x] Operator-validated against a tagged dev build (`c11 DEV c11-117.app`): pane-tab X now brings the tab to the front and surfaces the confirm card on it.

Lattice ticket: C11-117.