### PR TITLE
Release v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-06-14
+
+Feature release. Headline: **two new coding agents and a hang catcher** — GitHub Copilot CLI and Grok Build join as first-class c11 agents with full conversation-store resume wiring, and a real-time main-thread hang monitor now suspends the stalled thread, captures its stack off-thread, and reports to a local log plus Sentry/PostHog (on by default in Release). Alongside it: a batch of resume/reliability fixes (crash-resume, browser-freeze, inspector divider hit-test), a markdown-pane live-reload and font-zoom pass, and a consistent white-outline selection signal in the sidebar.
+
+### Added
+
+- **GitHub Copilot CLI as a built-in agent.** Launches as a first-class c11 coding agent with conversation-store resume wiring, so a Copilot surface resumes its own session on restore; the agent name is localized in all six locales. ([265414a88](https://github.com/Stage-11-Agentics/c11/commit/265414a88), [234022829](https://github.com/Stage-11-Agentics/c11/commit/234022829))
+- **Grok Build as a first-class coding agent.** Same first-class treatment — launcher entry, conversation-store resume, localized name. ([c279a085e](https://github.com/Stage-11-Agentics/c11/commit/c279a085e), [4d8e66a84](https://github.com/Stage-11-Agentics/c11/commit/4d8e66a84))
+- **Real-time main-thread hang monitor.** A watchdog thread detects main-thread stalls, suspends the stuck thread, and captures its stack off-thread, writing a local log and reporting to Sentry/PostHog. On by default in Release builds. Workspace-shape breadcrumbs are attached to each report so hang triage in Sentry shows the layout state at the time of the stall. ([#244](https://github.com/Stage-11-Agentics/c11/pull/244), [#236](https://github.com/Stage-11-Agentics/c11/pull/236))
+- **`c11 state save` / `state verify` / `app restart` CLI.** Operator-grade whole-app session verbs: checkpoint the full app session synchronously while c11 keeps running, dry-run the resume decision per terminal panel (exits non-zero if any conversation wouldn't resume), and perform a clean-shutdown-then-relaunch that brings layout and conversations back. Ships alongside the crash-resume fix below. ([#239](https://github.com/Stage-11-Agentics/c11/pull/239))
+- **Markdown pane: font zoom.** `Cmd+=` / `Cmd+-` / `Cmd+0` zoom the rendered markdown in and out and reset it. ([#241](https://github.com/Stage-11-Agentics/c11/pull/241))
+
+### Changed
+
+- **Markdown pane live-reload is debounced and theme rendering is cached.** Rapid edits to an open markdown file reload smoothly instead of thrashing, and theme application no longer re-parses on every render. ([#241](https://github.com/Stage-11-Agentics/c11/pull/241))
+- **The white outline is now the single, consistent selection signal in the sidebar.** Selected workspaces — including custom-colored ones — get one uniform thick white border instead of the prior mix of selection treatments. ([#234](https://github.com/Stage-11-Agentics/c11/pull/234), [a8870deeb](https://github.com/Stage-11-Agentics/c11/commit/a8870deeb))
+- **Etch session capture enabled (local-only).** Session capture is on for the Etch surface under a local-only, public-repo-safe posture. ([a2cfd1106](https://github.com/Stage-11-Agentics/c11/commit/a2cfd1106))
+- **c11-browser skill prefers `get text` / `get html` over `eval` for content extraction.** `eval` is rejected by strict-CSP sites (e.g. Hacker News); the skill now nudges agents toward the content-read verbs that work everywhere. ([#247](https://github.com/Stage-11-Agentics/c11/pull/247))
+
+### Fixed
+
+- **Crash-resume reliability (C11-131).** After an unclean exit, c11 now restores layout and verifies each conversation against its on-disk transcript before resuming, with an e2e harness covering the path. ([#239](https://github.com/Stage-11-Agentics/c11/pull/239))
+- **Browser portal geometry-sync / browser-freeze (C11-132).** Hardened the browser portal's geometry sync — dirty-ID batching, settled-layout deferral, and an epsilon guard — to stop the WebContent process from freezing during split/workspace churn. ([#237](https://github.com/Stage-11-Agentics/c11/pull/237))
+- **Inspector divider hit-test gated to pointer events (C11-133).** The hosted-inspector divider hit-test no longer runs on keyboard events, and divider candidates are cached — removing work from a typing-latency-sensitive path. ([#240](https://github.com/Stage-11-Agentics/c11/pull/240))
+- **Hang monitor: suspend-window deadlock removed and floating-point reads validated (#245).** Fixes a deadlock in the suspend window and adds validation of the captured FP register reads. ([#245](https://github.com/Stage-11-Agentics/c11/pull/245))
+- **`c11 trigger-flash` / `cancel-flash` resolve cross-workspace surface refs.** A `surface:N` ref owned by another workspace used to fail with "Surface not found" unless `--workspace` was also passed; the flash handlers now resolve the owning workspace globally (a shared `v2ResolveTargetSurface` helper), matching `get-metadata` / `set-metadata` and the title-bar verbs. ([#247](https://github.com/Stage-11-Agentics/c11/pull/247))
+
+### Thanks to 1 contributor!
+
+- [@BenevolentFutures](https://github.com/BenevolentFutures)
+
+### Built and shipped by
+
+Stage 11 Agentics. Operator:agent, fused.
+
 ## [0.51.0] - 2026-06-04
 
 Feature release. Headline: **session resume, rebuilt** — a TUI-agnostic conversation store replaces the per-TUI wrapper pattern, so Claude Code, Codex, Opencode, and Kimi surfaces each resume their own session instead of racing lifecycle hooks, and a per-workspace launch picker lets the operator choose exactly which workspaces come back. Alongside it: the sidebar gains a Waiting Agent + workspace nav cluster, and the CLI grows `--cwd` on `new-split`/`new-pane` and `--title` on `new-workspace`.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -1775,10 +1775,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1856,7 +1856,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1866,7 +1866,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1897,7 +1897,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1907,7 +1907,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -1975,10 +1975,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1993,14 +1993,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2015,14 +2015,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2038,10 +2038,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2057,10 +2057,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 108;
+				CURRENT_PROJECT_VERSION = 109;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.51.0;
+				MARKETING_VERSION = 0.52.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Release v0.52.0

Feature release. Headline: **two new coding agents and a hang catcher** — GitHub Copilot CLI and Grok Build join as first-class c11 agents with full conversation-store resume wiring, and a real-time main-thread hang monitor now suspends the stalled thread, captures its stack off-thread, and reports to a local log plus Sentry/PostHog (on by default in Release).

### Added
- **GitHub Copilot CLI** as a built-in agent (resume wiring + localized name).
- **Grok Build** as a first-class coding agent (resume wiring + localized name).
- **Real-time main-thread hang monitor** — watchdog thread, off-thread stack capture, local log + Sentry/PostHog, workspace-shape breadcrumbs. On by default in Release. (#244, #236)
- **`c11 state save` / `state verify` / `app restart`** whole-app session CLI. (#239)
- **Markdown pane font zoom** (Cmd+=/-/0). (#241)

### Changed
- Markdown pane: debounced live-reload + theme caching. (#241)
- Sidebar: white outline is now the single, consistent selection signal. (#234)
- Etch session capture enabled (local-only).

### Fixed
- Crash-resume reliability + e2e harness (C11-131, #239).
- Browser portal geometry-sync / browser-freeze (C11-132, #237).
- Inspector divider hit-test gated to pointer events (C11-133, #240).
- Hang monitor: suspend-window deadlock removed + FP-read validation (#245).

### Version
- `MARKETING_VERSION` 0.51.0 → 0.52.0
- `CURRENT_PROJECT_VERSION` 108 → 109

### Security threat-model recheck
Signals fired (AppDelegate, BrowserWindowPortal touched) but **no untrusted-input vectors changed** — no `application(_:open:)` URL-handler change, no `WKWebViewConfiguration`/`WKUserContentController`, no JS-eval, no socket security surface. Diffs are the hang-monitor wiring and browser-portal geometry sync. Threat-model posture unchanged.

## Test plan (staging smoke — `c11 STAGING rel-v0.52.0`, Release config)
- [x] App launches clean; no startup regression with the hang monitor wired. Watchdog thread `com.stage11.c11.hang-monitor` running `MainThreadHangMonitor.runLoop()` confirmed via `sample`.
- [x] GitHub Copilot and Grok Build appear in Settings → Agents.
- [x] Sidebar workspace selection renders as the single consistent white outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)