### PR TITLE
skills/c11: read agent identity from env vars instead of hardcoding claude-code

### DIFF
--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -40,10 +40,12 @@ At session start — always, in this order:
 ```bash
 c11 identify                                                        # Your workspace/surface/pane refs (JSON)
 c11 tree                                                            # Spatial layout of the current workspace + hierarchical listing
-c11 set-agent --type claude-code --model claude-opus-4-7            # Declare terminal_type + model (mandatory)
+c11 set-agent --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"   # Persist agent identity (env vars pre-seeded by c11's spawn path; trust them)
 c11 rename-tab       --surface "$C11_SURFACE_ID" "<your role>"      # Title — what this surface is (mandatory)
 c11 set-description  --surface "$C11_SURFACE_ID" "<why it's open>"  # Description — what you're doing right now (mandatory)
 ```
+
+**On `$C11_AGENT_TYPE` and `$C11_AGENT_MODEL`.** c11's spawn path pre-seeds these env vars with the agent it thinks it's launching — `claude-code`, `codex`, `kimi`, `opencode`, `github-copilot`, or any kebab-case custom value the operator configured. The `c11 set-agent` call above persists them to surface metadata, which is what the sidebar chip and orchestration filters actually read from. **If either env var is empty** you were launched outside the c11 wrapper path (or the operator's shell didn't pre-seed); substitute your own values — e.g. `--type github-copilot --model <your-current-model>` — and do not guess. Read your model name from your runtime's own status banner, not from this skill's examples.
 
 > **Binary bug (as of 2026-04-18):** `C11_TAB_ID` is exported equal to the workspace UUID, not the tab UUID. Bare `c11 rename-tab "<role>"` (and any other tab-scoped command that defaults to `C11_TAB_ID`) errors with `not_found: Tab not found`. Always pass `--surface "$C11_SURFACE_ID"` for tab-scoped commands (`rename-tab`, `set-title`, `set-description`) until this is fixed — `C11_SURFACE_ID` itself is correct.
 
@@ -106,8 +108,9 @@ The rule is intentionally narrow. It does **not** cover `"read /path/to/X and fo
 `c11 set-agent` writes `terminal_type` and `model` to the surface manifest:
 
 ```bash
-c11 set-agent --type claude-code --model claude-opus-4-7
-c11 set-agent --type codex --task lat-412
+c11 set-agent --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"   # canonical: trust the env vars c11 pre-seeded
+c11 set-agent --task lat-412                                        # partial write: just update the task ID
+c11 set-agent --type <your-terminal-type> --model <your-model>      # explicit override when env vars are empty/wrong
 ```
 
 Common types: `claude-code`, `codex`, `kimi`, `opencode`. Any kebab-case string is accepted. Inside Claude Code, `claude.session_id` is populated automatically by the wrapper.


### PR DESCRIPTION
## Summary

- **What changed?** Replaces the hardcoded `c11 set-agent --type claude-code --model claude-opus-4-7` examples in `skills/c11/SKILL.md` (both the "Orient first" and "Agent declaration" sections) with the env-var pattern `--type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"`. Adds a brief explanatory paragraph noting that c11's spawn path pre-seeds these env vars per agent, with explicit fallback guidance when they're empty.
- **Why?** The previous examples were Claude-Code-biased — non-Claude agents (Codex, Kimi, OpenCode, and the GitHub Copilot CLI addition in #215) that follow the skill literally copy the example values and write the wrong `terminal_type`, violating `PHILOSOPHY.md`'s "agent-agnostic by construction" rule. c11 already pre-seeds the correct values in env vars (documented at SKILL.md line 25 since v1; set by `Resources/bin/claude` and `Resources/bin/codex` wrappers). The skill just wasn't reading them.

Discovered while testing GitHub Copilot CLI integration locally for #215 — Copilot loaded the skill, copied the `claude-code` example verbatim, and mis-declared its `terminal_type` as `claude-code` even though it's a different CLI shell. Per maintainer redirect in #210 (split this out from the wiring PR), here it is on its own.

Companion to #215; references #210.

## Testing

- 6 insertions / 3 deletions in `skills/c11/SKILL.md` only — no code, no build, no tests.
- Manual review: the env vars referenced (`C11_AGENT_TYPE`, `C11_AGENT_MODEL`) are the names already documented at SKILL.md line 25 and in `skills/c11/references/api.md`, and are the same identifiers `Resources/bin/claude` and `Resources/bin/codex` read at startup. The fallback placeholder (`<your-terminal-type>` / `<your-model>`) matches the convention used elsewhere in the file.

## Demo Video

Not applicable — no UI or behavior change. Pure SKILL.md content edit.

- Video URL or attachment: _n/a_

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes — _n/a, pure SKILL.md content_
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved