### PR TITLE
C11-119: Waiting Agent + workspace nav cluster in sidebar

### DIFF
--- a/Sources/BrandColors.swift
+++ b/Sources/BrandColors.swift
@@ -16,6 +16,7 @@ enum BrandColors {
     static let whiteHex      = "#e8e8e8"
     static let goldHex       = "#c9a84c"
     static let goldFaintHex  = "#c9a84c33"
+    static let paperFillHex  = "#E8E2D0"
 
     static let black: NSColor      = srgb(0x00, 0x00, 0x00)
     static let surface: NSColor    = srgb(0x0a, 0x0a, 0x0a)
@@ -24,6 +25,7 @@ enum BrandColors {
     static let white: NSColor      = srgb(0xe8, 0xe8, 0xe8)
     static let gold: NSColor       = srgb(0xc9, 0xa8, 0x4c)
     static let goldFaint: NSColor  = srgb(0xc9, 0xa8, 0x4c, alpha: 0x33)
+    static let paperFill: NSColor  = srgb(0xE8, 0xE2, 0xD0)
 
     static var blackSwiftUI: Color     { Color(nsColor: black) }
     static var surfaceSwiftUI: Color   { Color(nsColor: surface) }
@@ -32,6 +34,7 @@ enum BrandColors {
     static var whiteSwiftUI: Color     { Color(nsColor: white) }
     static var goldSwiftUI: Color      { Color(nsColor: gold) }
     static var goldFaintSwiftUI: Color { Color(nsColor: goldFaint) }
+    static var paperFillSwiftUI: Color { Color(nsColor: paperFill) }
 
     private static func srgb(_ r: Int, _ g: Int, _ b: Int, alpha a: Int = 0xFF) -> NSColor {
         NSColor(
@@ -53,6 +56,7 @@ extension BrandColors {
         ("white",      whiteHex),
         ("gold",       goldHex),
         ("gold_faint", goldFaintHex),
+        ("paper_fill", paperFillHex),
     ]
 
     /// Font family c11 ships with. Terminal content is owned by the

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9632,7 +9632,7 @@ private struct SidebarFooterButtons: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            SidebarJumpToUnreadButton()
+            SidebarWaitingAgentCluster()
             HStack(spacing: 4) {
                 SidebarHelpMenuButton(onSendFeedback: onSendFeedback)
                 UpdatePill(model: updateViewModel)
@@ -10577,90 +10577,222 @@ private struct SidebarHelpMenuButton: View {
     }
 }
 
-private struct SidebarJumpToUnreadButton: View {
+// MARK: - Waiting Agent + Workspace Nav Cluster
+
+private struct SidebarWaitingAgentCluster: View {
     @EnvironmentObject private var notificationStore: TerminalNotificationStore
+    @EnvironmentObject private var tabManager: TabManager
 
     private var display: StatusBarButtonDisplay {
         StatusBarButtonDisplay(unreadCount: notificationStore.unreadCount)
     }
 
-    private var label: String {
-        String(
-            localized: "statusBar.nextNotification.title",
-            defaultValue: "Next Notification"
-        )
+    private var isFirstWorkspace: Bool {
+        guard let currentId = tabManager.selectedTabId,
+              let idx = tabManager.tabs.firstIndex(where: { $0.id == currentId }) else { return true }
+        return idx == 0
     }
 
-    private var accessibilityLabel: String {
-        String(
-            localized: "statusBar.jumpToUnread.accessibility",
-            defaultValue: "Jump to next unread notification"
-        )
-    }
-
-    private var shortcutText: String {
-        KeyboardShortcutSettings.shortcut(for: .jumpToUnread).displayString
+    private var isLastWorkspace: Bool {
+        guard let currentId = tabManager.selectedTabId,
+              let idx = tabManager.tabs.firstIndex(where: { $0.id == currentId }) else { return true }
+        return idx == tabManager.tabs.count - 1
     }
 
     var body: some View {
-        let display = self.display
-        return Button(action: jump) {
-            HStack(spacing: 6) {
-                Text(label)
-                    .font(.system(size: 11, weight: .semibold))
-                    .lineLimit(1)
-
-                if let badge = display.badgeText {
-                    Text(badge)
-                        .font(.system(size: 9, weight: .bold))
-                        .monospacedDigit()
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 1)
-                        .background(
-                            Capsule(style: .continuous)
-                                .fill(BrandColors.blackSwiftUI.opacity(0.18))
-                        )
-                        .foregroundColor(BrandColors.blackSwiftUI)
-                        .accessibilityHidden(true)
-                }
-
-                Spacer(minLength: 4)
-
-                Text(shortcutText)
-                    .font(.system(size: 10, weight: .medium))
-                    .monospacedDigit()
-                    .opacity(0.72)
-                    .lineLimit(1)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 16)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(cmuxAccentColor().opacity(display.isEnabled ? 1.0 : 0.18))
+        VStack(spacing: 1) {
+            WaitingAgentRow(display: display, onJump: jump)
+            WorkspaceNavRow(
+                isFirstDisabled: isFirstWorkspace,
+                isLastDisabled: isLastWorkspace,
+                onPrevious: goToPreviousWorkspace,
+                onNext: goToNextWorkspace
             )
-            .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(cmuxAccentColor().opacity(display.isEnabled ? 0 : 0.5), lineWidth: 1)
-            )
-            .foregroundColor(display.isEnabled ? BrandColors.blackSwiftUI : .secondary)
-            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
-        .buttonStyle(.plain)
-        .disabled(!display.isEnabled)
-        .opacity(display.isEnabled ? 1.0 : 0.72)
-        .accessibilityIdentifier("SidebarJumpToUnreadButton")
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityValue(display.badgeText ?? "")
-        .safeHelp(
-            KeyboardShortcutSettings.Action.jumpToUnread.tooltip(label)
-        )
     }
 
     private func jump() {
         DispatchQueue.main.async {
             AppDelegate.shared?.jumpToLatestUnread()
         }
+    }
+
+    private func goToPreviousWorkspace() {
+        tabManager.selectPreviousTab()
+    }
+
+    private func goToNextWorkspace() {
+        tabManager.selectNextTab()
+    }
+}
+
+private struct WaitingAgentRow: View {
+    let display: StatusBarButtonDisplay
+    let onJump: () -> Void
+
+    private var isLit: Bool { display.isEnabled }
+
+    private var label: String {
+        String(localized: "sidebar.waitingAgent.title", defaultValue: "Waiting Agent")
+    }
+
+    private var shortcutText: String {
+        KeyboardShortcutSettings.shortcut(for: .jumpToUnread).displayString
+    }
+
+    private var accessibilityLabel: String {
+        String(localized: "sidebar.waitingAgent.accessibility", defaultValue: "Jump to next waiting agent")
+    }
+
+    var body: some View {
+        Button(action: onJump) {
+            HStack(spacing: 0) {
+                Text(label)
+                    .font(.system(size: 11, weight: .semibold))
+                    .lineLimit(1)
+
+                Spacer(minLength: 4)
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\u{2192}")
+                        .font(.system(size: 13, weight: .medium))
+                    Text(shortcutText)
+                        .font(.system(size: 9, weight: .medium))
+                        .opacity(isLit ? 0.6 : 0.5)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isLit ? BrandColors.paperFillSwiftUI : BrandColors.surfaceSwiftUI)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(BrandColors.goldSwiftUI, lineWidth: 0.75)
+                    .opacity(isLit ? 1 : 0)
+            )
+            .foregroundColor(isLit ? BrandColors.blackSwiftUI : BrandColors.whiteSwiftUI)
+            .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("SidebarWaitingAgentButton")
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(display.badgeText ?? "")
+        .safeHelp(
+            KeyboardShortcutSettings.Action.jumpToUnread.tooltip(label)
+        )
+    }
+}
+
+private struct WorkspaceNavRow: View {
+    let isFirstDisabled: Bool
+    let isLastDisabled: Bool
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+
+    var body: some View {
+        HStack(spacing: 1) {
+            WorkspaceArrowButton(
+                glyph: "\u{25B2}",
+                isDisabled: isFirstDisabled,
+                action: onPrevious,
+                tooltipText: KeyboardShortcutSettings.Action.prevSidebarTab.tooltip(
+                    String(localized: "sidebar.workspaceNav.previous", defaultValue: "Previous Workspace")
+                ),
+                accessibilityText: String(localized: "sidebar.workspaceNav.previous.accessibility", defaultValue: "Go to previous workspace")
+            )
+            WorkspaceArrowButton(
+                glyph: "\u{25BC}",
+                isDisabled: isLastDisabled,
+                action: onNext,
+                tooltipText: KeyboardShortcutSettings.Action.nextSidebarTab.tooltip(
+                    String(localized: "sidebar.workspaceNav.next", defaultValue: "Next Workspace")
+                ),
+                accessibilityText: String(localized: "sidebar.workspaceNav.next.accessibility", defaultValue: "Go to next workspace")
+            )
+        }
+    }
+}
+
+private struct WorkspaceArrowButton: View {
+    let glyph: String
+    let isDisabled: Bool
+    let action: () -> Void
+    let tooltipText: String
+    let accessibilityText: String
+
+    @State private var isHovering = false
+    @State private var isPressed = false
+    @State private var repeatTimer: Timer?
+
+    private var isActive: Bool { (isHovering || isPressed) && !isDisabled }
+
+    var body: some View {
+        Text(glyph)
+            .font(.system(size: 10, weight: .medium))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(BrandColors.surfaceSwiftUI)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .stroke(BrandColors.goldSwiftUI, lineWidth: 1.5)
+                    .opacity(isActive ? 1 : 0)
+            )
+            .foregroundColor(
+                isDisabled
+                    ? BrandColors.whiteSwiftUI.opacity(0.3)
+                    : isActive
+                        ? BrandColors.goldSwiftUI
+                        : BrandColors.whiteSwiftUI
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+            .onHover { hovering in
+                guard !isDisabled else { return }
+                isHovering = hovering
+            }
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard !isDisabled, !isPressed else { return }
+                        isPressed = true
+                        action()
+                        startRepeat()
+                    }
+                    .onEnded { _ in
+                        isPressed = false
+                        stopRepeat()
+                    }
+            )
+            .accessibilityLabel(accessibilityText)
+            .accessibilityAddTraits(isDisabled ? .isStaticText : .isButton)
+            .safeHelp(isDisabled ? "" : tooltipText)
+            .onDisappear { stopRepeat() }
+    }
+
+    private func startRepeat() {
+        repeatTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false) { _ in
+            DispatchQueue.main.async {
+                self.repeatTimer = Timer.scheduledTimer(withTimeInterval: 0.12, repeats: true) { _ in
+                    DispatchQueue.main.async {
+                        guard self.isPressed, !self.isDisabled else {
+                            self.stopRepeat()
+                            return
+                        }
+                        self.action()
+                    }
+                }
+            }
+        }
+    }
+
+    private func stopRepeat() {
+        repeatTimer?.invalidate()
+        repeatTimer = nil
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10677,10 +10677,11 @@ private struct WaitingAgentRow: View {
                         lineWidth: isLit ? 0.75 : 1
                     )
             )
-            .foregroundColor(isLit ? BrandColors.blackSwiftUI : BrandColors.whiteSwiftUI)
+            .foregroundColor(isLit ? BrandColors.blackSwiftUI : BrandColors.whiteSwiftUI.opacity(0.4))
             .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
         }
         .buttonStyle(.plain)
+        .disabled(!isLit)
         .accessibilityIdentifier("SidebarWaitingAgentButton")
         .accessibilityLabel(accessibilityLabel)
         .accessibilityValue(display.badgeText ?? "")

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10618,10 +10618,12 @@ private struct SidebarWaitingAgentCluster: View {
     }
 
     private func goToPreviousWorkspace() {
+        guard !isFirstWorkspace else { return }
         tabManager.selectPreviousTab()
     }
 
     private func goToNextWorkspace() {
+        guard !isLastWorkspace else { return }
         tabManager.selectNextTab()
     }
 }
@@ -10670,8 +10672,10 @@ private struct WaitingAgentRow: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(BrandColors.goldSwiftUI, lineWidth: 0.75)
-                    .opacity(isLit ? 1 : 0)
+                    .stroke(
+                        isLit ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI,
+                        lineWidth: isLit ? 0.75 : 1
+                    )
             )
             .foregroundColor(isLit ? BrandColors.blackSwiftUI : BrandColors.whiteSwiftUI)
             .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
@@ -10740,8 +10744,10 @@ private struct WorkspaceArrowButton: View {
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .stroke(BrandColors.goldSwiftUI, lineWidth: 1.5)
-                    .opacity(isActive ? 1 : 0)
+                    .stroke(
+                        isActive ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI,
+                        lineWidth: isActive ? 1.5 : 1
+                    )
             )
             .foregroundColor(
                 isDisabled


### PR DESCRIPTION
## Summary
- Replaces the "Next Notification" sidebar button with a two-row **Waiting Agent** cluster
- **Row 1**: "Waiting Agent" button with paper-fill lit state (warm off-white `#E8E2D0`) and thin gold hairline when agents are waiting, void-fill rest state with white glyphs
- **Row 2**: ▲/▼ workspace navigation arrows (prev/next), gold stroke on hover, disabled at first/last workspace, press-and-hold auto-repeat for fast scrubbing
- Adds `paperFill` (`#E8E2D0`) to `BrandColors` palette

## Files changed
- `Sources/BrandColors.swift` -- new `paperFill` color token
- `Sources/ContentView.swift` -- `SidebarJumpToUnreadButton` replaced by `SidebarWaitingAgentCluster` (composed of `WaitingAgentRow`, `WorkspaceNavRow`, `WorkspaceArrowButton`)

## Design spec
`docs/c11-waiting-agent-cluster-plan.md`

## Test plan
- [ ] Build verification (xcodebuild succeeds)
- [ ] Visual: sidebar shows "Waiting Agent" label with arrow and shortcut chip at rest (void fill, white text)
- [ ] Visual: when unread notifications exist, row 1 fills with warm off-white paper tone and gold hairline
- [ ] Functional: clicking "Waiting Agent" jumps to the waiting agent (same as old ⌥V behavior)
- [ ] Visual: ▲/▼ arrows show gold stroke + gold glyph on hover
- [ ] Functional: arrows navigate between workspaces without wrapping
- [ ] Functional: ▲ disabled at first workspace, ▼ disabled at last workspace (30% opacity, no hover response)
- [ ] Functional: press-and-hold on arrows auto-repeats for fast workspace scrubbing
- [ ] Regression: help/update pill row below the cluster is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)