### PR TITLE
BrowserPanelView: add "Open in Default Browser" toolbar button

### DIFF
--- a/.lattice/plans/task_01KSJQFW9SHAG8K11JNWVCPJ6W.md
+++ b/.lattice/plans/task_01KSJQFW9SHAG8K11JNWVCPJ6W.md
@@ -1,0 +1,77 @@
+# Plan: C11-118 — Browser "Open in Default Browser" toolbar button
+
+## 1. Insertion points in `Sources/Panels/BrowserPanelView.swift`
+
+- **HStack call-site, line 871–874:** insert `openInExternalBrowserButton` between `browserProfileButton` and `browserThemeModeButton`.
+- **View definition section:** add `openInExternalBrowserButton` computed property immediately after `browserProfileButton` (ends line 1005) and before `browserThemeModeButton` (begins line 1007).
+- **Predicate:** add `canPopOutCurrentURL` near the other browser predicates (e.g. just above the new button definition).
+
+## 2. The button view
+
+```swift
+private var openInExternalBrowserButton: some View {
+    Button(action: {
+        guard let url = panel.currentURL, canPopOutCurrentURL else { return }
+        NSWorkspace.shared.open(url)
+    }) {
+        Image(systemName: "arrow.up.right.square")
+            .symbolRenderingMode(.monochrome)
+            .cmuxFlatSymbolColorRendering()
+            .font(.system(size: devToolsButtonIconSize, weight: .medium))
+            .foregroundStyle(devToolsColorOption.color)
+            .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+    }
+    .buttonStyle(OmnibarAddressButtonStyle())
+    .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+    .disabled(!canPopOutCurrentURL)
+    .opacity(canPopOutCurrentURL ? 1.0 : 0.4)
+    .safeHelp(String(localized: "browser.openExternal.help", defaultValue: "Open in Default Browser"))
+    .accessibilityLabel(String(localized: "browser.openExternal.accessibilityLabel", defaultValue: "Open in default browser"))
+    .accessibilityIdentifier("BrowserOpenExternalButton")
+}
+```
+
+Mirrors `browserProfileButton` for style (OmnibarAddressButtonStyle, addressBarButtonSize, cmuxFlatSymbolColorRendering, devToolsColorOption tint) and the back/forward button pattern for the disabled-state opacity dimming.
+
+## 3. The predicate
+
+```swift
+private var canPopOutCurrentURL: Bool {
+    guard let url = panel.currentURL else { return false }
+    let scheme = url.scheme?.lowercased() ?? ""
+    if scheme.isEmpty || scheme == "about" { return false }
+    return true
+}
+```
+
+`panel.currentURL: URL?` is `@Published` (see `Sources/Panels/BrowserPanel.swift:2128`), so SwiftUI re-evaluates the predicate when navigation lands.
+
+## 4. New xcstrings keys
+
+Two new entries in `Resources/Localizable.xcstrings`:
+
+| Key | en source |
+|---|---|
+| `browser.openExternal.help` | `Open in Default Browser` |
+| `browser.openExternal.accessibilityLabel` | `Open in default browser` |
+
+English value lives in `defaultValue:` at the call site; xcstrings entry holds the en source-of-truth plus a stringUnit per locale. Following the existing pattern for `browser.profile.buttonHelp` (line 10414) and `browser.theme.buttonHelp` (line 11072), I'll insert the new entries in alphabetical order. Six locales (ja/uk/ko/zh-Hans/zh-Hant/ru) start empty — translator fills them.
+
+## 5. Imports
+
+`AppKit` is already imported (line 5), so `NSWorkspace.shared.open(_:)` is available without changes.
+
+## 6. Translator sub-agent
+
+After the implementation commit lands the English entries, spawn a translator in a fresh c11 split. Prompt file at `/tmp/c11-118-translator-prompt.md`. Translator's scope: the two new keys, six locales, second commit on `feat/browser-popout-button`, nothing else.
+
+## 7. Verification
+
+1. `xcodebuild -project GhosttyTabs.xcodeproj -scheme c11-logic -configuration Debug -destination "platform=macOS" build` — green compile.
+2. Self-review against the 8 acceptance criteria.
+3. Optionally `./scripts/reload.sh --tag popout-btn` for an operator-visible tagged build (mention tag in final report).
+4. Open PR.
+
+## 8. Out of scope (confirming)
+
+No menu wiring, no keyboard shortcut, no right-click entry, no "open in specific browser" submenu, no surface-close-after-popout, no changes to `panel.currentURL` plumbing, no new tests (mock-only fakes blocked by c11 test-quality policy).

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -10278,6 +10278,42 @@
             "state": "translated",
             "value": "Open in default browser"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトブラウザで開く"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 브라우저에서 열기"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть в браузере по умолчанию"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити в браузері за замовчуванням"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在默认浏览器中打开"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在預設瀏覽器中開啟"
+          }
         }
       }
     },
@@ -10288,6 +10324,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "Open in Default Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトブラウザで開く"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본 브라우저에서 열기"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть в браузере по умолчанию"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити в браузері за замовчуванням"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在默认浏览器中打开"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在預設瀏覽器中開啟"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -10270,6 +10270,28 @@
         }
       }
     },
+    "browser.openExternal.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in default browser"
+          }
+        }
+      }
+    },
+    "browser.openExternal.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in Default Browser"
+          }
+        }
+      }
+    },
     "browser.openInDefaultBrowser": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -869,6 +869,7 @@ struct BrowserPanelView: View {
                     browserImportHintToolbarChip
                 }
                 browserProfileButton
+                openInExternalBrowserButton
                 browserThemeModeButton
                 developerToolsButton
             }
@@ -1002,6 +1003,34 @@ struct BrowserPanelView: View {
             )
         )
         .accessibilityIdentifier("BrowserProfileButton")
+    }
+
+    private var canPopOutCurrentURL: Bool {
+        guard let url = panel.currentURL else { return false }
+        let scheme = url.scheme?.lowercased() ?? ""
+        if scheme.isEmpty || scheme == "about" { return false }
+        return true
+    }
+
+    private var openInExternalBrowserButton: some View {
+        Button(action: {
+            guard let url = panel.currentURL, canPopOutCurrentURL else { return }
+            NSWorkspace.shared.open(url)
+        }) {
+            Image(systemName: "arrow.up.right.square")
+                .symbolRenderingMode(.monochrome)
+                .cmuxFlatSymbolColorRendering()
+                .font(.system(size: devToolsButtonIconSize, weight: .medium))
+                .foregroundStyle(devToolsColorOption.color)
+                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        }
+        .buttonStyle(OmnibarAddressButtonStyle())
+        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        .disabled(!canPopOutCurrentURL)
+        .opacity(canPopOutCurrentURL ? 1.0 : 0.4)
+        .safeHelp(String(localized: "browser.openExternal.help", defaultValue: "Open in Default Browser"))
+        .accessibilityLabel(String(localized: "browser.openExternal.accessibilityLabel", defaultValue: "Open in default browser"))
+        .accessibilityIdentifier("BrowserOpenExternalButton")
     }
 
     private var browserThemeModeButton: some View {


### PR DESCRIPTION
## Summary

Adds a one-click pop-out button to the c11 browser surface. The currently loaded URL opens in the system default browser via `NSWorkspace.shared.open(_:)`. The c11 surface stays put.

- **Placement:** right accessory cluster, between Profile and Theme.
- **Icon:** `arrow.up.right.square` (Apple's standard external-link glyph).
- **Tooltip:** "Open in Default Browser" (localized to all six c11 locales).
- **Disabled state:** `panel.currentURL` is nil OR scheme is empty/`about:`. Mirrors back/forward dimming pattern (40% opacity).
- **Keyboard shortcut:** none in v1 (browser surfaces are already congested for Cmd-keys; icon is discoverable).
- **AX identifier:** `BrowserOpenExternalButton`.

Closes C11-118.

### Localization

Two new keys: `browser.openExternal.help` (tooltip) and `browser.openExternal.accessibilityLabel` (VoiceOver). The existing `browser.openInDefaultBrowser` key already carried the identical English phrase with all six target locales translated — translations were copied verbatim in commit 2 rather than re-spawning a translator pane.

## Test plan

- [x] Logic build green: `xcodebuild -project GhosttyTabs.xcodeproj -scheme c11-logic build`
- [ ] Tagged build: `./scripts/reload.sh --tag popout-btn` and visually confirm the button sits between Profile and Theme on a browser surface
- [ ] Load `https://example.com`, click the button → opens in macOS default browser, c11 surface stays
- [ ] New-tab page (no URL): button renders disabled (40% opacity, no action on click)
- [ ] Hover shows tooltip "Open in Default Browser"
- [ ] AX identifier `BrowserOpenExternalButton` present (verify in Accessibility Inspector if convenient)

Generated with [Claude Code](https://claude.com/claude-code)