### PR TITLE
CLI: resolve cross-workspace surface refs in trigger-flash/cancel-flash

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8383,6 +8383,43 @@ class TerminalController {
         )
     }
 
+    /// Resolve the (workspace, surface) target for a surface-addressed command.
+    ///
+    /// When an explicit `surface_id` is supplied, its owning workspace is found
+    /// across ALL workspaces, so a cross-workspace `surface:N` ref resolves even
+    /// without `--workspace` — matching how `surface.get_metadata`/`set_metadata`
+    /// and the title-bar verbs already resolve (`v2ResolveSurfaceForMetadata`,
+    /// `v2ResolveWorkspaceForTitleBar`). Only when no `surface_id` is given do we
+    /// fall back to the resolved/focused workspace's focused surface.
+    ///
+    /// Must be called on the main actor (reads TabManager/Workspace state).
+    private func v2ResolveTargetSurface(
+        params: [String: Any],
+        tabManager: TabManager
+    ) -> (workspace: Workspace, surfaceId: UUID)? {
+        if let surfaceId = v2UUID(params, "surface_id") {
+            guard let owner = tabManager.tabs.first(where: { $0.panels[surfaceId] != nil }) else {
+                return nil
+            }
+            return (owner, surfaceId)
+        }
+        guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager),
+              let focused = ws.focusedPanelId else {
+            return nil
+        }
+        return (ws, focused)
+    }
+
+    /// Shared not-found error for the surface-target verbs: distinguishes an
+    /// explicit ref we couldn't locate from the no-surface-and-no-focus case.
+    private func v2SurfaceTargetNotFound(params: [String: Any]) -> V2CallResult {
+        if let surfaceId = v2UUID(params, "surface_id") {
+            return .err(code: "not_found", message: "Surface not found",
+                        data: ["surface_id": surfaceId.uuidString])
+        }
+        return .err(code: "not_found", message: "No focused surface", data: nil)
+    }
+
     private func v2SurfaceTriggerFlash(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -8407,18 +8444,8 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to trigger flash", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
-
-            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
-            guard let surfaceId else {
-                result = .err(code: "not_found", message: "No focused surface", data: nil)
-                return
-            }
-            guard ws.panels[surfaceId] != nil else {
-                result = .err(code: "not_found", message: "Surface not found", data: ["surface_id": surfaceId.uuidString])
+            guard let (ws, surfaceId) = v2ResolveTargetSurface(params: params, tabManager: tabManager) else {
+                result = v2SurfaceTargetNotFound(params: params)
                 return
             }
 
@@ -8449,18 +8476,8 @@ class TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to cancel flash", data: nil)
         v2MainSync {
-            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
-                result = .err(code: "not_found", message: "Workspace not found", data: nil)
-                return
-            }
-
-            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
-            guard let surfaceId else {
-                result = .err(code: "not_found", message: "No focused surface", data: nil)
-                return
-            }
-            guard ws.panels[surfaceId] != nil else {
-                result = .err(code: "not_found", message: "Surface not found", data: ["surface_id": surfaceId.uuidString])
+            guard let (ws, surfaceId) = v2ResolveTargetSurface(params: params, tabManager: tabManager) else {
+                result = v2SurfaceTargetNotFound(params: params)
                 return
             }
 

--- a/skills/c11-browser/SKILL.md
+++ b/skills/c11-browser/SKILL.md
@@ -130,6 +130,8 @@ Use supported high-level commands (`click`, `fill`, `press`, `scroll`, `wait`, `
 
 Some complex pages can reject or break the JavaScript used for rich snapshots and ad-hoc evaluation.
 
+**Prefer `get text body` / `get html body` for reading page content; reserve `eval` for interaction and computed checks.** `eval` and `snapshot --interactive` run injected JavaScript that strict-CSP or framebusting sites (Hacker News is a known case) reject with `js_error` — even for something as trivial as `eval "1+1"` — whereas `get text`/`get html` read the already-rendered DOM and keep working. Reach for `eval` when you genuinely need to run script on the page, not as the default way to extract content.
+
 Recovery steps:
 
 ```bash


### PR DESCRIPTION
Pre-v0.52.0 papercut fix from staging dogfeedback.

## Bug (reproduced)
`trigger-flash` / `cancel-flash` resolved the **workspace first** (defaulting to the caller's focused workspace), then looked for the surface only *within* it. So a cross-workspace `surface:N` ref failed with `Surface not found` unless `--workspace` was also passed — while `get_metadata`/`set_metadata` and the title-bar verbs already resolve the owning workspace **globally**.

Reproduced against the live app (caller in ws2, surface:51 in ws1):
```
get-metadata  --surface surface:51            → OK (resolves globally)
trigger-flash --surface surface:51            → Error: not_found: Surface not found
trigger-flash --surface surface:51 -w ws1     → OK
```

## Fix
Add a shared `v2ResolveTargetSurface(params:tabManager:)` helper — explicit `surface_id` → find owning workspace across all tabs (mirrors `v2ResolveSurfaceForMetadata`); otherwise fall back to the focused workspace's focused surface — and route both flash handlers through it. Additive: same-workspace and `--workspace`-qualified calls behave exactly as before; cross-workspace refs that previously errored now resolve.

## Scope
Deliberately limited to the **reported + reproduced** verbs (flash). The same workspace-scoped pattern exists in `surface.focus`, `surface.close`, `set_custom_color`, and the notification verbs; sweeping those — including a destructive `close` and focus-intent `focus` — is tracked as a follow-up rather than rushed into a release. The new helper is written to make that sweep a one-line change per handler.

## Also
Nudges the `c11-browser` skill to prefer `get text`/`get html` over `eval` for content extraction (`eval` is rejected by strict-CSP sites like Hacker News). Installed copy synced via `scripts/sync-installed-skills.sh`.

## Validation
Local compile + CI build; behavioral repro (cross-workspace flash) will run on the rebased v0.52.0 staging build before publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)