### PR TITLE
Real-time main-thread hang catcher with off-thread stack capture

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -25,8 +25,6 @@
 		1A1EC322E65B74DEDAAD08A5 /* DefaultAgentConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF9D5EC78046EDA9B54AC68 /* DefaultAgentConfigTests.swift */; };
 		1BA5C5B28E1CE348469E1778 /* MetadataStoreRevisionCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */; };
 		1D57711F82EF7A25FB6FEA23 /* Codex.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1C8E6BE23CECF1DA9531BA /* Codex.swift */; };
-		F60C0DEA00000000000C0001 /* Grok.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60C0DEA00000000000C0002 /* Grok.swift */; };
-		F60C0DEA00000000000C0101 /* GitHubCopilot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60C0DEA00000000000C0102 /* GitHubCopilot.swift */; };
 		1D765B8279AE9949576A5FE1 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8016BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift */; };
 		1E77E8B74098A7D7B928631C /* SurfaceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A815208E655A7AFBCEE667 /* SurfaceActivity.swift */; };
 		1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
@@ -51,11 +49,13 @@
 		505E486F8B252007A3CFE688 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
 		53A8353DD72E0C6954D5F42A /* ChromeScaleSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */; };
 		53D5E057358DF622C3B16996 /* ChromeScaleObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */; };
+		5535B0220F7520ADFB17EC99 /* HangBacktrace.c in Sources */ = {isa = PBXBuildFile; fileRef = 51C0D2C1212976BCF837B620 /* HangBacktrace.c */; };
 		55741FF81E130E9AB8AE64FB /* WorkspaceSnapshotConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */; };
 		55A25D62B29EA263FABD5931 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 		56240252C16E6E32305412E0 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
 		56D5F7E29DC4C9999E4EDA7B /* DefaultAgentProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */; };
 		573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
+		5AE9C6CE7FCF928F695FE26D /* MainThreadHangMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB26BFF19A91FD51B78AF28E /* MainThreadHangMonitor.swift */; };
 		5AEB95ABF100C21BFCDB40E4 /* C11ThemeLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F015 /* C11ThemeLoaderTests.swift */; };
 		5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		5E5FA83B76AB6FA59171D8C2 /* HealthFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */; };
@@ -329,6 +329,7 @@
 		E6C1381837332D3B253A0C42 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		E7E728D3008386FFA3E28065 /* WorkspacePullRequestSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */; };
 		E81B5FA9C3AF8FAB6C10C623 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
+		E9E24C866C5E61B887F6E726 /* MainThreadHangDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */; };
 		EAD9B00B1CD68D5F1C61CEDF /* ConversationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B9B8C3641F9801C6A45757 /* ConversationStrategyTests.swift */; };
 		EC224F7B0F7E77A981DFEC5A /* StateDirectoryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */; };
 		F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
@@ -337,6 +338,8 @@
 		F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */; };
 		F5D4593C9E4FA636B735FFBF /* TomlSubsetParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F003 /* TomlSubsetParserTests.swift */; };
 		F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
+		F60C0DEA00000000000C0001 /* Grok.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60C0DEA00000000000C0002 /* Grok.swift */; };
+		F60C0DEA00000000000C0101 /* GitHubCopilot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60C0DEA00000000000C0102 /* GitHubCopilot.swift */; };
 		F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */; };
 		FB100000A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB100001A1B2C3D4E5F60718 /* BrowserImportProfilesUITests.swift */; };
 		FDA0BE0001234A1CD69B5467 /* FullDiskAccessProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7017BF1A1B2C3D4E5F60718 /* FullDiskAccessProbeTests.swift */; };
@@ -417,6 +420,7 @@
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
 		491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 		4979C511C7C076498CDF3515 /* ResumeAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResumeAction.swift; path = Conversation/ResumeAction.swift; sourceTree = "<group>"; };
+		51C0D2C1212976BCF837B620 /* HangBacktrace.c */ = {isa = PBXFileReference; includeInIndex = 1; path = HangBacktrace.c; sourceTree = "<group>"; };
 		51D3CB3B7B4231D786E8883E /* ShutdownSentinel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShutdownSentinel.swift; path = Conversation/ShutdownSentinel.swift; sourceTree = "<group>"; };
 		54017DD4C9F6BE7CFA98C2F7 /* Opencode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Opencode.swift; path = Conversation/Strategies/Opencode.swift; sourceTree = "<group>"; };
 		58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPanelTests.swift; sourceTree = "<group>"; };
@@ -425,10 +429,10 @@
 		660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationCrashRecoveryTests.swift; path = ConversationCrashRecoveryTests.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
 		76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentProjectConfig.swift; sourceTree = "<group>"; };
+		7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		7B69B687B665752E5EAC57D4 /* Store.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Store.swift; path = Conversation/Store.swift; sourceTree = "<group>"; };
 		7CC7DA94810490BDE375738E /* ConversationScraperTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationScraperTests.swift; sourceTree = "<group>"; };
 		7DEEEA4C9921D5BDE4EF06E3 /* Strategy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strategy.swift; path = Conversation/Strategy.swift; sourceTree = "<group>"; };
-		7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* c11UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentResolverTests.swift; sourceTree = "<group>"; };
@@ -562,8 +566,6 @@
 		A8C9388437A24EE58C8AAA71 /* Ref.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Ref.swift; path = Conversation/Ref.swift; sourceTree = "<group>"; };
 		AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClaudeCodeScraper.swift; path = Conversation/Scrapers/ClaudeCodeScraper.swift; sourceTree = "<group>"; };
 		AE1C8E6BE23CECF1DA9531BA /* Codex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codex.swift; path = Conversation/Strategies/Codex.swift; sourceTree = "<group>"; };
-		F60C0DEA00000000000C0002 /* Grok.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Grok.swift; path = Conversation/Strategies/Grok.swift; sourceTree = "<group>"; };
-		F60C0DEA00000000000C0102 /* GitHubCopilot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GitHubCopilot.swift; path = Conversation/Strategies/GitHubCopilot.swift; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 		B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceCmdDUITests.swift; sourceTree = "<group>"; };
 		B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWindowConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOrderingTests.swift; sourceTree = "<group>"; };
+		BE61F2503F50546EC21A9868 /* HangBacktrace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HangBacktrace.h; sourceTree = "<group>"; };
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
 		C11104F01 /* GitContextResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metadata/GitContextResolver.swift; sourceTree = "<group>"; };
@@ -707,8 +710,10 @@
 		DH022BF1A1B2C3D4E5F60718 /* CLIResolutionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIResolutionSnapshotTests.swift; sourceTree = "<group>"; };
 		DH023BF1A1B2C3D4E5F60718 /* TerminalControllerTelemetryWorkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerTelemetryWorkerTests.swift; sourceTree = "<group>"; };
 		E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
+		E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThreadHangDetectorTests.swift; sourceTree = "<group>"; };
 		E25359D87534E2AF54EA0E5F /* SurfaceActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceActivityTests.swift; sourceTree = "<group>"; };
 		E2BDE4F4D562EC49C639CF86 /* Kimi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Kimi.swift; path = Conversation/Strategies/Kimi.swift; sourceTree = "<group>"; };
+		EB26BFF19A91FD51B78AF28E /* MainThreadHangMonitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThreadHangMonitor.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 		F1000002A1B2C3D4E5F60718 /* c11Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
@@ -717,6 +722,8 @@
 		F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigTests.swift; sourceTree = "<group>"; };
 		F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 		F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
+		F60C0DEA00000000000C0002 /* Grok.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Grok.swift; path = Conversation/Strategies/Grok.swift; sourceTree = "<group>"; };
+		F60C0DEA00000000000C0102 /* GitHubCopilot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GitHubCopilot.swift; path = Conversation/Strategies/GitHubCopilot.swift; sourceTree = "<group>"; };
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
 		F6B62D2ECDC52E5244D9C6E3 /* DefaultAgentConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentConfig.swift; sourceTree = "<group>"; };
 		F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
@@ -1004,6 +1011,9 @@
 				E2BDE4F4D562EC49C639CF86 /* Kimi.swift */,
 				54017DD4C9F6BE7CFA98C2F7 /* Opencode.swift */,
 				AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */,
+				EB26BFF19A91FD51B78AF28E /* MainThreadHangMonitor.swift */,
+				51C0D2C1212976BCF837B620 /* HangBacktrace.c */,
+				BE61F2503F50546EC21A9868 /* HangBacktrace.h */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1156,6 +1166,7 @@
 				93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */,
 				660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */,
 				7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */,
+				E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1472,6 +1483,7 @@
 				C1133000000000000000B001 /* DefaultAgentLaunchCompositionTests.swift in Sources */,
 				05F26BA3460B93D9FA5FFAD0 /* ConversationCrashRecoveryTests.swift in Sources */,
 				5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */,
+				E9E24C866C5E61B887F6E726 /* MainThreadHangDetectorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1637,6 +1649,8 @@
 				A7EA137511C5D411B2960587 /* Kimi.swift in Sources */,
 				60785E8E82CF86BCF4A26738 /* Opencode.swift in Sources */,
 				767FF8ADAC0F182A4534E12B /* ClaudeCodeScraper.swift in Sources */,
+				5AE9C6CE7FCF928F695FE26D /* MainThreadHangMonitor.swift in Sources */,
+				5535B0220F7520ADFB17EC99 /* HangBacktrace.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2546,6 +2546,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // telemetry consent inside CrashDiagnostics itself.
         CrashDiagnostics.shared.install()
 
+        // Real-time main-thread watchdog: captures a backtrace *while* main is
+        // wedged (the beachball case a CFRunLoopObserver can't see). Writes a
+        // local hang log unconditionally; forwards to Sentry/PostHog only with
+        // telemetry consent. Opt out with C11_HANG_MONITOR=0.
+        MainThreadHangMonitor.shared.installIfNeeded()
+
         if telemetryEnabled && !isRunningUnderXCTest {
             PostHogAnalytics.shared.startIfNeeded()
         }

--- a/Sources/HangBacktrace.c
+++ b/Sources/HangBacktrace.c
@@ -1,0 +1,52 @@
+#include "HangBacktrace.h"
+
+#if defined(__arm64__)
+
+#include <pthread/stack_np.h>
+
+int c11_capture_thread_backtrace(thread_t thread, uintptr_t *out, int max_frames) {
+    if (out == NULL || max_frames <= 0) {
+        return 0;
+    }
+
+    arm_thread_state64_t state;
+    mach_msg_type_number_t count = ARM_THREAD_STATE64_COUNT;
+    if (thread_get_state(thread, ARM_THREAD_STATE64,
+                         (thread_state_t)&state, &count) != KERN_SUCCESS) {
+        return 0;
+    }
+
+    int n = 0;
+    // Leaf frame: the program counter the thread is currently parked on.
+    out[n++] = (uintptr_t)__darwin_arm_thread_state64_get_pc(state);
+
+    // Walk the saved frame-pointer chain. pthread_stack_frame_decode_np reads
+    // [fp] (next fp) and [fp+8] (return address) and strips pointer-auth bits
+    // from both — the part a pure-Swift walk can't do without ptrauth intrinsics.
+    uintptr_t fp = (uintptr_t)__darwin_arm_thread_state64_get_fp(state);
+    while (fp != 0 && (fp & 0xF) == 0 && n < max_frames) {
+        uintptr_t ret = 0;
+        uintptr_t next = pthread_stack_frame_decode_np(fp, &ret);
+        if (ret != 0) {
+            out[n++] = ret;
+        }
+        // Frame pointers must climb monotonically; anything else means a corrupt
+        // or exhausted chain.
+        if (next <= fp) {
+            break;
+        }
+        fp = next;
+    }
+    return n;
+}
+
+#else
+
+int c11_capture_thread_backtrace(thread_t thread, uintptr_t *out, int max_frames) {
+    (void)thread;
+    (void)out;
+    (void)max_frames;
+    return 0;
+}
+
+#endif /* __arm64__ */

--- a/Sources/HangBacktrace.h
+++ b/Sources/HangBacktrace.h
@@ -1,0 +1,17 @@
+#ifndef C11_HANG_BACKTRACE_H
+#define C11_HANG_BACKTRACE_H
+
+#include <mach/mach.h>
+#include <stdint.h>
+
+/// Capture a thread's call stack by reading its register state and walking the
+/// frame-pointer chain. `out[0]` is the leaf PC; subsequent entries are
+/// PAC-stripped return addresses (via `pthread_stack_frame_decode_np`).
+///
+/// The caller MUST `thread_suspend(thread)` before calling and `thread_resume`
+/// after — this function only reads. Cross-thread safe (no calling-thread stack
+/// bounds check, unlike `backtrace_from_fp`). Returns the number of addresses
+/// written, 0 on failure or on non-arm64 architectures.
+int c11_capture_thread_backtrace(thread_t thread, uintptr_t *out, int max_frames);
+
+#endif /* C11_HANG_BACKTRACE_H */

--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -1,0 +1,324 @@
+import AppKit
+import Darwin
+import Foundation
+
+/// Pure decision core for main-thread hang detection.
+///
+/// Split out from `MainThreadHangMonitor` so the stall/recovery state machine
+/// can be unit-tested with injected timestamps — no real threads, no wall clock.
+/// `evaluate(nowUptime:lastAckUptime:)` is called once per watchdog tick and
+/// returns what the live monitor should do.
+struct MainThreadHangDetector {
+    /// A stall must persist at least this long before it counts as a hang worth
+    /// snapshotting. Kept above any normal main-thread turn to avoid noise.
+    let stallThresholdMs: Double
+    /// While a single hang persists, re-snapshot no more often than this — the
+    /// wedge may move (or deepen) and a second stack is often more informative.
+    let recaptureIntervalMs: Double
+
+    private var inEpisode = false
+    private var episodeStartUptime: Double = 0
+    private var lastCaptureUptime: Double = 0
+
+    init(stallThresholdMs: Double = 2000, recaptureIntervalMs: Double = 5000) {
+        self.stallThresholdMs = stallThresholdMs
+        self.recaptureIntervalMs = recaptureIntervalMs
+    }
+
+    enum Decision: Equatable {
+        case none
+        /// Main has been unresponsive for `gapMs`. `recapture` is false for the
+        /// first detection of an episode, true for subsequent snapshots of the
+        /// same ongoing hang.
+        case capture(gapMs: Double, recapture: Bool)
+        /// Main answered again; the episode that lasted `durationMs` is over.
+        case recovered(durationMs: Double)
+    }
+
+    /// Drive the state machine one tick.
+    /// - Parameters:
+    ///   - nowUptime: current `ProcessInfo.processInfo.systemUptime`.
+    ///   - lastAckUptime: uptime at which the main thread last acknowledged a
+    ///     heartbeat. While main is wedged this stops advancing, so the gap grows.
+    mutating func evaluate(nowUptime: Double, lastAckUptime: Double) -> Decision {
+        let gapMs = max(0, (nowUptime - lastAckUptime) * 1000.0)
+
+        if gapMs >= stallThresholdMs {
+            if !inEpisode {
+                inEpisode = true
+                episodeStartUptime = lastAckUptime
+                lastCaptureUptime = nowUptime
+                return .capture(gapMs: gapMs, recapture: false)
+            }
+            if (nowUptime - lastCaptureUptime) * 1000.0 >= recaptureIntervalMs {
+                lastCaptureUptime = nowUptime
+                return .capture(gapMs: gapMs, recapture: true)
+            }
+            return .none
+        }
+
+        if inEpisode {
+            inEpisode = false
+            let durationMs = max(0, (nowUptime - episodeStartUptime) * 1000.0)
+            return .recovered(durationMs: durationMs)
+        }
+        return .none
+    }
+
+    /// Test-only introspection into episode state.
+    var isInEpisode: Bool { inEpisode }
+}
+
+/// Real-time main-thread watchdog.
+///
+/// A dedicated background thread pings the main thread on a fixed heartbeat. When
+/// main stops answering for `stallThresholdMs`, the watchdog **suspends the main
+/// thread and walks its stack right then** — the artifact a `CFRunLoopObserver`
+/// cannot produce, because the observer can't run while main is wedged inside a
+/// single callback (the classic beachball).
+///
+/// Ships enabled in Release (opt out with `C11_HANG_MONITOR=0`). Every record is
+/// written to a local hang log unconditionally — it never leaves the machine —
+/// and, when telemetry consent is granted, forwarded to Sentry + PostHog.
+final class MainThreadHangMonitor: @unchecked Sendable {
+    static let shared = MainThreadHangMonitor()
+
+    private let tickIntervalMs: Double = 250
+    private let maxFrames = 96
+    private var detector = MainThreadHangDetector()
+
+    private let lock = NSLock()
+    private var lastAckUptime: TimeInterval = 0
+    private var pingOutstanding = false
+
+    private var mainThread: thread_t = mach_port_t(MACH_PORT_NULL)
+    private var installed = false
+
+    private let logURL: URL
+
+    private init() {
+        logURL = Self.resolveLogURL()
+    }
+
+    // MARK: Install
+
+    /// Install the watchdog. Must be called on the main thread — it captures the
+    /// main thread's mach port, which is the thread the watchdog later suspends.
+    func installIfNeeded() {
+        guard Thread.isMainThread else { return }
+        guard !installed else { return }
+        guard Self.isEnabled else { return }
+        installed = true
+
+        mainThread = pthread_mach_thread_np(pthread_self())
+        let now = ProcessInfo.processInfo.systemUptime
+        lock.lock(); lastAckUptime = now; lock.unlock()
+
+        let thread = Thread { [weak self] in self?.runLoop() }
+        thread.name = "com.stage11.c11.hang-monitor"
+        thread.qualityOfService = .background
+        thread.stackSize = 512 * 1024
+        thread.start()
+    }
+
+    /// On by default; opt out via env. Never runs under the XCTest host, where
+    /// suspending the main thread would fight the harness's own timing.
+    static var isEnabled: Bool {
+        let env = ProcessInfo.processInfo.environment
+        if env["C11_HANG_MONITOR"] == "0" || env["CMUX_HANG_MONITOR"] == "0" { return false }
+        if env["XCTestConfigurationFilePath"] != nil { return false }
+        if NSClassFromString("XCTestCase") != nil { return false }
+        return true
+    }
+
+    // MARK: Watchdog loop (runs on the background thread)
+
+    private func runLoop() {
+        let tick = tickIntervalMs / 1000.0
+        while true {
+            Thread.sleep(forTimeInterval: tick)
+            sendHeartbeat()
+
+            let now = ProcessInfo.processInfo.systemUptime
+            lock.lock(); let ack = lastAckUptime; lock.unlock()
+
+            switch detector.evaluate(nowUptime: now, lastAckUptime: ack) {
+            case .none:
+                break
+            case .capture(let gapMs, let recapture):
+                handleHang(gapMs: gapMs, recapture: recapture)
+            case .recovered(let durationMs):
+                handleRecovery(durationMs: durationMs)
+            }
+        }
+    }
+
+    /// Post a heartbeat the main thread will acknowledge. While main is wedged the
+    /// previous ping stays queued (`pingOutstanding`), so we stop posting new ones
+    /// and `lastAckUptime` simply stops advancing — exactly the signal we want.
+    private func sendHeartbeat() {
+        lock.lock()
+        if pingOutstanding { lock.unlock(); return }
+        pingOutstanding = true
+        lock.unlock()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let now = ProcessInfo.processInfo.systemUptime
+            self.lock.lock()
+            self.lastAckUptime = now
+            self.pingOutstanding = false
+            self.lock.unlock()
+        }
+    }
+
+    // MARK: Hang handling
+
+    private func handleHang(gapMs: Double, recapture: Bool) {
+        let stack = captureMainBacktrace()
+        let kind = recapture ? "hang.persist" : "hang.begin"
+
+        var lines: [String] = []
+        lines.append("=== c11 \(kind) \(Self.timestamp()) stalledMs=\(Int(gapMs)) pid=\(getpid()) ===")
+        if stack.isEmpty {
+            lines.append("  <no backtrace captured>")
+        } else {
+            for (i, frame) in stack.enumerated() {
+                lines.append(String(format: "  %2d  %@", i, frame))
+            }
+        }
+        lines.append("")
+        appendToLog(lines.joined(separator: "\n") + "\n")
+
+        reportTelemetry(gapMs: gapMs, recapture: recapture, stack: stack)
+    }
+
+    private func handleRecovery(durationMs: Double) {
+        appendToLog("=== c11 hang.end \(Self.timestamp()) totalMs=\(Int(durationMs)) pid=\(getpid()) ===\n\n")
+    }
+
+    // MARK: Backtrace capture
+
+    /// Suspend the main thread, capture its stack via the C unwinder, then resume
+    /// — symbolicating only *after* resume, since symbolication can take locks the
+    /// suspended thread may hold (a deadlock if done first).
+    ///
+    /// The unwind lives in C (`c11_capture_thread_backtrace`) because cross-thread
+    /// stack walking needs `pthread_stack_frame_decode_np` for pointer-auth
+    /// stripping, which isn't exposed to Swift; `backtrace_from_fp` is unusable
+    /// here because it validates the FP against the *calling* thread's stack and so
+    /// can't read another thread's frames.
+    private func captureMainBacktrace() -> [String] {
+        guard mainThread != mach_port_t(MACH_PORT_NULL) else { return [] }
+        guard thread_suspend(mainThread) == KERN_SUCCESS else {
+            return ["<thread_suspend failed>"]
+        }
+
+        var raw = [UInt](repeating: 0, count: maxFrames)
+        let frameCount = raw.withUnsafeMutableBufferPointer { buffer -> Int in
+            Int(c11_capture_thread_backtrace(mainThread, buffer.baseAddress!, Int32(maxFrames)))
+        }
+
+        // Resume as soon as the raw addresses are copied out — keep the suspend
+        // window to register read + memory walk only.
+        thread_resume(mainThread)
+
+        guard frameCount > 0 else { return ["<no frames captured>"] }
+        return symbolicate((0..<frameCount).map { UnsafeMutableRawPointer(bitPattern: raw[$0]) })
+    }
+
+    private func symbolicate(_ addrs: [UnsafeMutableRawPointer?]) -> [String] {
+        guard !addrs.isEmpty else { return [] }
+        var mutable = addrs
+        guard let symbols = backtrace_symbols(&mutable, Int32(addrs.count)) else {
+            return addrs.map { ptr in
+                ptr.map { String(format: "0x%016lx", UInt(bitPattern: $0)) } ?? "0x0"
+            }
+        }
+        defer { free(symbols) }
+        var out: [String] = []
+        out.reserveCapacity(addrs.count)
+        for i in 0..<addrs.count {
+            if let c = symbols[i] { out.append(String(cString: c)) }
+        }
+        return out
+    }
+
+    // MARK: Telemetry
+
+    private func reportTelemetry(gapMs: Double, recapture: Bool, stack: [String]) {
+        let top = stack.prefix(24).enumerated()
+            .map { "\($0.offset)\t\($0.element)" }
+            .joined(separator: "\n")
+        sentryCaptureWarning(
+            "main thread hang \(Int(gapMs))ms\(recapture ? " (persist)" : "")",
+            category: "hang",
+            data: [
+                "stalled_ms": Int(gapMs),
+                "recapture": recapture,
+                "stack": top,
+            ],
+            contextKey: "hang"
+        )
+        PostHogAnalytics.shared.captureMainThreadHang(
+            stalledMs: gapMs,
+            recapture: recapture,
+            topFrame: stack.first ?? ""
+        )
+    }
+
+    // MARK: Local log
+
+    private func appendToLog(_ text: String) {
+        guard let data = text.data(using: .utf8) else { return }
+        if let handle = try? FileHandle(forWritingTo: logURL) {
+            defer { try? handle.close() }
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: data)
+        } else {
+            try? FileManager.default.createDirectory(
+                at: logURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try? data.write(to: logURL, options: .atomic)
+        }
+    }
+
+    private static func timestamp() -> String {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f.string(from: Date())
+    }
+
+    /// Mirrors the debug-log path conventions: an explicit override wins, then a
+    /// tag-derived `/tmp` path next to the other debug logs for tagged dev builds,
+    /// and finally a durable per-user log under `~/Library/Logs/c11/` for the
+    /// production app (where `/tmp` would be wiped on reboot).
+    private static func resolveLogURL() -> URL {
+        let env = ProcessInfo.processInfo.environment
+
+        if let explicit = env["C11_HANG_LOG"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicit.isEmpty {
+            return URL(fileURLWithPath: explicit)
+        }
+
+        if let debugLog = env["CMUX_DEBUG_LOG"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !debugLog.isEmpty {
+            let base = URL(fileURLWithPath: debugLog)
+            let name = base.lastPathComponent
+            let stem = name.lastIndex(of: ".").map { String(name[..<$0]) } ?? name
+            return base.deletingLastPathComponent().appendingPathComponent("\(stem)-hang.log")
+        }
+
+        if let tag = env["CMUX_TAG"]?.trimmingCharacters(in: .whitespacesAndNewlines), !tag.isEmpty {
+            let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+            let slug = String(tag.unicodeScalars.map { allowed.contains($0) ? Character($0) : "-" })
+            return URL(fileURLWithPath: "/tmp/c11-hang-\(slug).log")
+        }
+
+        let logs = FileManager.default
+            .urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Logs/c11", isDirectory: true)
+        return logs.appendingPathComponent("hang.log")
+    }
+}

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -81,6 +81,19 @@ final class PostHogAnalytics {
         }
     }
 
+    /// Capture a main-thread hang detected by `MainThreadHangMonitor`. Self-gated
+    /// on telemetry consent (`isEnabled`) and SDK start, like every other event.
+    func captureMainThreadHang(stalledMs: Double, recapture: Bool, topFrame: String) {
+        dispatchAsyncOnWorkQueue { [weak self] in
+            guard let self, self.didStart, self.isEnabled else { return }
+            PostHogSDK.shared.capture("c11_main_thread_hang", properties: [
+                "stalled_ms": Int(stalledMs),
+                "recapture": recapture,
+                "top_frame": topFrame,
+            ])
+        }
+    }
+
     private func startIfNeededOnWorkQueue() {
         guard !didStart else { return }
         guard isEnabled else { return }

--- a/c11-Bridging-Header.h
+++ b/c11-Bridging-Header.h
@@ -1,3 +1,6 @@
 // Swift ↔ C bridging header. Exposes libghostty's C API to the Swift codebase
 // (terminal surfaces, key event plumbing, renderer lifecycle).
 #import "ghostty.h"
+
+// Cross-thread main-thread stack capture for MainThreadHangMonitor.
+#import "Sources/HangBacktrace.h"

--- a/c11Tests/MainThreadHangDetectorTests.swift
+++ b/c11Tests/MainThreadHangDetectorTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Pure, in-process tests for `MainThreadHangDetector` — the stall/recovery
+/// state machine behind `MainThreadHangMonitor`. Timestamps are injected, so
+/// these exercise real decision behavior without threads or a wall clock.
+final class MainThreadHangDetectorTests: XCTestCase {
+
+    // Decisions carry Doubles derived from subtraction, so compare with
+    // tolerance rather than exact equality.
+    private func assertCapture(
+        _ decision: MainThreadHangDetector.Decision,
+        gapMs: Double, recapture: Bool,
+        _ file: StaticString = #filePath, _ line: UInt = #line
+    ) {
+        guard case let .capture(actualGap, actualRecapture) = decision else {
+            return XCTFail("expected .capture, got \(decision)", file: file, line: line)
+        }
+        XCTAssertEqual(actualGap, gapMs, accuracy: 0.5, file: file, line: line)
+        XCTAssertEqual(actualRecapture, recapture, file: file, line: line)
+    }
+
+    private func assertRecovered(
+        _ decision: MainThreadHangDetector.Decision,
+        durationMs: Double,
+        _ file: StaticString = #filePath, _ line: UInt = #line
+    ) {
+        guard case let .recovered(actual) = decision else {
+            return XCTFail("expected .recovered, got \(decision)", file: file, line: line)
+        }
+        XCTAssertEqual(actual, durationMs, accuracy: 0.5, file: file, line: line)
+    }
+
+    // MARK: - No hang
+
+    func testHealthyHeartbeatsNeverFire() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        // Main acks ~250ms before each tick: gap stays ~250ms, well under threshold.
+        var t = 100.0
+        for _ in 0..<40 {
+            XCTAssertEqual(d.evaluate(nowUptime: t, lastAckUptime: t - 0.25), .none)
+            t += 0.25
+        }
+        XCTAssertFalse(d.isInEpisode)
+    }
+
+    func testGapBelowThresholdDoesNotFire() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        // 1.9s gap — under the 2s threshold.
+        XCTAssertEqual(d.evaluate(nowUptime: 110.0, lastAckUptime: 108.1), .none)
+        XCTAssertFalse(d.isInEpisode)
+    }
+
+    // MARK: - Hang onset
+
+    func testCrossingThresholdEmitsFirstCapture() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        // ack frozen at t=100; by t=102.2 the gap is 2200ms.
+        assertCapture(d.evaluate(nowUptime: 102.2, lastAckUptime: 100.0), gapMs: 2200, recapture: false)
+        XCTAssertTrue(d.isInEpisode)
+    }
+
+    func testFirstCaptureFiresExactlyOncePerEpisode() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        assertCapture(d.evaluate(nowUptime: 102.2, lastAckUptime: 100.0), gapMs: 2200, recapture: false)
+        // Still hung, but not yet time to re-snapshot (< 5s since last capture).
+        XCTAssertEqual(d.evaluate(nowUptime: 103.0, lastAckUptime: 100.0), .none)
+        XCTAssertEqual(d.evaluate(nowUptime: 105.0, lastAckUptime: 100.0), .none)
+    }
+
+    // MARK: - Recapture while still hung
+
+    func testRecaptureAfterIntervalWhileStillHung() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        assertCapture(d.evaluate(nowUptime: 102.2, lastAckUptime: 100.0), gapMs: 2200, recapture: false)
+        // 5s after the first capture (t=107.2): re-snapshot.
+        assertCapture(d.evaluate(nowUptime: 107.2, lastAckUptime: 100.0), gapMs: 7200, recapture: true)
+    }
+
+    // MARK: - Recovery
+
+    func testRecoveryEmitsEpisodeDuration() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        // Episode starts: ack frozen at 100, detected at 102.2.
+        _ = d.evaluate(nowUptime: 102.2, lastAckUptime: 100.0)
+        XCTAssertTrue(d.isInEpisode)
+        // Main recovers: ack jumps to 104.0 (it drained the queued ping). The
+        // episode lasted from 100.0 until now (104.05) ≈ 4050ms.
+        assertRecovered(d.evaluate(nowUptime: 104.05, lastAckUptime: 104.0), durationMs: 4050)
+        XCTAssertFalse(d.isInEpisode)
+    }
+
+    func testRecoveryThenSecondHangIsANewEpisode() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        _ = d.evaluate(nowUptime: 102.2, lastAckUptime: 100.0)          // hang 1 begin
+        _ = d.evaluate(nowUptime: 104.05, lastAckUptime: 104.0)         // hang 1 recover
+        // New stall starting from a fresh frozen ack at 200.
+        assertCapture(d.evaluate(nowUptime: 202.5, lastAckUptime: 200.0), gapMs: 2500, recapture: false)
+    }
+
+    func testNoRecoveredEventWithoutAPriorEpisode() {
+        var d = MainThreadHangDetector(stallThresholdMs: 2000, recaptureIntervalMs: 5000)
+        // Healthy from the start — a small gap must not be reported as recovery.
+        XCTAssertEqual(d.evaluate(nowUptime: 100.1, lastAckUptime: 100.0), .none)
+    }
+}


### PR DESCRIPTION
## Why

A beachball is a wedged main thread. Diagnosing the 2026-06-14 force-quit (a ~4s main-thread wedge on app activation that left **no `.ips`, no signal, no useful artifact** — the app drained a queued quit and exited `exit(0)` right as Force Quit landed) surfaced that c11 has no tool that captures *where* the main thread is stuck, in the moment, in Release:

- **`CmuxMainRunLoopStallMonitor`** is a `CFRunLoopObserver` — it can't run while main is wedged inside a single callback. It only reports a `gapMs` *after* recovery, with **no stack**, and is **`#if DEBUG`-only**.
- **MetricKit `MXHangDiagnostic`** carries a stack but arrives aggregated on a *later* launch.

## What

`MainThreadHangMonitor`: a dedicated background thread pings main on a 250ms heartbeat. When main stops answering for **2s**, the watchdog **suspends the main thread and walks its stack right then**, resumes, and symbolicates — exactly the artifact a run-loop observer can't get.

Cross-thread unwinding needs `pthread_stack_frame_decode_np` for pointer-auth stripping (not exposed to Swift) and **can't** use `backtrace_from_fp` (it validates the FP against the *calling* thread's stack and silently walks the wrong thread — caught during validation). So the walk lives in a small C helper (`HangBacktrace.c`) behind the bridging header; Swift owns suspend/resume + symbolication.

- **On by default in Release**; opt out with `C11_HANG_MONITOR=0`. Never runs under the XCTest host.
- **Local hang log always** (never leaves the machine): durable `~/Library/Logs/c11/hang.log` for production, or a `/tmp` `-hang.log` next to the other debug logs for tagged dev builds.
- **With telemetry consent**, forwarded to Sentry (`sentryCaptureWarning`) and PostHog (new `captureMainThreadHang` event).

## Validation

- **State machine** — `MainThreadHangDetector` factored out as a pure type; 8 unit tests (`c11LogicTests`) cover onset, single-fire-per-episode, recapture-while-hung, recovery duration, re-arm, and no-false-positives. ✅
- **Capture mechanism** — the cross-thread suspend → unwind → symbolicate path validated against a genuinely blocked main thread (correctly captured `__semwait_signal` → `sleepForTimeInterval` → `main`; the `backtrace_from_fp` approach was rejected here because it captured the watchdog's own stack). ✅
- **Live wiring** — tagged build confirmed the `com.stage11.c11.hang-monitor` watchdog thread running (`installIfNeeded` → `runLoop` → `sendHeartbeat`), no startup regression, no false-positive hang entries during normal use. ✅

## Notes / possible follow-ups

- Backtraces are emitted as `backtrace_symbols` output (module + address + mangled Swift symbol + offset); programmatic Swift demangling is a deliberate v1 omission.
- No in-app "force a hang" trigger exists, so the full real-app *capture* path wasn't exercised end-to-end (the mechanism was proven in isolation against a real blocked thread). A DEBUG-gated hang trigger would make that a one-command check and give the operator a way to test it directly — happy to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)