### PR TITLE
Add Grok Build as a first-class c11 coding agent

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -10925,7 +10925,7 @@ struct CMUXCLI {
 
         case "set":
             guard commandArgs.count >= 2 else {
-                let valid = ["claude-code", "codex", "kimi", "opencode", "custom"].joined(separator: ", ")
+                let valid = ["claude-code", "codex", "grok", "kimi", "opencode", "custom"].joined(separator: ", ")
                 throw CLIError(message: "default-agent set requires <type>. Valid: \(valid)")
             }
             let response = try sendV1Command("default_agent set \(commandArgs[1])", client: client)

--- a/Sources/AgentChip.swift
+++ b/Sources/AgentChip.swift
@@ -122,6 +122,8 @@ enum AgentChipResolver {
             return "AgentIcons/claude-code"
         case "codex":
             return "AgentIcons/codex"
+        case "grok":
+            return "AgentIcons/grok"
         case "kimi":
             return "AgentIcons/kimi"
         case "opencode":
@@ -141,6 +143,7 @@ enum AgentChipResolver {
         switch terminalType {
         case "claude-code":  return "sparkles"
         case "codex":        return "chevron.left.forwardslash.chevron.right"
+        case "grok":         return "bolt.fill"
         case "kimi":         return "moon.stars"
         case "opencode":     return "curlybraces"
         case "shell":        return "terminal.fill"

--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -223,6 +223,8 @@ final class AgentDetector: @unchecked Sendable {
             return "claude-code"
         case "codex", "codex-cli":
             return "codex"
+        case "grok", "grok-cli", "grok-pager":
+            return "grok"
         case "kimi", "kimi-cli":
             return "kimi"
         case "opencode", "opencode-cli":

--- a/Sources/AgentRestartRegistry.swift
+++ b/Sources/AgentRestartRegistry.swift
@@ -145,7 +145,8 @@ struct AgentRestartRegistry: Sendable {
     ///
     /// Codex uses `--last` best-effort to resume the most recent session
     /// globally. Opencode and kimi have no verified resume flag and launch
-    /// fresh — best-effort is preferable to a broken flag.
+    /// fresh — best-effort is preferable to a broken flag. Grok supports
+    /// `--resume` without an id to attach to the most recent session.
     static let phase1: AgentRestartRegistry = .init(name: "phase1", rows: [
         Row(terminalType: "claude-code") { sessionId, metadata in
             guard let raw = sessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -172,6 +173,11 @@ struct AgentRestartRegistry: Sendable {
             // codex resume --last resumes the most recent codex session globally.
             // Best-effort: may not match the exact session in the snapshot.
             "codex resume --last\n"
+        },
+        Row(terminalType: "grok") { _, _ in
+            // grok --resume (no id) attaches to the most recent session.
+            // Best-effort: may not match the exact session in the snapshot.
+            "grok --always-approve --resume\n"
         },
         Row(terminalType: "opencode") { _, _ in
             // no stable resume flag known; launches fresh.

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -561,6 +561,7 @@ struct AgentSkillsOnboardingSheet: View {
 
     @State private var claudeOptIn: Bool = false
     @State private var codexOptIn: Bool = false
+    @State private var grokOptIn: Bool = false
     @State private var kimiOptIn: Bool = false
     @State private var opencodeOptIn: Bool = false
     @State private var initializedDefaultOptIns: Bool = false
@@ -607,7 +608,7 @@ struct AgentSkillsOnboardingSheet: View {
     }
 
     private var anySelected: Bool {
-        initializedDefaultOptIns && (claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn)
+        initializedDefaultOptIns && (claudeOptIn || codexOptIn || grokOptIn || kimiOptIn || opencodeOptIn)
     }
 
     private var hasActionNeeded: Bool {
@@ -909,6 +910,7 @@ struct AgentSkillsOnboardingSheet: View {
         switch target {
         case .claude: return $claudeOptIn
         case .codex: return $codexOptIn
+        case .grok: return $grokOptIn
         case .kimi: return $kimiOptIn
         case .opencode: return $opencodeOptIn
         }
@@ -918,6 +920,7 @@ struct AgentSkillsOnboardingSheet: View {
         let selections: [(SkillInstallerTarget, Bool)] = [
             (.claude, claudeOptIn),
             (.codex, codexOptIn),
+            (.grok, grokOptIn),
             (.kimi, kimiOptIn),
             (.opencode, opencodeOptIn),
         ]
@@ -986,6 +989,7 @@ struct AgentSkillsOnboardingSheet: View {
         let defaults = AgentSkillsOnboarding.defaultOptIns(for: rows)
         claudeOptIn = defaults[.claude] ?? false
         codexOptIn = defaults[.codex] ?? false
+        grokOptIn = defaults[.grok] ?? false
         kimiOptIn = defaults[.kimi] ?? false
         opencodeOptIn = defaults[.opencode] ?? false
     }

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -6,6 +6,7 @@ import Foundation
 enum AgentType: String, Codable, CaseIterable, Identifiable {
     case claudeCode = "claude-code"
     case codex
+    case grok
     case kimi
     case opencode
     case custom
@@ -20,6 +21,8 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
             return String(localized: "agentType.claudeCode", defaultValue: "Claude Code")
         case .codex:
             return String(localized: "agentType.codex", defaultValue: "Codex")
+        case .grok:
+            return String(localized: "agentType.grok", defaultValue: "Grok Build")
         case .kimi:
             return String(localized: "agentType.kimi", defaultValue: "Kimi")
         case .opencode:
@@ -36,6 +39,7 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .claudeCode: return "claude --dangerously-skip-permissions"
         case .codex:      return "codex --yolo"
+        case .grok:       return "grok --always-approve"
         case .kimi:       return "kimi"
         case .opencode:   return "opencode run --dangerously-skip-permissions"
         case .custom:     return ""

--- a/Sources/SkillInstaller.swift
+++ b/Sources/SkillInstaller.swift
@@ -6,6 +6,7 @@ import CryptoKit
 enum SkillInstallerTarget: String, CaseIterable {
     case claude
     case codex
+    case grok
     case kimi
     case opencode
 
@@ -13,6 +14,7 @@ enum SkillInstallerTarget: String, CaseIterable {
         switch self {
         case .claude: return "Claude Code"
         case .codex: return "Codex"
+        case .grok: return "Grok Build"
         case .kimi: return "Kimi"
         case .opencode: return "OpenCode"
         }

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -33,7 +33,7 @@ public enum MetadataKey {
     ]
 
     public static let canonicalTerminalTypes: Set<String> = [
-        "claude-code", "codex", "kimi", "opencode", "shell", "unknown"
+        "claude-code", "codex", "grok", "kimi", "opencode", "shell", "unknown"
     ]
 }
 

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -30,6 +30,12 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
     }
 
+    func testFactoryGrokCommandIncludesAlwaysApprove() {
+        let entry = AgentConfig.factory(for: .grok)
+        XCTAssertEqual(entry.command, "grok --always-approve")
+        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+    }
+
     func testFactoryCustomHasEmptyDefaults() {
         let entry = AgentConfig.factory(for: .custom)
         XCTAssertEqual(entry.command, "")

--- a/docs/adding-a-new-agent.md
+++ b/docs/adding-a-new-agent.md
@@ -1,0 +1,90 @@
+# Adding a new coding agent to c11
+
+c11 treats coding agents (Claude Code, Codex, Grok Build, Kimi, OpenCode) as first-class peers: each one is in the A-button picker, gets an icon in the sidebar chip, auto-detects from process listings, can install c11 skills into its config dir, and resumes across snapshots. Adding a new one is mechanical — there's a fixed set of surfaces to extend.
+
+This doc is the checklist. Grok Build is the worked example; replace `grok` / `Grok Build` / `--always-approve` with the new agent's name/flag wherever they appear.
+
+## Pre-flight
+
+Before editing code, capture three facts about the new agent:
+
+1. **Binary name.** What runs on PATH (`grok`, `aider`, `cursor-cli`, …).
+2. **Auto-approve flag.** The CLI flag that bypasses per-tool confirmation prompts — c11 launches agents in that mode by default (parallel to `claude --dangerously-skip-permissions`, `codex --yolo`, `grok --always-approve`, `opencode run --dangerously-skip-permissions`). If the agent has no such mode, leave it bare; flag it in the contributor commit so reviewers know.
+3. **Resume command.** How the agent picks up its most recent session. `grok --resume`, `codex resume --last`, etc. If there's no stable resume flag, the restart registry launches fresh — best-effort, same as Kimi/OpenCode today.
+
+If the agent's config root convention is `~/.<name>/` (Claude → `~/.claude/`, Grok → `~/.grok/`), the `SkillInstaller` will wire up automatically once you add the enum case. If it isn't, you'll need a small override there too — flag it.
+
+## The surfaces to update
+
+All paths are relative to `code/c11/`. Order doesn't matter — the changes are independent.
+
+### Required (without these the agent does not work as a c11 agent)
+
+1. **`Sources/DefaultAgentConfig.swift` — `AgentType` enum.** Add a new `case` with kebab-case raw value. Extend the three switch statements (`displayName`, `factoryCommand`, `factoryInitialPrompt`). `displayName` uses `String(localized:)` — write English only; spawn a localization sub-agent after (see `CLAUDE.md` → Localization).
+
+2. **`Sources/SurfaceMetadataStore.swift` — `canonicalTerminalTypes`.** Add the kebab-case string. Without this, the sidebar treats the new agent as `unknown` even when explicitly declared.
+
+3. **`CLI/c11.swift` — `default-agent set` valid-types message.** Search for the hard-coded `["claude-code", "codex", ...]` list and add the new value. CLI ergonomics only — the resolver is enum-driven and accepts the new case automatically.
+
+4. **`Sources/AgentChip.swift` — icon mapping.**
+   - `iconAssetName(forTerminalType:)`: add a case returning `"AgentIcons/<type>"`.
+   - `sfSymbolFallback(forTerminalType:)`: pick an SF Symbol that visually distinguishes the agent. Used until a real asset ships in `Assets.xcassets/AgentIcons/`. Existing fallbacks: `sparkles`, `chevron.left.forwardslash.chevron.right`, `bolt.fill`, `moon.stars`, `curlybraces`. Avoid collisions; the chip is the operator's at-a-glance identifier.
+
+5. **`Sources/AgentDetector.swift` — heuristic `classify`.** Add the binary name(s) to the exact `comm` match. If the binary is wrapped by `node`, add an `args` substring match in the node branch. The detector reads process listings — it does not screen-scrape banners (don't add banner matching; it drifts across releases).
+
+### Strongly recommended (parity with existing agents)
+
+6. **`Sources/AgentRestartRegistry.swift` — `phase1` rows.** Add a `Row(terminalType: "<type>")` with a resolver closure that returns the resume command string (trailing `\n` preserved). If the agent has no resume flag, return a fresh launch command — best-effort matches Kimi/OpenCode.
+
+7. **`Sources/SkillInstaller.swift` — `SkillInstallerTarget`.** Add the enum case (raw value lower-case, matches the `~/.<name>/` config root convention). `displayName` is the user-facing label. Skill files install into `~/.<name>/skills/` automatically.
+
+8. **`Sources/AgentSkillsView.swift` — onboarding sheet opt-ins.** Add `@State private var <name>OptIn: Bool = false`, then thread it through `anySelected`, `optInBinding(for:)`, `applySelection()`, and `applyDefaultOptIns(rows:)`. The Settings view inherits from `AgentType.allCases`, so no extra work there.
+
+### Documentation
+
+9. **`skills/c11/SKILL.md`** — extend the "Common types" list and the per-TUI prompt-delivery one-liner under "Launching sub-agents."
+
+10. **`skills/c11/references/api.md`** — extend the `CMUX_AGENT_TYPE` env-var description and the `--type` accepted-values bullet.
+
+11. **`skills/c11/references/metadata.md`** — extend the `terminal_type` canonical values list.
+
+12. **`skills/c11/references/orchestration.md`** — add a `### <agent>` subsection under "Per-agent launch quirks." Document the auto-approve flag, any auth gotchas, and whether the agent self-reports via the skill or needs special handling.
+
+### Tests
+
+13. **`c11Tests/DefaultAgentConfigTests.swift`** — add a `testFactory<Name>CommandIncludes<Flag>` mirroring the existing claude/codex/grok tests. `testFactoryDefaultsHaveAllAgents` and the codable round-trip tests cover the new case automatically via `AgentType.allCases`.
+
+## Run the tests
+
+```bash
+cd code/c11
+xcodebuild -project GhosttyTabs.xcodeproj -scheme c11-logic -configuration Debug \
+  -destination "platform=macOS" test
+```
+
+`c11-logic` is host-free and safe to run locally even when prod c11 is running (see `CLAUDE.md` → "Testing policy"). Wall time ~30s warm.
+
+If you also touched `AgentRestartRegistry.swift`, run `c11-unit` via `scripts/test-unit-local.sh` — `AgentRestartRegistryTests` lives there.
+
+## Validate end-to-end
+
+The clean local path is to build, launch a *tagged* DEV build, and exercise the agent:
+
+```bash
+./scripts/reload.sh --tag <slug>
+./scripts/launch-tagged-automation.sh <slug>
+```
+
+In the tagged build: Settings → Agents & Automation → Agent Launcher Button → pick the new agent, then click the A button on a fresh pane. The agent should launch with its auto-approve flag baked in. Sidebar chip should show the new icon (SF Symbol fallback if no asset shipped).
+
+Do not `open` an untagged `c11 DEV.app` from DerivedData while prod c11 is running — they fight for sockets. See `CLAUDE.md` → "Testing policy" for the why.
+
+## A note on runtime extensibility
+
+Today, agent registration is **compile-time**. Adding a new first-class agent means editing Swift, building c11, and shipping a new build. The `.custom` agent type exists as a partial runtime escape hatch — operators can set Settings → Default Agent → Custom to any launch command without rebuilding — but `.custom` has one slot, no sidebar branding, no auto-detection, and no snapshot resume.
+
+A data-driven agent registry (loading agent definitions from `~/.config/c11/agents/<name>.toml` and contributing rows to the same surfaces above) is feasible and would let operators add fully-branded agents at runtime. It is not built yet. If you find yourself adding a fifth or sixth coding agent and the friction is starting to bite, that's the moment to design it — not before.
+
+## Sequencing for the PR
+
+Land the surfaces (1–8) and tests (13) in one commit. Land the docs (9–12) and the contributor-doc updates (this file) in a second. The reviewer's eye doesn't want to traverse twelve files of Swift *plus* prose at once — and the docs land cleanly even if Swift review takes a round-trip.

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -110,7 +110,7 @@ c11 set-agent --type claude-code --model claude-opus-4-7
 c11 set-agent --type codex --task lat-412
 ```
 
-Common types: `claude-code`, `codex`, `kimi`, `opencode`. Any kebab-case string is accepted. Inside Claude Code, `claude.session_id` is populated automatically by the wrapper.
+Common types: `claude-code`, `codex`, `grok`, `kimi`, `opencode`. Any kebab-case string is accepted. Inside Claude Code, `claude.session_id` is populated automatically by the wrapper.
 
 ## Targeting
 
@@ -387,7 +387,7 @@ Treat `flash_state` as a forward-compatible enum — future c11 versions may add
 
 When you spawn a sub-agent, give it its own c11 surface (`c11 new-split` or `c11 new-pane`) and launch the agent inside that surface. The operator gets full observability through c11 (sidebar status, title and description, screen content), and the sub-agent runs as a full-fledged interactive instance instead of a headless detached process.
 
-**Use `c11 default-agent launch --in-surface <ref>` to do the launch.** It is the canonical programmatic path: c11 owns the per-TUI prompt-delivery contract (claude-code positional, post-ready sendText for codex/opencode/kimi), so the same call works regardless of which agent the operator has configured. No shell interpolation, no per-TUI branching in caller code.
+**Use `c11 default-agent launch --in-surface <ref>` to do the launch.** It is the canonical programmatic path: c11 owns the per-TUI prompt-delivery contract (claude-code positional, post-ready sendText for codex/grok/opencode/kimi), so the same call works regardless of which agent the operator has configured. No shell interpolation, no per-TUI branching in caller code.
 
 ```bash
 cat > /tmp/lat-xxx-prompt.md <<'EOF'

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -53,7 +53,7 @@ Most commands default to the caller's context via env vars — no flags needed w
 | `CMUX_SOCKET_PATH` | Override socket path (default `/tmp/cmux.sock`; auto-discovers tagged/debug sockets) |
 | `CMUX_SOCKET_PASSWORD` | Socket auth password (if set in Settings) |
 | `CMUX_SHELL_INTEGRATION` | Set to `1` in c11 terminals — use to detect you're inside c11 (also exported as `C11_SHELL_INTEGRATION=1`) |
-| `CMUX_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `kimi`, `opencode`, kebab-case custom); read at surface start |
+| `CMUX_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `grok`, `kimi`, `opencode`, kebab-case custom); read at surface start |
 | `CMUX_AGENT_MODEL` | Declared agent model identifier |
 | `CMUX_AGENT_TASK` | Declared agent task ID |
 
@@ -174,7 +174,7 @@ c11 set-agent --type codex --task lat-412
 c11 set-agent --type opencode --model <model-id>
 ```
 
-- `--type` accepts canonical values (`claude-code`, `codex`, `kimi`, `opencode`) and any kebab-case custom value.
+- `--type` accepts canonical values (`claude-code`, `codex`, `grok`, `kimi`, `opencode`) and any kebab-case custom value.
 - Writes land as `source: declare` in the M2 metadata store, overriding heuristic auto-detection but not user-explicit writes.
 - Environment declaration: `CMUX_AGENT_TYPE`, `CMUX_AGENT_MODEL`, `CMUX_AGENT_TASK` in the surface's startup env are read once at surface-child-process start. `C11_*` variants are the primary names going forward; `CMUX_*` still works.
 - Clear with `c11 clear-metadata --key terminal_type` (no `c11 unset-agent`).

--- a/skills/c11/references/metadata.md
+++ b/skills/c11/references/metadata.md
@@ -30,7 +30,7 @@ These keys have a defined shape and render in the sidebar or title bar. Any writ
 | `task` | string | ≤ 128 chars | sidebar: monospace tag |
 | `model` | string | kebab-case, ≤ 64 chars | sidebar chip |
 | `progress` | number | 0.0 – 1.0 | sidebar: progress bar |
-| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `kimi`, `opencode`, `shell`, `unknown`. Open-ended. |
+| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `grok`, `kimi`, `opencode`, `shell`, `unknown`. Open-ended. |
 | `title` | string | plain text, ≤ 256 chars | title bar + sidebar tab label (truncated) |
 | `description` | string | Markdown subset (bold/italic, inline `code`, lists, headings, blockquotes, links, rules — no images, fenced code, or tables), ≤ 2048 chars | title bar expanded region |
 | `worktree` | string | ≤ 128 chars (basename) | sidebar chip with colored-dot prefix. Only rendered when the surface's cwd is inside a *linked* git worktree (`git worktree add ...`). Color is a stable hash of the absolute worktree path. **Derived** — written by c11 runtime, not by agents. |

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -209,6 +209,12 @@ The claude PATH wrapper at `Resources/bin/claude` is a **grandfathered, Claude C
 - **Use `codex --yolo`, not `codex exec`.** `codex exec` is headless and non-interactive, appropriate only for background jobs whose output will be read after completion. For a visible c11 surface where the operator should be able to watch or take over, `codex --yolo` is the right invocation.
 - **No PATH wrapper.** codex does not get a c11 wrapper. The sub-agent self-reports sidebar status by calling `c11 set-status` / `c11 set-metadata` from its own lifecycle, following instructions in the c11 skill it loads at session start.
 
+### grok
+
+- **Use `grok --always-approve`.** Grok Build's auto-approve flag (parallel to claude's `--dangerously-skip-permissions` and codex's `--yolo`). TUI alias is `/yolo`. Headless mode is `grok agent` or `grok -p`; do not use either for a visible c11 surface.
+- **Auth gotcha.** OIDC-acquired tokens (`grok login` browser flow) currently 403 at the chat endpoint for non-Heavy SuperGrok tiers. Use an `XAI_API_KEY` from console.x.ai instead; it bypasses the Heavy-only gate.
+- **No PATH wrapper.** Status comes from skill-driven self-reporting, same as codex/opencode/kimi.
+
 ### opencode, kimi, others
 
 - **No PATH wrapper.** Like codex, status comes from skill-driven self-reporting. If an agent hasn't been taught to self-report, the sidebar won't show status for it; that is expected, not a bug.


### PR DESCRIPTION
## Summary
- Wires Grok Build (binary `grok`, auto-approve flag `--always-approve`) into c11 as a peer of `claude-code`, `codex`, `kimi`, `opencode`.
- 13 source surfaces updated: `AgentType` enum, sidebar chip, agent detector, restart registry, skill installer, onboarding sheet, CLI validation, canonical terminal types, plus the c11 skill docs (`SKILL.md` + three reference pages, including a Grok subsection under per-agent launch quirks with the `XAI_API_KEY` auth note).
- New contributor doc `docs/adding-a-new-agent.md` capturing the surfaces to update for the next agent we add, with a note on runtime extensibility (today agent types are compile-time; `.custom` is the partial escape hatch).
- One new logic test (`testFactoryGrokCommandIncludesAlwaysApprove`); the existing `AgentType.allCases`-driven tests pick up the new case automatically.

## Why
We use Grok Build alongside Claude/Codex/Kimi/OpenCode. Without first-class registration it can't be picked in the A-button picker, isn't detected by the sidebar, doesn't resume across snapshots, and doesn't get skill install support — all of which are wired up here.

## Test plan
- [x] `xcodebuild -project GhosttyTabs.xcodeproj -scheme c11-logic -configuration Debug -destination "platform=macOS" test` — green
- [x] Build (`build-for-testing`) clean across the full `c11` target (c11-logic links against it)
- [ ] Operator-side validation: pick Grok in Settings → Default Agent, click A button, confirm `grok --always-approve` launches in the new pane with the c11 skill loading prompt
- [ ] Confirm sidebar chip renders with the `bolt.fill` SF Symbol fallback (no bundled asset yet)
- [ ] Confirm `c11 set-agent --type grok` and `c11 default-agent set grok` both succeed
- [ ] Optional: localization pass for `agentType.grok` → "Grok Build" across `Localizable.xcstrings` (ja/uk/ko/zh-Hans/zh-Hant/ru) — separate change

🤖 Generated with [Claude Code](https://claude.com/claude-code)