### PR TITLE
Land #215: GitHub Copilot CLI as a built-in agent type (rebased)

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -9034,7 +9034,7 @@ struct CMUXCLI {
 
             Subcommands:
               get                              Print the configured default agent type.
-              set <type>                       Set the default agent (claude-code | codex | kimi | opencode | custom).
+              set <type>                       Set the default agent (claude-code | codex | kimi | opencode | github-copilot | custom).
               launch [flags]                   Launch the default (or --agent <type>) agent.
 
             launch flags:
@@ -11033,7 +11033,7 @@ struct CMUXCLI {
 
         case "set":
             guard commandArgs.count >= 2 else {
-                let valid = ["claude-code", "codex", "grok", "kimi", "opencode", "custom"].joined(separator: ", ")
+                let valid = ["claude-code", "codex", "grok", "kimi", "opencode", "github-copilot", "custom"].joined(separator: ", ")
                 throw CLIError(message: "default-agent set requires <type>. Valid: \(valid)")
             }
             let response = try sendV1Command("default_agent set \(commandArgs[1])", client: client)

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		1BA5C5B28E1CE348469E1778 /* MetadataStoreRevisionCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */; };
 		1D57711F82EF7A25FB6FEA23 /* Codex.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1C8E6BE23CECF1DA9531BA /* Codex.swift */; };
 		F60C0DEA00000000000C0001 /* Grok.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60C0DEA00000000000C0002 /* Grok.swift */; };
+		F60C0DEA00000000000C0101 /* GitHubCopilot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60C0DEA00000000000C0102 /* GitHubCopilot.swift */; };
 		1D765B8279AE9949576A5FE1 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8016BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift */; };
 		1E77E8B74098A7D7B928631C /* SurfaceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A815208E655A7AFBCEE667 /* SurfaceActivity.swift */; };
 		1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
@@ -562,6 +563,7 @@
 		AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClaudeCodeScraper.swift; path = Conversation/Scrapers/ClaudeCodeScraper.swift; sourceTree = "<group>"; };
 		AE1C8E6BE23CECF1DA9531BA /* Codex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codex.swift; path = Conversation/Strategies/Codex.swift; sourceTree = "<group>"; };
 		F60C0DEA00000000000C0002 /* Grok.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Grok.swift; path = Conversation/Strategies/Grok.swift; sourceTree = "<group>"; };
+		F60C0DEA00000000000C0102 /* GitHubCopilot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GitHubCopilot.swift; path = Conversation/Strategies/GitHubCopilot.swift; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 				CC1299AE998DF9F78A383294 /* ClaudeCode.swift */,
 				AE1C8E6BE23CECF1DA9531BA /* Codex.swift */,
 				F60C0DEA00000000000C0002 /* Grok.swift */,
+				F60C0DEA00000000000C0102 /* GitHubCopilot.swift */,
 				E2BDE4F4D562EC49C639CF86 /* Kimi.swift */,
 				54017DD4C9F6BE7CFA98C2F7 /* Opencode.swift */,
 				AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */,
@@ -1630,6 +1633,7 @@
 				20A2EC594F0DF1560BB0E28E /* ClaudeCode.swift in Sources */,
 				1D57711F82EF7A25FB6FEA23 /* Codex.swift in Sources */,
 				F60C0DEA00000000000C0001 /* Grok.swift in Sources */,
+				F60C0DEA00000000000C0101 /* GitHubCopilot.swift in Sources */,
 				A7EA137511C5D411B2960587 /* Kimi.swift in Sources */,
 				60785E8E82CF86BCF4A26738 /* Opencode.swift in Sources */,
 				767FF8ADAC0F182A4534E12B /* ClaudeCodeScraper.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		47C976CFA2AD3633C427D15D /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 		4A5A1F18E3F574F301890675 /* StdinHandlerFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7112BF1A1B2C3D4E5F60718 /* StdinHandlerFormattingTests.swift */; };
 		4BF73AE4358BED37E9D90771 /* WorkspaceApplyChromeScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */; };
+		4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */ = {isa = PBXBuildFile; fileRef = D13A1E9CE25B945CC90A8D02 /* copilot */; };
 		505E486F8B252007A3CFE688 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
 		53A8353DD72E0C6954D5F42A /* ChromeScaleSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */; };
 		53D5E057358DF622C3B16996 /* ChromeScaleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */; };
@@ -53,7 +54,9 @@
 		55A25D62B29EA263FABD5931 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 		56240252C16E6E32305412E0 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
 		56D5F7E29DC4C9999E4EDA7B /* DefaultAgentProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */; };
+		573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		5AEB95ABF100C21BFCDB40E4 /* C11ThemeLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F015 /* C11ThemeLoaderTests.swift */; };
+		5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		5E5FA83B76AB6FA59171D8C2 /* HealthFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */; };
 		5F20D96106D7E1D0215F6D66 /* DefaultAgentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C80718F1B0DC883CC3D99 /* DefaultAgentSettingsView.swift */; };
 		60785E8E82CF86BCF4A26738 /* Opencode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54017DD4C9F6BE7CFA98C2F7 /* Opencode.swift */; };
@@ -391,6 +394,7 @@
 				C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */,
 				C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
+				4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */,
 			);
 			name = "Copy CLI";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -423,6 +427,7 @@
 		7B69B687B665752E5EAC57D4 /* Store.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Store.swift; path = Conversation/Store.swift; sourceTree = "<group>"; };
 		7CC7DA94810490BDE375738E /* ConversationScraperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationScraperTests.swift; sourceTree = "<group>"; };
 		7DEEEA4C9921D5BDE4EF06E3 /* Strategy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strategy.swift; path = Conversation/Strategy.swift; sourceTree = "<group>"; };
+		7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* c11UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentResolverTests.swift; sourceTree = "<group>"; };
@@ -605,6 +610,7 @@
 		CC40100AA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessProbe.swift; sourceTree = "<group>"; };
 		D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneNavigationKeybindUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionsUITests.swift; sourceTree = "<group>"; };
+		D13A1E9CE25B945CC90A8D02 /* copilot */ = {isa = PBXFileReference; includeInIndex = 1; name = copilot; path = Resources/bin/copilot; sourceTree = "<group>"; };
 		D1BEF00001A1B2C3D4E5F719 /* open */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/open; sourceTree = SOURCE_ROOT; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
 		D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceTitleBarRenderTests.swift; sourceTree = "<group>"; };
@@ -831,6 +837,7 @@
 				F1000003A1B2C3D4E5F60718 /* c11Tests */,
 				A5001042 /* Products */,
 				F31B76FA995543756EA155C1 /* Frameworks */,
+				D13A1E9CE25B945CC90A8D02 /* copilot */,
 			);
 			sourceTree = "<group>";
 		};
@@ -1145,6 +1152,7 @@
 				14C14C792CC3845B19215A4A /* WorkspaceConversationResumeTests.swift */,
 				93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */,
 				660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */,
+				7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1460,6 +1468,7 @@
 				C1133000000000000000A001 /* CwdParamResolutionTests.swift in Sources */,
 				C1133000000000000000B001 /* DefaultAgentLaunchCompositionTests.swift in Sources */,
 				05F26BA3460B93D9FA5FFAD0 /* ConversationCrashRecoveryTests.swift in Sources */,
+				5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1709,6 +1718,7 @@
 				14D792EBB09AC36ADFF389EC /* ShutdownSentinelTests.swift in Sources */,
 				6B3658A83D3C83E088A1FD10 /* SurfaceActivityTests.swift in Sources */,
 				C9C4527E2DE6F3E83518AE34 /* WorkspaceConversationResumeTests.swift in Sources */,
+				573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -3903,6 +3903,53 @@
         }
       }
     },
+    "agentType.githubCopilot": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "GitHub Copilot"
+          }
+        }
+      }
+    },
     "agentType.grok": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/bin/copilot
+++ b/Resources/bin/copilot
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# c11 copilot wrapper - auto-declare terminal_type for GitHub Copilot CLI.
+#
+# When running inside a c11 terminal (CMUX_SURFACE_ID set + socket live),
+# this wrapper marks the surface as terminal_type=github-copilot via
+# `c11 set-agent` so the sidebar chip, default-agent picker, and any
+# orchestration that filters by terminal_type all see Copilot as a
+# first-class agent. Outside c11 (or when the socket is unreachable),
+# it passes through to the real copilot binary unchanged.
+#
+# Modeled on `Resources/bin/codex`. See that wrapper for the reference
+# implementation of the auto-declare pattern and the constraints all
+# wrappers honour:
+#
+#   1. Pass-through when not in a c11 terminal or socket is down.
+#   2. Pass-through for non-interactive subcommands (would lie about
+#      the surface's terminal_type — surface isn't an interactive copilot
+#      session if it's running `copilot --help`).
+#   3. Best-effort background write so startup latency is unaffected.
+#   4. Always exec the real binary at the end.
+#
+# Why no session-id capture (unlike Claude Code's wrapper)?
+#
+#   GitHub Copilot CLI manages its own session-store.db at ~/.copilot/
+#   and exposes `/resume` for in-session resume. It doesn't accept a
+#   `--session-id <id>` at launch, so we can't pre-write a session id
+#   to surface metadata the way the claude wrapper does. The c11
+#   session-restore path falls back to the default behaviour, which is
+#   acceptable for now — `copilot /resume` from within a restored
+#   surface continues the most recent session in cwd.
+
+set -uo pipefail
+
+# Find the real copilot binary, skipping our own directory.
+find_real_copilot() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/copilot" ]] && printf '%s' "$d/copilot" && return 0
+    done
+    return 1
+}
+
+# Return 0 only when CMUX_SOCKET_PATH points to a live c11 socket.
+c11_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir c11_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    c11_bin="$self_dir/c11"
+    [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+    [[ -n "$c11_bin" ]] || return 1
+
+    # Bounded check so copilot startup isn't blocked behind the CLI default
+    # timeout (15s) when the socket is stale or hung.
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$c11_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+# Pass through if not in a c11 terminal, hooks are disabled, or the
+# socket is unavailable.
+IN_C11=0
+if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
+    IN_C11=1
+fi
+
+if [[ "$IN_C11" == "0" || "${CMUX_COPILOT_HOOKS_DISABLED:-}" == "1" ]] || ! c11_socket_available; then
+    REAL_COPILOT="$(find_real_copilot)" || { echo "Error: copilot not found in PATH" >&2; exit 127; }
+    exec "$REAL_COPILOT" "$@"
+fi
+
+REAL_COPILOT="$(find_real_copilot)" || { echo "Error: copilot not found in PATH" >&2; exit 127; }
+
+# Pass through for non-interactive invocations that shouldn't flip the
+# surface's terminal_type to "github-copilot" — the surface isn't an
+# interactive copilot session in these cases.
+#
+# Copilot CLI uses flags rather than subcommands for non-interactive
+# modes:
+#   -p / --prompt        non-interactive scripting (one-shot prompt)
+#   --acp                start as Agent Client Protocol server (not a TUI)
+#   -h / --help          help
+#   -V / --version       version
+#   --connect            attach to a remote session (different surface model)
+for arg in "$@"; do
+    case "$arg" in
+        -p|--prompt|--acp|--help|-h|--version|-V|--connect)
+            exec "$REAL_COPILOT" "$@"
+            ;;
+    esac
+done
+
+# Resolve the c11 binary (bundle-relative first, fall back to PATH so a
+# misconfigured bundle still works in dev builds).
+self_dir="$(cd "$(dirname "$0")" && pwd)"
+c11_bin="$self_dir/c11"
+[[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+
+# Best-effort surface-metadata write: mark this surface as a
+# github-copilot terminal so the sidebar chip and any orchestration
+# filtering by terminal_type see it. Background so copilot startup
+# latency is unaffected; `disown` so a stale write can't keep the
+# wrapper process alive after `exec`.
+if [[ -n "$c11_bin" ]]; then
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" set-agent --type github-copilot \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+fi
+
+exec "$REAL_COPILOT" "$@"

--- a/Sources/AgentChip.swift
+++ b/Sources/AgentChip.swift
@@ -128,6 +128,8 @@ enum AgentChipResolver {
             return "AgentIcons/kimi"
         case "opencode":
             return "AgentIcons/opencode"
+        case "github-copilot":
+            return "AgentIcons/github-copilot"
         case "shell":
             return "AgentIcons/shell"
         case "unknown":
@@ -141,14 +143,15 @@ enum AgentChipResolver {
     /// is missing at runtime.
     static func sfSymbolFallback(forTerminalType terminalType: String) -> String {
         switch terminalType {
-        case "claude-code":  return "sparkles"
-        case "codex":        return "chevron.left.forwardslash.chevron.right"
-        case "grok":         return "bolt.fill"
-        case "kimi":         return "moon.stars"
-        case "opencode":     return "curlybraces"
-        case "shell":        return "terminal.fill"
-        case "unknown":      return "questionmark.square.dashed"
-        default:             return "questionmark.square.dashed"
+        case "claude-code":    return "sparkles"
+        case "codex":          return "chevron.left.forwardslash.chevron.right"
+        case "grok":           return "bolt.fill"
+        case "kimi":           return "moon.stars"
+        case "opencode":       return "curlybraces"
+        case "github-copilot": return "paperplane.fill"
+        case "shell":          return "terminal.fill"
+        case "unknown":        return "questionmark.square.dashed"
+        default:               return "questionmark.square.dashed"
         }
     }
 }

--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -229,6 +229,8 @@ final class AgentDetector: @unchecked Sendable {
             return "kimi"
         case "opencode", "opencode-cli":
             return "opencode"
+        case "copilot":
+            return "github-copilot"
         default:
             break
         }
@@ -246,6 +248,9 @@ final class AgentDetector: @unchecked Sendable {
             }
             if a.contains("opencode-cli") || a.contains("sst/opencode") || a.contains("/opencode") {
                 return "opencode"
+            }
+            if a.contains("@github/copilot") || a.contains("/copilot") {
+                return "github-copilot"
             }
         }
 

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -564,6 +564,7 @@ struct AgentSkillsOnboardingSheet: View {
     @State private var grokOptIn: Bool = false
     @State private var kimiOptIn: Bool = false
     @State private var opencodeOptIn: Bool = false
+    @State private var copilotOptIn: Bool = false
     @State private var initializedDefaultOptIns: Bool = false
     @State private var selectedAction: AgentSkillsOnboardingAction = .install
 
@@ -608,7 +609,7 @@ struct AgentSkillsOnboardingSheet: View {
     }
 
     private var anySelected: Bool {
-        initializedDefaultOptIns && (claudeOptIn || codexOptIn || grokOptIn || kimiOptIn || opencodeOptIn)
+        initializedDefaultOptIns && (claudeOptIn || codexOptIn || grokOptIn || kimiOptIn || opencodeOptIn || copilotOptIn)
     }
 
     private var hasActionNeeded: Bool {
@@ -913,6 +914,7 @@ struct AgentSkillsOnboardingSheet: View {
         case .grok: return $grokOptIn
         case .kimi: return $kimiOptIn
         case .opencode: return $opencodeOptIn
+        case .copilot: return $copilotOptIn
         }
     }
 
@@ -923,6 +925,7 @@ struct AgentSkillsOnboardingSheet: View {
             (.grok, grokOptIn),
             (.kimi, kimiOptIn),
             (.opencode, opencodeOptIn),
+            (.copilot, copilotOptIn),
         ]
         var selectedKeys: Set<String> = []
         for (target, _) in selections.filter({ $0.1 }) {
@@ -992,6 +995,7 @@ struct AgentSkillsOnboardingSheet: View {
         grokOptIn = defaults[.grok] ?? false
         kimiOptIn = defaults[.kimi] ?? false
         opencodeOptIn = defaults[.opencode] ?? false
+        copilotOptIn = defaults[.copilot] ?? false
     }
 }
 

--- a/Sources/Conversation/Strategies/GitHubCopilot.swift
+++ b/Sources/Conversation/Strategies/GitHubCopilot.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Fresh-launch-only strategy for GitHub Copilot CLI. Copilot manages its own
+/// session-store.db at `~/.copilot/` and exposes `/resume` for in-session
+/// resume, but accepts no `--session-id <id>` at launch — so c11 cannot
+/// pre-write or hand back a session id the way the Claude Code strategy does
+/// (see `Resources/bin/copilot`, which deliberately skips session capture for
+/// this reason). Capture therefore acts only on a hook/manual push or a
+/// wrapper-claim placeholder; resume launches fresh, matching Kimi/Opencode.
+struct GitHubCopilotStrategy: ConversationStrategy {
+    let kind: String = "github-copilot"
+
+    init() {}
+
+    func capture(inputs: ConversationStrategyInputs) -> ConversationRef? {
+        if let push = inputs.push, !push.placeholder {
+            return push
+        }
+        return inputs.wrapperClaim
+    }
+
+    func resume(ref: ConversationRef) -> ResumeAction {
+        if ref.placeholder {
+            return .skip(reason: "fresh-launch-only")
+        }
+        switch ref.state {
+        case .alive, .suspended:
+            return .typeCommand(text: conversationShellQuote("copilot"), submitWithReturn: true)
+        default:
+            return .skip(reason: "state=\(ref.state.rawValue) not auto-resumable")
+        }
+    }
+}

--- a/Sources/Conversation/StrategyRegistry.swift
+++ b/Sources/Conversation/StrategyRegistry.swift
@@ -30,14 +30,16 @@ struct ConversationStrategyRegistry: Sendable {
 
     /// Default v1 registry. Lands strategies for every built-in agent type:
     /// claude-code (push-primary), codex (pull-primary, ambiguity-aware),
-    /// grok (best-effort resume), opencode and kimi (fresh-launch only).
+    /// grok (best-effort resume), opencode/kimi/github-copilot (fresh-launch
+    /// only).
     static let v1: ConversationStrategyRegistry = {
         ConversationStrategyRegistry(strategies: [
             ClaudeCodeStrategy(),
             CodexStrategy(),
             GrokStrategy(),
             OpencodeStrategy(),
-            KimiStrategy()
+            KimiStrategy(),
+            GitHubCopilotStrategy()
         ])
     }()
 }

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -9,6 +9,7 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
     case grok
     case kimi
     case opencode
+    case githubCopilot = "github-copilot"
     case custom
 
     var id: String { rawValue }
@@ -27,6 +28,8 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
             return String(localized: "agentType.kimi", defaultValue: "Kimi")
         case .opencode:
             return String(localized: "agentType.opencode", defaultValue: "OpenCode")
+        case .githubCopilot:
+            return String(localized: "agentType.githubCopilot", defaultValue: "GitHub Copilot")
         case .custom:
             return String(localized: "agentType.custom", defaultValue: "Custom")
         }
@@ -37,12 +40,13 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
     /// values for the other agents.
     var factoryCommand: String {
         switch self {
-        case .claudeCode: return "claude --dangerously-skip-permissions"
-        case .codex:      return "codex --yolo"
-        case .grok:       return "grok --always-approve"
-        case .kimi:       return "kimi"
-        case .opencode:   return "opencode run --dangerously-skip-permissions"
-        case .custom:     return ""
+        case .claudeCode:    return "claude --dangerously-skip-permissions"
+        case .codex:         return "codex --yolo"
+        case .grok:          return "grok --always-approve"
+        case .kimi:          return "kimi"
+        case .opencode:      return "opencode run --dangerously-skip-permissions"
+        case .githubCopilot: return "copilot --allow-all --autopilot"
+        case .custom:        return ""
         }
     }
 

--- a/Sources/SkillInstaller.swift
+++ b/Sources/SkillInstaller.swift
@@ -9,6 +9,7 @@ enum SkillInstallerTarget: String, CaseIterable {
     case grok
     case kimi
     case opencode
+    case copilot
 
     var displayName: String {
         switch self {
@@ -17,6 +18,7 @@ enum SkillInstallerTarget: String, CaseIterable {
         case .grok: return "Grok Build"
         case .kimi: return "Kimi"
         case .opencode: return "OpenCode"
+        case .copilot: return "GitHub Copilot"
         }
     }
 

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -33,7 +33,7 @@ public enum MetadataKey {
     ]
 
     public static let canonicalTerminalTypes: Set<String> = [
-        "claude-code", "codex", "grok", "kimi", "opencode", "shell", "unknown"
+        "claude-code", "codex", "grok", "kimi", "opencode", "github-copilot", "shell", "unknown"
     ]
 }
 

--- a/c11Tests/AgentDetectorTests.swift
+++ b/c11Tests/AgentDetectorTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Covers `AgentDetector.classify(comm:args:)` — the pure classifier exposed
+/// for tests so we can exercise the binary-match table without a live ps scan.
+final class AgentDetectorTests: XCTestCase {
+
+    // MARK: - Direct comm matches
+
+    func testClassifyClaudeReturnsClaudeCode() {
+        XCTAssertEqual(AgentDetector.classify(comm: "claude", args: ""), "claude-code")
+        XCTAssertEqual(AgentDetector.classify(comm: "claude-code", args: ""), "claude-code")
+    }
+
+    func testClassifyCopilotReturnsGitHubCopilot() {
+        XCTAssertEqual(AgentDetector.classify(comm: "copilot", args: ""), "github-copilot")
+    }
+
+    func testClassifyCodexReturnsCodex() {
+        XCTAssertEqual(AgentDetector.classify(comm: "codex", args: ""), "codex")
+    }
+
+    // MARK: - Node-wrapped matches via args substring
+
+    func testClassifyNodeWrappedCopilotBinPathReturnsGitHubCopilot() {
+        let args = "node /Users/me/.nvm/versions/node/v24.11.1/bin/copilot --allow-all --autopilot"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "github-copilot")
+    }
+
+    func testClassifyNodeWrappedGitHubCopilotPackagePathReturnsGitHubCopilot() {
+        let args = "node /Users/me/.nvm/versions/node/v24.11.1/lib/node_modules/@github/copilot/dist/main.js"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "github-copilot")
+    }
+
+    func testClassifyNodeWrappedClaudeCodeReturnsClaudeCode() {
+        let args = "node /Users/me/.npm/global/lib/node_modules/@anthropic-ai/claude-code/dist/cli.js"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "claude-code")
+    }
+
+    // MARK: - Negative cases
+
+    func testClassifyUnrelatedNodeProcessReturnsUnknown() {
+        let args = "node /Users/me/project/server.js"
+        XCTAssertEqual(AgentDetector.classify(comm: "node", args: args), "unknown")
+    }
+
+    func testClassifyZshReturnsShell() {
+        XCTAssertEqual(AgentDetector.classify(comm: "zsh", args: ""), "shell")
+        XCTAssertEqual(AgentDetector.classify(comm: "-zsh", args: ""), "shell")
+    }
+}

--- a/c11Tests/ConversationStrategyTests.swift
+++ b/c11Tests/ConversationStrategyTests.swift
@@ -23,6 +23,7 @@ final class ConversationStrategyTests: XCTestCase {
         XCTAssertNotNil(r.strategy(forKind: "grok"))
         XCTAssertNotNil(r.strategy(forKind: "opencode"))
         XCTAssertNotNil(r.strategy(forKind: "kimi"))
+        XCTAssertNotNil(r.strategy(forKind: "github-copilot"))
         XCTAssertNil(r.strategy(forKind: "cursor"))
     }
 
@@ -296,6 +297,43 @@ final class ConversationStrategyTests: XCTestCase {
         let strategy = GrokStrategy()
         let ref = ConversationRef(
             kind: "grok",
+            id: "wrapper-claim:foo",
+            placeholder: true,
+            capturedAt: Date(),
+            capturedVia: .wrapperClaim,
+            state: .unknown
+        )
+        guard case .skip(let reason) = strategy.resume(ref: ref) else {
+            XCTFail("expected skip")
+            return
+        }
+        XCTAssertEqual(reason, "fresh-launch-only")
+    }
+
+    // MARK: - GitHub Copilot strategy
+
+    func testGitHubCopilotAliveTypesShellQuotedCommand() {
+        let strategy = GitHubCopilotStrategy()
+        let ref = ConversationRef(
+            kind: "github-copilot",
+            id: "real-id",
+            placeholder: false,
+            capturedAt: Date(),
+            capturedVia: .hook,
+            state: .alive
+        )
+        guard case .typeCommand(let text, let submit) = strategy.resume(ref: ref) else {
+            XCTFail("expected typeCommand")
+            return
+        }
+        XCTAssertEqual(text, "'copilot'")
+        XCTAssertTrue(submit)
+    }
+
+    func testGitHubCopilotPlaceholderResumeSkips() {
+        let strategy = GitHubCopilotStrategy()
+        let ref = ConversationRef(
+            kind: "github-copilot",
             id: "wrapper-claim:foo",
             placeholder: true,
             capturedAt: Date(),

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -36,6 +36,17 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
     }
 
+    func testFactoryGitHubCopilotCommandIncludesAllowAllAndAutopilot() {
+        let entry = AgentConfig.factory(for: .githubCopilot)
+        XCTAssertEqual(entry.command, "copilot --allow-all --autopilot")
+        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+    }
+
+    func testAgentTypeGitHubCopilotRawValueIsKebabCase() {
+        XCTAssertEqual(AgentType.githubCopilot.rawValue, "github-copilot")
+    }
+
+
     func testFactoryCustomHasEmptyDefaults() {
         let entry = AgentConfig.factory(for: .custom)
         XCTAssertEqual(entry.command, "")

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -53,7 +53,7 @@ Auto-exported into every c11 surface child process.
 | `C11_SOCKET_PATH` | Override socket path (auto-discovers tagged/debug sockets) |
 | `C11_SOCKET_PASSWORD` | Socket auth password (if set in Settings) |
 | `C11_SHELL_INTEGRATION` | Set to `1` in c11 terminals — use to detect you're inside c11 |
-| `C11_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `grok`, `kimi`, `opencode`, kebab-case custom); read at surface start |
+| `C11_AGENT_TYPE` | Declared agent TUI type (`claude-code`, `codex`, `grok`, `kimi`, `opencode`, `github-copilot`, kebab-case custom); read at surface start |
 | `C11_AGENT_MODEL` | Declared agent model identifier |
 | `C11_AGENT_TASK` | Declared agent task ID |
 
@@ -190,7 +190,7 @@ c11 set-agent --type codex --task lat-412
 c11 set-agent --type opencode --model <model-id>
 ```
 
-- `--type` accepts canonical values (`claude-code`, `codex`, `grok`, `kimi`, `opencode`) and any kebab-case custom value.
+- `--type` accepts canonical values (`claude-code`, `codex`, `grok`, `kimi`, `opencode`, `github-copilot`) and any kebab-case custom value.
 - Writes land as `source: declare` in the metadata store, overriding heuristic auto-detection but not user-explicit writes.
 - Environment declaration: `C11_AGENT_TYPE`, `C11_AGENT_MODEL`, `C11_AGENT_TASK` in the surface's startup env are read once at surface-child-process start.
 - Clear with `c11 clear-metadata --key terminal_type` (no `c11 unset-agent`).

--- a/skills/c11/references/metadata.md
+++ b/skills/c11/references/metadata.md
@@ -30,7 +30,7 @@ These keys have a defined shape and render in the sidebar or title bar. Any writ
 | `task` | string | ≤ 128 chars | sidebar: monospace tag |
 | `model` | string | kebab-case, ≤ 64 chars | sidebar chip |
 | `progress` | number | 0.0 – 1.0 | sidebar: progress bar |
-| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `grok`, `kimi`, `opencode`, `shell`, `unknown`. Open-ended. |
+| `terminal_type` | string | kebab-case, ≤ 32 chars | sidebar chip. Canonical values: `claude-code`, `codex`, `grok`, `kimi`, `opencode`, `github-copilot`, `shell`, `unknown`. Open-ended. |
 | `title` | string | plain text, ≤ 256 chars | title bar + sidebar tab label (truncated) |
 | `description` | string | Markdown subset (bold/italic, inline `code`, lists, headings, blockquotes, links, rules — no images, fenced code, or tables), ≤ 2048 chars | title bar expanded region |
 | `worktree` | string | ≤ 128 chars (basename) | sidebar chip with colored-dot prefix. Only rendered when the surface's cwd is inside a *linked* git worktree (`git worktree add ...`). Color is a stable hash of the absolute worktree path. **Derived** — written by c11 runtime, not by agents. |


### PR DESCRIPTION
## Land #215: GitHub Copilot CLI as a built-in agent type (rebased + modernized)

Rebases and lands external PR #215 (author **MdMxMyr** `<maxmeyer@live.nl>`, commit 81123c0, 2026-05-29) onto current `main` (after #242/Grok landed). Operator cleared #215 to merge (2026-06-12) with an extra-scrutiny flag (external author shipping an executable wrapper). Closes C11-137.

### Commits
1. **`Add GitHub Copilot CLI as a built-in agent type`** — the contributor's original commit, cherry-picked with authorship preserved. Adds `github-copilot` across the canonical surfaces (`AgentType.githubCopilot`, `canonicalTerminalTypes`, `AgentChip` icon + `paperplane.fill` fallback, `AgentDetector` comm/node-args match, CLI valid list, `SkillInstaller` target, onboarding opt-in), ships `Resources/bin/copilot` (session wrapper, bundled via the Copy CLI phase), and adds `c11Tests/AgentDetectorTests.swift`. Conflicts (grok now adjacent) resolved keeping both agents; pbxproj resolved via union of HEAD + the PR's genuine additions.
2. **`GitHub Copilot: wire resume into the conversation store + localize agent name`** (my follow-up) — #215 added no conversation strategy. Adds `GitHubCopilotStrategy` to `ConversationStrategyRegistry.v1` (fresh-launch-only — copilot has no `--session-id` launch flag; the wrapper deliberately skips session capture for this reason), + pbxproj membership, registry-test update, copilot strategy tests, and the 6-locale `agentType.githubCopilot` localization.

### Wrapper security audit (`Resources/bin/copilot`) — PASS
- PATH-scoped, gated on `CMUX_SURFACE_ID` + a live socket (bounded 0.75s ping); passes through otherwise.
- **No persistent writes outside c11's runtime** — its only side effect is `c11 set-agent` over c11's own socket. Does not touch `~/.copilot/`, dotfiles, or tenant config.
- Clean fall-through to the real binary (skips its own dir to avoid self-exec); non-interactive flags (`-p/--prompt/--acp/--help/--version/--connect`) pass through without flipping `terminal_type`.
- Minimal capture (no session id), kill switch `CMUX_COPILOT_HOOKS_DISABLED`. Idiomatic — mirrors the `codex`/`claude` sibling wrappers.

### Validation
- Full Debug app build: **BUILD SUCCEEDED**.
- `c11-logic` / `DefaultAgentConfigTests` (30 tests): **TEST SUCCEEDED** (incl. both copilot tests).
- Tagged build (`pr-215-land`): `default-agent set/get github-copilot` ✓, valid-types list includes both grok + github-copilot ✓, `set-agent --type github-copilot` round-trips canonical ✓, **bundled `copilot` wrapper present + executable in the app bundle** ✓.
- Copilot CLI binary not installed here → c11-side plumbing + bundled-wrapper-executable validated (no faked e2e). Conversation host tests deferred to CI (pre-existing local-only `SurfaceActivityTests` compile error, untouched by this PR).

Original PR: #215 · Ticket: C11-137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
