### PR TITLE
CMUX-6: remove Tier 1 persistence rollback env vars + remap scaffolding

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4202,10 +4202,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 let workspace = context.tabManager.tabs[wsIdx]
                 // Clear every live surface- and pane-layer entry on this
                 // workspace so the only surviving data path is "loaded from
-                // disk". Both clears run before the rollback-env gate so the
-                // CMUX_DISABLE_METADATA_PERSIST=1 path also fully drops live
-                // state — otherwise live writes would bleed through an
-                // intended no-op round-trip.
+                // disk".
                 for panelId in workspace.panels.keys {
                     SurfaceMetadataStore.shared.removeSurface(
                         workspaceId: workspace.id,
@@ -4222,10 +4219,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     )
                 }
 
-                // Replay persisted metadata from the snapshot. Skipped when
-                // CMUX_DISABLE_METADATA_PERSIST=1 is set — matches the
-                // production restore path's rollback semantics.
-                if PersistedMetadataBridge.isPersistDisabled { continue }
+                // Replay persisted metadata from the snapshot.
                 for panelSnapshot in wsSnapshot.panels {
                     guard let persistedValues = panelSnapshot.metadata else { continue }
                     let values = PersistedMetadataBridge.decodeValues(persistedValues)

--- a/Sources/LaunchResumePicker.swift
+++ b/Sources/LaunchResumePicker.swift
@@ -51,10 +51,8 @@ enum LaunchResumePolicy: String, CaseIterable {
 /// from `AppSessionSnapshot`; the picker view itself never reaches back
 /// into the snapshot.
 struct LaunchResumePickerEntry: Identifiable, Hashable {
-    /// Stable workspace UUID — survives across restarts when
-    /// `SessionPersistencePolicy.stableWorkspaceIdsEnabled` is true (the
-    /// default). Used as the picker's selection key and to filter the
-    /// snapshot at apply time.
+    /// Stable workspace UUID — survives across restarts. Used as the
+    /// picker's selection key and to filter the snapshot at apply time.
     let id: UUID
     /// Window index in the snapshot (0 = primary). Used to group rows
     /// when more than one window's worth of state is being offered.

--- a/Sources/PersistedMetadata.swift
+++ b/Sources/PersistedMetadata.swift
@@ -77,15 +77,6 @@ struct PersistedMetadataSource: Codable, Sendable, Equatable {
 // MARK: - Persist-direction bridge ([String: Any] → persisted)
 
 enum PersistedMetadataBridge {
-    /// Rollback safety net. When `CMUX_DISABLE_METADATA_PERSIST=1` is in
-    /// the app's launch environment, metadata is omitted from snapshots
-    /// on write and ignored on restore. App-launch-scope only — the CLI
-    /// is a separate process, so setting the var on a `cmux` invocation
-    /// has no effect. Deletable in a followup PR once Phase 2 is stable.
-    static var isPersistDisabled: Bool {
-        ProcessInfo.processInfo.environment["CMUX_DISABLE_METADATA_PERSIST"] == "1"
-    }
-
     /// Enforce the 64 KiB per-entity cap at the persistence boundary.
     /// Bug-guard only — the live store already caps writes. If exceeded,
     /// drop keys (largest encoded first) until under cap, logging each

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -21,53 +21,6 @@ enum SessionPersistencePolicy {
     static let maxScrollbackLinesPerTerminal: Int = 4000
     static let maxScrollbackCharactersPerTerminal: Int = 400_000
 
-    /// Tier 1 persistence, Phase 1: stable panel UUIDs across app restarts.
-    ///
-    /// When `true` (default), session-restore injects each `SessionPanelSnapshot.id`
-    /// into the restored panel's constructor so external consumers (Lattice, CLI,
-    /// scripted tests) can cache panel IDs across restarts.
-    ///
-    /// Setting `CMUX_DISABLE_STABLE_PANEL_IDS=1` reverts to the old behavior (fresh
-    /// UUID per restored panel + `oldToNewPanelIds` remap inside the workspace).
-    /// Kept as a one-release rollback safety net; delete in a followup PR.
-    static var stablePanelIdsEnabled: Bool {
-        !envFlagEnabled("CMUX_DISABLE_STABLE_PANEL_IDS")
-    }
-
-    /// Tier 1 persistence, Phase 1.5: stable workspace UUIDs across app restarts.
-    ///
-    /// When `true` (default), `TabManager.restoreSessionSnapshot` injects each
-    /// `SessionWorkspaceSnapshot.id` into the restored workspace's constructor so
-    /// external consumers (Lattice, CLI, scripted tests) can cache the
-    /// `(workspaceId, surfaceId)` tuple across restarts. This is a hard
-    /// prerequisite for Phase 2 (persistent `SurfaceMetadataStore`), which keys
-    /// on that tuple.
-    ///
-    /// Setting `CMUX_DISABLE_STABLE_WORKSPACE_IDS=1` reverts to the old behavior
-    /// (fresh UUID per restored workspace). App launch scope only — set via
-    /// `launchctl setenv` or the parent shell before launching the app; setting
-    /// it on the `cmux` CLI invocation has no effect. Kept as a one-release
-    /// rollback safety net; delete in a followup PR.
-    static var stableWorkspaceIdsEnabled: Bool {
-        !envFlagEnabled("CMUX_DISABLE_STABLE_WORKSPACE_IDS")
-    }
-
-    /// Tier 1 persistence, Phase 3: persist `statusEntries` across app restart.
-    ///
-    /// When `true` (default), restored workspaces rebuild their `statusEntries`
-    /// from the session snapshot with each entry stamped `staleFromRestart: true`.
-    /// The sidebar renders stale entries with reduced emphasis until the agent
-    /// re-announces the status; the first fresh write clears the flag.
-    ///
-    /// Setting `CMUX_DISABLE_STATUS_ENTRY_PERSIST=1` reverts to the pre-Phase-3
-    /// behavior (discard `statusEntries` on restore). App-launch-scope only —
-    /// set via `launchctl setenv` or the parent shell before launching the app;
-    /// setting it on the `cmux` CLI invocation has no effect. Kept as a
-    /// one-release rollback safety net.
-    static var statusEntryPersistEnabled: Bool {
-        !envFlagEnabled("CMUX_DISABLE_STATUS_ENTRY_PERSIST")
-    }
-
     /// C11-24: startup-restore agent restart.
     ///
     /// When `true` (default), `Workspace.restoreSessionSnapshot` consults the
@@ -366,8 +319,8 @@ struct SessionPanelSnapshot: Codable, Sendable {
 
     /// C11-24: per-surface ConversationRefs for the active conversation
     /// (and v1.x history). Embedded directly on the panel snapshot so the
-    /// conversation follows the panel through `oldToNewPanelIds` remapping
-    /// naturally. Optional for backcompat with pre-C11-24 snapshots; the
+    /// conversation follows the panel across a restart naturally. Optional
+    /// for backcompat with pre-C11-24 snapshots; the
     /// read-side bridge in `WorkspaceSnapshotConversationBridge` lifts
     /// legacy `claude.session_id` reserved metadata into a ConversationRef
     /// for one release window (removed in 0.46.0 / v1.1).

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5547,13 +5547,9 @@ extension TabManager {
             // Tier 1 persistence, Phase 1.5: thread the snapshot's workspace
             // UUID into the restored workspace so `(workspaceId, surfaceId)`
             // tuples cached by external consumers (Lattice, CLI, scripted
-            // tests) stay valid across restart. `CMUX_DISABLE_STABLE_WORKSPACE_IDS=1`
-            // reverts to fresh-UUID minting for one-release rollback.
-            let restoredWorkspaceId: UUID? = SessionPersistencePolicy.stableWorkspaceIdsEnabled
-                ? workspaceSnapshot.id
-                : nil
+            // tests) stay valid across restart.
             let workspace = Workspace(
-                id: restoredWorkspaceId,
+                id: workspaceSnapshot.id,
                 title: workspaceSnapshot.stableDefaultTitle ?? workspaceSnapshot.processTitle,
                 stableDefaultTitle: workspaceSnapshot.stableDefaultTitle,
                 workingDirectory: workspaceSnapshot.currentDirectory,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -250,28 +250,19 @@ extension Workspace {
 
         let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
         let leafEntries = restoreSessionLayout(snapshot.layout)
-        // When `SessionPersistencePolicy.stablePanelIdsEnabled` is true (default),
-        // this map is an identity: snapshot id == restored panel id, because
-        // `createPanel` threads `snapshot.id` into the panel constructor. When
-        // `CMUX_DISABLE_STABLE_PANEL_IDS=1` is set, restored panels mint fresh
-        // UUIDs and this map genuinely remaps old→new. Both focus restore (below)
-        // and pane selection (inside `restorePane`) route through this map so the
-        // two paths share one lookup.
-        var oldToNewPanelIds: [UUID: UUID] = [:]
+        // Panel UUIDs are stable across restart: `createPanel` threads each
+        // `snapshot.id` into the panel constructor, so a restored panel keeps
+        // the snapshot's id. Restore paths key directly on the snapshot id.
 
         for entry in leafEntries {
             restorePane(
                 entry.paneId,
                 snapshot: entry.snapshot,
-                panelSnapshotsById: panelSnapshotsById,
-                oldToNewPanelIds: &oldToNewPanelIds
+                panelSnapshotsById: panelSnapshotsById
             )
         }
 
-        restoreSurfaceMetadataFromSnapshot(
-            panels: snapshot.panels,
-            oldToNewPanelIds: oldToNewPanelIds
-        )
+        restoreSurfaceMetadataFromSnapshot(panels: snapshot.panels)
 
         // CMUX-11 Phase 3: rehydrate PaneMetadataStore entries from each
         // restored leaf and prune any pane metadata not in the live set.
@@ -304,26 +295,20 @@ extension Workspace {
         // each entry with `staleFromRestart: true` so the sidebar can render
         // them with reduced emphasis until the agent re-announces the value.
         // `agentPIDs` stays cleared — a PID from a prior boot is meaningless.
-        // `CMUX_DISABLE_STATUS_ENTRY_PERSIST=1` reverts to the pre-Phase-3
-        // discard-on-restore behavior.
-        if SessionPersistencePolicy.statusEntryPersistEnabled {
-            statusEntries = snapshot.statusEntries.reduce(into: [:]) { acc, snap in
-                let url = snap.url.flatMap { URL(string: $0) }
-                let format = snap.format.flatMap { SidebarMetadataFormat(rawValue: $0) } ?? .plain
-                acc[snap.key] = SidebarStatusEntry(
-                    key: snap.key,
-                    value: snap.value,
-                    icon: snap.icon,
-                    color: snap.color,
-                    url: url,
-                    priority: snap.priority ?? 0,
-                    format: format,
-                    timestamp: Date(timeIntervalSince1970: snap.timestamp),
-                    staleFromRestart: true
-                )
-            }
-        } else {
-            statusEntries.removeAll()
+        statusEntries = snapshot.statusEntries.reduce(into: [:]) { acc, snap in
+            let url = snap.url.flatMap { URL(string: $0) }
+            let format = snap.format.flatMap { SidebarMetadataFormat(rawValue: $0) } ?? .plain
+            acc[snap.key] = SidebarStatusEntry(
+                key: snap.key,
+                value: snap.value,
+                icon: snap.icon,
+                color: snap.color,
+                url: url,
+                priority: snap.priority ?? 0,
+                format: format,
+                timestamp: Date(timeIntervalSince1970: snap.timestamp),
+                staleFromRestart: true
+            )
         }
         agentPIDs.removeAll()
         logEntries = snapshot.logEntries.map { entry in
@@ -339,11 +324,10 @@ extension Workspace {
 
         recomputeListeningPorts()
 
-        if let focusedOldPanelId = snapshot.focusedPanelId,
-           let focusedNewPanelId = oldToNewPanelIds[focusedOldPanelId],
-           panels[focusedNewPanelId] != nil {
-            focusPanel(focusedNewPanelId)
-        } else if let fallbackFocusedPanelId = focusedPanelId, panels[fallbackFocusedPanelId] != nil {
+        if let focusedPanelId = snapshot.focusedPanelId,
+           panels[focusedPanelId] != nil {
+            focusPanel(focusedPanelId)
+        } else if let fallbackFocusedPanelId = self.focusedPanelId, panels[fallbackFocusedPanelId] != nil {
             focusPanel(fallbackFocusedPanelId)
         } else {
             scheduleFocusReconcile()
@@ -368,14 +352,12 @@ extension Workspace {
         if ConversationStorePolicy.isDisabled {
             scheduleAgentRestartLegacy(
                 from: snapshot,
-                registry: .phase1,
-                oldToNewPanelIds: oldToNewPanelIds
+                registry: .phase1
             )
         } else {
             scheduleAgentRestart(
                 from: snapshot,
-                registry: ConversationStrategyRegistry.v1,
-                oldToNewPanelIds: oldToNewPanelIds
+                registry: ConversationStrategyRegistry.v1
             )
         }
     }
@@ -385,8 +367,7 @@ extension Workspace {
     /// the panel snapshot via AgentRestartRegistry. Removed in 0.46.0/v1.1.
     private func scheduleAgentRestartLegacy(
         from snapshot: SessionWorkspaceSnapshot,
-        registry: AgentRestartRegistry,
-        oldToNewPanelIds: [UUID: UUID]
+        registry: AgentRestartRegistry
     ) {
         guard SessionPersistencePolicy.agentRestartOnRestoreEnabled else { return }
         var commands: [(panelId: UUID, command: String)] = []
@@ -407,9 +388,8 @@ extension Workspace {
             deadline: .now() + SessionPersistencePolicy.agentRestartDelay
         ) { [weak self] in
             guard let self else { return }
-            for (snapshotPanelId, command) in commands {
-                let livePanelId = oldToNewPanelIds[snapshotPanelId] ?? snapshotPanelId
-                guard let terminalPanel = self.panels[livePanelId] as? TerminalPanel else {
+            for (panelId, command) in commands {
+                guard let terminalPanel = self.panels[panelId] as? TerminalPanel else {
                     continue
                 }
                 TextBoxSubmit.send(command, via: terminalPanel.surface)
@@ -521,14 +501,11 @@ extension Workspace {
     /// still nil at the 2.5s mark (and `sendKey` silently drops) no
     /// longer hides the submission.
     ///
-    /// `oldToNewPanelIds` lets the routine remap snapshot panel ids to
-    /// the freshly minted ids when the stable-panel-id rollback flag is
-    /// set. Under default behaviour (`stablePanelIdsEnabled` true) the
-    /// map is an identity and the lookup is the snapshot id directly.
+    /// Panel ids are stable across restart, so the live panel id equals the
+    /// snapshot panel id resolved in `pendingRestartPlans`.
     private func scheduleAgentRestart(
         from snapshot: SessionWorkspaceSnapshot,
-        registry: ConversationStrategyRegistry,
-        oldToNewPanelIds: [UUID: UUID]
+        registry: ConversationStrategyRegistry
     ) {
         let plans = pendingRestartPlans(from: snapshot, registry: registry)
         guard !plans.isEmpty else { return }
@@ -536,9 +513,8 @@ extension Workspace {
             deadline: .now() + SessionPersistencePolicy.agentRestartDelay
         ) { [weak self] in
             guard let self else { return }
-            for (snapshotPanelId, action) in plans {
-                let livePanelId = oldToNewPanelIds[snapshotPanelId] ?? snapshotPanelId
-                self.executeResumeAction(action, on: livePanelId)
+            for (panelId, action) in plans {
+                self.executeResumeAction(action, on: panelId)
             }
         }
     }
@@ -609,13 +585,12 @@ extension Workspace {
 
     /// CMUX-11 Phase 3: pull `PaneMetadataStore` values + sources for a pane,
     /// run them through the persistence bridge, and apply the 64 KiB cap.
-    /// Returns `(nil, nil)` when the store is empty, the rollback flag is
-    /// set, or the pane UUID could not be parsed — keeping snapshots minimal.
+    /// Returns `(nil, nil)` when the store is empty or the pane UUID could
+    /// not be parsed — keeping snapshots minimal.
     private func persistedPaneMetadata(
         forPaneUUID paneUUID: UUID?
     ) -> ([String: PersistedJSONValue]?, [String: PersistedMetadataSource]?) {
         guard let paneUUID else { return (nil, nil) }
-        if PersistedMetadataBridge.isPersistDisabled { return (nil, nil) }
         let snapshot = PaneMetadataStore.shared.getMetadata(workspaceId: id, paneId: paneUUID)
         if snapshot.metadata.isEmpty && snapshot.sources.isEmpty {
             return (nil, nil)
@@ -740,10 +715,7 @@ extension Workspace {
 
         let persistedMetadata: [String: PersistedJSONValue]?
         let persistedMetadataSources: [String: PersistedMetadataSource]?
-        if PersistedMetadataBridge.isPersistDisabled {
-            persistedMetadata = nil
-            persistedMetadataSources = nil
-        } else {
+        do {
             let snapshot = SurfaceMetadataStore.shared.getMetadata(
                 workspaceId: id,
                 surfaceId: panelId
@@ -892,38 +864,31 @@ extension Workspace {
     private func restorePane(
         _ paneId: PaneID,
         snapshot: SessionPaneLayoutSnapshot,
-        panelSnapshotsById: [UUID: SessionPanelSnapshot],
-        oldToNewPanelIds: inout [UUID: UUID]
+        panelSnapshotsById: [UUID: SessionPanelSnapshot]
     ) {
         let existingPanelIds = bonsplitController
             .tabs(inPane: paneId)
             .compactMap { panelIdFromSurfaceId($0.id) }
-        let desiredOldPanelIds = snapshot.panelIds.filter { panelSnapshotsById[$0] != nil }
+        let desiredPanelIds = snapshot.panelIds.filter { panelSnapshotsById[$0] != nil }
 
         var createdPanelIds: [UUID] = []
-        for oldPanelId in desiredOldPanelIds {
-            guard let panelSnapshot = panelSnapshotsById[oldPanelId] else { continue }
+        for desiredPanelId in desiredPanelIds {
+            guard let panelSnapshot = panelSnapshotsById[desiredPanelId] else { continue }
             guard let createdPanelId = createPanel(from: panelSnapshot, inPane: paneId) else { continue }
             createdPanelIds.append(createdPanelId)
-            oldToNewPanelIds[oldPanelId] = createdPanelId
         }
 
         guard !createdPanelIds.isEmpty else { return }
 
-        for oldPanelId in existingPanelIds where !createdPanelIds.contains(oldPanelId) {
-            _ = closePanel(oldPanelId, force: true)
+        for existingPanelId in existingPanelIds where !createdPanelIds.contains(existingPanelId) {
+            _ = closePanel(existingPanelId, force: true)
         }
 
         for (index, panelId) in createdPanelIds.enumerated() {
             _ = reorderSurface(panelId: panelId, toIndex: index)
         }
 
-        let selectedPanelId: UUID? = {
-            if let selectedOldId = snapshot.selectedPanelId {
-                return oldToNewPanelIds[selectedOldId]
-            }
-            return createdPanelIds.first
-        }()
+        let selectedPanelId: UUID? = snapshot.selectedPanelId ?? createdPanelIds.first
 
         if let selectedPanelId,
            let selectedTabId = surfaceIdFromPanelId(selectedPanelId) {
@@ -933,13 +898,11 @@ extension Workspace {
     }
 
     private func createPanel(from snapshot: SessionPanelSnapshot, inPane paneId: PaneID) -> UUID? {
-        // Phase 1 of the Tier 1 persistence plan: restore-time ID injection.
-        // When stable panel IDs are enabled, pass the snapshot's id through to
-        // the panel constructor so external consumers (surface.list callers,
-        // cached-id scripts) see the same UUID across restarts.
-        let restoredPanelId: UUID? = SessionPersistencePolicy.stablePanelIdsEnabled
-            ? snapshot.id
-            : nil
+        // Tier 1 persistence: restore-time ID injection. Pass the snapshot's
+        // id through to the panel constructor so external consumers
+        // (surface.list callers, cached-id scripts) see the same UUID across
+        // restarts.
+        let restoredPanelId: UUID? = snapshot.id
 
         switch snapshot.type {
         case .terminal:
@@ -7101,20 +7064,14 @@ final class Workspace: Identifiable, ObservableObject {
     /// the precedence chain (the snapshot IS the prior session's source of
     /// truth). Runs before `pruneSurfaceMetadata` so anything not in the
     /// current panel set gets cleaned up on the same tick.
-    ///
-    /// Respects `CMUX_DISABLE_METADATA_PERSIST=1` as a rollback safety net —
-    /// when set, the snapshot's metadata is ignored and surfaces start with
-    /// an empty store.
     private func restoreSurfaceMetadataFromSnapshot(
-        panels snapshotPanels: [SessionPanelSnapshot],
-        oldToNewPanelIds: [UUID: UUID]
+        panels snapshotPanels: [SessionPanelSnapshot]
     ) {
-        if PersistedMetadataBridge.isPersistDisabled { return }
         for panelSnapshot in snapshotPanels {
             guard let persistedValues = panelSnapshot.metadata else { continue }
             let persistedSources = panelSnapshot.metadataSources ?? [:]
-            let newPanelId = oldToNewPanelIds[panelSnapshot.id] ?? panelSnapshot.id
-            guard panels[newPanelId] != nil else { continue }
+            let panelId = panelSnapshot.id
+            guard panels[panelId] != nil else { continue }
             var values = PersistedMetadataBridge.decodeValues(persistedValues)
             var sources = PersistedMetadataBridge.decodeSources(persistedSources)
             // CMUX-10: persistent-flash timers are process-local and never
@@ -7125,7 +7082,7 @@ final class Workspace: Identifiable, ObservableObject {
             sources.removeValue(forKey: FlashState.metadataKey)
             SurfaceMetadataStore.shared.restoreFromSnapshot(
                 workspaceId: id,
-                surfaceId: newPanelId,
+                surfaceId: panelId,
                 values: values,
                 sources: sources
             )
@@ -7138,13 +7095,9 @@ final class Workspace: Identifiable, ObservableObject {
     /// new pane UUID, preserving the original `(source, ts)` records so the
     /// precedence chain survives the restart. Silent — same contract as the
     /// surface restore path.
-    ///
-    /// Skipped when `CMUX_DISABLE_METADATA_PERSIST=1` is set in the app's
-    /// launch environment.
     private func restorePaneMetadataFromSnapshot(
         leafEntries: [SessionPaneRestoreEntry]
     ) {
-        if PersistedMetadataBridge.isPersistDisabled { return }
         for entry in leafEntries {
             guard let persistedValues = entry.snapshot.metadata,
                   !persistedValues.isEmpty else { continue }

--- a/c11Tests/PanelIdentityRestoreTests.swift
+++ b/c11Tests/PanelIdentityRestoreTests.swift
@@ -125,12 +125,4 @@ final class PanelIdentityRestoreTests: XCTestCase {
 
         XCTAssertEqual(Set(restored.panels.keys), expected)
     }
-
-    @MainActor
-    func testStablePanelIdsPolicyIsOnByDefault() {
-        XCTAssertTrue(
-            SessionPersistencePolicy.stablePanelIdsEnabled,
-            "Phase 1 default: panel IDs are stable across restarts unless CMUX_DISABLE_STABLE_PANEL_IDS is set"
-        )
-    }
 }

--- a/c11Tests/WorkspaceIdentityRestoreTests.swift
+++ b/c11Tests/WorkspaceIdentityRestoreTests.swift
@@ -94,11 +94,4 @@ final class WorkspaceIdentityRestoreTests: XCTestCase {
         XCTAssertNotNil(manager.selectedTabId)
         XCTAssertEqual(manager.selectedTabId, manager.tabs.first?.id)
     }
-
-    func testStableWorkspaceIdsPolicyIsOnByDefault() {
-        XCTAssertTrue(
-            SessionPersistencePolicy.stableWorkspaceIdsEnabled,
-            "Phase 1.5 default: workspace IDs are stable across restarts unless CMUX_DISABLE_STABLE_WORKSPACE_IDS is set"
-        )
-    }
 }

--- a/docs/c11-tier1-persistence-plan.md
+++ b/docs/c11-tier1-persistence-plan.md
@@ -1,5 +1,15 @@
 # c11 — Tier 1 Persistence Plan
 
+> **Rollback scaffolding removed (CMUX-6).** The one-release rollback
+> safety nets this plan describes — the `CMUX_DISABLE_STABLE_PANEL_IDS`,
+> `CMUX_DISABLE_STABLE_WORKSPACE_IDS`, `CMUX_DISABLE_METADATA_PERSIST`,
+> and `CMUX_DISABLE_STATUS_ENTRY_PERSIST` env vars, plus the
+> `oldToNewPanelIds` identity-map remap — have shipped, stabilized, and
+> been deleted. Stable panel/workspace IDs, metadata persistence, and
+> status-entry persistence are now unconditional. The rollback notes
+> below are retained as a planning retrospective; the env vars and remap
+> they reference no longer exist in the codebase.
+
 **Status:** plan (not scheduled). **Author:** conversation 2026-04-18.
 **Revised:** 2026-04-18 after Trident plan review — fixed metadata-type fidelity,
 reframed Phase 1 as a constructor refactor (not a remap removal), added

--- a/docs/conversation-store-architecture.md
+++ b/docs/conversation-store-architecture.md
@@ -322,7 +322,7 @@ All commands resolve `--surface` from `CMUX_SURFACE_ID` if unset, **without fall
 
 ### Per-panel embedded (source of truth)
 
-`SurfaceConversations { active: ConversationRef?, history: [ConversationRef] }` is embedded directly on each `SessionPanelSnapshot`, not as a sibling map keyed by surface id. Embedding makes the conversation follow the panel through `oldToNewPanelIds` remapping naturally, eliminates the orphan-map class of bugs that a sibling map keyed by old surface ids would invite when stable panel ids are disabled, and removes the need for an explicit pruning rule for surfaces that no longer exist.
+`SurfaceConversations { active: ConversationRef?, history: [ConversationRef] }` is embedded directly on each `SessionPanelSnapshot`, not as a sibling map keyed by surface id. Embedding makes the conversation follow the panel across a restart naturally, eliminates the orphan-map class of bugs that a sibling map keyed by old surface ids would invite, and removes the need for an explicit pruning rule for surfaces that no longer exist.
 
 On capture, the `ConversationStore` is asked for active+history refs for each panel and the result is serialized into that panel's snapshot. On restore, the executor reads the field per-panel, populates the in-memory `ConversationStore` for the new surfaces, then schedules the resume pass that already exists in `Workspace.scheduleAgentRestart` — but the pass now consults `ConversationStore` + strategy registry instead of the inline `pendingRestartCommands` registry lookup.
 

--- a/docs/socket-api-reference.md
+++ b/docs/socket-api-reference.md
@@ -89,18 +89,11 @@ Legacy values `"full"` and `"notifications"` still accepted.
 ```
 
 Panel IDs (also called surface IDs) are stable across app restarts within the
-same machine. External consumers may cache them across sessions. Set
-`CMUX_DISABLE_STABLE_PANEL_IDS=1` in the app's environment to revert to
-per-restart UUID regeneration (one-release rollback safety net; will be removed
-in a followup release).
+same machine. External consumers may cache them across sessions.
 
 Workspace IDs are also stable across app restarts within the same machine.
 External consumers may cache `(workspace_id, surface_id)` tuples across
-sessions. Set `CMUX_DISABLE_STABLE_WORKSPACE_IDS=1` in the app's launch
-environment (via `launchctl setenv` or the parent shell before launching the
-app — setting it on the `cmux` CLI invocation has no effect) to revert to
-per-restart UUID regeneration. One-release rollback safety net; will be removed
-in a followup release.
+sessions.
 
 ### Input
 
@@ -181,15 +174,6 @@ rest of the blob survives. Numbers round-trip as double-precision
 floats — callers needing integer fidelity should convert explicitly
 after reading.
 
-**Rollback:** set `CMUX_DISABLE_METADATA_PERSIST=1` in the app's launch
-environment (e.g. `launchctl setenv CMUX_DISABLE_METADATA_PERSIST 1`
-then relaunch, or export it in the parent shell that launches the
-`.app`). When set, snapshot writes emit `null` for both `metadata`
-and `metadataSources` and restore ignores any persisted values. The
-variable is **app-launch-scope only** — setting it on a `cmux` CLI
-invocation has no effect, because the CLI is a separate process from
-the running app.
-
 ### c11 Chrome Themes (CMUX-35)
 
 c11 chrome theme lifecycle lives under the `theme.*` method family. Read-only
@@ -234,7 +218,6 @@ macOS focus or raise the app.
 | `CMUX_SOCKET_MODE` | Override access mode (`cmuxOnly`, `allowAll`, `off`) |
 | `CMUX_WORKSPACE_ID` | Auto-set: current workspace ID |
 | `CMUX_SURFACE_ID` | Auto-set: current surface ID |
-| `CMUX_DISABLE_METADATA_PERSIST` | App-launch-scope rollback: `1` skips persist on write and ignores on restore. See Surface Metadata Persistence above. |
 | `TERM_PROGRAM` | Set to `ghostty` |
 | `TERM` | Set to `xterm-ghostty` |
 

--- a/tests_v2/test_metadata_persistence.py
+++ b/tests_v2/test_metadata_persistence.py
@@ -6,27 +6,12 @@ reload-from-disk round-trip via the DEBUG-only `debug.session.save_and_load`
 socket command, then reads the metadata back via `surface.get_metadata`
 and asserts every typed value plus every source record survives.
 
-Two variants, selected by the `CMUX_DISABLE_METADATA_PERSIST` env var
-in the RUNNING APP (not just the test process):
-
-- Main variant (env var unset in app):
-    All metadata + sources round-trip. Sources preserve `.explicit`
-    attribution and positive `ts`.
-
-- Rollback variant (env var `=1` in app launch env):
-    Snapshot omits `metadata` / `metadataSources`; after save_and_load
-    the live store is empty and the on-disk snapshot panels carry
-    `metadata: null`.
-
-CI launches the same test file twice — once without the env var, once
-with — to cover both paths. Setting the env var on the test process
-alone has no effect because the CLI is a separate process from the
-running app; the var must reach the app's launch environment.
+All metadata + sources round-trip. Sources preserve `.explicit`
+attribution and positive `ts`.
 """
 
 from __future__ import annotations
 
-import json
 import os
 import sys
 import time
@@ -38,30 +23,11 @@ from cmux import cmux, cmuxError
 
 
 SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
-# Whether the test process itself knows this run targets the rollback path.
-# Note: this only indicates the caller's *expectation*. The running app's
-# env is what actually controls the behavior under test.
-TEST_EXPECTS_ROLLBACK = os.environ.get("CMUX_DISABLE_METADATA_PERSIST") == "1"
 
 
 def _must(cond: bool, msg: str) -> None:
     if not cond:
         raise cmuxError(msg)
-
-
-def _snapshot_path() -> Path | None:
-    """Locate the session snapshot JSON on disk. The filename embeds the
-    app's bundle identifier, so glob for `session-*.json` under the
-    c11mux application-support directory."""
-    app_support = Path.home() / "Library" / "Application Support" / "c11mux"
-    if not app_support.exists():
-        return None
-    candidates = sorted(
-        app_support.glob("session-*.json"),
-        key=lambda p: p.stat().st_mtime,
-        reverse=True,
-    )
-    return candidates[0] if candidates else None
 
 
 def _fresh_surface(c) -> tuple[str, str]:
@@ -137,61 +103,7 @@ def _run_main_variant(c) -> None:
                 f"{k} ts should be positive: {src}",
             )
 
-        print("PASS: Tier 1 Phase 2 metadata persistence (main variant)")
-    finally:
-        try:
-            c.close_workspace(workspace_id)
-        except Exception:
-            pass
-
-
-def _run_rollback_variant(c) -> None:
-    workspace_id, surface_id = _fresh_surface(c)
-    try:
-        c._call(
-            "surface.set_metadata",
-            {
-                "surface_id": surface_id,
-                "mode": "merge",
-                "source": "explicit",
-                "metadata": {"title": "Rollback test", "progress": 0.5},
-            },
-        )
-        c._call("debug.session.save_and_load", {})
-        got = c._call(
-            "surface.get_metadata",
-            {"surface_id": surface_id, "include_sources": True},
-        ) or {}
-        md = got.get("metadata") or {}
-        sources = got.get("metadata_sources") or {}
-        _must(md == {}, f"Rollback: expected empty live store, got {md}")
-        _must(sources == {}, f"Rollback: expected empty live sources, got {sources}")
-
-        snap_path = _snapshot_path()
-        _must(
-            snap_path is not None and snap_path.exists(),
-            f"Rollback: session snapshot file missing at {snap_path}",
-        )
-        snap = json.loads(snap_path.read_text())
-        checked = 0
-        for win in snap.get("windows", []):
-            tabs = (win.get("tabManager") or {}).get("workspaces") or []
-            for ws in tabs:
-                for panel in ws.get("panels") or []:
-                    # Rollback contract: the capture path emits nil for both
-                    # fields, which JSONEncoder drops from the on-disk blob.
-                    _must(
-                        "metadata" not in panel or panel.get("metadata") is None,
-                        f"Rollback: snapshot panel has metadata: {panel}",
-                    )
-                    _must(
-                        "metadataSources" not in panel
-                        or panel.get("metadataSources") is None,
-                        f"Rollback: snapshot panel has metadataSources: {panel}",
-                    )
-                    checked += 1
-        _must(checked > 0, "Rollback: snapshot contained no panels to check")
-        print("PASS: Tier 1 Phase 2 metadata persistence (rollback variant)")
+        print("PASS: Tier 1 Phase 2 metadata persistence")
     finally:
         try:
             c.close_workspace(workspace_id)
@@ -201,10 +113,7 @@ def _run_rollback_variant(c) -> None:
 
 def main() -> int:
     with cmux(SOCKET_PATH) as client:
-        if TEST_EXPECTS_ROLLBACK:
-            _run_rollback_variant(client)
-        else:
-            _run_main_variant(client)
+        _run_main_variant(client)
     return 0
 
 

--- a/tests_v2/test_pane_metadata_persistence.py
+++ b/tests_v2/test_pane_metadata_persistence.py
@@ -6,20 +6,9 @@ reload-from-disk cycle via the DEBUG-only `debug.session.save_and_load`
 socket command, then reads the metadata back via `pane.get_metadata` and
 asserts every value plus every source attribution survived.
 
-Mirrors `test_metadata_persistence.py` but on the pane axis. Two variants,
-selected by the `CMUX_DISABLE_METADATA_PERSIST` env var **in the running
-app**:
-
-- Main variant (env var unset in the app):
-    Pane metadata + sources round-trip; the on-disk snapshot's pane layout
-    leaves carry `id`, `metadata`, and `metadataSources`.
-
-- Rollback variant (env var `=1` in the app launch env):
-    Both the live store and the on-disk snapshot omit pane metadata.
-
-CI runs the same test file twice — once without the env var, once with —
-to cover both paths. Setting the env var on the test process alone has no
-effect because the CLI is a separate process from the app.
+Mirrors `test_metadata_persistence.py` but on the pane axis. Pane metadata
++ sources round-trip; the on-disk snapshot's pane layout leaves carry `id`,
+`metadata`, and `metadataSources`.
 """
 
 from __future__ import annotations
@@ -36,7 +25,6 @@ from cmux import cmux, cmuxError
 
 
 SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
-TEST_EXPECTS_ROLLBACK = os.environ.get("CMUX_DISABLE_METADATA_PERSIST") == "1"
 
 
 def _must(cond: bool, msg: str) -> None:
@@ -172,63 +160,7 @@ def _run_main_variant(c: cmux) -> None:
                         )
         _must(found_pane, f"snapshot did not contain our pane id={pane_id}")
 
-        print("PASS: CMUX-11 Phase 3 pane metadata persistence (main variant)")
-    finally:
-        try:
-            c.close_workspace(workspace_id)
-        except Exception:
-            pass
-
-
-def _run_rollback_variant(c: cmux) -> None:
-    workspace_id, pane_id = _fresh_workspace_and_pane(c)
-    try:
-        c._call(
-            "pane.set_metadata",
-            {
-                "workspace_id": workspace_id,
-                "pane_id": pane_id,
-                "mode": "merge",
-                "source": "explicit",
-                "metadata": {"title": "Rollback", "progress": 0.5},
-            },
-        )
-        c._call("debug.session.save_and_load", {})
-        got = c._call(
-            "pane.get_metadata",
-            {
-                "workspace_id": workspace_id,
-                "pane_id": pane_id,
-                "include_sources": True,
-            },
-        ) or {}
-        md = got.get("metadata") or {}
-        sources = got.get("metadata_sources") or {}
-        _must(md == {}, f"Rollback: expected empty pane store, got {md}")
-        _must(sources == {}, f"Rollback: expected empty pane sources, got {sources}")
-
-        snap_path = _snapshot_path()
-        _must(
-            snap_path is not None and snap_path.exists(),
-            f"Rollback: session snapshot file missing at {snap_path}",
-        )
-        snap = json.loads(snap_path.read_text())
-        checked = 0
-        for win in snap.get("windows", []):
-            for ws in (win.get("tabManager") or {}).get("workspaces") or []:
-                for pane in _iter_pane_layout_nodes(ws.get("layout")):
-                    _must(
-                        "metadata" not in pane or pane.get("metadata") is None,
-                        f"Rollback: snapshot pane has metadata: {pane}",
-                    )
-                    _must(
-                        "metadataSources" not in pane
-                        or pane.get("metadataSources") is None,
-                        f"Rollback: snapshot pane has metadataSources: {pane}",
-                    )
-                    checked += 1
-        _must(checked > 0, "Rollback: snapshot contained no pane leaves to check")
-        print("PASS: CMUX-11 Phase 3 pane metadata persistence (rollback variant)")
+        print("PASS: CMUX-11 Phase 3 pane metadata persistence")
     finally:
         try:
             c.close_workspace(workspace_id)
@@ -238,10 +170,7 @@ def _run_rollback_variant(c: cmux) -> None:
 
 def main() -> int:
     with cmux(SOCKET_PATH) as client:
-        if TEST_EXPECTS_ROLLBACK:
-            _run_rollback_variant(client)
-        else:
-            _run_main_variant(client)
+        _run_main_variant(client)
     return 0
 
 

--- a/tests_v2/test_status_entry_persistence.py
+++ b/tests_v2/test_status_entry_persistence.py
@@ -12,12 +12,7 @@ Flow:
      stale-clearing path exercises the Phase 3 override of
      `shouldReplaceStatusEntry`).
 
-Two variants, selected by `CMUX_DISABLE_STATUS_ENTRY_PERSIST` in the
-running app (not the test process):
-
-- Main variant (env var unset in app): all fields round-trip.
-- Rollback variant (env var `=1` in app launch env): statusEntries
-  are discarded on restore per pre-Phase-3 behavior.
+All fields round-trip across the save/reload cycle.
 """
 
 from __future__ import annotations
@@ -33,7 +28,6 @@ from cmux import cmux, cmuxError
 
 
 SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
-TEST_EXPECTS_ROLLBACK = os.environ.get("CMUX_DISABLE_STATUS_ENTRY_PERSIST") == "1"
 
 STATUS_KEY = "phase3.smoke"
 STATUS_VALUE = "Running"
@@ -160,28 +154,7 @@ def _run_main_variant(client, cli: str) -> None:
             f"Entry missing after re-announce: {still_there!r}",
         )
 
-        print("PASS: Tier 1 Phase 3 statusEntries persistence (main variant)")
-    finally:
-        try:
-            client.close_workspace(workspace_id)
-        except Exception:
-            pass
-
-
-def _run_rollback_variant(client, cli: str) -> None:
-    workspace_id = client.new_workspace()
-    try:
-        _set_status(cli, workspace_id)
-
-        rt = client._call("debug.session.save_and_load", {})
-        _must(rt is not None, "debug.session.save_and_load returned no result")
-
-        after = _list_status(cli, workspace_id)
-        _must(
-            "No status" in after or after == "",
-            f"Rollback: expected empty statusEntries after restore, got {after!r}",
-        )
-        print("PASS: Tier 1 Phase 3 statusEntries persistence (rollback variant)")
+        print("PASS: Tier 1 Phase 3 statusEntries persistence")
     finally:
         try:
             client.close_workspace(workspace_id)
@@ -192,10 +165,7 @@ def _run_rollback_variant(client, cli: str) -> None:
 def main() -> int:
     cli = _find_cli_binary()
     with cmux(SOCKET_PATH) as client:
-        if TEST_EXPECTS_ROLLBACK:
-            _run_rollback_variant(client, cli)
-        else:
-            _run_main_variant(client, cli)
+        _run_main_variant(client, cli)
     return 0
 
 


### PR DESCRIPTION
Pure-deletion cleanup of the Tier 1 persistence rollback safety nets (Lattice **CMUX-6**). These nets date to mid-April and have been stable across many releases; CI on the base SHA is green. Stable panel/workspace IDs, metadata persistence, and status-entry persistence are now unconditional.

## Env vars removed (each + its fallback path)
- `CMUX_DISABLE_STABLE_PANEL_IDS` (Phase 1)
- `CMUX_DISABLE_STABLE_WORKSPACE_IDS` (Phase 1.5)
- `CMUX_DISABLE_METADATA_PERSIST` (Phase 2)
- `CMUX_DISABLE_STATUS_ENTRY_PERSIST` (Phase 3 — confirmed present, not a no-op bullet)

`envFlagEnabled` and the out-of-scope `CMUX_DISABLE_AGENT_RESTART` flag are retained.

## Scaffolding removed
- The `oldToNewPanelIds` identity-map remap and every pass-through parameter thread (`restoreSessionSnapshot`, `restorePane`, `scheduleAgentRestart`, `scheduleAgentRestartLegacy`, `restoreSurfaceMetadataFromSnapshot`). With stable panel IDs always on, the map was always identity (`map[x] ?? x == x`); restore paths now key directly on the snapshot id. `createPanel` always injects `snapshot.id`.
- The `stablePanelIdsEnabled` / `stableWorkspaceIdsEnabled` / `statusEntryPersistEnabled` / `isPersistDisabled` predicates and all their call sites (skip/branch paths collapse to the persist-always behavior).

## Tests
- **Deleted two rollback-toggle tests** that only asserted a now-deleted predicate was on by default — these tested the removed scaffolding, so they're deleted with it (in-scope, not test-weakening):
  - `PanelIdentityRestoreTests.testStablePanelIdsPolicyIsOnByDefault`
  - `WorkspaceIdentityRestoreTests.testStableWorkspaceIdsPolicyIsOnByDefault`
  - The behavioral round-trip tests that verify ID stability across restore **remain**.
- Dropped the `_run_rollback_variant` path + `TEST_EXPECTS_ROLLBACK` dispatch from the three `tests_v2/` persistence socket tests, keeping the main persist variant.

## Docs
- Removed the rollback env-var sections + env-var table row from `docs/socket-api-reference.md`.
- Added a removal banner to `docs/c11-tier1-persistence-plan.md` (retained as a planning retrospective per the ticket notes, not deleted).
- Reworded the `docs/conversation-store-architecture.md` rationale that referenced the deleted remap. (Historical review-pack snapshots left untouched as point-in-time records.)

## Verification
- `c11-logic` test scheme: **`** TEST SUCCEEDED **`** — the snapshot round-trip acceptance + converter suites exercise the refactored restore path.
- `rg` gate clean: zero live references to any of the four env vars, the four predicates, or `oldToNewPanelIds` across Sources/tests/skills/operator docs.
- Net diff: ~329 lines removed.

Note: a local `build-for-testing` of the host `c11-unit` scheme fails to compile `c11Tests/SurfaceActivityTests.swift` (a file untouched by this PR) — a pre-existing local SDK/Xcode artifact; base-SHA CI is green on that same file. The full host suite runs in CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)