### PR TITLE
C11-134: workspace-shape breadcrumbs for Sentry hang triage

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2249,7 +2249,6 @@ final class WindowBrowserPortal: NSObject {
             entriesByWebViewId[webViewId] = entry
             entry.containerView?.isHidden = true
             didHide = true
-#if DEBUG
             let anchorWindowDesc: String
             if anchor == nil {
                 anchorWindowDesc = "deallocated"
@@ -2260,11 +2259,19 @@ final class WindowBrowserPortal: NSObject {
             } else {
                 anchorWindowDesc = "other"
             }
+#if DEBUG
             dlog(
                 "browser.portal.orphan.hide web=\(browserPortalDebugToken(entry.webView)) " +
                 "anchor=\(browserPortalDebugToken(anchor)) anchorWindow=\(anchorWindowDesc)"
             )
 #endif
+            // C11-134: orphaned portal entries signal teardown/remount churn —
+            // the shape we need visible in Sentry hang reports.
+            sentryBreadcrumb("portal.orphan.hide", category: "portal", data: [
+                "layer": "browser",
+                "anchor": anchorWindowDesc,
+                "entryCount": entriesByWebViewId.count,
+            ])
         }
         return didHide
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -891,9 +891,7 @@ class TabManager: ObservableObject {
         }
         didSet {
             guard selectedTabId != oldValue else { return }
-            sentryBreadcrumb("workspace.switch", data: [
-                "tabCount": tabs.count
-            ])
+            sentryBreadcrumb("workspace.switch", data: surfaceShapeSummary(tabCount: tabs.count))
 
             // Phase 0 instrumentation: open a signpost interval spanning the
             // entire switch (didSet → queued async block) so Instruments.app
@@ -1321,7 +1319,7 @@ class TabManager: ObservableObject {
         let snapshot = workspaceCreationSnapshot()
         let nextTabCount = snapshot.tabs.count + 1
         let defaultTitle = Self.defaultWorkspaceTitle(number: nextTabCount)
-        sentryBreadcrumb("workspace.create", data: ["tabCount": nextTabCount])
+        sentryBreadcrumb("workspace.create", data: surfaceShapeSummary(tabCount: nextTabCount))
         let explicitWorkingDirectory = normalizedWorkingDirectory(overrideWorkingDirectory)
         let workingDirectory = explicitWorkingDirectory ?? preferredWorkingDirectoryForNewTab(snapshot: snapshot)
         let inheritedConfig = inheritedTerminalConfigForNewWorkspace(snapshot: snapshot)
@@ -2528,9 +2526,31 @@ class TabManager: ObservableObject {
         return trimmed
     }
 
+    /// C11-134: global per-type surface counts across all workspaces, merged
+    /// into lifecycle breadcrumbs so Sentry hang reports carry workspace
+    /// shape. Counts only — never titles or URLs.
+    private func surfaceShapeSummary(tabCount: Int) -> [String: Any] {
+        var counts = SurfaceShapeCounts()
+        for workspace in tabs {
+            for panel in workspace.panels.values {
+                switch panel.panelType {
+                case .terminal: counts.terminals += 1
+                case .browser: counts.browsers += 1
+                case .markdown: counts.markdown += 1
+                }
+            }
+        }
+        return [
+            "tabCount": tabCount,
+            "terminals": counts.terminals,
+            "browsers": counts.browsers,
+            "markdown": counts.markdown,
+        ]
+    }
+
     func closeWorkspace(_ workspace: Workspace) {
         guard tabs.count > 1 else { return }
-        sentryBreadcrumb("workspace.close", data: ["tabCount": tabs.count - 1])
+        sentryBreadcrumb("workspace.close", data: surfaceShapeSummary(tabCount: tabs.count - 1))
         clearWorkspaceGitProbes(workspaceId: workspace.id)
         sidebarSelectedWorkspaceIds.remove(workspace.id)
 
@@ -3717,7 +3737,9 @@ class TabManager: ObservableObject {
         guard let tab = tabs.first(where: { $0.id == tabId }),
               tab.panels[surfaceId] != nil else { return nil }
         tab.clearSplitZoom()
-        sentryBreadcrumb("split.create", data: ["direction": String(describing: direction)])
+        var splitCrumbData = surfaceShapeSummary(tabCount: tabs.count)
+        splitCrumbData["direction"] = String(describing: direction)
+        sentryBreadcrumb("split.create", data: splitCrumbData)
         return newSplit(tabId: tabId, surfaceId: surfaceId, direction: direction, focus: focus)
     }
 

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1163,6 +1163,13 @@ final class WindowTerminalPortal: NSObject {
                 "frame=\(portalLogFrame(entry.hostedView?.frame ?? .zero)) " +
                 "entryCount=\(entriesByHostedId.count)"
             )
+            // C11-134: orphaned portal entries signal teardown/remount churn —
+            // the shape we need visible in Sentry hang reports.
+            sentryBreadcrumb("portal.orphan.hide", category: "portal", data: [
+                "layer": "terminal",
+                "anchor": anchorWindowDesc,
+                "entryCount": entriesByHostedId.count,
+            ])
         }
         return didHide
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5114,6 +5114,13 @@ struct ClosedBrowserPanelRestoreSnapshot {
     let fallbackAnchorPaneId: UUID?
 }
 
+/// C11-134: per-type surface counts carried by `surface.shape` breadcrumbs.
+struct SurfaceShapeCounts: Equatable {
+    var terminals = 0
+    var browsers = 0
+    var markdown = 0
+}
+
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 @MainActor
@@ -5807,6 +5814,35 @@ final class Workspace: Identifiable, ObservableObject {
             }
             bonsplitController.selectTab(initialTabId)
         }
+
+        // C11-134: breadcrumb this workspace's surface shape (per-type panel
+        // counts) whenever it changes, so Sentry hang reports can answer "how
+        // many browser surfaces were open?". Counts only — never titles or
+        // URLs. removeDuplicates keeps it to genuine state changes; debounce
+        // coalesces bulk transitions like session restore.
+        surfaceShapeBreadcrumbCancellable = $panels
+            .map { panels -> SurfaceShapeCounts in
+                var counts = SurfaceShapeCounts()
+                for panel in panels.values {
+                    switch panel.panelType {
+                    case .terminal: counts.terminals += 1
+                    case .browser: counts.browsers += 1
+                    case .markdown: counts.markdown += 1
+                    }
+                }
+                return counts
+            }
+            .removeDuplicates()
+            .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+            .sink { [weak self] counts in
+                guard let self else { return }
+                sentryBreadcrumb("surface.shape", category: "shape", data: [
+                    "workspace": String(self.id.uuidString.prefix(8)),
+                    "terminals": counts.terminals,
+                    "browsers": counts.browsers,
+                    "markdown": counts.markdown,
+                ])
+            }
     }
 
     deinit {
@@ -5947,6 +5983,7 @@ final class Workspace: Identifiable, ObservableObject {
 #endif
     private var layoutFollowUpObservers: [NSObjectProtocol] = []
     private var layoutFollowUpPanelsCancellable: AnyCancellable?
+    private var surfaceShapeBreadcrumbCancellable: AnyCancellable?
     private var layoutFollowUpTimeoutWorkItem: DispatchWorkItem?
     private var layoutFollowUpReason: String?
     private var layoutFollowUpTerminalFocusPanelId: UUID?


### PR DESCRIPTION
## Why

Sentry AppHang events for c11 carry only lifecycle/update/http breadcrumbs, so fleet hang reports (C11-1: 135 events, 8 users) cannot answer "how many browser surfaces were open at hang time?" — the exact correlation needed during the 2026-06-12 multi-browser freeze triage. Lattice ticket: **C11-134**.

## What

- **`Workspace`**: new `surface.shape` breadcrumb (per-type panel counts) on every change to the workspace's panels. Combine pipeline on `$panels` with `removeDuplicates` + 500 ms debounce → state-change-only volume, bulk transitions (session restore) coalesce to one crumb. Counts only — no titles, no URLs.
- **`TabManager`**: existing `workspace.switch` / `workspace.create` / `workspace.close` / `split.create` breadcrumbs now carry global per-type surface counts alongside `tabCount`.
- **Both portals**: `portal.orphan.hide` breadcrumb (layer, anchor state, entry count) — orphaned portal entries are the teardown/remount-churn signal from the triage. Browser-portal `anchorWindowDesc` computation moved out of `#if DEBUG` so the breadcrumb ships in Release; `dlog` stays gated.

All paths use the consent-gated `sentryBreadcrumb()` helper.

## Validation

- Debug build green; `c11-logic` suite: 911 tests, 0 failures.
- End-to-end delivery: the lifecycle crumbs already visible in C11-1 events use the identical helper/consent gate; these additions ride the same pipeline. First real fleet event with the new crumbs will confirm in the Sentry UI (noted on the ticket).
- No user-facing strings added (telemetry only — no localization pass needed).
- Per test policy: no fake source-shape tests added; the breadcrumb emission seam is observed behavior at the Sentry boundary.

Related: C11-132 / C11-133 (fix work, in flight on a separate lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)