### PR TITLE
drawbridge: GitHub-native fallback when Zulip is unreachable from CI

### DIFF
--- a/.github/workflows/drawbridge.yml
+++ b/.github/workflows/drawbridge.yml
@@ -467,6 +467,7 @@ jobs:
        needs.drawbridge-judge.result == 'failure')
     permissions:
       contents: read
+      issues: write         # GitHub-native fallback ping (label + assignee)
     steps:
       - name: Checkout trusted default branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -490,6 +491,7 @@ jobs:
       - name: Compose and send notification
         env:
           ZULIP_BOT_API_KEY: ${{ secrets.ZULIP_BOT_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
           ROUTE: ${{ needs.drawbridge-gate.outputs.route }}
           MODE: ${{ needs.drawbridge-gate.outputs.mode }}
           REVIEW_URL: ${{ needs.drawbridge-review.outputs.comment_url }}
@@ -498,6 +500,30 @@ jobs:
           FALLBACK_NUMBER: ${{ needs.drawbridge-judge.outputs.item_number || github.event.pull_request.number || github.event.issue.number || inputs.item_number }}
         run: |
           set -euo pipefail
+
+          # Zulip lives on the tailnet only (CoreDNS split DNS; no public
+          # record — see TRIAGE_POLICY.md operational notes). Until the
+          # runner joins via an ephemeral Tailscale step, delivery from CI
+          # can fail with DNS errors. Degrade to a GitHub-native ping
+          # (label + assignee) instead of failing the run red on every
+          # inbound item — a red X here reads as a broken pipeline to
+          # contributors when it's only the messenger that slipped.
+          notify_or_fallback() {
+            if scripts/drawbridge/notify.sh TRIAGE_POLICY.md /tmp/notify.md; then
+              return 0
+            fi
+            echo "::warning::drawbridge-notify: Zulip unreachable from this runner; using GitHub-native fallback ping"
+            local assignee
+            assignee="$(python3 scripts/drawbridge/gates.py --emit-config-key fallback_assignee --policy TRIAGE_POLICY.md 2>/dev/null | jq -r . || true)"
+            if [[ -n "${FALLBACK_NUMBER:-}" ]]; then
+              gh label create "drawbridge:notify-failed" --color "d93f0b" \
+                --description "Drawbridge: maintainer ping failed; GitHub-native fallback used" 2>/dev/null || true
+              gh issue edit "$FALLBACK_NUMBER" --add-label "drawbridge:notify-failed" || true
+              if [[ -n "$assignee" && "$assignee" != "null" ]]; then
+                gh issue edit "$FALLBACK_NUMBER" --add-assignee "$assignee" || true
+              fi
+            fi
+          }
 
           # Hard-failure path: the pipeline errored before producing its
           # artifacts. Send a manual-triage ping instead of going silent.
@@ -510,7 +536,7 @@ jobs:
               echo "- **Run:** $RUN_URL"
               echo "- No verdict/gate artifacts were produced; nothing was merged, labeled, or commented."
             } > /tmp/notify.md
-            scripts/drawbridge/notify.sh TRIAGE_POLICY.md /tmp/notify.md
+            notify_or_fallback
             exit 0
           fi
 
@@ -547,4 +573,4 @@ jobs:
             fi
           } > /tmp/notify.md
 
-          scripts/drawbridge/notify.sh TRIAGE_POLICY.md /tmp/notify.md
+          notify_or_fallback

--- a/TRIAGE_POLICY.md
+++ b/TRIAGE_POLICY.md
@@ -81,7 +81,17 @@ Anything larger escalates no matter how clean it looks.
 
 1. **Zulip** (primary): channel `c11`, topic `drawbridge`, posted by the bot
    account. Token lives in the `ZULIP_BOT_API_KEY` repo secret — never in files.
-2. Email: deliberately not wired yet. Add a channel by extending
+   **Reachability:** `zulip.stage11.ai` resolves only inside the tailnet (CoreDNS
+   split DNS; no public record), so delivery from GitHub-hosted runners fails
+   until the notify job joins the tailnet via an ephemeral, ACL-scoped
+   `tailscale/github-action` step (pending: maintainer mints the auth key,
+   scoped to Zulip:443 only).
+2. **GitHub-native fallback** (automatic): when Zulip is unreachable, the notify
+   job labels the item `drawbridge:notify-failed` and assigns the
+   `fallback_assignee` from the machine config instead of failing the run red —
+   a red X on an inbound PR reads as a broken pipeline to contributors when
+   it's only the messenger that slipped.
+3. Email: deliberately not wired yet. Add a channel by extending
    `scripts/drawbridge/notify.sh` and documenting it here.
 
 ## Tone
@@ -171,6 +181,7 @@ exact root-level path.
     "channel": "c11",
     "topic": "drawbridge",
     "bot_email": "mcp-bot@zulip.stage11.ai"
-  }
+  },
+  "fallback_assignee": "BenevolentFutures"
 }
 ```


### PR DESCRIPTION
## What

First real traffic (3 runs) surfaced that `zulip.stage11.ai` is **tailnet-only** — split DNS, no public record — so every notify from a GitHub-hosted runner failed with `curl (6)` and marked the run **red on contributors' PRs**.

- `notify_or_fallback()`: Zulip failure → `drawbridge:notify-failed` label + assign `fallback_assignee` (new machine-config key) + `::warning::`, exit 0.
- Notify job: `issues: write` + `GH_TOKEN` for the fallback path.
- `TRIAGE_POLICY.md`: documents the tailnet constraint and the pending ephemeral `tailscale/github-action` wiring (maintainer mints an ACL-scoped key, Zulip:443 only) for true CI→Zulip delivery.

Spec feedback recorded in `ideation/drawbridge/instantiation-notes-c11.md`: conformance checks must validate notify delivery *from the runner environment*, not the implementing agent's machine.

## Validation

- 40/40 gate tests, `--emit-config-key fallback_assignee` resolves, YAML parses, `bash -n` clean on the rewritten step

🤖 Generated with [Claude Code](https://claude.com/claude-code)