### PR TITLE
Hang monitor: remove suspend-window deadlock + validate FP reads

### DIFF
--- a/Sources/HangBacktrace.c
+++ b/Sources/HangBacktrace.c
@@ -2,6 +2,7 @@
 
 #if defined(__arm64__)
 
+#include <mach/mach_vm.h>
 #include <pthread/stack_np.h>
 
 int c11_capture_thread_backtrace(thread_t thread, uintptr_t *out, int max_frames) {
@@ -25,6 +26,22 @@ int c11_capture_thread_backtrace(thread_t thread, uintptr_t *out, int max_frames
     // from both — the part a pure-Swift walk can't do without ptrauth intrinsics.
     uintptr_t fp = (uintptr_t)__darwin_arm_thread_state64_get_fp(state);
     while (fp != 0 && (fp & 0xF) == 0 && n < max_frames) {
+        // Validate that the 16 bytes at fp ([fp] = next fp, [fp+8] = return
+        // address) are mapped before pthread_stack_frame_decode_np dereferences
+        // them. A corrupt or exhausted chain — exactly the state this tool is
+        // meant to survive and report — must not fault the watchdog. mach_vm_read
+        // returns an error instead of raising, and (unlike malloc) is safe to
+        // call while the target thread is suspended. The thread is parked, so
+        // its stack memory is stable across the probe and the decode.
+        uintptr_t frame[2];
+        mach_vm_size_t read = 0;
+        if (mach_vm_read_overwrite(mach_task_self(),
+                                   (mach_vm_address_t)fp, sizeof(frame),
+                                   (mach_vm_address_t)frame, &read) != KERN_SUCCESS
+            || read != sizeof(frame)) {
+            break;
+        }
+
         uintptr_t ret = 0;
         uintptr_t next = pthread_stack_frame_decode_np(fp, &ret);
         if (ret != 0) {

--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -94,9 +94,17 @@ final class MainThreadHangMonitor: @unchecked Sendable {
     private var mainThread: thread_t = mach_port_t(MACH_PORT_NULL)
     private var installed = false
 
+    /// Reused address buffer for stack capture. Preallocated once so no heap
+    /// allocation ever happens inside the `thread_suspend`/`thread_resume` window
+    /// — a `malloc` there would deadlock if the suspended main thread holds the
+    /// malloc lock. Only ever touched on the watchdog thread, which captures
+    /// serially, so the single shared buffer is safe.
+    private var frameBuffer: [UInt]
+
     private let logURL: URL
 
     private init() {
+        frameBuffer = [UInt](repeating: 0, count: maxFrames)
         logURL = Self.resolveLogURL()
     }
 
@@ -210,21 +218,23 @@ final class MainThreadHangMonitor: @unchecked Sendable {
     /// can't read another thread's frames.
     private func captureMainBacktrace() -> [String] {
         guard mainThread != mach_port_t(MACH_PORT_NULL) else { return [] }
+
+        // Nothing inside the suspend window may allocate or take an app-level
+        // lock: if main is suspended while holding (e.g.) the malloc lock, any
+        // allocation here would block forever and wedge the process. The buffer
+        // is preallocated; the C unwinder only reads memory via mach_vm calls.
         guard thread_suspend(mainThread) == KERN_SUCCESS else {
             return ["<thread_suspend failed>"]
         }
-
-        var raw = [UInt](repeating: 0, count: maxFrames)
-        let frameCount = raw.withUnsafeMutableBufferPointer { buffer -> Int in
+        let frameCount = frameBuffer.withUnsafeMutableBufferPointer { buffer -> Int in
             Int(c11_capture_thread_backtrace(mainThread, buffer.baseAddress!, Int32(maxFrames)))
         }
-
-        // Resume as soon as the raw addresses are copied out — keep the suspend
-        // window to register read + memory walk only.
         thread_resume(mainThread)
 
         guard frameCount > 0 else { return ["<no frames captured>"] }
-        return symbolicate((0..<frameCount).map { UnsafeMutableRawPointer(bitPattern: raw[$0]) })
+        // Symbolication (which allocates and can take locks the suspended thread
+        // may have held) happens only after resume.
+        return symbolicate((0..<frameCount).map { UnsafeMutableRawPointer(bitPattern: frameBuffer[$0]) })
     }
 
     private func symbolicate(_ addrs: [UnsafeMutableRawPointer?]) -> [String] {

--- a/c11-Bridging-Header.h
+++ b/c11-Bridging-Header.h
@@ -3,4 +3,6 @@
 #import "ghostty.h"
 
 // Cross-thread main-thread stack capture for MainThreadHangMonitor.
+// Path-qualified deliberately: a quote-include resolves relative to this header's
+// own directory (the repo root), so it does not depend on HEADER_SEARCH_PATHS.
 #import "Sources/HangBacktrace.h"


### PR DESCRIPTION
Follow-up to #244, addressing the [Drawbridge deep review](https://github.com/Stage-11-Agentics/c11/pull/244#issuecomment). Lands findings 1 & 2; assesses 3–5.

## Finding 1 — blocker: suspend-window allocation deadlock ✅ fixed
`captureMainBacktrace()` allocated its address buffer with `[UInt](repeating:count:)` **after** `thread_suspend`. If main was suspended while holding the malloc lock (likely during an allocation-related hang), the watchdog's `malloc` blocks on a lock the suspended thread can never release → the process is permanently wedged. The hang catcher would *cause* the unrecoverable hang.

**Fix:** preallocate a reused `frameBuffer` in `init()`. Capture runs serially on the watchdog thread, so one shared buffer is safe, and nothing inside the suspend window allocates anymore.

## Finding 2 — major: FP-chain reads weren't validated ✅ fixed
The C walk dereferenced each frame pointer via `pthread_stack_frame_decode_np` with no check that the address was mapped. A corrupt chain (exactly the state this tool should survive) could SIGSEGV the watchdog — and since it's on by default in Release, a self-inflicted crash is worse than the hang.

**Fix:** probe each frame's 16 bytes with `mach_vm_read_overwrite` (returns an error instead of faulting; lock-free and safe inside the suspend window) before decoding. **Re-validated against a genuinely blocked main thread** — still captures the full, correct stack (`__semwait_signal → sleepForTimeInterval → main`).

## Finding 4 — nit ✅ documented
Added a comment that the bridging-header import is path-qualified on purpose: a quote-include resolves relative to the header's own directory (repo root), so it doesn't depend on `HEADER_SEARCH_PATHS`. (Avoids a riskier per-target search-path change.)

## Finding 3 — minor: assessed, intentionally not changed
The suggested move would **break** consistency: every one of the ~86 `c11LogicTests`-target files already lives in `c11Tests/`. The C11-105 footgun was a *side-effecting socket* test in the wrong target; this test is pure and already in the correct (logic) target. Moving it alone makes it the lone outlier. Happy to revisit if we want to migrate the whole logic suite to a `c11LogicTests/` dir as a separate cleanup.

## Finding 5 — nit: no action
Expected `xcodeproj`-gem normalization, already landed in #244.

## On the default-on-Release policy
Confirmed by the maintainer: the watchdog ships enabled by default in production (opt out with `C11_HANG_MONITOR=0`), which is exactly what motivated finding 2's crash-safety hardening.

## Validation
- `c11-logic` scheme: 8/8 `MainThreadHangDetectorTests` pass; full `c11` target compiles with the updated `HangBacktrace.c`. ✅
- Finding-2 probe path validated in isolation against a real blocked main thread (correct stack, no fault). ✅
- No pbxproj churn (3 source files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)