### PR TITLE
Markdown pane: debounced live-reload, theme caching, font zoom (Cmd+=/-/0)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		CC401009A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401008A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift */; };
 		CC40100BA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC40100AA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift */; };
 		CFA9529EA1B3835E1A2586A2 /* DescriptionSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */; };
+		4D11AA01B2C3D4E5F6071920 /* MarkdownPanelFontScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D11AA02B2C3D4E5F6071921 /* MarkdownPanelFontScaleTests.swift */; };
 		D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */; };
 		D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
 		D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */ = {isa = PBXBuildFile; fileRef = D1BEF00001A1B2C3D4E5F719 /* open */; };
@@ -607,6 +608,7 @@
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
 		D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarRenderTests.swift; sourceTree = "<group>"; };
 		D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptionSanitizerTests.swift; sourceTree = "<group>"; };
+		4D11AA02B2C3D4E5F6071921 /* MarkdownPanelFontScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelFontScaleTests.swift; sourceTree = "<group>"; };
 		D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelIdentityRestoreTests.swift; sourceTree = "<group>"; };
 		D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIdentityRestoreTests.swift; sourceTree = "<group>"; };
 		D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedMetadata.swift; sourceTree = "<group>"; };
@@ -1067,6 +1069,7 @@
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 				D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */,
 				D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */,
+				4D11AA02B2C3D4E5F6071921 /* MarkdownPanelFontScaleTests.swift */,
 				D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */,
 				D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */,
 				D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */,
@@ -1401,6 +1404,7 @@
 				176BB8C7A69033D4F4671809 /* MailboxOutboxWatcherTests.swift in Sources */,
 				39AF4F57C52E593EC8CF0680 /* MailboxSurfaceResolverTests.swift in Sources */,
 				C49B42317DA68794CC9C29E4 /* MailboxULIDTests.swift in Sources */,
+				4D11AA01B2C3D4E5F6071920 /* MarkdownPanelFontScaleTests.swift in Sources */,
 				A5FA2032A22C7558D3C7FABB /* MetadataPersistencePrecedenceTests.swift in Sources */,
 				657579B3785D58411C3804B6 /* MetadataPersistenceRoundTripTests.swift in Sources */,
 				AF258345FA9BD35CA62B9C6C /* MetadataPersistenceUncoercibleTests.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11017,11 +11017,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let handled: Bool
             switch action {
             case .zoomIn:
-                handled = manager.zoomInFocusedBrowser()
+                handled = manager.zoomInFocusedBrowser() || manager.zoomInFocusedMarkdown()
             case .zoomOut:
-                handled = manager.zoomOutFocusedBrowser()
+                handled = manager.zoomOutFocusedBrowser() || manager.zoomOutFocusedMarkdown()
             case .reset:
-                handled = manager.resetZoomFocusedBrowser()
+                handled = manager.resetZoomFocusedBrowser() || manager.resetZoomFocusedMarkdown()
             }
             #if DEBUG
             logBrowserZoomShortcutTrace(

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -55,6 +55,56 @@ final class MarkdownPanel: Panel, ObservableObject {
     /// Tracks the appearance used for the last mermaid render pass.
     private var lastRenderedDark: Bool?
 
+    // MARK: - Font scale (zoom)
+
+    /// Multiplier applied to all theme font sizes. 1.0 = default.
+    @Published private(set) var fontScale: Double
+
+    static let fontScaleRange: ClosedRange<Double> = 0.5...3.0
+    static let fontScaleStep: Double = 0.1
+    private static let fontScaleDefaultsKey = "markdown.fontScale.lastUsed"
+
+    /// Clamp to the supported range and round to one step's precision so
+    /// repeated +/- cycles don't accumulate floating-point drift.
+    static func normalizedFontScale(_ value: Double) -> Double {
+        let clamped = min(max(value, fontScaleRange.lowerBound), fontScaleRange.upperBound)
+        return (clamped * 10).rounded() / 10
+    }
+
+    private static func lastUsedFontScale() -> Double {
+        let stored = UserDefaults.standard.double(forKey: fontScaleDefaultsKey)
+        guard stored > 0 else { return 1.0 }
+        return normalizedFontScale(stored)
+    }
+
+    @discardableResult
+    func zoomIn() -> Bool {
+        setFontScale(fontScale + Self.fontScaleStep)
+    }
+
+    @discardableResult
+    func zoomOut() -> Bool {
+        setFontScale(fontScale - Self.fontScaleStep)
+    }
+
+    @discardableResult
+    func resetZoom() -> Bool {
+        setFontScale(1.0)
+    }
+
+    /// Restore a persisted scale without updating the last-used default.
+    func applyRestoredFontScale(_ value: Double) {
+        fontScale = Self.normalizedFontScale(value)
+    }
+
+    private func setFontScale(_ value: Double) -> Bool {
+        let normalized = Self.normalizedFontScale(value)
+        guard normalized != fontScale else { return true }
+        fontScale = normalized
+        UserDefaults.standard.set(normalized, forKey: Self.fontScaleDefaultsKey)
+        return true
+    }
+
     /// Observer for system appearance changes.
     private var appearanceObserver: NSObjectProtocol?
 
@@ -65,7 +115,14 @@ final class MarkdownPanel: Panel, ObservableObject {
     private nonisolated(unsafe) var fileWatchSource: DispatchSourceFileSystemObject?
     private var fileDescriptor: Int32 = -1
     private var isClosed: Bool = false
-    private let watchQueue = DispatchQueue(label: "com.stage11.c11.markdown-file-watch", qos: .utility)
+    private nonisolated let watchQueue = DispatchQueue(label: "com.stage11.c11.markdown-file-watch", qos: .utility)
+
+    /// Pending debounced reload. Accessed only on `watchQueue`.
+    private nonisolated(unsafe) var pendingReload: DispatchWorkItem?
+    /// Trailing debounce applied to watcher-driven reloads so agents
+    /// stream-appending to a watched file coalesce into one reparse per
+    /// burst instead of one per write event.
+    private static let reloadDebounce: TimeInterval = 0.15
 
     /// Maximum number of reattach attempts after a file delete/rename event.
     private static let maxReattachAttempts = 6
@@ -85,6 +142,7 @@ final class MarkdownPanel: Panel, ObservableObject {
         self.workspaceId = workspaceId
         self.filePath = filePath
         self.displayTitle = Self.titleForFilePath(filePath)
+        self.fontScale = Self.lastUsedFontScale()
 
         if filePath != nil {
             loadFileContent()
@@ -133,6 +191,10 @@ final class MarkdownPanel: Panel, ObservableObject {
         isClosed = true
         stopFileWatcher()
         stopAppearanceObserver()
+        watchQueue.async { [weak self] in
+            self?.pendingReload?.cancel()
+            self?.pendingReload = nil
+        }
     }
 
     func triggerFlash() {
@@ -149,41 +211,86 @@ final class MarkdownPanel: Panel, ObservableObject {
             parseSegments()
             return
         }
-        do {
-            let newContent = try String(contentsOfFile: filePath, encoding: .utf8)
-            content = newContent
-            isFileUnavailable = false
-        } catch {
-            // Fallback: try ISO Latin-1, which accepts all 256 byte values,
-            // covering legacy encodings like Windows-1252.
-            if let data = FileManager.default.contents(atPath: filePath),
-               let decoded = String(data: data, encoding: .isoLatin1) {
-                content = decoded
-                isFileUnavailable = false
-            } else {
-                isFileUnavailable = true
-            }
+        applyExternalContent(Self.readContent(path: filePath))
+    }
+
+    /// Read file content with the UTF-8 → ISO Latin-1 fallback chain.
+    /// Safe to call from any queue.
+    private nonisolated static func readContent(path: String) -> String? {
+        if let content = try? String(contentsOfFile: path, encoding: .utf8) {
+            return content
         }
+        // Fallback: try ISO Latin-1, which accepts all 256 byte values,
+        // covering legacy encodings like Windows-1252.
+        if let data = FileManager.default.contents(atPath: path),
+           let decoded = String(data: data, encoding: .isoLatin1) {
+            return decoded
+        }
+        return nil
+    }
+
+    /// Apply content produced by a read (sync or debounced). Skips the
+    /// reparse + republish entirely when the content is unchanged, which is
+    /// the common case for spurious watcher events.
+    private func applyExternalContent(_ newContent: String?) {
+        guard !isClosed else { return }
+        guard let newContent else {
+            isFileUnavailable = true
+            return
+        }
+        let wasUnavailable = isFileUnavailable
+        isFileUnavailable = false
+        guard newContent != content || wasUnavailable else { return }
+        content = newContent
         parseSegments()
+    }
+
+    /// Schedule a debounced reload on the watch queue. Coalesces bursts of
+    /// file events; the file read happens off the main thread.
+    private nonisolated func scheduleDebouncedReload(path: String) {
+        watchQueue.async { [weak self] in
+            guard let self else { return }
+            self.pendingReload?.cancel()
+            let item = DispatchWorkItem { [weak self] in
+                guard let self else { return }
+                let result = Self.readContent(path: path)
+                DispatchQueue.main.async {
+                    self.applyExternalContent(result)
+                }
+            }
+            self.pendingReload = item
+            self.watchQueue.asyncAfter(deadline: .now() + Self.reloadDebounce, execute: item)
+        }
     }
 
     // MARK: - Fenced code segment parsing
 
-    /// Stable ID from segment index and content prefix.
-    private static func segmentId(index: Int, content: String) -> String {
-        let prefix = String(content.prefix(64))
-        return "\(index):\(prefix.hashValue)"
+    /// Stable ID from segment index and full content. Hashing the whole
+    /// content (not a prefix) guarantees the ID changes whenever the segment
+    /// changes — a prefix hash let edits past the prefix keep a stale ID,
+    /// which preserved outdated rendered diagrams indefinitely.
+    static func segmentId(index: Int, content: String) -> String {
+        "\(index):\(content.count):\(content.hashValue)"
     }
+
+    /// Compiled fenced-code pattern cached per tag set. Renderers register at
+    /// app startup, so in practice this compiles once.
+    private static var cachedFencedCodePattern: (tags: Set<String>, regex: NSRegularExpression?)?
 
     /// Build a regex that matches fenced code blocks for all registered renderer tags.
     /// Pattern captures: group 1 = language tag, group 2 = code content.
     private static func buildFencedCodePattern() -> NSRegularExpression? {
         let tags = FencedCodeRendererRegistry.shared.supportedTags
         guard !tags.isEmpty else { return nil }
+        if let cached = cachedFencedCodePattern, cached.tags == tags {
+            return cached.regex
+        }
         let escaped = tags.map { NSRegularExpression.escapedPattern(for: $0) }
         let alternation = escaped.joined(separator: "|")
         let pattern = "```(\(alternation))\\s*\\n([\\s\\S]*?)```"
-        return try? NSRegularExpression(pattern: pattern, options: [])
+        let regex = try? NSRegularExpression(pattern: pattern, options: [])
+        cachedFencedCodePattern = (tags, regex)
+        return regex
     }
 
     /// Parse content into segments, splitting on fenced code blocks with registered renderers.
@@ -361,20 +468,21 @@ final class MarkdownPanel: Panel, ObservableObject {
                 // even if the new file is already readable (atomic save case).
                 DispatchQueue.main.async {
                     self.stopFileWatcher()
-                    self.loadFileContent()
-                    if self.isFileUnavailable {
-                        // File not yet replaced — retry until it reappears.
-                        self.scheduleReattach(attempt: 1)
-                    } else {
-                        // File already replaced — reattach to the new inode immediately.
+                    guard let path = self.filePath else { return }
+                    if FileManager.default.fileExists(atPath: path) {
+                        // File already replaced — reattach to the new inode
+                        // immediately; content loads via the debounced path.
                         self.startFileWatcher()
+                        self.scheduleDebouncedReload(path: path)
+                    } else {
+                        // File not yet replaced — retry until it reappears.
+                        self.isFileUnavailable = true
+                        self.scheduleReattach(attempt: 1)
                     }
                 }
             } else {
-                // Content changed — reload.
-                DispatchQueue.main.async {
-                    self.loadFileContent()
-                }
+                // Content changed — reload (debounced, read off-main).
+                self.scheduleDebouncedReload(path: filePath)
             }
         }
 

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -134,7 +134,7 @@ struct MarkdownPanelView: View {
         return VStack(alignment: .leading, spacing: 4) {
             ScrollView(.horizontal, showsIndicators: true) {
                 Text(code)
-                    .font(.system(size: 13, design: .monospaced))
+                    .font(.system(size: 13 * panel.fontScale, design: .monospaced))
                     .foregroundColor(colorScheme == .dark
                         ? Color(red: 0.9, green: 0.9, blue: 0.9)
                         : Color(red: 0.2, green: 0.2, blue: 0.2))
@@ -148,7 +148,7 @@ struct MarkdownPanelView: View {
 
             if let hint {
                 Text(hint)
-                    .font(.system(size: 11))
+                    .font(.system(size: 11 * panel.fontScale))
                     .foregroundColor(.secondary)
                     .textSelection(.enabled)
             }
@@ -310,14 +310,32 @@ struct MarkdownPanelView: View {
             : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
     }
 
+    /// Theme instances cached per (appearance, font scale). Rebuilding the
+    /// theme on every body evaluation churned ~20 closure allocations and
+    /// invalidated the MarkdownUI environment, forcing full re-parse and
+    /// re-layout of every segment on unrelated app events.
+    @MainActor private static var themeCache: [String: Theme] = [:]
+
+    private static func cachedTheme(isDark: Bool, fontScale: Double) -> Theme {
+        let key = "\(isDark ? "d" : "l"):\(Int((fontScale * 100).rounded()))"
+        if let cached = themeCache[key] { return cached }
+        let theme = buildTheme(isDark: isDark, fontScale: fontScale)
+        themeCache[key] = theme
+        return theme
+    }
+
     private var cmuxMarkdownTheme: Theme {
-        let isDark = colorScheme == .dark
+        Self.cachedTheme(isDark: colorScheme == .dark, fontScale: panel.fontScale)
+    }
+
+    private static func buildTheme(isDark: Bool, fontScale: Double) -> Theme {
+        let scale = CGFloat(fontScale)
 
         return Theme()
             // Text
             .text {
                 ForegroundColor(isDark ? .white.opacity(0.9) : .primary)
-                FontSize(14)
+                FontSize(14 * scale)
             }
             // Headings
             .heading1 { configuration in
@@ -325,7 +343,7 @@ struct MarkdownPanelView: View {
                     configuration.label
                         .markdownTextStyle {
                             FontWeight(.bold)
-                            FontSize(28)
+                            FontSize(28 * scale)
                             ForegroundColor(isDark ? .white : .primary)
                         }
                     Divider()
@@ -337,7 +355,7 @@ struct MarkdownPanelView: View {
                     configuration.label
                         .markdownTextStyle {
                             FontWeight(.bold)
-                            FontSize(22)
+                            FontSize(22 * scale)
                             ForegroundColor(isDark ? .white : .primary)
                         }
                     Divider()
@@ -348,7 +366,7 @@ struct MarkdownPanelView: View {
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.semibold)
-                        FontSize(18)
+                        FontSize(18 * scale)
                         ForegroundColor(isDark ? .white : .primary)
                     }
                     .markdownMargin(top: 16, bottom: 8)
@@ -357,7 +375,7 @@ struct MarkdownPanelView: View {
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.semibold)
-                        FontSize(16)
+                        FontSize(16 * scale)
                         ForegroundColor(isDark ? .white : .primary)
                     }
                     .markdownMargin(top: 12, bottom: 6)
@@ -366,7 +384,7 @@ struct MarkdownPanelView: View {
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.medium)
-                        FontSize(14)
+                        FontSize(14 * scale)
                         ForegroundColor(isDark ? .white : .primary)
                     }
                     .markdownMargin(top: 10, bottom: 4)
@@ -375,7 +393,7 @@ struct MarkdownPanelView: View {
                 configuration.label
                     .markdownTextStyle {
                         FontWeight(.medium)
-                        FontSize(13)
+                        FontSize(13 * scale)
                         ForegroundColor(isDark ? .white.opacity(0.7) : .secondary)
                     }
                     .markdownMargin(top: 8, bottom: 4)
@@ -386,7 +404,7 @@ struct MarkdownPanelView: View {
                     configuration.label
                         .markdownTextStyle {
                             FontFamilyVariant(.monospaced)
-                            FontSize(13)
+                            FontSize(13 * scale)
                             ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
                         }
                         .padding(12)
@@ -400,7 +418,7 @@ struct MarkdownPanelView: View {
             // Inline code
             .code {
                 FontFamilyVariant(.monospaced)
-                FontSize(13)
+                FontSize(13 * scale)
                 ForegroundColor(isDark ? Color(red: 0.85, green: 0.6, blue: 0.95) : Color(red: 0.6, green: 0.2, blue: 0.7))
                 BackgroundColor(isDark
                     ? Color(nsColor: NSColor(white: 0.18, alpha: 1.0))
@@ -415,7 +433,7 @@ struct MarkdownPanelView: View {
                     configuration.label
                         .markdownTextStyle {
                             ForegroundColor(isDark ? .white.opacity(0.6) : .secondary)
-                            FontSize(14)
+                            FontSize(14 * scale)
                         }
                         .padding(.leading, 12)
                 }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -287,6 +287,9 @@ struct SessionMarkdownPanelSnapshot: Codable, Sendable {
     /// (empty state — not yet bound to a file). Unbound panels are not
     /// recreated on restore; see Workspace.createPanel(from:inPane:).
     var filePath: String?
+    /// Font scale multiplier (1.0 = default). Optional for backwards
+    /// compatibility; old snapshots decode with nil.
+    var fontScale: Double? = nil
 }
 
 struct SessionPanelSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3151,6 +3151,28 @@ class TabManager: ObservableObject {
         focusedBrowserPanel?.resetZoom() ?? false
     }
 
+    /// Returns the focused panel if it's a MarkdownPanel, nil otherwise
+    var focusedMarkdownPanel: MarkdownPanel? {
+        guard let tab = selectedWorkspace,
+              let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId] as? MarkdownPanel
+    }
+
+    @discardableResult
+    func zoomInFocusedMarkdown() -> Bool {
+        focusedMarkdownPanel?.zoomIn() ?? false
+    }
+
+    @discardableResult
+    func zoomOutFocusedMarkdown() -> Bool {
+        focusedMarkdownPanel?.zoomOut() ?? false
+    }
+
+    @discardableResult
+    func resetZoomFocusedMarkdown() -> Bool {
+        focusedMarkdownPanel?.resetZoom() ?? false
+    }
+
     @discardableResult
     func toggleDeveloperToolsFocusedBrowser() -> Bool {
         focusedBrowserPanel?.toggleDeveloperTools() ?? false

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -710,7 +710,10 @@ extension Workspace {
             guard let markdownPanel = panel as? MarkdownPanel else { return nil }
             terminalSnapshot = nil
             browserSnapshot = nil
-            markdownSnapshot = SessionMarkdownPanelSnapshot(filePath: markdownPanel.filePath)
+            markdownSnapshot = SessionMarkdownPanelSnapshot(
+                filePath: markdownPanel.filePath,
+                fontScale: markdownPanel.fontScale
+            )
         }
 
         let persistedMetadata: [String: PersistedJSONValue]?
@@ -955,6 +958,9 @@ extension Workspace {
                 panelId: restoredPanelId
             ) else {
                 return nil
+            }
+            if let restoredScale = snapshot.markdown?.fontScale {
+                markdownPanel.applyRestoredFontScale(restoredScale)
             }
             applySessionPanelMetadata(snapshot, toPanelId: markdownPanel.id)
             return markdownPanel.id

--- a/c11Tests/MarkdownPanelFontScaleTests.swift
+++ b/c11Tests/MarkdownPanelFontScaleTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+@MainActor
+final class MarkdownPanelFontScaleTests: XCTestCase {
+    private let lastUsedDefaultsKey = "markdown.fontScale.lastUsed"
+    private var savedLastUsed: Any?
+
+    override func setUp() async throws {
+        savedLastUsed = UserDefaults.standard.object(forKey: lastUsedDefaultsKey)
+        UserDefaults.standard.removeObject(forKey: lastUsedDefaultsKey)
+    }
+
+    override func tearDown() async throws {
+        if let savedLastUsed {
+            UserDefaults.standard.set(savedLastUsed, forKey: lastUsedDefaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: lastUsedDefaultsKey)
+        }
+    }
+
+    // MARK: - Scale normalization
+
+    func testNormalizedFontScaleClampsToRange() {
+        XCTAssertEqual(MarkdownPanel.normalizedFontScale(0.1), MarkdownPanel.fontScaleRange.lowerBound)
+        XCTAssertEqual(MarkdownPanel.normalizedFontScale(10.0), MarkdownPanel.fontScaleRange.upperBound)
+        XCTAssertEqual(MarkdownPanel.normalizedFontScale(1.0), 1.0)
+    }
+
+    func testNormalizedFontScaleRoundsToOneStep() {
+        // Repeated float additions like 1.0 + 0.1 + 0.1 drift; the normalizer
+        // must land on exact tenths so equality short-circuits work.
+        XCTAssertEqual(MarkdownPanel.normalizedFontScale(1.0 + 0.1 + 0.1), 1.2)
+        XCTAssertEqual(MarkdownPanel.normalizedFontScale(0.9999999), 1.0)
+    }
+
+    // MARK: - Zoom stepping on a live panel
+
+    func testZoomInOutAndResetStepTheScale() {
+        let panel = MarkdownPanel(workspaceId: UUID())
+        defer { panel.close() }
+
+        XCTAssertEqual(panel.fontScale, 1.0)
+        panel.zoomIn()
+        XCTAssertEqual(panel.fontScale, 1.1)
+        panel.zoomIn()
+        XCTAssertEqual(panel.fontScale, 1.2)
+        panel.zoomOut()
+        XCTAssertEqual(panel.fontScale, 1.1)
+        panel.resetZoom()
+        XCTAssertEqual(panel.fontScale, 1.0)
+    }
+
+    func testZoomOutClampsAtLowerBound() {
+        let panel = MarkdownPanel(workspaceId: UUID())
+        defer { panel.close() }
+
+        for _ in 0..<100 { panel.zoomOut() }
+        XCTAssertEqual(panel.fontScale, MarkdownPanel.fontScaleRange.lowerBound)
+        for _ in 0..<100 { panel.zoomIn() }
+        XCTAssertEqual(panel.fontScale, MarkdownPanel.fontScaleRange.upperBound)
+    }
+
+    func testNewPanelsInheritLastUsedScale() {
+        let first = MarkdownPanel(workspaceId: UUID())
+        first.zoomIn()
+        first.zoomIn()
+        XCTAssertEqual(first.fontScale, 1.2)
+        first.close()
+
+        let second = MarkdownPanel(workspaceId: UUID())
+        defer { second.close() }
+        XCTAssertEqual(second.fontScale, 1.2)
+    }
+
+    func testApplyRestoredFontScaleDoesNotChangeLastUsedDefault() {
+        let panel = MarkdownPanel(workspaceId: UUID())
+        defer { panel.close() }
+
+        panel.applyRestoredFontScale(2.0)
+        XCTAssertEqual(panel.fontScale, 2.0)
+
+        let next = MarkdownPanel(workspaceId: UUID())
+        defer { next.close() }
+        XCTAssertEqual(next.fontScale, 1.0, "restore must not leak into the new-panel default")
+    }
+
+    // MARK: - Segment identity
+
+    func testSegmentIdChangesWhenContentBeyondPrefixChanges() {
+        // Regression: the ID hashed only the first 64 chars, so a fenced
+        // block edited past that prefix kept its ID and its stale rendered
+        // image was preserved indefinitely.
+        let prefix = String(repeating: "a", count: 64)
+        let original = prefix + "graph TD; A-->B"
+        let edited = prefix + "graph TD; A-->C"
+
+        XCTAssertNotEqual(
+            MarkdownPanel.segmentId(index: 0, content: original),
+            MarkdownPanel.segmentId(index: 0, content: edited)
+        )
+    }
+
+    func testSegmentIdStableForIdenticalContent() {
+        let content = "## Heading\n\nsome body text"
+        XCTAssertEqual(
+            MarkdownPanel.segmentId(index: 3, content: content),
+            MarkdownPanel.segmentId(index: 3, content: content)
+        )
+        XCTAssertNotEqual(
+            MarkdownPanel.segmentId(index: 3, content: content),
+            MarkdownPanel.segmentId(index: 4, content: content)
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Deep audit of the markdown surface, prompted by hard-to-reproduce performance oddities. Three performance fixes, one correctness fix, and a new font-zoom feature.

### Performance fixes

- **Debounced live-reload (the likely root cause of the reported issues).** Every kqueue `.write`/`.extend` event used to trigger a synchronous main-thread file read + full regex reparse + full MarkdownUI re-parse/re-layout of the document. Agents stream-appending to a watched file (the primary live-reload use case) caused bursts of O(document) main-thread work per write — it only manifests while a file is actively being written and scales with file size, which is why it was hard to reproduce. Watcher reloads now coalesce behind a 150 ms trailing debounce, file reads happen off-main on the watch queue, and unchanged content short-circuits without republishing.
- **MarkdownUI theme caching.** The theme (~20 closures) was rebuilt on every body evaluation, and the view observes app-wide publishers (`ThemeManager.shared`, `paneInteractionRuntime`), so unrelated app events invalidated the MarkdownUI environment and forced full re-parse/re-layout of every segment. Themes are now cached per (appearance, font scale).
- **Fenced-code regex caching** per renderer tag set (was recompiled on every parse).

### Correctness fix

- **Stale rendered diagrams.** Segment IDs hashed only the first 64 chars of a block, so a mermaid diagram edited past that prefix kept its ID and its outdated rendered image indefinitely. IDs now hash the full content. Covered by a regression test.

### New feature: markdown font zoom

Cmd+= / Cmd+- / Cmd+0 now zoom the focused markdown pane, riding the existing browser-zoom shortcut rail (`handleCustomShortcut` → `TabManager`). Model focus is mutually exclusive across panel types, so terminal (Ghostty) and browser zoom behavior are unchanged. Scale clamps to 0.5–3.0 in 0.1 steps, persists per panel in session snapshots (mirroring browser `pageZoom`), and the last-used scale seeds new panels.

## Validation

- `c11-logic` scheme: 8/8 new tests pass (`MarkdownPanelFontScaleTests` — clamping, FP-drift rounding, zoom stepping on a live panel, last-used inheritance, restore isolation, segment-ID regression).
- Tagged build (`md-zoom`), validated end-to-end with screenshots:
  - Cmd+= ×4 → scale 1.4 (visually confirmed larger text + re-wrap), Cmd+- → 1.3, Cmd+0 → 1.0.
  - Live reload: file rewritten after pane open → new content rendered through the debounced path.
  - Mermaid block rendered to an image through the unchanged renderer pipeline.
  - 500-line append burst: app and socket fully responsive throughout.

## Suggestions not implemented (follow-up candidates)

- Lazy layout (`LazyVStack`) for very large documents — needs care around text selection and scroll stability.
- A single shared mouse-event monitor instead of one app-global monitor per markdown surface.
- Mermaid renders are serialized on one queue that blocks up to 15 s per diagram, which also delays cancellations; a non-blocking wait would let cancellation land mid-render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)