### PR TITLE
Land #212: Grok Build as a built-in agent type (rebased)

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -11033,7 +11033,7 @@ struct CMUXCLI {
 
         case "set":
             guard commandArgs.count >= 2 else {
-                let valid = ["claude-code", "codex", "kimi", "opencode", "custom"].joined(separator: ", ")
+                let valid = ["claude-code", "codex", "grok", "kimi", "opencode", "custom"].joined(separator: ", ")
                 throw CLIError(message: "default-agent set requires <type>. Valid: \(valid)")
             }
             let response = try sendV1Command("default_agent set \(commandArgs[1])", client: client)

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		1A1EC322E65B74DEDAAD08A5 /* DefaultAgentConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF9D5EC78046EDA9B54AC68 /* DefaultAgentConfigTests.swift */; };
 		1BA5C5B28E1CE348469E1778 /* MetadataStoreRevisionCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */; };
 		1D57711F82EF7A25FB6FEA23 /* Codex.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1C8E6BE23CECF1DA9531BA /* Codex.swift */; };
+		F60C0DEA00000000000C0001 /* Grok.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60C0DEA00000000000C0002 /* Grok.swift */; };
 		1D765B8279AE9949576A5FE1 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8016BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift */; };
 		1E77E8B74098A7D7B928631C /* SurfaceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A815208E655A7AFBCEE667 /* SurfaceActivity.swift */; };
 		1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
@@ -555,6 +556,7 @@
 		A8C9388437A24EE58C8AAA71 /* Ref.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Ref.swift; path = Conversation/Ref.swift; sourceTree = "<group>"; };
 		AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClaudeCodeScraper.swift; path = Conversation/Scrapers/ClaudeCodeScraper.swift; sourceTree = "<group>"; };
 		AE1C8E6BE23CECF1DA9531BA /* Codex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codex.swift; path = Conversation/Strategies/Codex.swift; sourceTree = "<group>"; };
+		F60C0DEA00000000000C0002 /* Grok.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Grok.swift; path = Conversation/Strategies/Grok.swift; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
@@ -988,6 +990,7 @@
 				3536E1F26D365D81206EFAAC /* SnapshotBridge.swift */,
 				CC1299AE998DF9F78A383294 /* ClaudeCode.swift */,
 				AE1C8E6BE23CECF1DA9531BA /* Codex.swift */,
+				F60C0DEA00000000000C0002 /* Grok.swift */,
 				E2BDE4F4D562EC49C639CF86 /* Kimi.swift */,
 				54017DD4C9F6BE7CFA98C2F7 /* Opencode.swift */,
 				AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */,
@@ -1617,6 +1620,7 @@
 				DA3897B93D91D4806BA1EA57 /* SnapshotBridge.swift in Sources */,
 				20A2EC594F0DF1560BB0E28E /* ClaudeCode.swift in Sources */,
 				1D57711F82EF7A25FB6FEA23 /* Codex.swift in Sources */,
+				F60C0DEA00000000000C0001 /* Grok.swift in Sources */,
 				A7EA137511C5D411B2960587 /* Kimi.swift in Sources */,
 				60785E8E82CF86BCF4A26738 /* Opencode.swift in Sources */,
 				767FF8ADAC0F182A4534E12B /* ClaudeCodeScraper.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3903,6 +3903,53 @@
         }
       }
     },
+    "agentType.grok": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Grok Build"
+          }
+        }
+      }
+    },
     "agentType.kimi": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AgentChip.swift
+++ b/Sources/AgentChip.swift
@@ -122,6 +122,8 @@ enum AgentChipResolver {
             return "AgentIcons/claude-code"
         case "codex":
             return "AgentIcons/codex"
+        case "grok":
+            return "AgentIcons/grok"
         case "kimi":
             return "AgentIcons/kimi"
         case "opencode":
@@ -141,6 +143,7 @@ enum AgentChipResolver {
         switch terminalType {
         case "claude-code":  return "sparkles"
         case "codex":        return "chevron.left.forwardslash.chevron.right"
+        case "grok":         return "bolt.fill"
         case "kimi":         return "moon.stars"
         case "opencode":     return "curlybraces"
         case "shell":        return "terminal.fill"

--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -223,6 +223,8 @@ final class AgentDetector: @unchecked Sendable {
             return "claude-code"
         case "codex", "codex-cli":
             return "codex"
+        case "grok", "grok-cli", "grok-pager":
+            return "grok"
         case "kimi", "kimi-cli":
             return "kimi"
         case "opencode", "opencode-cli":

--- a/Sources/AgentRestartRegistry.swift
+++ b/Sources/AgentRestartRegistry.swift
@@ -145,7 +145,8 @@ struct AgentRestartRegistry: Sendable {
     ///
     /// Codex uses `--last` best-effort to resume the most recent session
     /// globally. Opencode and kimi have no verified resume flag and launch
-    /// fresh — best-effort is preferable to a broken flag.
+    /// fresh — best-effort is preferable to a broken flag. Grok supports
+    /// `--resume` without an id to attach to the most recent session.
     static let phase1: AgentRestartRegistry = .init(name: "phase1", rows: [
         Row(terminalType: "claude-code") { sessionId, metadata in
             guard let raw = sessionId?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -172,6 +173,11 @@ struct AgentRestartRegistry: Sendable {
             // codex resume --last resumes the most recent codex session globally.
             // Best-effort: may not match the exact session in the snapshot.
             "codex resume --last\n"
+        },
+        Row(terminalType: "grok") { _, _ in
+            // grok --resume (no id) attaches to the most recent session.
+            // Best-effort: may not match the exact session in the snapshot.
+            "grok --always-approve --resume\n"
         },
         Row(terminalType: "opencode") { _, _ in
             // no stable resume flag known; launches fresh.

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -561,6 +561,7 @@ struct AgentSkillsOnboardingSheet: View {
 
     @State private var claudeOptIn: Bool = false
     @State private var codexOptIn: Bool = false
+    @State private var grokOptIn: Bool = false
     @State private var kimiOptIn: Bool = false
     @State private var opencodeOptIn: Bool = false
     @State private var initializedDefaultOptIns: Bool = false
@@ -607,7 +608,7 @@ struct AgentSkillsOnboardingSheet: View {
     }
 
     private var anySelected: Bool {
-        initializedDefaultOptIns && (claudeOptIn || codexOptIn || kimiOptIn || opencodeOptIn)
+        initializedDefaultOptIns && (claudeOptIn || codexOptIn || grokOptIn || kimiOptIn || opencodeOptIn)
     }
 
     private var hasActionNeeded: Bool {
@@ -909,6 +910,7 @@ struct AgentSkillsOnboardingSheet: View {
         switch target {
         case .claude: return $claudeOptIn
         case .codex: return $codexOptIn
+        case .grok: return $grokOptIn
         case .kimi: return $kimiOptIn
         case .opencode: return $opencodeOptIn
         }
@@ -918,6 +920,7 @@ struct AgentSkillsOnboardingSheet: View {
         let selections: [(SkillInstallerTarget, Bool)] = [
             (.claude, claudeOptIn),
             (.codex, codexOptIn),
+            (.grok, grokOptIn),
             (.kimi, kimiOptIn),
             (.opencode, opencodeOptIn),
         ]
@@ -986,6 +989,7 @@ struct AgentSkillsOnboardingSheet: View {
         let defaults = AgentSkillsOnboarding.defaultOptIns(for: rows)
         claudeOptIn = defaults[.claude] ?? false
         codexOptIn = defaults[.codex] ?? false
+        grokOptIn = defaults[.grok] ?? false
         kimiOptIn = defaults[.kimi] ?? false
         opencodeOptIn = defaults[.opencode] ?? false
     }

--- a/Sources/Conversation/Strategies/Grok.swift
+++ b/Sources/Conversation/Strategies/Grok.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Best-effort resume strategy for Grok Build. Grok exposes `grok --resume`
+/// (no id) to attach to the most recent session globally, but ships no
+/// SessionStart hook and no verified per-session transcript path c11 can
+/// scrape. So capture is fresh-launch-only — it acts on a hook/manual push
+/// or a wrapper-claim placeholder, same shape as Kimi/Opencode in v1.
+///
+/// When a non-placeholder ref does exist (alive/suspended), `resume()` types
+/// the best-effort `grok --always-approve --resume`, mirroring the
+/// `AgentRestartRegistry.phase1` fallback row. The command carries no
+/// interpolated id, so there is no untrusted-input surface to shell-quote.
+struct GrokStrategy: ConversationStrategy {
+    let kind: String = "grok"
+
+    init() {}
+
+    func capture(inputs: ConversationStrategyInputs) -> ConversationRef? {
+        if let push = inputs.push, !push.placeholder {
+            return push
+        }
+        return inputs.wrapperClaim
+    }
+
+    func resume(ref: ConversationRef) -> ResumeAction {
+        if ref.placeholder {
+            return .skip(reason: "fresh-launch-only")
+        }
+        switch ref.state {
+        case .alive, .suspended:
+            // grok --resume (no id) attaches to the most recent session.
+            // Best-effort: may not match the exact session in the snapshot.
+            return .typeCommand(text: "grok --always-approve --resume", submitWithReturn: true)
+        default:
+            return .skip(reason: "state=\(ref.state.rawValue) not auto-resumable")
+        }
+    }
+}

--- a/Sources/Conversation/StrategyRegistry.swift
+++ b/Sources/Conversation/StrategyRegistry.swift
@@ -28,13 +28,14 @@ struct ConversationStrategyRegistry: Sendable {
         Array(strategies.keys).sorted()
     }
 
-    /// Default v1 registry. Lands the four strategies the plan specifies:
+    /// Default v1 registry. Lands strategies for every built-in agent type:
     /// claude-code (push-primary), codex (pull-primary, ambiguity-aware),
-    /// opencode and kimi (fresh-launch only).
+    /// grok (best-effort resume), opencode and kimi (fresh-launch only).
     static let v1: ConversationStrategyRegistry = {
         ConversationStrategyRegistry(strategies: [
             ClaudeCodeStrategy(),
             CodexStrategy(),
+            GrokStrategy(),
             OpencodeStrategy(),
             KimiStrategy()
         ])

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -6,6 +6,7 @@ import Foundation
 enum AgentType: String, Codable, CaseIterable, Identifiable {
     case claudeCode = "claude-code"
     case codex
+    case grok
     case kimi
     case opencode
     case custom
@@ -20,6 +21,8 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
             return String(localized: "agentType.claudeCode", defaultValue: "Claude Code")
         case .codex:
             return String(localized: "agentType.codex", defaultValue: "Codex")
+        case .grok:
+            return String(localized: "agentType.grok", defaultValue: "Grok Build")
         case .kimi:
             return String(localized: "agentType.kimi", defaultValue: "Kimi")
         case .opencode:
@@ -36,6 +39,7 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
         switch self {
         case .claudeCode: return "claude --dangerously-skip-permissions"
         case .codex:      return "codex --yolo"
+        case .grok:       return "grok --always-approve"
         case .kimi:       return "kimi"
         case .opencode:   return "opencode run --dangerously-skip-permissions"
         case .custom:     return ""

--- a/Sources/SkillInstaller.swift
+++ b/Sources/SkillInstaller.swift
@@ -6,6 +6,7 @@ import CryptoKit
 enum SkillInstallerTarget: String, CaseIterable {
     case claude
     case codex
+    case grok
     case kimi
     case opencode
 
@@ -13,6 +14,7 @@ enum SkillInstallerTarget: String, CaseIterable {
         switch self {
         case .claude: return "Claude Code"
         case .codex: return "Codex"
+        case .grok: return "Grok Build"
         case .kimi: return "Kimi"
         case .opencode: return "OpenCode"
         }

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -33,7 +33,7 @@ public enum MetadataKey {
     ]
 
     public static let canonicalTerminalTypes: Set<String> = [
-        "claude-code", "codex", "kimi", "opencode", "shell", "unknown"
+        "claude-code", "codex", "grok", "kimi", "opencode", "shell", "unknown"
     ]
 }
 

--- a/c11Tests/ConversationStrategyTests.swift
+++ b/c11Tests/ConversationStrategyTests.swift
@@ -16,10 +16,11 @@ final class ConversationStrategyTests: XCTestCase {
 
     // MARK: - Registry
 
-    func testV1RegistryContainsTheFourKinds() {
+    func testV1RegistryContainsTheBuiltInKinds() {
         let r = ConversationStrategyRegistry.v1
         XCTAssertNotNil(r.strategy(forKind: "claude-code"))
         XCTAssertNotNil(r.strategy(forKind: "codex"))
+        XCTAssertNotNil(r.strategy(forKind: "grok"))
         XCTAssertNotNil(r.strategy(forKind: "opencode"))
         XCTAssertNotNil(r.strategy(forKind: "kimi"))
         XCTAssertNil(r.strategy(forKind: "cursor"))
@@ -269,6 +270,43 @@ final class ConversationStrategyTests: XCTestCase {
         }
         XCTAssertEqual(text, "'kimi'")
         XCTAssertTrue(submit)
+    }
+
+    // MARK: - Grok strategy
+
+    func testGrokAliveTypesBestEffortResume() {
+        let strategy = GrokStrategy()
+        let ref = ConversationRef(
+            kind: "grok",
+            id: "real-id",
+            placeholder: false,
+            capturedAt: Date(),
+            capturedVia: .hook,
+            state: .alive
+        )
+        guard case .typeCommand(let text, let submit) = strategy.resume(ref: ref) else {
+            XCTFail("expected typeCommand")
+            return
+        }
+        XCTAssertEqual(text, "grok --always-approve --resume")
+        XCTAssertTrue(submit)
+    }
+
+    func testGrokPlaceholderResumeSkips() {
+        let strategy = GrokStrategy()
+        let ref = ConversationRef(
+            kind: "grok",
+            id: "wrapper-claim:foo",
+            placeholder: true,
+            capturedAt: Date(),
+            capturedVia: .wrapperClaim,
+            state: .unknown
+        )
+        guard case .skip(let reason) = strategy.resume(ref: ref) else {
+            XCTFail("expected skip")
+            return
+        }
+        XCTAssertEqual(reason, "fresh-launch-only")
     }
 
     // MARK: - Shell-quoting helper

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -30,6 +30,12 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
     }
 
+    func testFactoryGrokCommandIncludesAlwaysApprove() {
+        let entry = AgentConfig.factory(for: .grok)
+        XCTAssertEqual(entry.command, "grok --always-approve")
+        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+    }
+
     func testFactoryCustomHasEmptyDefaults() {
         let entry = AgentConfig.factory(for: .custom)
         XCTAssertEqual(entry.command, "")

--- a/docs/adding-a-new-agent.md
+++ b/docs/adding-a-new-agent.md
@@ -1,0 +1,90 @@
+# Adding a new coding agent to c11
+
+c11 treats coding agents (Claude Code, Codex, Grok Build, Kimi, OpenCode) as first-class peers: each one is in the A-button picker, gets an icon in the sidebar chip, auto-detects from process listings, can install c11 skills into its config dir, and resumes across snapshots. Adding a new one is mechanical — there's a fixed set of surfaces to extend.
+
+This doc is the checklist. Grok Build is the worked example; replace `grok` / `Grok Build` / `--always-approve` with the new agent's name/flag wherever they appear.
+
+## Pre-flight
+
+Before editing code, capture three facts about the new agent:
+
+1. **Binary name.** What runs on PATH (`grok`, `aider`, `cursor-cli`, …).
+2. **Auto-approve flag.** The CLI flag that bypasses per-tool confirmation prompts — c11 launches agents in that mode by default (parallel to `claude --dangerously-skip-permissions`, `codex --yolo`, `grok --always-approve`, `opencode run --dangerously-skip-permissions`). If the agent has no such mode, leave it bare; flag it in the contributor commit so reviewers know.
+3. **Resume command.** How the agent picks up its most recent session. `grok --resume`, `codex resume --last`, etc. If there's no stable resume flag, the restart registry launches fresh — best-effort, same as Kimi/OpenCode today.
+
+If the agent's config root convention is `~/.<name>/` (Claude → `~/.claude/`, Grok → `~/.grok/`), the `SkillInstaller` will wire up automatically once you add the enum case. If it isn't, you'll need a small override there too — flag it.
+
+## The surfaces to update
+
+All paths are relative to `code/c11/`. Order doesn't matter — the changes are independent.
+
+### Required (without these the agent does not work as a c11 agent)
+
+1. **`Sources/DefaultAgentConfig.swift` — `AgentType` enum.** Add a new `case` with kebab-case raw value. Extend the three switch statements (`displayName`, `factoryCommand`, `factoryInitialPrompt`). `displayName` uses `String(localized:)` — write English only; spawn a localization sub-agent after (see `CLAUDE.md` → Localization).
+
+2. **`Sources/SurfaceMetadataStore.swift` — `canonicalTerminalTypes`.** Add the kebab-case string. Without this, the sidebar treats the new agent as `unknown` even when explicitly declared.
+
+3. **`CLI/c11.swift` — `default-agent set` valid-types message.** Search for the hard-coded `["claude-code", "codex", ...]` list and add the new value. CLI ergonomics only — the resolver is enum-driven and accepts the new case automatically.
+
+4. **`Sources/AgentChip.swift` — icon mapping.**
+   - `iconAssetName(forTerminalType:)`: add a case returning `"AgentIcons/<type>"`.
+   - `sfSymbolFallback(forTerminalType:)`: pick an SF Symbol that visually distinguishes the agent. Used until a real asset ships in `Assets.xcassets/AgentIcons/`. Existing fallbacks: `sparkles`, `chevron.left.forwardslash.chevron.right`, `bolt.fill`, `moon.stars`, `curlybraces`. Avoid collisions; the chip is the operator's at-a-glance identifier.
+
+5. **`Sources/AgentDetector.swift` — heuristic `classify`.** Add the binary name(s) to the exact `comm` match. If the binary is wrapped by `node`, add an `args` substring match in the node branch. The detector reads process listings — it does not screen-scrape banners (don't add banner matching; it drifts across releases).
+
+### Strongly recommended (parity with existing agents)
+
+6. **`Sources/AgentRestartRegistry.swift` — `phase1` rows.** Add a `Row(terminalType: "<type>")` with a resolver closure that returns the resume command string (trailing `\n` preserved). If the agent has no resume flag, return a fresh launch command — best-effort matches Kimi/OpenCode.
+
+7. **`Sources/SkillInstaller.swift` — `SkillInstallerTarget`.** Add the enum case (raw value lower-case, matches the `~/.<name>/` config root convention). `displayName` is the user-facing label. Skill files install into `~/.<name>/skills/` automatically.
+
+8. **`Sources/AgentSkillsView.swift` — onboarding sheet opt-ins.** Add `@State private var <name>OptIn: Bool = false`, then thread it through `anySelected`, `optInBinding(for:)`, `applySelection()`, and `applyDefaultOptIns(rows:)`. The Settings view inherits from `AgentType.allCases`, so no extra work there.
+
+### Documentation
+
+9. **`skills/c11/SKILL.md`** — extend the "Common types" list and the per-TUI prompt-delivery one-liner under "Launching sub-agents."
+
+10. **`skills/c11/references/api.md`** — extend the `CMUX_AGENT_TYPE` env-var description and the `--type` accepted-values bullet.
+
+11. **`skills/c11/references/metadata.md`** — extend the `terminal_type` canonical values list.
+
+12. **`skills/c11/references/orchestration.md`** — add a `### <agent>` subsection under "Per-agent launch quirks." Document the auto-approve flag, any auth gotchas, and whether the agent self-reports via the skill or needs special handling.
+
+### Tests
+
+13. **`c11Tests/DefaultAgentConfigTests.swift`** — add a `testFactory<Name>CommandIncludes<Flag>` mirroring the existing claude/codex/grok tests. `testFactoryDefaultsHaveAllAgents` and the codable round-trip tests cover the new case automatically via `AgentType.allCases`.
+
+## Run the tests
+
+```bash
+cd code/c11
+xcodebuild -project GhosttyTabs.xcodeproj -scheme c11-logic -configuration Debug \
+  -destination "platform=macOS" test
+```
+
+`c11-logic` is host-free and safe to run locally even when prod c11 is running (see `CLAUDE.md` → "Testing policy"). Wall time ~30s warm.
+
+If you also touched `AgentRestartRegistry.swift`, run `c11-unit` via `scripts/test-unit-local.sh` — `AgentRestartRegistryTests` lives there.
+
+## Validate end-to-end
+
+The clean local path is to build, launch a *tagged* DEV build, and exercise the agent:
+
+```bash
+./scripts/reload.sh --tag <slug>
+./scripts/launch-tagged-automation.sh <slug>
+```
+
+In the tagged build: Settings → Agents & Automation → Agent Launcher Button → pick the new agent, then click the A button on a fresh pane. The agent should launch with its auto-approve flag baked in. Sidebar chip should show the new icon (SF Symbol fallback if no asset shipped).
+
+Do not `open` an untagged `c11 DEV.app` from DerivedData while prod c11 is running — they fight for sockets. See `CLAUDE.md` → "Testing policy" for the why.
+
+## A note on runtime extensibility
+
+Today, agent registration is **compile-time**. Adding a new first-class agent means editing Swift, building c11, and shipping a new build. The `.custom` agent type exists as a partial runtime escape hatch — operators can set Settings → Default Agent → Custom to any launch command without rebuilding — but `.custom` has one slot, no sidebar branding, no auto-detection, and no snapshot resume.
+
+A data-driven agent registry (loading agent definitions from `~/.config/c11/agents/<name>.toml` and contributing rows to the same surfaces above) is feasible and would let operators add fully-branded agents at runtime. It is not built yet. If you find yourself adding a fifth or sixth coding agent and the friction is starting to bite, that's the moment to design it — not before.
+
+## Sequencing for the PR
+
+Land the surfaces (1–8) and tests (13) in one commit. Land the docs (9–12) and the contributor-doc updates (this file) in a second. The reviewer's eye doesn't want to traverse twelve files of Swift *plus* prose at once — and the docs land cleanly even if Swift review takes a round-trip.

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -115,7 +115,7 @@ c11 set-agent --task lat-412                                        # partial wr
 c11 set-agent --type <your-terminal-type> --model <your-model>      # explicit override when env vars are empty/wrong
 ```
 
-Common types: `claude-code`, `codex`, `kimi`, `opencode`. Any kebab-case string is accepted. Inside Claude Code, `claude.session_id` is populated automatically by the wrapper.
+Common types: `claude-code`, `codex`, `grok`, `kimi`, `opencode`. Any kebab-case string is accepted. Inside Claude Code, `claude.session_id` is populated automatically by the wrapper.
 
 ## Targeting
 
@@ -398,7 +398,7 @@ Treat `flash_state` as a forward-compatible enum — future c11 versions may add
 
 When you spawn a sub-agent, give it its own c11 surface (`c11 new-split` or `c11 new-pane`) and launch the agent inside that surface. The operator gets full observability through c11 (sidebar status, title and description, screen content), and the sub-agent runs as a full-fledged interactive instance instead of a headless detached process.
 
-**Use `c11 default-agent launch --in-surface <ref>` to do the launch.** It is the canonical programmatic path: c11 owns the per-TUI prompt-delivery contract (claude-code positional, post-ready sendText for codex/opencode/kimi), so the same call works regardless of which agent the operator has configured. No shell interpolation, no per-TUI branching in caller code.
+**Use `c11 default-agent launch --in-surface <ref>` to do the launch.** It is the canonical programmatic path: c11 owns the per-TUI prompt-delivery contract (claude-code positional, post-ready sendText for codex/grok/opencode/kimi), so the same call works regardless of which agent the operator has configured. No shell interpolation, no per-TUI branching in caller code.
 
 ```bash
 cat > /tmp/lat-xxx-prompt.md <<'EOF'

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -53,7 +53,7 @@ Auto-exported into every c11 surface child process.
 | `C11_SOCKET_PATH` | Override socket path (auto-discovers tagged/debug sockets) |
 | `C11_SOCKET_PASSWORD` | Socket auth password (if set in Settings) |
 | `C11_SHELL_INTEGRATION` | Set to `1` in c11 terminals — use to detect you're inside c11 |
-| `C11_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `kimi`, `opencode`, kebab-case custom); read at surface start |
+| `C11_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `grok`, `kimi`, `opencode`, kebab-case custom); read at surface start |
 | `C11_AGENT_MODEL` | Declared agent model identifier |
 | `C11_AGENT_TASK` | Declared agent task ID |
 
@@ -190,7 +190,7 @@ c11 set-agent --type codex --task lat-412
 c11 set-agent --type opencode --model <model-id>
 ```
 
-- `--type` accepts canonical values (`claude-code`, `codex`, `kimi`, `opencode`) and any kebab-case custom value.
+- `--type` accepts canonical values (`claude-code`, `codex`, `grok`, `kimi`, `opencode`) and any kebab-case custom value.
 - Writes land as `source: declare` in the metadata store, overriding heuristic auto-detection but not user-explicit writes.
 - Environment declaration: `C11_AGENT_TYPE`, `C11_AGENT_MODEL`, `C11_AGENT_TASK` in the surface's startup env are read once at surface-child-process start.
 - Clear with `c11 clear-metadata --key terminal_type` (no `c11 unset-agent`).

--- a/skills/c11/references/metadata.md
+++ b/skills/c11/references/metadata.md
@@ -30,7 +30,7 @@ These keys have a defined shape and render in the sidebar or title bar. Any writ
 | `task` | string | ≤ 128 chars | sidebar: monospace tag |
 | `model` | string | kebab-case, ≤ 64 chars | sidebar chip |
 | `progress` | number | 0.0 – 1.0 | sidebar: progress bar |
-| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `kimi`, `opencode`, `shell`, `unknown`. Open-ended. |
+| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `grok`, `kimi`, `opencode`, `shell`, `unknown`. Open-ended. |
 | `title` | string | plain text, ≤ 256 chars | title bar + sidebar tab label (truncated) |
 | `description` | string | Markdown subset (bold/italic, inline `code`, lists, headings, blockquotes, links, rules — no images, fenced code, or tables), ≤ 2048 chars | title bar expanded region |
 | `worktree` | string | ≤ 128 chars (basename) | sidebar chip with colored-dot prefix. Only rendered when the surface's cwd is inside a *linked* git worktree (`git worktree add ...`). Color is a stable hash of the absolute worktree path. **Derived** — written by c11 runtime, not by agents. |

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -209,6 +209,12 @@ The claude PATH wrapper at `Resources/bin/claude` is a **grandfathered, Claude C
 - **Use `codex --yolo`, not `codex exec`.** `codex exec` is headless and non-interactive, appropriate only for background jobs whose output will be read after completion. For a visible c11 surface where the operator should be able to watch or take over, `codex --yolo` is the right invocation.
 - **No PATH wrapper.** codex does not get a c11 wrapper. The sub-agent self-reports sidebar status by calling `c11 set-status` / `c11 set-metadata` from its own lifecycle, following instructions in the c11 skill it loads at session start.
 
+### grok
+
+- **Use `grok --always-approve`.** Grok Build's auto-approve flag (parallel to claude's `--dangerously-skip-permissions` and codex's `--yolo`). TUI alias is `/yolo`. Headless mode is `grok agent` or `grok -p`; do not use either for a visible c11 surface.
+- **Auth gotcha.** OIDC-acquired tokens (`grok login` browser flow) currently 403 at the chat endpoint for non-Heavy SuperGrok tiers. Use an `XAI_API_KEY` from console.x.ai instead; it bypasses the Heavy-only gate.
+- **No PATH wrapper.** Status comes from skill-driven self-reporting, same as codex/opencode/kimi.
+
 ### opencode, kimi, others
 
 - **No PATH wrapper.** Like codex, status comes from skill-driven self-reporting. If an agent hasn't been taught to self-report, the sidebar won't show status for it; that is expected, not a bug.


### PR DESCRIPTION
## Land #212: Grok Build as a built-in agent type (rebased + modernized)

Rebases and lands external PR #212 (author **Atin** `<atin@atin.me>`, commit 75c0550, 2026-05-26) onto current `main`. Operator cleared #212 to merge (2026-06-12); this is the reviewed + modernized landing. Closes C11-136.

### Commits
1. **`Add Grok Build as a first-class c11 coding agent`** — the contributor's original commit, cherry-picked with authorship preserved. Adds `grok` across the canonical agent surfaces: `AgentType` enum, `canonicalTerminalTypes`, `AgentChip` icon + `bolt.fill` SF-symbol fallback, `AgentDetector.classify`, `default-agent set` valid list, `SkillInstaller` target, `AgentSkillsView` onboarding opt-ins, a factory test, `docs/adding-a-new-agent.md` (a contributor checklist), and skill docs. Only conflict was `skills/c11/references/api.md` (resolved keeping main's `C11_*` naming + adding grok).
2. **`Grok: wire resume into the conversation store + localize agent name`** (my follow-up) — #212 predates the **conversation store** (landed 0.44). It wired grok resume only into `AgentRestartRegistry.phase1`, now the kill-switch fallback (`CMUX_DISABLE_CONVERSATION_STORE=1`, removal scheduled 0.46). The live resume path is `ConversationStrategyRegistry.v1`, and every other built-in agent has **both** a registry row and a conversation strategy. This adds the missing `GrokStrategy` (fresh-launch-only capture; best-effort `grok --always-approve --resume` for alive/suspended), registers it in `v1` (+ pbxproj membership), updates `ConversationStrategyTests`, and localizes `agentType.grok = "Grok Build"` across all six locales. Kept the phase1 fallback row for parity.

### Validation
- Full Debug app build: **BUILD SUCCEEDED**.
- `c11-logic` / `DefaultAgentConfigTests` (28 tests): **TEST SUCCEEDED** (incl. the grok factory test).
- Tagged build (`pr-212-land`): `default-agent set/get grok` ✓, valid-types list includes grok ✓, `set-agent --type grok` round-trips with `terminal_type` stored canonical ✓. **Operator confirmed Grok Build launches live.**
- Grok CLI binary not installed here → c11-side plumbing validated only (no faked e2e). Conversation host tests deferred to CI (pre-existing local-only `SurfaceActivityTests` compile error, untouched by this PR).

Original PR: #212 · Ticket: C11-136

🤖 Generated with [Claude Code](https://claude.com/claude-code)
