### PR TITLE
drawbridge: pass github_token explicitly to claude-code-action

### DIFF
--- a/.github/workflows/drawbridge.yml
+++ b/.github/workflows/drawbridge.yml
@@ -142,6 +142,9 @@ jobs:
         uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1.0.134
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Explicit token skips the action's GitHub-App OIDC exchange,
+          # which needs id-token: write we deliberately don't grant.
+          github_token: ${{ github.token }}
           prompt: "Read scripts/drawbridge/prompts/judge.md and follow it exactly."
           claude_args: >-
             --model claude-sonnet-4-6
@@ -420,6 +423,9 @@ jobs:
         uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1.0.134
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Explicit token skips the action's GitHub-App OIDC exchange,
+          # which needs id-token: write we deliberately don't grant.
+          github_token: ${{ github.token }}
           prompt: "Read scripts/drawbridge/prompts/deep-review.md and follow it exactly."
           claude_args: >-
             --model claude-opus-4-8


### PR DESCRIPTION
The action's default auth path is a GitHub-App OIDC exchange needing `id-token: write`, which the judge/review jobs deliberately lack — so Claude never actually ran; every verdict was the fail-safe escalation. Explicit `github_token: ${{ github.token }}` (read-only in those jobs) skips the exchange. Found via live `workflow_dispatch` test after wiring the real token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)