### PR TITLE
drawbridge: deliver Zulip pings from CI via ephemeral tailnet join

### DIFF
--- a/.github/workflows/drawbridge-sweep.yml
+++ b/.github/workflows/drawbridge-sweep.yml
@@ -65,6 +65,14 @@ jobs:
             fi
           } > /tmp/digest.md
 
+      # Zulip is tailnet-only; ephemeral ACL-scoped join (see drawbridge.yml).
+      - name: Join tailnet (ephemeral, scoped to Zulip)
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Post digest
         env:
           ZULIP_BOT_API_KEY: ${{ secrets.ZULIP_BOT_API_KEY }}

--- a/.github/workflows/drawbridge.yml
+++ b/.github/workflows/drawbridge.yml
@@ -488,6 +488,18 @@ jobs:
           name: drawbridge-gates-${{ needs.drawbridge-judge.outputs.item_type }}-${{ needs.drawbridge-judge.outputs.item_number }}
           path: /tmp/gate
 
+      # Zulip is tailnet-only (see TRIAGE_POLICY.md). Join as an ephemeral,
+      # ACL-scoped node (tag:ci → pine 443/53 only); the node self-removes
+      # when the job ends. continue-on-error: the GitHub-native fallback in
+      # notify_or_fallback carries the ping if the join fails.
+      - name: Join tailnet (ephemeral, scoped to Zulip)
+        continue-on-error: true
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Compose and send notification
         env:
           ZULIP_BOT_API_KEY: ${{ secrets.ZULIP_BOT_API_KEY }}

--- a/TRIAGE_POLICY.md
+++ b/TRIAGE_POLICY.md
@@ -82,10 +82,10 @@ Anything larger escalates no matter how clean it looks.
 1. **Zulip** (primary): channel `c11`, topic `drawbridge`, posted by the bot
    account. Token lives in the `ZULIP_BOT_API_KEY` repo secret — never in files.
    **Reachability:** `zulip.stage11.ai` resolves only inside the tailnet (CoreDNS
-   split DNS; no public record), so delivery from GitHub-hosted runners fails
-   until the notify job joins the tailnet via an ephemeral, ACL-scoped
-   `tailscale/github-action` step (pending: maintainer mints the auth key,
-   scoped to Zulip:443 only).
+   split DNS; no public record). The notify and sweep jobs join the tailnet via
+   an ephemeral `tailscale/github-action` step: OAuth client (repo secrets
+   `TS_OAUTH_CLIENT_ID`/`TS_OAUTH_SECRET`) mints `tag:ci` nodes that the ACL
+   pins to pine's 443/53 and that self-remove when the job ends.
 2. **GitHub-native fallback** (automatic): when Zulip is unreachable, the notify
    job labels the item `drawbridge:notify-failed` and assigns the
    `fallback_assignee` from the machine config instead of failing the run red —


### PR DESCRIPTION
Completes the notify lane: the notify job and nightly sweep join the tailnet as ephemeral `tag:ci` nodes via `tailscale/github-action` (pinned v4.1.2). ACL pins `tag:ci` to pine's 443/53 only; OAuth client can mint only `tag:ci` keys; nodes self-remove after each run. Join failure degrades to the GitHub-native fallback from #223.

Live delivery test from a real runner follows merge via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)