### PR TITLE
default-agent: stale ~/.c11/agents.json no longer pins the A button to Claude

### DIFF
--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -125,10 +125,35 @@ struct DefaultAgentConfig: Codable, Equatable {
     /// fall back to factory defaults at use time.
     var agents: [AgentType: AgentConfig]
 
+    /// Whether `defaultAgent` was explicitly specified by the source this
+    /// config was decoded from. `true` for programmatically-built configs and
+    /// for JSON that carries a `defaultAgent` key; `false` only when a decoded
+    /// blob omits the key (and `defaultAgent` therefore holds the fallback).
+    ///
+    /// Project-level overrides key off this: a `.c11/agents.json` that doesn't
+    /// state a `defaultAgent` must NOT silently force the fallback over the
+    /// user's Settings pick (see `overrideDefaultAgent`). Excluded from
+    /// `Equatable` so value comparisons stay shape-based.
+    var hasExplicitDefaultAgent: Bool = true
+
+    /// The agent this config should impose on a *consumer* that already has its
+    /// own default (i.e. project config overriding the user default). `nil` when
+    /// the default was never explicitly stated, so the consumer keeps its own.
+    var overrideDefaultAgent: AgentType? {
+        hasExplicitDefaultAgent ? defaultAgent : nil
+    }
+
     /// Returns the config for `agent`, falling back to factory if the operator
     /// never edited that one.
     func config(for agent: AgentType) -> AgentConfig {
         agents[agent] ?? .factory(for: agent)
+    }
+
+    // Shape-based equality: `hasExplicitDefaultAgent` is provenance metadata,
+    // not part of the config's value, so two configs with the same selection
+    // and per-agent entries compare equal regardless of how they were built.
+    static func == (lhs: DefaultAgentConfig, rhs: DefaultAgentConfig) -> Bool {
+        lhs.defaultAgent == rhs.defaultAgent && lhs.agents == rhs.agents
     }
 
     /// Factory shape: claude-code is the default, every agent pre-filled with
@@ -144,12 +169,30 @@ struct DefaultAgentConfig: Codable, Equatable {
     init(defaultAgent: AgentType, agents: [AgentType: AgentConfig]) {
         self.defaultAgent = defaultAgent
         self.agents = agents
+        self.hasExplicitDefaultAgent = true
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        self.defaultAgent = (try? c.decode(AgentType.self, forKey: .defaultAgent)) ?? .claudeCode
-        if let agentsByRaw = try? c.decode([String: AgentConfig].self, forKey: .agents) {
+        // Track explicit presence so an omitted `defaultAgent` doesn't read as
+        // a deliberate "launch claude-code" override when this config is used at
+        // the project level.
+        if c.contains(.defaultAgent) {
+            self.defaultAgent = try c.decode(AgentType.self, forKey: .defaultAgent)
+            self.hasExplicitDefaultAgent = true
+        } else {
+            self.defaultAgent = .claudeCode
+            self.hasExplicitDefaultAgent = false
+        }
+        // `agents` must be the v2 dict shape when present. A legacy pre-v0.48
+        // file (an *array* of {id,displayName,command}) must NOT silently decode
+        // to an empty dict and let this whole config masquerade as a valid
+        // override — that's the bug where a stale ~/.c11/agents.json pinned the
+        // A button to claude-code regardless of Settings. Throwing here makes
+        // `DefaultAgentProjectConfig.find`'s `try?` reject the file outright so
+        // resolution falls through to the user's Settings default.
+        if c.contains(.agents) {
+            let agentsByRaw = try c.decode([String: AgentConfig].self, forKey: .agents)
             var byType: [AgentType: AgentConfig] = [:]
             for (raw, cfg) in agentsByRaw {
                 if let t = AgentType(rawValue: raw) { byType[t] = cfg }

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -176,9 +176,12 @@ struct DefaultAgentConfig: Codable, Equatable {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         // Track explicit presence so an omitted `defaultAgent` doesn't read as
         // a deliberate "launch claude-code" override when this config is used at
-        // the project level.
-        if c.contains(.defaultAgent) {
-            self.defaultAgent = try c.decode(AgentType.self, forKey: .defaultAgent)
+        // the project level. A present-but-corrupt value (e.g. an unknown agent
+        // name) is treated like the user-level store has always treated it:
+        // fall back to claude-code, and — since the stated value was unusable —
+        // do NOT count it as an explicit override.
+        if let decoded = try? c.decode(AgentType.self, forKey: .defaultAgent) {
+            self.defaultAgent = decoded
             self.hasExplicitDefaultAgent = true
         } else {
             self.defaultAgent = .claudeCode

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -32,8 +32,12 @@ enum DefaultAgentResolver {
         userDefault: DefaultAgentConfig,
         projectConfig: DefaultAgentConfig?
     ) -> (agent: AgentType, launch: ResolvedAgentLaunch) {
+        // A project config only overrides the agent selection when it actually
+        // states a `defaultAgent`; a file that omits the key (or a legacy file
+        // that no longer decodes) must not displace the user's Settings pick.
+        let projectDefault: AgentType? = projectConfig?.overrideDefaultAgent ?? nil
         let agent = explicitAgent
-            ?? projectConfig?.defaultAgent
+            ?? projectDefault
             ?? userDefault.defaultAgent
 
         // Project-level per-agent config beats user-level for the chosen agent.

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -73,6 +73,44 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(decoded.defaultAgent, .claudeCode)
     }
 
+    func testDecodeWithDefaultAgentMarksItExplicit() throws {
+        let decoded = try JSONDecoder().decode(
+            DefaultAgentConfig.self,
+            from: Data(#"{"defaultAgent":"codex"}"#.utf8)
+        )
+        XCTAssertTrue(decoded.hasExplicitDefaultAgent)
+        XCTAssertEqual(decoded.overrideDefaultAgent, .codex)
+    }
+
+    func testDecodeWithoutDefaultAgentHasNoOverride() throws {
+        // Falls back to claude-code for `defaultAgent`, but exposes no override
+        // so a project consumer keeps its own selection.
+        let decoded = try JSONDecoder().decode(
+            DefaultAgentConfig.self,
+            from: Data(#"{"agents":{}}"#.utf8)
+        )
+        XCTAssertEqual(decoded.defaultAgent, .claudeCode)
+        XCTAssertFalse(decoded.hasExplicitDefaultAgent)
+        XCTAssertNil(decoded.overrideDefaultAgent)
+    }
+
+    func testLegacyArrayAgentsShapeIsRejected() {
+        // Pre-v0.48 `~/.c11/agents.json`: an array of {id,displayName,command}
+        // with no `defaultAgent`. Must fail to decode rather than silently
+        // become an empty-but-valid claude-code override (the A-button bug).
+        let legacy = #"{"agents":[{"id":"claudeCode","displayName":"Claude Code","command":"claude --dangerously-skip-permissions"}]}"#
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(DefaultAgentConfig.self, from: Data(legacy.utf8))
+        )
+    }
+
+    func testProgrammaticConfigIsExplicit() {
+        // The memberwise init always represents a deliberate selection.
+        let cfg = DefaultAgentConfig(defaultAgent: .kimi, agents: [:])
+        XCTAssertTrue(cfg.hasExplicitDefaultAgent)
+        XCTAssertEqual(cfg.overrideDefaultAgent, .kimi)
+    }
+
     // MARK: - envMap parsing
 
     func testEnvMapParsesKeyValueLines() {

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -71,6 +71,10 @@ final class DefaultAgentConfigTests: XCTestCase {
         let data = Data(json.utf8)
         let decoded = try JSONDecoder().decode(DefaultAgentConfig.self, from: data)
         XCTAssertEqual(decoded.defaultAgent, .claudeCode)
+        // A corrupt value is not a usable selection, so it must not act as a
+        // project-level override either — same fall-through as an absent key.
+        XCTAssertFalse(decoded.hasExplicitDefaultAgent)
+        XCTAssertNil(decoded.overrideDefaultAgent)
     }
 
     func testDecodeWithDefaultAgentMarksItExplicit() throws {

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -83,6 +83,36 @@ final class DefaultAgentResolverTests: XCTestCase {
         XCTAssertEqual(launch.command, "kimi --user-flag")
     }
 
+    func testProjectConfigWithoutExplicitDefaultDoesNotOverrideUser() throws {
+        // A v2 project file with per-agent entries but no `defaultAgent` key must
+        // keep the user's Settings pick, not silently force the claude-code
+        // fallback. Regression for the stale-~/.c11/agents.json A-button bug.
+        let project = try JSONDecoder().decode(
+            DefaultAgentConfig.self,
+            from: Data(#"{"agents":{}}"#.utf8)
+        )
+        let (agent, _) = DefaultAgentResolver.resolve(
+            explicitAgent: nil,
+            userDefault: DefaultAgentConfig(defaultAgent: .codex, agents: [:]),
+            projectConfig: project
+        )
+        XCTAssertEqual(agent, .codex)
+    }
+
+    func testProjectConfigWithExplicitDefaultStillOverridesUser() throws {
+        // The honored-override path must keep working after the fix.
+        let project = try JSONDecoder().decode(
+            DefaultAgentConfig.self,
+            from: Data(#"{"defaultAgent":"kimi","agents":{}}"#.utf8)
+        )
+        let (agent, _) = DefaultAgentResolver.resolve(
+            explicitAgent: nil,
+            userDefault: DefaultAgentConfig(defaultAgent: .codex, agents: [:]),
+            projectConfig: project
+        )
+        XCTAssertEqual(agent, .kimi)
+    }
+
     // MARK: - command builder
 
     func testBuildCommandClaudeAppendsInitialPromptAsPositional() {


### PR DESCRIPTION
## Summary

Fixes the bug where the pane **A** (Agent Launcher) button always launches Claude regardless of what's selected under **Settings → Default Agent**. The Settings picker appears to update (and does persist) but the next left-click on **A** still launches Claude.

## Root cause

The A button resolves its agent through `DefaultAgentResolver.resolve`, precedence:

```
explicitAgent  ??  projectConfig?.defaultAgent  ??  userDefault.defaultAgent
```

`projectConfig` is the result of walking **up** from the launch cwd looking for `.c11/agents.json` (`DefaultAgentProjectConfig.find`). Two decoder behaviors combined into a silent footgun:

1. `DefaultAgentConfig.init(from:)` was fully lenient — every field decoded with `try?`, so it **never threw**. A *missing* `defaultAgent` key fell back to `.claudeCode`, and a **legacy pre-v0.48 file** (an `agents` **array** of `{id,displayName,command}` rather than the v2 dict) still "decoded" into an empty-but-valid config.
2. Because that config is non-nil with `defaultAgent == .claudeCode`, it short-circuited the resolver **before** the user's Settings pick (`userDefault.defaultAgent`) was ever read.

Net effect: a stale **`~/.c11/agents.json`** in the home directory — an ancestor of nearly every working directory — pins the A button to Claude everywhere, regardless of Settings. Right-click "set default" updates Settings, but the next left-click still resolves through the project override.

Confirmed on a machine running v0.50.0 (build 107): a home-dir `~/.c11/agents.json` in the old array format, mtime predating the v0.48 redesign. Compiling the exact decoder against that file reproduced `defaultAgent = claude-code, agents.count = 0` from a non-nil decode.

## Fix

- Track whether `defaultAgent` was explicitly present at decode time (`hasExplicitDefaultAgent`) and expose `overrideDefaultAgent` (`nil` when the key was absent). The resolver now only lets a project config override the agent selection when it **actually states one** — an absent key no longer forces the fallback over the user's Settings pick.
- Reject a legacy **array-shaped** `agents` at decode time (throw) so `DefaultAgentProjectConfig.find`'s `try?` discards the file and resolution falls through to the user's Settings default, instead of the file masquerading as a valid claude-code override.
- Custom `==` keeps `DefaultAgentConfig` equality shape-based (the new provenance flag is metadata, not value).

User-level behavior is unchanged: the stored Settings blob always carries `defaultAgent` (the encoder always writes it), so `hasExplicitDefaultAgent` is always `true` for it.

## Validation

- Standalone resolver harness covering all four paths: legacy-array → rejected → Settings honored; no-`defaultAgent` v2 → no override; explicit v2 → overrides; right-click explicit → still wins. All pass.
- `xcodebuild build-for-testing -scheme c11-unit` compiles green (full project + test target).
- New unit tests in `DefaultAgentResolverTests` and `DefaultAgentConfigTests` (run by CI per the repo's host-test policy):
  - project config without explicit default doesn't override the user pick
  - project config with explicit default still overrides
  - explicit/absent `defaultAgent` provenance + `overrideDefaultAgent`
  - legacy array `agents` shape is rejected

## Note for affected users

Anyone with a pre-v0.48 `~/.c11/agents.json` should delete or rewrite it (only `defaultAgent` is read by current c11). After this fix, such a file no longer hijacks the A button even if left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
