### PR TITLE
Add GitHub Copilot CLI as a built-in agent type

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -8986,7 +8986,7 @@ struct CMUXCLI {
 
             Subcommands:
               get                              Print the configured default agent type.
-              set <type>                       Set the default agent (claude-code | codex | kimi | opencode | custom).
+              set <type>                       Set the default agent (claude-code | codex | kimi | opencode | github-copilot | custom).
               launch [flags]                   Launch the default (or --agent <type>) agent.
 
             launch flags:
@@ -10938,7 +10938,7 @@ struct CMUXCLI {
 
         case "set":
             guard commandArgs.count >= 2 else {
-                let valid = ["claude-code", "codex", "kimi", "opencode", "custom"].joined(separator: ", ")
+                let valid = ["claude-code", "codex", "kimi", "opencode", "github-copilot", "custom"].joined(separator: ", ")
                 throw CLIError(message: "default-agent set requires <type>. Valid: \(valid)")
             }
             let response = try sendV1Command("default_agent set \(commandArgs[1])", client: client)

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -40,15 +40,17 @@
 		47C976CFA2AD3633C427D15D /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 		4A5A1F18E3F574F301890675 /* StdinHandlerFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7112BF1A1B2C3D4E5F60718 /* StdinHandlerFormattingTests.swift */; };
 		4BF73AE4358BED37E9D90771 /* WorkspaceApplyChromeScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */; };
+		4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */ = {isa = PBXBuildFile; fileRef = D13A1E9CE25B945CC90A8D02 /* copilot */; };
 		505E486F8B252007A3CFE688 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
 		53A8353DD72E0C6954D5F42A /* ChromeScaleSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */; };
 		53D5E057358DF622C3B16996 /* ChromeScaleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */; };
 		55741FF81E130E9AB8AE64FB /* WorkspaceSnapshotConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */; };
 		55A25D62B29EA263FABD5931 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
-		C11105B2C3D4E5F6071802 /* SocketControlSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11105B2C3D4E5F6071801 /* SocketControlSafetyTests.swift */; };
 		56240252C16E6E32305412E0 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
 		56D5F7E29DC4C9999E4EDA7B /* DefaultAgentProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */; };
+		573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		5AEB95ABF100C21BFCDB40E4 /* C11ThemeLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F015 /* C11ThemeLoaderTests.swift */; };
+		5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		5E5FA83B76AB6FA59171D8C2 /* HealthFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */; };
 		5F20D96106D7E1D0215F6D66 /* DefaultAgentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C80718F1B0DC883CC3D99 /* DefaultAgentSettingsView.swift */; };
 		60C99BCDF095711E213AAF1C /* BrowserImportMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */; };
@@ -151,17 +153,6 @@
 		A5C101A8 /* WorkspaceCloseOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B8 /* WorkspaceCloseOverlayController.swift */; };
 		A5C101A9 /* WorkspaceCloseOverlayHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C101B9 /* WorkspaceCloseOverlayHostView.swift */; };
 		A5C11005 /* AgentChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C11006 /* AgentChip.swift */; };
-		C11104B01 /* GitContextResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F01 /* GitContextResolver.swift */; };
-		C11104B02 /* WorktreeColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F02 /* WorktreeColorPalette.swift */; };
-		C11104B03 /* WorktreeChipModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F03 /* WorktreeChipModel.swift */; };
-		C11104B04 /* WorktreeChipsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F04 /* WorktreeChipsRow.swift */; };
-		C11106S01 /* SocketMetadataSourceValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106S01F /* SocketMetadataSourceValidator.swift */; };
-		C11104B05 /* GitContextResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F05 /* GitContextResolverTests.swift */; };
-		C11104B06 /* WorktreeChipProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F06 /* WorktreeChipProjectorTests.swift */; };
-		C11104B07 /* MetadataDerivedPrecedenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F07 /* MetadataDerivedPrecedenceTests.swift */; };
-		C11106B01 /* GitContextResolverCacheWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106F01 /* GitContextResolverCacheWiringTests.swift */; };
-		C11106B02 /* ProcessGitRunnerTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106F02 /* ProcessGitRunnerTimeoutTests.swift */; };
-		C11106B03 /* SocketDerivedSourceRejectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106F03 /* SocketDerivedSourceRejectionTests.swift */; };
 		A5C11007 /* AgentChipBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C11008 /* AgentChipBadge.swift */; };
 		A5C36003 /* StatusBarButtonDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C36013 /* StatusBarButtonDisplay.swift */; };
 		A5F1001001A1B2C3D4E5F001 /* ThemedValueAST.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F001 /* ThemedValueAST.swift */; };
@@ -219,6 +210,18 @@
 		BAE105919F0262DEA7D0DE0C /* MailboxIOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7104BF1A1B2C3D4E5F60718 /* MailboxIOTests.swift */; };
 		BFBD47384819D160EF689A52 /* WorkspaceBlueprintMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8019BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintMarkdownTests.swift */; };
 		C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
+		C11104B01 /* GitContextResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F01 /* GitContextResolver.swift */; };
+		C11104B02 /* WorktreeColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F02 /* WorktreeColorPalette.swift */; };
+		C11104B03 /* WorktreeChipModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F03 /* WorktreeChipModel.swift */; };
+		C11104B04 /* WorktreeChipsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F04 /* WorktreeChipsRow.swift */; };
+		C11104B05 /* GitContextResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F05 /* GitContextResolverTests.swift */; };
+		C11104B06 /* WorktreeChipProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F06 /* WorktreeChipProjectorTests.swift */; };
+		C11104B07 /* MetadataDerivedPrecedenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11104F07 /* MetadataDerivedPrecedenceTests.swift */; };
+		C11105B2C3D4E5F6071802 /* SocketControlSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11105B2C3D4E5F6071801 /* SocketControlSafetyTests.swift */; };
+		C11106B01 /* GitContextResolverCacheWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106F01 /* GitContextResolverCacheWiringTests.swift */; };
+		C11106B02 /* ProcessGitRunnerTimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106F02 /* ProcessGitRunnerTimeoutTests.swift */; };
+		C11106B03 /* SocketDerivedSourceRejectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106F03 /* SocketDerivedSourceRejectionTests.swift */; };
+		C11106S01 /* SocketMetadataSourceValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11106S01F /* SocketMetadataSourceValidator.swift */; };
 		C116000100A1B2C3D4E5F010 /* ChromeScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000200A1B2C3D4E5F010 /* ChromeScale.swift */; };
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
 		C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1CDE00001A1B2C3D4E5F719 /* codex */; };
@@ -368,6 +371,7 @@
 				C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */,
 				C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
+				4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */,
 			);
 			name = "Copy CLI";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -389,6 +393,7 @@
 		6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
 		76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentProjectConfig.swift; sourceTree = "<group>"; };
+		7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* c11UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentResolverTests.swift; sourceTree = "<group>"; };
@@ -475,17 +480,6 @@
 		A5C101B9 /* WorkspaceCloseOverlayHostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/WorkspaceCloseOverlayHostView.swift; sourceTree = "<group>"; };
 		A5C102B0 /* PaneInteractionRuntimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneInteractionRuntimeTests.swift; sourceTree = "<group>"; };
 		A5C11006 /* AgentChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChip.swift; sourceTree = "<group>"; };
-		C11104F01 /* GitContextResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata/GitContextResolver.swift; sourceTree = "<group>"; };
-		C11104F02 /* WorktreeColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeColorPalette.swift; sourceTree = "<group>"; };
-		C11104F03 /* WorktreeChipModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeChipModel.swift; sourceTree = "<group>"; };
-		C11104F04 /* WorktreeChipsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeChipsRow.swift; sourceTree = "<group>"; };
-		C11106S01F /* SocketMetadataSourceValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata/SocketMetadataSourceValidator.swift; sourceTree = "<group>"; };
-		C11104F05 /* GitContextResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitContextResolverTests.swift; sourceTree = "<group>"; };
-		C11104F06 /* WorktreeChipProjectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeChipProjectorTests.swift; sourceTree = "<group>"; };
-		C11104F07 /* MetadataDerivedPrecedenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataDerivedPrecedenceTests.swift; sourceTree = "<group>"; };
-		C11106F01 /* GitContextResolverCacheWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitContextResolverCacheWiringTests.swift; sourceTree = "<group>"; };
-		C11106F02 /* ProcessGitRunnerTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitRunnerTimeoutTests.swift; sourceTree = "<group>"; };
-		C11106F03 /* SocketDerivedSourceRejectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketDerivedSourceRejectionTests.swift; sourceTree = "<group>"; };
 		A5C11008 /* AgentChipBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChipBadge.swift; sourceTree = "<group>"; };
 		A5C36013 /* StatusBarButtonDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBar/StatusBarButtonDisplay.swift; sourceTree = "<group>"; };
 		A5C36031 /* StatusBarButtonDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusBarButtonDisplayTests.swift; sourceTree = "<group>"; };
@@ -543,6 +537,18 @@
 		BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOrderingTests.swift; sourceTree = "<group>"; };
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
+		C11104F01 /* GitContextResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata/GitContextResolver.swift; sourceTree = "<group>"; };
+		C11104F02 /* WorktreeColorPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeColorPalette.swift; sourceTree = "<group>"; };
+		C11104F03 /* WorktreeChipModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeChipModel.swift; sourceTree = "<group>"; };
+		C11104F04 /* WorktreeChipsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/WorktreeChipsRow.swift; sourceTree = "<group>"; };
+		C11104F05 /* GitContextResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitContextResolverTests.swift; sourceTree = "<group>"; };
+		C11104F06 /* WorktreeChipProjectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorktreeChipProjectorTests.swift; sourceTree = "<group>"; };
+		C11104F07 /* MetadataDerivedPrecedenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataDerivedPrecedenceTests.swift; sourceTree = "<group>"; };
+		C11105B2C3D4E5F6071801 /* SocketControlSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlSafetyTests.swift; sourceTree = "<group>"; };
+		C11106F01 /* GitContextResolverCacheWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitContextResolverCacheWiringTests.swift; sourceTree = "<group>"; };
+		C11106F02 /* ProcessGitRunnerTimeoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessGitRunnerTimeoutTests.swift; sourceTree = "<group>"; };
+		C11106F03 /* SocketDerivedSourceRejectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketDerivedSourceRejectionTests.swift; sourceTree = "<group>"; };
+		C11106S01F /* SocketMetadataSourceValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata/SocketMetadataSourceValidator.swift; sourceTree = "<group>"; };
 		C112400B1B2C3D4E5F60718 /* WorkspaceRestartCommandsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRestartCommandsTests.swift; sourceTree = "<group>"; };
 		C116000200A1B2C3D4E5F010 /* ChromeScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chrome/ChromeScale.swift; sourceTree = "<group>"; };
 		C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleSettingsTests.swift; sourceTree = "<group>"; };
@@ -559,6 +565,7 @@
 		CC40100AA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessProbe.swift; sourceTree = "<group>"; };
 		D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneNavigationKeybindUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionsUITests.swift; sourceTree = "<group>"; };
+		D13A1E9CE25B945CC90A8D02 /* copilot */ = {isa = PBXFileReference; includeInIndex = 1; name = copilot; path = Resources/bin/copilot; sourceTree = "<group>"; };
 		D1BEF00001A1B2C3D4E5F719 /* open */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/open; sourceTree = SOURCE_ROOT; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
 		D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarRenderTests.swift; sourceTree = "<group>"; };
@@ -666,7 +673,6 @@
 		F6B62D2ECDC52E5244D9C6E3 /* DefaultAgentConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentConfig.swift; sourceTree = "<group>"; };
 		F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
 		F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
-		C11105B2C3D4E5F6071801 /* SocketControlSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlSafetyTests.swift; sourceTree = "<group>"; };
 		F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyEnsureFocusWindowActivationTests.swift; sourceTree = "<group>"; };
 		FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
 		FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportMappingTests.swift; sourceTree = "<group>"; };
@@ -784,6 +790,7 @@
 				F1000003A1B2C3D4E5F60718 /* c11Tests */,
 				A5001042 /* Products */,
 				F31B76FA995543756EA155C1 /* Frameworks */,
+				D13A1E9CE25B945CC90A8D02 /* copilot */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1074,6 +1081,7 @@
 				C11106F01 /* GitContextResolverCacheWiringTests.swift */,
 				C11106F02 /* ProcessGitRunnerTimeoutTests.swift */,
 				C11106F03 /* SocketDerivedSourceRejectionTests.swift */,
+				7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1387,6 +1395,7 @@
 				C11106B01 /* GitContextResolverCacheWiringTests.swift in Sources */,
 				C11106B02 /* ProcessGitRunnerTimeoutTests.swift in Sources */,
 				C11106B03 /* SocketDerivedSourceRejectionTests.swift in Sources */,
+				5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1615,6 +1624,7 @@
 				D7C11260A1B2C3D4E5F60718 /* SurfaceLifecycleTests.swift in Sources */,
 				1A1EC322E65B74DEDAAD08A5 /* DefaultAgentConfigTests.swift in Sources */,
 				0C8D60FC511085983B359106 /* DefaultAgentResolverTests.swift in Sources */,
+				573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/bin/copilot
+++ b/Resources/bin/copilot
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# c11 copilot wrapper - auto-declare terminal_type for GitHub Copilot CLI.
+#
+# When running inside a c11 terminal (CMUX_SURFACE_ID set + socket live),
+# this wrapper marks the surface as terminal_type=github-copilot via
+# `c11 set-agent` so the sidebar chip, default-agent picker, and any
+# orchestration that filters by terminal_type all see Copilot as a
+# first-class agent. Outside c11 (or when the socket is unreachable),
+# it passes through to the real copilot binary unchanged.
+#
+# Modeled on `Resources/bin/codex`. See that wrapper for the reference
+# implementation of the auto-declare pattern and the constraints all
+# wrappers honour:
+#
+#   1. Pass-through when not in a c11 terminal or socket is down.
+#   2. Pass-through for non-interactive subcommands (would lie about
+#      the surface's terminal_type — surface isn't an interactive copilot
+#      session if it's running `copilot --help`).
+#   3. Best-effort background write so startup latency is unaffected.
+#   4. Always exec the real binary at the end.
+#
+# Why no session-id capture (unlike Claude Code's wrapper)?
+#
+#   GitHub Copilot CLI manages its own session-store.db at ~/.copilot/
+#   and exposes `/resume` for in-session resume. It doesn't accept a
+#   `--session-id <id>` at launch, so we can't pre-write a session id
+#   to surface metadata the way the claude wrapper does. The c11
+#   session-restore path falls back to the default behaviour, which is
+#   acceptable for now — `copilot /resume` from within a restored
+#   surface continues the most recent session in cwd.
+
+set -uo pipefail
+
+# Find the real copilot binary, skipping our own directory.
+find_real_copilot() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/copilot" ]] && printf '%s' "$d/copilot" && return 0
+    done
+    return 1
+}
+
+# Return 0 only when CMUX_SOCKET_PATH points to a live c11 socket.
+c11_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir c11_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    c11_bin="$self_dir/c11"
+    [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+    [[ -n "$c11_bin" ]] || return 1
+
+    # Bounded check so copilot startup isn't blocked behind the CLI default
+    # timeout (15s) when the socket is stale or hung.
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$c11_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+# Pass through if not in a c11 terminal, hooks are disabled, or the
+# socket is unavailable.
+IN_C11=0
+if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
+    IN_C11=1
+fi
+
+if [[ "$IN_C11" == "0" || "${CMUX_COPILOT_HOOKS_DISABLED:-}" == "1" ]] || ! c11_socket_available; then
+    REAL_COPILOT="$(find_real_copilot)" || { echo "Error: copilot not found in PATH" >&2; exit 127; }
+    exec "$REAL_COPILOT" "$@"
+fi
+
+REAL_COPILOT="$(find_real_copilot)" || { echo "Error: copilot not found in PATH" >&2; exit 127; }
+
+# Pass through for non-interactive invocations that shouldn't flip the
+# surface's terminal_type to "github-copilot" — the surface isn't an
+# interactive copilot session in these cases.
+#
+# Copilot CLI uses flags rather than subcommands for non-interactive
+# modes:
+#   -p / --prompt        non-interactive scripting (one-shot prompt)
+#   --acp                start as Agent Client Protocol server (not a TUI)
+#   -h / --help          help
+#   -V / --version       version
+#   --connect            attach to a remote session (different surface model)
+for arg in "$@"; do
+    case "$arg" in
+        -p|--prompt|--acp|--help|-h|--version|-V|--connect)
+            exec "$REAL_COPILOT" "$@"
+            ;;
+    esac
+done
+
+# Resolve the c11 binary (bundle-relative first, fall back to PATH so a
+# misconfigured bundle still works in dev builds).
+self_dir="$(cd "$(dirname "$0")" && pwd)"
+c11_bin="$self_dir/c11"
+[[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+
+# Best-effort surface-metadata write: mark this surface as a
+# github-copilot terminal so the sidebar chip and any orchestration
+# filtering by terminal_type see it. Background so copilot startup
+# latency is unaffected; `disown` so a stale write can't keep the
+# wrapper process alive after `exec`.
+if [[ -n "$c11_bin" ]]; then
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" set-agent --type github-copilot \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+fi
+
+exec "$REAL_COPILOT" "$@"

--- a/Sources/AgentChip.swift
+++ b/Sources/AgentChip.swift
@@ -126,6 +126,8 @@ enum AgentChipResolver {
             return "AgentIcons/kimi"
         case "opencode":
             return "AgentIcons/opencode"
+        case "github-copilot":
+            return "AgentIcons/github-copilot"
         case "shell":
             return "AgentIcons/shell"
         case "unknown":
@@ -139,13 +141,14 @@ enum AgentChipResolver {
     /// is missing at runtime.
     static func sfSymbolFallback(forTerminalType terminalType: String) -> String {
         switch terminalType {
-        case "claude-code":  return "sparkles"
-        case "codex":        return "chevron.left.forwardslash.chevron.right"
-        case "kimi":         return "moon.stars"
-        case "opencode":     return "curlybraces"
-        case "shell":        return "terminal.fill"
-        case "unknown":      return "questionmark.square.dashed"
-        default:             return "questionmark.square.dashed"
+        case "claude-code":    return "sparkles"
+        case "codex":          return "chevron.left.forwardslash.chevron.right"
+        case "kimi":           return "moon.stars"
+        case "opencode":       return "curlybraces"
+        case "github-copilot": return "paperplane.fill"
+        case "shell":          return "terminal.fill"
+        case "unknown":        return "questionmark.square.dashed"
+        default:               return "questionmark.square.dashed"
         }
     }
 }

--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -227,6 +227,8 @@ final class AgentDetector: @unchecked Sendable {
             return "kimi"
         case "opencode", "opencode-cli":
             return "opencode"
+        case "copilot":
+            return "github-copilot"
         default:
             break
         }
@@ -244,6 +246,9 @@ final class AgentDetector: @unchecked Sendable {
             }
             if a.contains("opencode-cli") || a.contains("sst/opencode") || a.contains("/opencode") {
                 return "opencode"
+            }
+            if a.contains("@github/copilot") || a.contains("/copilot") {
+                return "github-copilot"
             }
         }
 

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -563,6 +563,7 @@ struct AgentSkillsOnboardingSheet: View {
     @State private var codexOptIn: Bool = false
     @State private var kimiOptIn: Bool = false
     @State private var opencodeOptIn: Bool = false
+    @State private var copilotOptIn: Bool = false
     @State private var initializedDefaultOptIns: Bool = false
     @State private var selectedAction: AgentSkillsOnboardingAction = .install
 
@@ -607,7 +608,7 @@ struct AgentSkillsOnboardingSheet: View {
     }
 
     private var anySelected: Bool {
-        initializedDefaultOptIns && (claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn)
+        initializedDefaultOptIns && (claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn || copilotOptIn)
     }
 
     private var hasActionNeeded: Bool {
@@ -911,6 +912,7 @@ struct AgentSkillsOnboardingSheet: View {
         case .codex: return $codexOptIn
         case .kimi: return $kimiOptIn
         case .opencode: return $opencodeOptIn
+        case .copilot: return $copilotOptIn
         }
     }
 
@@ -920,6 +922,7 @@ struct AgentSkillsOnboardingSheet: View {
             (.codex, codexOptIn),
             (.kimi, kimiOptIn),
             (.opencode, opencodeOptIn),
+            (.copilot, copilotOptIn),
         ]
         var selectedKeys: Set<String> = []
         for (target, _) in selections.filter({ $0.1 }) {
@@ -988,6 +991,7 @@ struct AgentSkillsOnboardingSheet: View {
         codexOptIn = defaults[.codex] ?? false
         kimiOptIn = defaults[.kimi] ?? false
         opencodeOptIn = defaults[.opencode] ?? false
+        copilotOptIn = defaults[.copilot] ?? false
     }
 }
 

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -8,6 +8,7 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
     case codex
     case kimi
     case opencode
+    case githubCopilot = "github-copilot"
     case custom
 
     var id: String { rawValue }
@@ -24,6 +25,8 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
             return String(localized: "agentType.kimi", defaultValue: "Kimi")
         case .opencode:
             return String(localized: "agentType.opencode", defaultValue: "OpenCode")
+        case .githubCopilot:
+            return String(localized: "agentType.githubCopilot", defaultValue: "GitHub Copilot")
         case .custom:
             return String(localized: "agentType.custom", defaultValue: "Custom")
         }
@@ -34,11 +37,12 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
     /// values for the other agents.
     var factoryCommand: String {
         switch self {
-        case .claudeCode: return "claude --dangerously-skip-permissions"
-        case .codex:      return "codex --yolo"
-        case .kimi:       return "kimi"
-        case .opencode:   return "opencode run --dangerously-skip-permissions"
-        case .custom:     return ""
+        case .claudeCode:    return "claude --dangerously-skip-permissions"
+        case .codex:         return "codex --yolo"
+        case .kimi:          return "kimi"
+        case .opencode:      return "opencode run --dangerously-skip-permissions"
+        case .githubCopilot: return "copilot --allow-all --autopilot"
+        case .custom:        return ""
         }
     }
 

--- a/Sources/SkillInstaller.swift
+++ b/Sources/SkillInstaller.swift
@@ -8,6 +8,7 @@ enum SkillInstallerTarget: String, CaseIterable {
     case codex
     case kimi
     case opencode
+    case copilot
 
     var displayName: String {
         switch self {
@@ -15,6 +16,7 @@ enum SkillInstallerTarget: String, CaseIterable {
         case .codex: return "Codex"
         case .kimi: return "Kimi"
         case .opencode: return "OpenCode"
+        case .copilot: return "GitHub Copilot"
         }
     }
 

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -33,7 +33,7 @@ public enum MetadataKey {
     ]
 
     public static let canonicalTerminalTypes: Set<String> = [
-        "claude-code", "codex", "kimi", "opencode", "shell", "unknown"
+        "claude-code", "codex", "kimi", "opencode", "github-copilot", "shell", "unknown"
     ]
 }
 

--- a/c11Tests/AgentDetectorTests.swift
+++ b/c11Tests/AgentDetectorTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Covers `AgentDetector.classify(comm:args:)` — the pure classifier exposed
+/// for tests so we can exercise the binary-match table without a live ps scan.
+final class AgentDetectorTests: XCTestCase {
+
+    // MARK: - Direct comm matches
+
+    func testClassifyClaudeReturnsClaudeCode() {
+        XCTAssertEqual(AgentDetector.classify(comm: "claude", args: ""), "claude-code")
+        XCTAssertEqual(AgentDetector.classify(comm: "claude-code", args: ""), "claude-code")
+    }
+
+    func testClassifyCopilotReturnsGitHubCopilot() {
+        XCTAssertEqual(AgentDetector.classify(comm: "copilot", args: ""), "github-copilot")
+    }
+
+    func testClassifyCodexReturnsCodex() {
+        XCTAssertEqual(AgentDetector.classify(comm: "codex", args: ""), "codex")
+    }
+
+    // MARK: - Node-wrapped matches via args substring
+
+    func testClassifyNodeWrappedCopilotBinPathReturnsGitHubCopilot() {
+        let args = "node /Users/me/.nvm/versions/node/v24.11.1/bin/copilot --allow-all --autopilot"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "github-copilot")
+    }
+
+    func testClassifyNodeWrappedGitHubCopilotPackagePathReturnsGitHubCopilot() {
+        let args = "node /Users/me/.nvm/versions/node/v24.11.1/lib/node_modules/@github/copilot/dist/main.js"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "github-copilot")
+    }
+
+    func testClassifyNodeWrappedClaudeCodeReturnsClaudeCode() {
+        let args = "node /Users/me/.npm/global/lib/node_modules/@anthropic-ai/claude-code/dist/cli.js"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "claude-code")
+    }
+
+    // MARK: - Negative cases
+
+    func testClassifyUnrelatedNodeProcessReturnsUnknown() {
+        let args = "node /Users/me/project/server.js"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "unknown")
+    }
+
+    func testClassifyZshReturnsShell() {
+        XCTAssertEqual(AgentDetector.classify(comm: "zsh", args: ""), "shell")
+        XCTAssertEqual(AgentDetector.classify(comm: "-zsh", args: ""), "shell")
+    }
+}

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -30,6 +30,16 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
     }
 
+    func testFactoryGitHubCopilotCommandIncludesAllowAllAndAutopilot() {
+        let entry = AgentConfig.factory(for: .githubCopilot)
+        XCTAssertEqual(entry.command, "copilot --allow-all --autopilot")
+        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+    }
+
+    func testAgentTypeGitHubCopilotRawValueIsKebabCase() {
+        XCTAssertEqual(AgentType.githubCopilot.rawValue, "github-copilot")
+    }
+
     func testFactoryCustomHasEmptyDefaults() {
         let entry = AgentConfig.factory(for: .custom)
         XCTAssertEqual(entry.command, "")

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -53,7 +53,7 @@ Auto-exported into every c11 surface child process.
 | `C11_SOCKET_PATH` | Override socket path (auto-discovers tagged/debug sockets) |
 | `C11_SOCKET_PASSWORD` | Socket auth password (if set in Settings) |
 | `C11_SHELL_INTEGRATION` | Set to `1` in c11 terminals — use to detect you're inside c11 |
-| `C11_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `kimi`, `opencode`, kebab-case custom); read at surface start |
+| `C11_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `kimi`, `opencode`, `github-copilot`, kebab-case custom); read at surface start |
 | `C11_AGENT_MODEL` | Declared agent model identifier |
 | `C11_AGENT_TASK` | Declared agent task ID |
 
@@ -174,7 +174,7 @@ c11 set-agent --type codex --task lat-412
 c11 set-agent --type opencode --model <model-id>
 ```
 
-- `--type` accepts canonical values (`claude-code`, `codex`, `kimi`, `opencode`) and any kebab-case custom value.
+- `--type` accepts canonical values (`claude-code`, `codex`, `kimi`, `opencode`, `github-copilot`) and any kebab-case custom value.
 - Writes land as `source: declare` in the metadata store, overriding heuristic auto-detection but not user-explicit writes.
 - Environment declaration: `C11_AGENT_TYPE`, `C11_AGENT_MODEL`, `C11_AGENT_TASK` in the surface's startup env are read once at surface-child-process start.
 - Clear with `c11 clear-metadata --key terminal_type` (no `c11 unset-agent`).

--- a/skills/c11/references/metadata.md
+++ b/skills/c11/references/metadata.md
@@ -30,7 +30,7 @@ These keys have a defined shape and render in the sidebar or title bar. Any writ
 | `task` | string | ≤ 128 chars | sidebar: monospace tag |
 | `model` | string | kebab-case, ≤ 64 chars | sidebar chip |
 | `progress` | number | 0.0 – 1.0 | sidebar: progress bar |
-| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `kimi`, `opencode`, `shell`, `unknown`. Open-ended. |
+| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `kimi`, `opencode`, `github-copilot`, `shell`, `unknown`. Open-ended. |
 | `title` | string | plain text, ≤ 256 chars | title bar + sidebar tab label (truncated) |
 | `description` | string | Markdown subset (bold/italic, inline `code`, lists, headings, blockquotes, links, rules — no images, fenced code, or tables), ≤ 2048 chars | title bar expanded region |
 | `worktree` | string | ≤ 128 chars (basename) | sidebar chip with colored-dot prefix. Only rendered when the surface's cwd is inside a *linked* git worktree (`git worktree add ...`). Color is a stable hash of the absolute worktree path. **Derived** — written by c11 runtime, not by agents. |


### PR DESCRIPTION
## Summary

- **What changed?** GitHub Copilot CLI (`npm install -g @github/copilot`) becomes a 5th first-class agent type alongside Claude Code, Codex, Kimi, and OpenCode. Touches `AgentDetector` (process detection — direct comm + node-wrapper args substring), `DefaultAgentConfig` (picker + factory command `copilot --allow-all --autopilot`), `SkillInstaller` (third checkbox → `~/.copilot/skills/`), `SurfaceMetadataStore` (canonical types), `AgentSkillsView` (UI mirror), `AgentChip` (SF Symbol fallback `paperplane.fill`), and `CLI/c11.swift` (default-agent set validation + help text). New `Resources/bin/copilot` wrapper auto-declares `terminal_type=github-copilot` via `c11 set-agent` and execs the real binary — mirrors `Resources/bin/codex`.
- **Why?** Copilot CLI is now a peer-shaped TUI: autopilot, `/fleet` parallel subagents, MCP, multi-model. The Anthropic-style `SKILL.md` files already work as-is — `~/.copilot/skills/` is the documented personal-skills path per Copilot CLI's docs. Fits the existing five-agent pattern cleanly without special-casing.

Per the redirect in #210, the `skills/c11/SKILL.md` example-bias fix is deferred to a follow-up PR using the env-var-driven approach (`CMUX_AGENT_TYPE` the way the existing wrappers set it). This PR keeps to the wiring + reference-doc canonical-type updates.

Closes #210.

## Testing

- Built locally via `./scripts/reload.sh --tag explore-copilot` and verified:
  - Skills install dialog shows **GitHub Copilot** as a third checkbox alongside Claude Code and Codex; "Not detected" footer correctly omits Copilot.
  - After "Update all", `~/.copilot/skills/c11/SKILL.md` is byte-identical to the bundled source.
  - `which copilot` inside a c11 pane resolves to the bundled wrapper at `Contents/Resources/bin/copilot` (proves the wrapper is on PATH ahead of the npm-installed real binary).
  - Running `copilot --allow-all --autopilot` in a fresh pane → wrapper auto-declares `terminal_type = github-copilot [declare @ <fresh timestamp>]` for that surface, verified via `c11 get-metadata --surface <id> --sources --key terminal_type`. No agent-side action required.
  - Sidebar chip renders the paper-plane SF Symbol for github-copilot surfaces.
  - Default-agent picker (Settings → Default Agent) lists "GitHub Copilot" with command `copilot --allow-all --autopilot`.
- Unit tests added in `c11Tests/AgentDetectorTests.swift` (direct-comm match + two node-wrapped Copilot variants + Claude regression sentinel + unrelated-node-process negative + zsh positive) and 2 new cases in `c11Tests/DefaultAgentConfigTests.swift` (`.githubCopilot` rawValue is `"github-copilot"`, factoryCommand is `copilot --allow-all --autopilot`). All ~10 new test cases pass.
- 63 pre-existing test failures in `c11Tests` (browser panels, window portals, IME, theming, command palette, tab manager) are environmental flake on this machine — zero overlap with anything this diff touches; failure list is stable across reruns.

## Demo Video

Demo video to follow as a PR comment — short capture of: install `@github/copilot` → c11 skills dialog shows GitHub Copilot → "Update all" → run `copilot` in a fresh pane → sidebar chip becomes paper-plane glyph reading "GitHub Copilot · <model>" with zero agent-side action.

- Video URL or attachment: _to follow as comment_

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed — `skills/c11/SKILL.md` content fix deferred to follow-up PR per #210 redirect; CHANGELOG.md not touched, happy to add an entry if preferred
- [x] I requested bot reviews after my latest commit (copy/paste block above)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved