### PR TITLE
New Workspace dialog: double-click to launch, fix centering

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6452,6 +6452,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let initialDirectory = focusedWorkspaceWorkingDirectory()
             ?? FileManager.default.homeDirectoryForCurrentUser.path
 
+        // Capture the operator's current screen before activating the dialog.
+        // NSWindow.center() always targets NSScreen.main (the menu-bar screen);
+        // on multi-monitor setups that misplaces the dialog off the screen the
+        // operator is actually working on. Read this now while the active main
+        // window is still key.
+        let targetScreen = NSApp.keyWindow?.screen
+            ?? NSApp.mainWindow?.screen
+            ?? NSScreen.main
+
         let rootView = CreateWorkspaceSheet(
             initialDirectory: initialDirectory,
             onCancel: { [weak self] in self?.createWorkspaceSheetWindow?.close() },
@@ -6483,9 +6492,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
         window.isReleasedWhenClosed = false
         window.level = .modalPanel
-        window.center()
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
+        // Defer centering: NSHostingController with .preferredContentSize
+        // syncs the window's content size during SwiftUI's first layout pass,
+        // so center()'ing before makeKey runs against a smaller-than-final
+        // frame and the dialog lands off-center once it grows. Position on
+        // the captured screen, with the standard HIG "1/3 from the top"
+        // vertical placement.
+        DispatchQueue.main.async { [weak window] in
+            guard let window, let screen = targetScreen else { return }
+            let visible = screen.visibleFrame
+            let frame = window.frame
+            let x = visible.origin.x + (visible.width - frame.width) / 2
+            let y = visible.origin.y + (visible.height - frame.height) * 2.0 / 3.0
+            window.setFrameOrigin(NSPoint(x: x, y: y))
+        }
         createWorkspaceSheetWindow = window
         createWorkspaceSheetCloseObserver = NotificationCenter.default.addObserver(
             forName: NSWindow.willCloseNotification,

--- a/Sources/CreateWorkspaceSheet.swift
+++ b/Sources/CreateWorkspaceSheet.swift
@@ -681,50 +681,60 @@ struct CreateWorkspaceSheet: View {
     @ViewBuilder
     private func blueprintCard(_ entry: BlueprintEntry, showLetters: Bool) -> some View {
         let isSelected = entry.id == selectionId
-        Button {
-            selectionId = entry.id
-            CreateWorkspaceLastLayout.save(entry.id)
-        } label: {
-            VStack(alignment: .center, spacing: 10) {
-                if showLetters, let topology = entry.shape.letterTopology {
-                    LetterCellIcon(topology: topology)
-                        .frame(width: 132, height: 78)
-                } else {
-                    OutlineShapeIcon(shape: entry.shape)
-                        .frame(width: 132, height: 78)
-                }
-                Text(entry.label)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(BrandColors.whiteSwiftUI)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                if let description = entry.description {
-                    Text(description)
-                        .font(.system(size: 11))
-                        .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.55))
-                        .multilineTextAlignment(.center)
-                        .lineLimit(3)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer(minLength: 0)
+        VStack(alignment: .center, spacing: 10) {
+            if showLetters, let topology = entry.shape.letterTopology {
+                LetterCellIcon(topology: topology)
+                    .frame(width: 132, height: 78)
+            } else {
+                OutlineShapeIcon(shape: entry.shape)
+                    .frame(width: 132, height: 78)
             }
-            .frame(width: 176, height: 168, alignment: .top)
-            .padding(.vertical, 14)
-            .padding(.horizontal, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(isSelected ? BrandColors.goldFaintSwiftUI : BrandColors.surface2SwiftUI)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(
-                        isSelected ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI,
-                        lineWidth: isSelected ? 1.5 : 0.5
-                    )
-            )
-            .contentShape(RoundedRectangle(cornerRadius: 10))
+            Text(entry.label)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(BrandColors.whiteSwiftUI)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            if let description = entry.description {
+                Text(description)
+                    .font(.system(size: 11))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.55))
+                    .multilineTextAlignment(.center)
+                    .lineLimit(3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
         }
-        .buttonStyle(.plain)
+        .frame(width: 176, height: 168, alignment: .top)
+        .padding(.vertical, 14)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isSelected ? BrandColors.goldFaintSwiftUI : BrandColors.surface2SwiftUI)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(
+                    isSelected ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI,
+                    lineWidth: isSelected ? 1.5 : 0.5
+                )
+        )
+        .contentShape(RoundedRectangle(cornerRadius: 10))
+        // Mirror the RecentRow gesture composition: single-click selects,
+        // double-click selects and submits. A SwiftUI Button swallows the
+        // second click, so the card is a plain View with composed taps.
+        .gesture(
+            TapGesture(count: 2).onEnded {
+                selectionId = entry.id
+                CreateWorkspaceLastLayout.save(entry.id)
+                submit()
+            }
+        )
+        .simultaneousGesture(
+            TapGesture(count: 1).onEnded {
+                selectionId = entry.id
+                CreateWorkspaceLastLayout.save(entry.id)
+            }
+        )
     }
 
     private var starterEntries: [BlueprintEntry] {


### PR DESCRIPTION
## Summary

Two small tweaks to the New Workspace dialog (`CreateWorkspaceSheet` + its presenter in `AppDelegate`).

### 1. Double-click a layout tile to launch (commit 1)
`CreateWorkspaceSheet.blueprintCard` only responded to single-click selection; the operator had to cross the dialog to the Create button to launch. Now double-click selects **and** submits, mirroring the existing double-click-a-folder behavior on `RecentRow` (`Sources/CreateWorkspaceSheet.swift:930-935`). Single-click still selects; visual styling is unchanged.

The card had to drop SwiftUI `Button` for a plain View with composed `.gesture(TapGesture(count: 2))` + `.simultaneousGesture(TapGesture(count: 1))` — `Button` swallows the second click of a count-2 tap. Same pattern as `RecentRow`.

### 2. Center the dialog on the operator's screen (commit 2)
`NSWindow.center()` had two problems for this dialog:

- **It ran before SwiftUI's layout settled.** `NSHostingController` with `.preferredContentSize` syncs the window's content size during the first layout pass, so `center()` positioned a smaller-than-final frame; the dialog landed off-center once it grew.
- **It always targets `NSScreen.main`** (the menu-bar screen). On multi-monitor setups it misplaces the dialog onto the wrong display.

Fix: capture the active main window's screen before activating the dialog, then center against its `visibleFrame` in a `DispatchQueue.main.async` block so the content size has settled. Uses standard HIG "1/3 from the top" vertical placement.

## Test plan

- [ ] File → New Workspace → double-click any layout tile → dialog closes and the new workspace appears with that layout applied
- [ ] Single-click a layout tile → tile selects (gold border) but dialog stays open (regression check on existing behavior)
- [ ] Open dialog on a single-monitor setup → dialog appears centered horizontally, ~1/3 from the top
- [ ] Open dialog with the active c11 window on a secondary monitor → dialog appears on that monitor, not the menu-bar monitor
- [ ] Open dialog, close it, reopen → no off-center jitter on second open
- [ ] Keyboard flow unchanged: arrows still navigate recents, Return still opens highlighted recent

🤖 Generated with [Claude Code](https://claude.com/claude-code)