### PR TITLE
Mailbox: route across all workspaces, stop silent drops

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -16643,7 +16643,7 @@ extension CMUXCLI {
         Per-workspace messaging primitive for coordinating between c11 surfaces.
         Full guide: docs/c11-mailbox-guide.md (agent quick-reference: skills/c11/SKILL.md).
 
-          send       write an envelope to the per-workspace outbox
+          send       deliver an envelope to a surface in any workspace
           recv       drain or peek the caller's inbox
           trace      pretty-print _dispatch.log lines for an envelope id
           tail       follow _dispatch.log
@@ -16654,7 +16654,8 @@ extension CMUXCLI {
           new-id     print a fresh Crockford base32 ULID (26 chars)
 
         Send flags:
-          --to <surface>          recipient surface name
+          --to <surface>          recipient surface name (any workspace)
+          --to-workspace <ref>    disambiguate a name shared across workspaces
           --topic <topic>         dotted topic token
           --body <text>           inline body (≤ 4096 bytes UTF-8)
           --body-ref <path>       absolute path to external body (body must be empty)
@@ -16744,6 +16745,7 @@ extension CMUXCLI {
         let tsOverride = optionValue(subArgs, name: "--ts")
         let contentType = optionValue(subArgs, name: "--content-type")
         let fromOverride = optionValue(subArgs, name: "--from")
+        let toWorkspace = optionValue(subArgs, name: "--to-workspace")
 
         if to == nil && topic == nil {
             throw CLIError(
@@ -16798,8 +16800,22 @@ extension CMUXCLI {
             contentType: contentType
         )
 
+        // Resolve which workspace actually hosts the recipient. The dispatcher
+        // is per-workspace, so the envelope must land in the recipient's outbox
+        // — which may be a different workspace than the sender's. Resolution
+        // also lets us fail loudly (non-zero exit) when the recipient does not
+        // exist, instead of dropping the message into an outbox where no
+        // dispatcher will ever resolve it. `to` is guaranteed non-nil here
+        // (topic-only sends were rejected above).
+        let targetWorkspaceId = try resolveMailboxTargetWorkspace(
+            client: client,
+            to: to ?? "",
+            senderWorkspaceId: workspaceId,
+            qualifier: toWorkspace
+        )
+
         let stateURL = try MailboxLayout.defaultStateURL()
-        let outboxURL = MailboxLayout.outboxURL(state: stateURL, workspaceId: workspaceId)
+        let outboxURL = MailboxLayout.outboxURL(state: stateURL, workspaceId: targetWorkspaceId)
         try FileManager.default.createDirectory(
             at: outboxURL,
             withIntermediateDirectories: true,
@@ -16815,12 +16831,86 @@ extension CMUXCLI {
             print(jsonString([
                 "id": envelope.id,
                 "outbox_path": targetURL.path,
-                "workspace_id": workspaceId.uuidString,
+                "workspace_id": targetWorkspaceId.uuidString,
+                "sender_workspace_id": workspaceId.uuidString,
                 "from": envelope.from
             ]))
         } else {
             print(envelope.id)
         }
+    }
+
+    /// Resolves which workspace's outbox a `--to` envelope should be written
+    /// into by asking the app for a cross-workspace view of live surfaces
+    /// (`mailbox.resolve`). Throws a non-zero `CLIError` when the recipient is
+    /// unknown (so the sender learns the message was not delivered) or when the
+    /// name is ambiguous across workspaces. Falls back to the sender's own
+    /// workspace if the socket is unreachable, so same-workspace delivery still
+    /// works offline; the dispatcher's unresolved-recipient rejection is the
+    /// backstop against a silent drop in that case.
+    private func resolveMailboxTargetWorkspace(
+        client: SocketClient,
+        to: String,
+        senderWorkspaceId: UUID,
+        qualifier: String?
+    ) throws -> UUID {
+        var params: [String: Any] = [
+            "to": to,
+            "sender_workspace_id": senderWorkspaceId.uuidString
+        ]
+        if let qualifier, !qualifier.isEmpty {
+            params["workspace"] = qualifier
+        }
+
+        let payload: [String: Any]
+        do {
+            payload = try client.sendV2(method: "mailbox.resolve", params: params)
+        } catch {
+            // Socket unreachable (or an older app without mailbox.resolve):
+            // preserve same-workspace delivery rather than failing the send.
+            return senderWorkspaceId
+        }
+
+        switch payload["resolution"] as? String {
+        case "unique":
+            guard
+                let idStr = payload["target_workspace_id"] as? String,
+                let id = UUID(uuidString: idStr)
+            else {
+                throw CLIError(message: "mailbox.resolve returned an invalid target workspace")
+            }
+            return id
+        case "ambiguous":
+            let candidates = (payload["candidates"] as? [[String: Any]]) ?? []
+            throw CLIError(message: mailboxAmbiguityMessage(to: to, candidates: candidates))
+        default:
+            throw CLIError(
+                message: String(
+                    localized: "mailbox.cli.error.unresolved-recipient",
+                    defaultValue: "No live surface named \"%@\" in any workspace. Message not sent."
+                ).replacingOccurrences(of: "%@", with: to)
+            )
+        }
+    }
+
+    private func mailboxAmbiguityMessage(to: String, candidates: [[String: Any]]) -> String {
+        var seenRefs: Set<String> = []
+        var refLines: [String] = []
+        for candidate in candidates {
+            guard let ref = candidate["workspace_ref"] as? String else { continue }
+            if seenRefs.insert(ref).inserted {
+                refLines.append("  \(ref)")
+            }
+        }
+        let header = String(
+            localized: "mailbox.cli.error.ambiguous-header",
+            defaultValue: "Surface \"%@\" exists in more than one workspace:"
+        ).replacingOccurrences(of: "%@", with: to)
+        let hint = String(
+            localized: "mailbox.cli.error.ambiguous-hint",
+            defaultValue: "Disambiguate with --to-workspace <workspace-ref>."
+        )
+        return ([header] + refLines + [hint]).joined(separator: "\n")
     }
 
     // MARK: - recv

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4690,6 +4690,39 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return nil
     }
 
+    /// Every live, mailbox-addressable surface across all windows and
+    /// workspaces in this instance. A surface is addressable when it carries a
+    /// `title` metadata value (the mailbox name). Reads the same
+    /// `SurfaceMetadataStore` `title` the per-workspace `MailboxSurfaceResolver`
+    /// uses, so global resolution matches local resolution exactly.
+    ///
+    /// Main-thread only: it enumerates each workspace's `@Published panels`.
+    /// Callers on the socket queue must hop to main first.
+    func mailboxAddressableSurfaces() -> [MailboxGlobalResolver.Surface] {
+        var result: [MailboxGlobalResolver.Surface] = []
+        for context in mainWindowContexts.values {
+            for workspace in context.tabManager.tabs {
+                for surfaceId in workspace.panels.keys {
+                    let (metadata, _) = SurfaceMetadataStore.shared.getMetadata(
+                        workspaceId: workspace.id,
+                        surfaceId: surfaceId
+                    )
+                    guard let name = metadata[MetadataKey.title] as? String, !name.isEmpty else {
+                        continue
+                    }
+                    result.append(
+                        MailboxGlobalResolver.Surface(
+                            workspaceId: workspace.id,
+                            surfaceId: surfaceId,
+                            name: name
+                        )
+                    )
+                }
+            }
+        }
+        return result
+    }
+
     @discardableResult
     func moveSurface(
         panelId: UUID,

--- a/Sources/Mailbox/MailboxDispatcher.swift
+++ b/Sources/Mailbox/MailboxDispatcher.swift
@@ -269,6 +269,24 @@ final class MailboxDispatcher {
         let recipients = resolveRecipients(envelope: envelope)
         log.append(.resolved(id: envelope.id, recipients: recipients.map(\.name)))
 
+        // Step 3a: a `to`-addressed envelope that resolves to nobody must NOT
+        // be silently cleaned-and-discarded. Quarantine it like a validation
+        // failure so the drop is observable: `_rejected/<id>.msg` + a `.err`
+        // sidecar + a `rejected` event in the dispatch log. The CLI sender
+        // resolves recipients up front and refuses to send to an unknown name,
+        // so in normal operation this fires only for raw-bash writers or a
+        // recipient that closed between send and dispatch. Topic-only
+        // envelopes (no `to`) keep the Stage-2 accept-but-empty contract and
+        // fall through to the no-op copy/handler steps below.
+        if envelope.to != nil && recipients.isEmpty {
+            rejectUnresolved(
+                id: envelope.id,
+                processingURL: processingURL,
+                to: envelope.to ?? ""
+            )
+            return
+        }
+
         // Step 4: copy into each recipient inbox.
         let envelopeBytes = (try? envelope.encode()) ?? Data()
         for recipient in recipients {
@@ -410,6 +428,32 @@ final class MailboxDispatcher {
                 elapsedMs: result.elapsedMs ?? elapsedMs
             )
         )
+    }
+
+    // MARK: - Unresolved-recipient rejection
+
+    /// A well-formed envelope whose `to` matches no live surface in this
+    /// workspace. Mirrors `quarantine` (rejected dir + `.err` sidecar +
+    /// `rejected` event) so an undeliverable message leaves a trail instead of
+    /// vanishing. Distinct reason string so `c11 mailbox trace` can tell a
+    /// malformed envelope from an unknown recipient.
+    private func rejectUnresolved(id: String, processingURL: URL, to: String) {
+        let reason = "no live surface named '\(to)' in workspace \(workspaceId.uuidString)"
+        let rejectedDir = MailboxLayout.rejectedURL(state: stateURL, workspaceId: workspaceId)
+        let rejectedMsg = rejectedDir.appendingPathComponent(
+            MailboxLayout.envelopeFilename(id: id)
+        )
+        let rejectedErr = rejectedDir.appendingPathComponent(
+            MailboxLayout.rejectedErrorFilename(id: id)
+        )
+        try? FileManager.default.createDirectory(
+            at: rejectedDir,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try? FileManager.default.moveItem(at: processingURL, to: rejectedMsg)
+        try? Data(reason.utf8).write(to: rejectedErr)
+        log.append(.rejected(id: id, reason: reason))
     }
 
     // MARK: - Quarantine

--- a/Sources/Mailbox/MailboxSurfaceResolver.swift
+++ b/Sources/Mailbox/MailboxSurfaceResolver.swift
@@ -112,3 +112,84 @@ struct MailboxSurfaceResolver {
         }
     }
 }
+
+/// Cross-workspace recipient resolution for `c11 mailbox send`.
+///
+/// Each workspace runs its own `MailboxDispatcher`, and that dispatcher only
+/// resolves names against surfaces in *its* workspace. So a `--to` naming a
+/// surface in another workspace resolves to an empty recipient set and the
+/// message is dropped. This resolver closes that gap: it answers "which
+/// workspace should this envelope be delivered into?" by scanning every live,
+/// addressable surface in the running c11 instance, so the CLI can route the
+/// envelope into the recipient's workspace outbox (where that workspace's own
+/// dispatcher then delivers it locally, unchanged).
+///
+/// Precedence is deterministic (documented in `docs/c11-mailbox-guide.md`):
+///   1. **Local-first.** If `name` matches one or more surfaces in the
+///      sender's own workspace, deliver there. This preserves the
+///      pre-cross-workspace behavior exactly — a same-workspace send never
+///      reaches into another workspace, even if a same-named surface exists
+///      elsewhere.
+///   2. Otherwise, among the other workspaces:
+///        * exactly one workspace matches  → deliver there;
+///        * more than one workspace matches → `.ambiguous` (the caller must
+///          disambiguate with a workspace qualifier);
+///        * none match → `.unresolved` (the caller surfaces a non-zero error).
+///   A `workspaceQualifier` short-circuits the precedence: only surfaces in
+///   that workspace are considered, and the result is `.unique` or
+///   `.unresolved`.
+///
+/// Multiple same-named surfaces inside the chosen workspace are returned
+/// together; the dispatcher fans out to all of them, matching how
+/// same-workspace duplicate names already behave.
+struct MailboxGlobalResolver {
+
+    /// One live, addressable surface anywhere in the instance.
+    struct Surface: Equatable {
+        let workspaceId: UUID
+        let surfaceId: UUID
+        let name: String
+    }
+
+    enum Resolution: Equatable {
+        /// Deliver into `workspaceId`; `surfaceIds` are the matching surfaces.
+        case unique(workspaceId: UUID, surfaceIds: [UUID])
+        /// `name` matches surfaces in more than one workspace and no qualifier
+        /// was supplied. Carries the candidates for a helpful error message.
+        case ambiguous(candidates: [Surface])
+        /// No live surface carries `name` (within the qualifier, if given).
+        case unresolved
+    }
+
+    /// Enumerates all addressable surfaces. Injected so the resolver is pure:
+    /// tests pass a fixed list, the socket handler binds it to the live
+    /// windows' workspaces.
+    let surfaces: () -> [Surface]
+
+    func resolve(
+        name: String,
+        senderWorkspaceId: UUID,
+        workspaceQualifier: UUID? = nil
+    ) -> Resolution {
+        let matches = surfaces().filter { $0.name == name }
+
+        if let qualifier = workspaceQualifier {
+            let scoped = matches.filter { $0.workspaceId == qualifier }
+            guard !scoped.isEmpty else { return .unresolved }
+            return .unique(workspaceId: qualifier, surfaceIds: scoped.map(\.surfaceId))
+        }
+
+        // Local-first: a match in the sender's own workspace always wins.
+        let local = matches.filter { $0.workspaceId == senderWorkspaceId }
+        if !local.isEmpty {
+            return .unique(workspaceId: senderWorkspaceId, surfaceIds: local.map(\.surfaceId))
+        }
+
+        guard !matches.isEmpty else { return .unresolved }
+        let workspaceIds = Set(matches.map(\.workspaceId))
+        if workspaceIds.count == 1, let only = workspaceIds.first {
+            return .unique(workspaceId: only, surfaceIds: matches.map(\.surfaceId))
+        }
+        return .ambiguous(candidates: matches)
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2885,6 +2885,10 @@ class TerminalController {
         case "surface.clear_metadata":
             return v2Result(id: id, self.v2SurfaceClearMetadata(params: params))
 
+        // Mailbox
+        case "mailbox.resolve":
+            return v2Result(id: id, self.v2MailboxResolve(params: params))
+
         // Panes
         case "pane.list":
             return v2Result(id: id, self.v2PaneList(params: params))
@@ -3259,6 +3263,7 @@ class TerminalController {
             "surface.set_metadata",
             "surface.get_metadata",
             "surface.clear_metadata",
+            "mailbox.resolve",
             "pane.list",
             "pane.focus",
             "pane.surfaces",
@@ -8706,6 +8711,107 @@ class TerminalController {
             return .err(code: err.code, message: err.message, data: err.detailData)
         } catch {
             return .err(code: "internal_error", message: "\(error)", data: nil)
+        }
+    }
+
+    // MARK: - Mailbox cross-workspace resolution
+
+    /// Resolves a mailbox recipient name to the workspace its envelope should
+    /// be delivered into, scanning every live surface across all windows.
+    /// Backs `c11 mailbox send`, which routes the envelope into the resolved
+    /// workspace's outbox so that workspace's own dispatcher delivers it.
+    ///
+    /// Params:
+    ///   * `to` (string, required) — recipient surface name.
+    ///   * `sender_workspace_id` (uuid, required) — the sender's workspace, so
+    ///     a local match takes precedence over same-named surfaces elsewhere.
+    ///   * `workspace` (string, optional) — disambiguates a name that lives in
+    ///     more than one workspace; a workspace UUID or a `workspace:*` ref.
+    ///
+    /// Returns `{ resolution: "unique"|"ambiguous"|"unresolved",
+    /// target_workspace_id?, target_workspace_ref?, surface_ids?, candidates }`.
+    private func v2MailboxResolve(params: [String: Any]) -> V2CallResult {
+        guard let to = v2String(params, "to"), !to.isEmpty else {
+            return .err(code: "invalid_to", message: "to is required", data: nil)
+        }
+        guard let senderWorkspaceId = v2UUID(params, "sender_workspace_id") else {
+            return .err(code: "invalid_sender_workspace_id", message: "sender_workspace_id must be a UUID", data: nil)
+        }
+        let qualifierStr = v2String(params, "workspace")
+
+        return v2MainSync {
+            let surfaces = AppDelegate.shared?.mailboxAddressableSurfaces() ?? []
+
+            // Translate the optional workspace qualifier (UUID or ref string)
+            // into a concrete workspace UUID. A raw UUID is honored even when
+            // that workspace currently has no addressable surface (it then
+            // resolves to `unresolved`, the honest answer). Otherwise match the
+            // qualifier against the ref strings of the live workspaces.
+            var qualifierUUID: UUID?
+            if let qualifierStr, !qualifierStr.isEmpty {
+                if let direct = UUID(uuidString: qualifierStr) {
+                    qualifierUUID = direct
+                } else {
+                    let workspaceIds = Set(surfaces.map(\.workspaceId))
+                    qualifierUUID = workspaceIds.first { wsId in
+                        if let ref = v2Ref(kind: .workspace, uuid: wsId) as? String {
+                            return ref == qualifierStr
+                        }
+                        return false
+                    }
+                    if qualifierUUID == nil {
+                        // Unknown workspace ref → nothing can match it.
+                        return .ok([
+                            "resolution": "unresolved",
+                            "candidates": self.mailboxCandidatePayload(
+                                surfaces.filter { $0.name == to }
+                            )
+                        ])
+                    }
+                }
+            }
+
+            let resolver = MailboxGlobalResolver(surfaces: { surfaces })
+            let resolution = resolver.resolve(
+                name: to,
+                senderWorkspaceId: senderWorkspaceId,
+                workspaceQualifier: qualifierUUID
+            )
+
+            let candidates = self.mailboxCandidatePayload(surfaces.filter { $0.name == to })
+            switch resolution {
+            case .unique(let workspaceId, let surfaceIds):
+                return .ok([
+                    "resolution": "unique",
+                    "target_workspace_id": workspaceId.uuidString,
+                    "target_workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+                    "surface_ids": surfaceIds.map(\.uuidString),
+                    "candidates": candidates
+                ])
+            case .ambiguous:
+                return .ok([
+                    "resolution": "ambiguous",
+                    "candidates": candidates
+                ])
+            case .unresolved:
+                return .ok([
+                    "resolution": "unresolved",
+                    "candidates": candidates
+                ])
+            }
+        }
+    }
+
+    private func mailboxCandidatePayload(
+        _ surfaces: [MailboxGlobalResolver.Surface]
+    ) -> [[String: Any]] {
+        surfaces.map { surface in
+            [
+                "workspace_id": surface.workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: surface.workspaceId),
+                "surface_id": surface.surfaceId.uuidString,
+                "name": surface.name
+            ]
         }
     }
 

--- a/c11Tests/MailboxDispatcherTests.swift
+++ b/c11Tests/MailboxDispatcherTests.swift
@@ -202,8 +202,12 @@ final class MailboxDispatcherTests: XCTestCase {
 
     // MARK: - Unknown recipient
 
-    func testResolveEmptyWhenRecipientNotLive() throws {
-        // No surface named "ghost" — recipient list is empty, no handler fires.
+    /// A `to`-addressed envelope that resolves to nobody must NOT be silently
+    /// cleaned-and-discarded (the cross-workspace silent-drop bug). It is
+    /// quarantined like a validation failure: `_rejected/<id>.msg` + a `.err`
+    /// sidecar + a `rejected` event, and no handler fires.
+    func testUnresolvedRecipientIsRejectedNotSilentlyDropped() throws {
+        // No surface named "ghost" — recipient list is empty.
         let builder = seedSurface(name: "builder")
         let dispatcher = makeDispatcher(surfaces: [builder])
         var handlerCalls = 0
@@ -215,7 +219,9 @@ final class MailboxDispatcherTests: XCTestCase {
         let envelope = try MailboxEnvelope.build(
             from: "builder",
             to: "ghost",
-            body: "anyone home?"
+            body: "anyone home?",
+            id: "01K3A2B7X8PQRTVWYZ0123456G",
+            ts: "2026-04-23T10:15:42Z"
         )
         try writeEnvelope(envelope)
 
@@ -224,9 +230,38 @@ final class MailboxDispatcherTests: XCTestCase {
         dispatcher.dispatchOne(url: outboxPath)
         dispatcher.log.flush()
 
+        // No handler fired; nothing was copied to an inbox.
         XCTAssertEqual(handlerCalls, 0)
-        let events = try readLog()
-        let resolved = events.first { $0["event"] as? String == "resolved" }
+
+        // The envelope landed in _rejected/ with a sidecar, not silently gone.
+        let rejected = MailboxLayout.rejectedURL(state: tempState, workspaceId: workspaceId)
+        let entries = try FileManager.default.contentsOfDirectory(atPath: rejected.path).sorted()
+        XCTAssertEqual(entries, ["\(envelope.id).err", "\(envelope.id).msg"])
+        let reason = try String(
+            contentsOf: rejected.appendingPathComponent("\(envelope.id).err"),
+            encoding: .utf8
+        )
+        XCTAssertTrue(reason.contains("ghost"), "rejection reason names the recipient")
+
+        // Outbox and processing are empty; the envelope was moved, not left behind.
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(
+                atPath: MailboxLayout.outboxURL(state: tempState, workspaceId: workspaceId).path
+            ),
+            []
+        )
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(
+                atPath: MailboxLayout.processingURL(state: tempState, workspaceId: workspaceId).path
+            ),
+            []
+        )
+
+        // Log sequence ends in `rejected`, with no `cleaned`.
+        let events = try readLog().compactMap { $0["event"] as? String }
+        XCTAssertEqual(events, ["received", "resolved", "rejected"])
+        XCTAssertFalse(events.contains("cleaned"))
+        let resolved = try readLog().first { $0["event"] as? String == "resolved" }
         XCTAssertEqual(resolved?["recipients"] as? [String], [])
     }
 

--- a/c11Tests/MailboxSurfaceResolverTests.swift
+++ b/c11Tests/MailboxSurfaceResolverTests.swift
@@ -141,3 +141,100 @@ final class MailboxSurfaceResolverTests: XCTestCase {
         XCTAssertEqual(row?.mailboxKeys.keys.sorted(), ["mailbox.delivery"])
     }
 }
+
+/// Cross-workspace recipient resolution. Pure — drives `MailboxGlobalResolver`
+/// with an injected surface list, no app or metadata store needed.
+final class MailboxGlobalResolverTests: XCTestCase {
+
+    private let wsA = UUID()
+    private let wsB = UUID()
+    private let wsC = UUID()
+
+    private func surface(_ ws: UUID, _ name: String) -> MailboxGlobalResolver.Surface {
+        MailboxGlobalResolver.Surface(workspaceId: ws, surfaceId: UUID(), name: name)
+    }
+
+    private func resolver(_ surfaces: [MailboxGlobalResolver.Surface]) -> MailboxGlobalResolver {
+        MailboxGlobalResolver(surfaces: { surfaces })
+    }
+
+    // MARK: - Local-first
+
+    func testLocalMatchWinsOverRemoteSameName() {
+        // "Reviewer" exists in both the sender's workspace and a remote one;
+        // the local one must win so same-workspace sends never reach out.
+        let local = surface(wsA, "Reviewer")
+        let remote = surface(wsB, "Reviewer")
+        let resolution = resolver([local, remote]).resolve(
+            name: "Reviewer",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [local.surfaceId]))
+    }
+
+    func testLocalDuplicateNamesFanOut() {
+        // Two "Builder" surfaces in the sender's workspace → both delivered.
+        let a = surface(wsA, "Builder")
+        let b = surface(wsA, "Builder")
+        let resolution = resolver([a, b]).resolve(name: "Builder", senderWorkspaceId: wsA)
+        guard case let .unique(workspaceId, surfaceIds) = resolution else {
+            return XCTFail("expected unique, got \(resolution)")
+        }
+        XCTAssertEqual(workspaceId, wsA)
+        XCTAssertEqual(Set(surfaceIds), [a.surfaceId, b.surfaceId])
+    }
+
+    // MARK: - Cross-workspace
+
+    func testResolvesToRemoteWorkspaceWhenNoLocalMatch() {
+        // Sender is in wsA; "Reviewer" only lives in wsB → deliver to wsB.
+        let remote = surface(wsB, "Reviewer")
+        let resolution = resolver([surface(wsA, "Builder"), remote]).resolve(
+            name: "Reviewer",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsB, surfaceIds: [remote.surfaceId]))
+    }
+
+    func testUnknownNameIsUnresolved() {
+        let resolution = resolver([surface(wsA, "Builder")]).resolve(
+            name: "Nobody",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unresolved)
+    }
+
+    // MARK: - Collision across workspaces
+
+    func testNameInMultipleRemoteWorkspacesIsAmbiguous() {
+        // Sender wsA has no "Reviewer"; both wsB and wsC do → ambiguous.
+        let b = surface(wsB, "Reviewer")
+        let c = surface(wsC, "Reviewer")
+        let resolution = resolver([b, c]).resolve(name: "Reviewer", senderWorkspaceId: wsA)
+        guard case let .ambiguous(candidates) = resolution else {
+            return XCTFail("expected ambiguous, got \(resolution)")
+        }
+        XCTAssertEqual(Set(candidates.map(\.workspaceId)), [wsB, wsC])
+    }
+
+    func testWorkspaceQualifierDisambiguates() {
+        let b = surface(wsB, "Reviewer")
+        let c = surface(wsC, "Reviewer")
+        let resolution = resolver([b, c]).resolve(
+            name: "Reviewer",
+            senderWorkspaceId: wsA,
+            workspaceQualifier: wsC
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsC, surfaceIds: [c.surfaceId]))
+    }
+
+    func testQualifierWithNoMatchIsUnresolved() {
+        let b = surface(wsB, "Reviewer")
+        let resolution = resolver([b]).resolve(
+            name: "Reviewer",
+            senderWorkspaceId: wsA,
+            workspaceQualifier: wsC
+        )
+        XCTAssertEqual(resolution, .unresolved)
+    }
+}

--- a/docs/c11-mailbox-guide.md
+++ b/docs/c11-mailbox-guide.md
@@ -10,7 +10,9 @@ This is the practical guide. For the agent-facing quick-reference see the "Inter
 
 ## What it is
 
-A per-workspace tree under `~/Library/Application Support/c11mux/workspaces/<workspace-uuid>/mailboxes/` that holds the outbox, per-recipient inboxes, an append-only dispatch log, and quarantine/processing scratch areas. The c11 process running the workspace owns one `MailboxDispatcher` that watches the outbox and routes whatever shows up.
+A per-workspace tree under `~/Library/Application Support/c11/workspaces/<workspace-uuid>/mailboxes/` that holds the outbox, per-recipient inboxes, an append-only dispatch log, and quarantine/processing scratch areas. The c11 process running the workspace owns one `MailboxDispatcher` that watches the outbox and routes whatever shows up.
+
+Recipients can live in **any** workspace, not just the sender's. `c11 mailbox send` resolves the recipient name across every live workspace in the instance and writes the envelope into the recipient workspace's own outbox, so that workspace's dispatcher delivers it locally (see [Cross-workspace routing](#cross-workspace-routing)).
 
 ```mermaid
 flowchart LR
@@ -98,7 +100,8 @@ Send flags accepted by the CLI:
 
 | Flag                  | Purpose                                                            |
 |-----------------------|--------------------------------------------------------------------|
-| `--to <surface>`      | Recipient surface name. Required in Stage 2 (topic-only rejected). |
+| `--to <surface>`      | Recipient surface name, in any workspace. Required in Stage 2 (topic-only rejected). |
+| `--to-workspace <ref>`| Disambiguate a name that exists in more than one workspace. A workspace UUID or `workspace:*` ref. |
 | `--topic <token>`     | Dotted topic. Stored on the envelope; not used for routing yet.    |
 | `--body <text>`       | Inline body, ≤ 4096 bytes UTF-8.                                   |
 | `--body-ref <path>`   | Absolute path to an external body. `--body` must be empty.         |
@@ -124,6 +127,29 @@ mv "$OUTBOX/.$ULID.tmp" "$OUTBOX/$ULID.msg"
 ```
 
 The dispatcher only sees files that match `*.msg` and do not start with `.`. Always write to a dot-prefixed `.tmp` sibling first and rename. A canonical reference lives at `Resources/bin/c11-mailbox-send-bash-example.sh`.
+
+> **Raw writers are workspace-local.** `outbox-dir` prints *your own* workspace's outbox, and a dispatcher only resolves names within its own workspace. So a raw file write reaches only recipients in your workspace. To deliver across workspaces, use `c11 mailbox send` (which resolves globally and routes for you) — or write into the recipient workspace's outbox directly. A raw envelope whose `to` matches nobody in that workspace is **rejected**, not silently dropped (see below).
+
+---
+
+## Cross-workspace routing
+
+`c11 mailbox send` resolves `--to` against every live surface in the running c11 instance, then writes the envelope into the **recipient's** workspace outbox. The recipient workspace's own dispatcher picks it up and delivers locally — same machinery as a same-workspace send, just a different outbox. The `from` field still names the sender; the dispatch trail lands in the recipient workspace's `_dispatch.log`.
+
+Resolution precedence is deterministic:
+
+1. **Local-first.** If the name matches a surface in *your* workspace, it is delivered there — a same-workspace send never reaches into another workspace, even if a same-named surface exists elsewhere. Existing same-workspace behavior is unchanged.
+2. Otherwise, among the other workspaces: exactly one match → delivered there; **more than one workspace** has the name → the send fails with an *ambiguous* error listing the candidate workspaces; no match anywhere → the send fails *unresolved* with a non-zero exit (the message is not written).
+
+**Name collisions across workspaces** (two surfaces both named `Builder` in different workspaces) are resolved by qualifying with `--to-workspace <ref>`:
+
+```bash
+c11 mailbox send --to Builder --to-workspace workspace:4 --body "go"
+```
+
+Multiple same-named surfaces *within one* workspace still fan out to all of them (unchanged) — that case is unique, not ambiguous.
+
+If the c11 socket is unreachable, `send` falls back to writing into your own workspace's outbox so same-workspace delivery still works offline; cross-workspace recipients then surface as a dispatcher *rejection* rather than a silent drop.
 
 ---
 
@@ -202,6 +228,7 @@ stateDiagram-v2
     Outbox --> Processing: dispatcher moveItem
     Processing --> Rejected: validation fails
     Processing --> Resolved: validate ok
+    Resolved --> Rejected: to matches no live surface
     Resolved --> Copied: per recipient inbox
     Copied --> HandlerRun: per delivery handler
     HandlerRun --> Cleaned: remove from _processing/
@@ -214,7 +241,7 @@ stateDiagram-v2
     end note
 ```
 
-The `received → resolved → copied → handler → cleaned` sequence shows up as discrete NDJSON lines in `_dispatch.log`. The `rejected` branch is the alternate terminal state and writes a `<id>.err` sibling explaining what failed.
+The `received → resolved → copied → handler → cleaned` sequence shows up as discrete NDJSON lines in `_dispatch.log`. The `rejected` branch is the alternate terminal state and writes a `<id>.err` sibling explaining what failed. A well-formed envelope whose `to` resolves to **no live surface** in the dispatching workspace takes the `rejected` branch too (reason: `no live surface named '<to>' …`) — an undeliverable message is quarantined with its sidecar, never silently cleaned.
 
 ---
 

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -464,7 +464,7 @@ the sub-agent's PR transitively requires another open PR to land first.
 
 ## Inter-agent messaging (mailbox)
 
-**c11 ships a per-workspace mailbox primitive.** Any agent in a surface can write an envelope to `_outbox/`; the c11-in-process dispatcher validates, resolves the recipient by surface name, copies into the recipient's inbox, and — for stdin-delivery recipients — writes a framed `<c11-msg>` block into the PTY.
+**c11 ships a mailbox primitive that routes across all workspaces.** Any agent in a surface can `c11 mailbox send --to <name>`; c11 resolves the recipient by surface name across every workspace in the instance, delivers into the recipient's inbox, and — for stdin-delivery recipients — writes a framed `<c11-msg>` block into the PTY. A recipient that matches no live surface is **rejected with a non-zero exit**, never silently dropped.
 
 This section is the agent-facing quick-reference. The full guide (filesystem layout, sequence diagrams, schema reference, dispatch log shape, patterns, anti-patterns, Stage 2 limits) lives in [`docs/c11-mailbox-guide.md`](../../docs/c11-mailbox-guide.md).
 
@@ -501,9 +501,11 @@ c11 mailbox send --to watcher --topic ci.status --urgent --body "CI red" \
 
 Auto-fills `version`, `id`, `ts`, `from` (resolved via the caller's surface title). Prints the envelope id on success.
 
+**Cross-workspace + collisions.** `--to` resolves across all workspaces, local-first: a match in your own workspace wins; otherwise the one workspace that has the name receives it. If the name exists in **more than one** other workspace the send fails *ambiguous* — disambiguate with `--to-workspace <ref>` (a workspace UUID or `workspace:*`). No match anywhere → non-zero *unresolved* exit, message not sent.
+
 **Stage 2 requires `--to`.** Topic-only sends (`--topic` with no `--to`) are rejected with a non-zero exit — topic subscribe/fan-out ships in Stage 3. Until then, always pair `--topic` with an explicit `--to <surface-name>`.
 
-**Raw file write (any process, any language):**
+**Raw file write (any process, any language)** — note this reaches only recipients in *your own* workspace (it bypasses global resolution); use the CLI to cross workspaces:
 
 ```bash
 OUTBOX=$(c11 mailbox outbox-dir)

--- a/skills/lattice-orchestrator/SKILL.md
+++ b/skills/lattice-orchestrator/SKILL.md
@@ -169,6 +169,7 @@ Same Architect, carrying spec-context forward. Covers:
 - **Per-screen functionality** (when there's a UI) — what each screen does, what state it owns.
 - **Optional screen layout diagrams** — Mermaid when layout itself is a decision point.
 - **Breakdown into tickets** — the work, sliced into Lattice tickets the Orchestrator spawns delegators against. **Bias toward shapes that maximize parallelism** — independent modules, narrow interfaces, schemas that ship ahead of consumers. Fewer dependencies = more parallel work = faster run. Ticket fidelity (verbose vs minimal) is operator-chosen in Phase 2.
+- **Reconcile against reality before ticketing — ticket the gap, not the plan.** When the build plan targets an existing codebase (a migration, a follow-on, "wire up the rest"), audit what is *already done* before minting tickets — a fast read-only Explore pass over the relevant modules, verdict per work-item (DONE / PARTIAL / MISSING) with file:line evidence. Mint tickets only for PARTIAL/MISSING. Build plans written ahead of the work routinely list items that landed in an earlier increment; ticketing them anyway spawns delegators that discover there's nothing to do. (Substrate wiki run: a Track-B audit found 4 of 5 sketched work-items already shipped — only 1 was real.)
 
 Operator confirms `BUILDPLAN.md` before Phase 2 begins. Iterate as long as needed — the cost of getting the plan wrong here is hours of misdirected delegator work downstream.
 
@@ -368,6 +369,32 @@ Bias toward:
 - **Legible failures.** Errors print why, what, and (when known) what to try. Stack traces alone are evidence, not diagnosis.
 
 Architects call this out explicitly in the project `CLAUDE.md` (Step 1.5) so every future delegator in the project sees it. The Build Plan (Step 2) reflects it in component design — observability is part of the spec, not a Phase-4 retrofit.
+
+---
+
+## Build for fast feedback: the test suite is the orchestrator's clock
+
+A delegator runs the project's tests every review cycle, with N delegators going at once — so
+suite speed is the biggest lever on a run's wall-clock. A slow suite, paid per-delegator
+per-review and serialized under load, turns a multi-hour run into one spent mostly *waiting on
+tests*.
+
+**Hard target: the default test gate runs in ≤60s — 2 minutes at the absolute max — for a small
+or early-stage project.** A slower default suite is a defect to fix, not a cost to absorb. The
+Architect bakes this in at Phase 1; delegators inherit it via the project `CLAUDE.md`.
+
+- **Parallelize by default** (`pytest -n auto` or the stack's equivalent). Serial-only is a harness bug.
+- **Keep the default gate hermetic** — no model load, embedding warmup, DB/container spin-up, or
+  network. Those go in a separate integration suite, run once before PR / in CI, never in the inner loop.
+- **Split the gate in the project CLAUDE.md:** a fast default command + a separately-named full command.
+- **Quarantine flaky + slow tests behind markers**, deselected from the gate. A test that flakes under
+  parallel load forces isolation re-runs and tempts "merge around it" — mark it, exclude it, ticket it.
+- **Measure it.** If the Architect can't state the suite's wall-clock in the BUILDPLAN, close that gap before dispatch.
+
+Worked example (Substrate wiki run, 2026-06-15): a ~22-min full suite (embedding-model + graph-DB
+spin-up) was paid by all 11 delegators per review, and two load-sensitive tests flaked under
+concurrency and forced repeated re-runs — suite latency, not reasoning, dominated the run. A
+hermetic ≤2-min parallel gate with those quarantined would have cut wall-clock by a large multiple.
 
 ---
 

--- a/skills/lattice-orchestrator/references/architect.md
+++ b/skills/lattice-orchestrator/references/architect.md
@@ -80,6 +80,12 @@ If CLAUDE.md already exists from prior project work, the Architect *updates* it 
 
 **Second pass at end of Step 2.** After BUILDPLAN.md is locked, the Architect updates CLAUDE.md to fill in tech-stack specifics, build / test / run commands, and any conventions that surfaced during the build plan. Two passes total: one declaration after SPEC.md, one finalization after BUILDPLAN.md.
 
+**Fast-test gate (HARD — see SKILL.md "Build for fast feedback").** Define TWO test commands in the project CLAUDE.md, not one:
+- `test` (fast, default): hermetic + parallel (`pytest -n auto` or the stack's equivalent), **≤60s / 2-min ceiling** for a small project. This is what delegators run every inner loop.
+- `test:full` (slow): integration / model / DB / e2e suite, run once at the validate step and in CI.
+
+Slow + flaky tests carry markers and are deselected from the default gate. If the natural suite is already slow, fixing/splitting it is itself an early ticket — and surface the suite's wall-clock in the BUILDPLAN so it's a decision, not a surprise discovered mid-run.
+
 The CLAUDE.md must include a **`## Lessons learned`** section pointing at `lessons-learned.md` (Step 1.6) and instructing future agents to append entries on failures, confusion, or thrash. Format and trigger conditions live in that section.
 
 ## Phase 1 Step 1.6 — `lessons-learned.md` (→ lessons-learned.md at project root)

--- a/skills/lattice-orchestrator/references/orchestrator.md
+++ b/skills/lattice-orchestrator/references/orchestrator.md
@@ -282,6 +282,17 @@ No interval → dynamic mode; the model self-paces by calling `ScheduleWakeup` a
 
 Three failure modes recur and have proven recovery procedures. Detection is mostly the same — a delegator's cost counter frozen across 2+ orchestrator ticks (≥9 min) is the canonical tell. Deep-read the screen to confirm one of these patterns, then apply the matching recovery. **Never trust `c11 send-key enter` alone** — Claude Code's TUI sometimes swallows synthetic Return; always pair it with a fresh `c11 send "<message>"` immediately before.
 
+### Before you treat a frozen cost counter as a stall: diagnose
+
+A frozen cost counter is the canonical stall tell — but it is *also* exactly what a delegator legitimately blocked on a long-running shell looks like (a multi-minute test suite, a model-driven build, a compile over a real corpus). Nudging a working delegator interrupts real work.
+
+So when cost is frozen but the screen shows `✻ <verb>` + a `N shell(s) still running` footer (or a visible long-running command), **confirm it's actually dead before intervening:**
+
+- `pgrep -fl "<worktree-slug>.*pytest"` (or the relevant command) — a live PID means it's working; leave it.
+- For output buffered behind `| tail` / `| grep`, read the task's `.output` file or a `tee`'d log directly to see real progress.
+
+Only nudge when the diagnosis shows the work is genuinely done (PID gone, log shows completion) but the delegator is idle/sleeping, OR there's an unsubmitted input buffer with no running shell. The "frozen cost + live shell = background-watching, not a stall" distinction prevented every false recovery on the Substrate wiki run (it fired ~6 times; each was a live ~22-min suite). The slow suite is the deeper fix — see SKILL.md "Build for fast feedback."
+
 ### Pattern: frozen cost across ≥2 ticks
 
 Symptoms: cost counter unchanged across ticks; api time unchanged; "Cooked for X" or "Baked for X" indicator with no monitor; input box may contain unsubmitted text like "check on the impl agent" or "check on the planner".
@@ -916,6 +927,17 @@ Record every auto-merged PR in `agents.md` under an "Auto-merges" subsection so 
 **The take-both-additive-registrations conflict pattern** — when a rebase hits a conflict because both branches added entries to the same registration file (`__init__.py` re-exports, CLI subcommand registries, mock provider registries), the resolution is almost always "take both additions, preserve order by ticket id." Don't choose one side; merge the union. This was the documented pattern from the EC v1.2.1 + Holodeck v1 Phase 3 closeout audits.
 
 **Conflict modes that need operator surfacing**: real semantic conflicts (both branches modified the same function's body, both renamed the same symbol, etc.) get surfaced via `🛑 NEEDS YOUR INPUT — <TICKET> auto-merge conflict` rather than guessed-at. Auto-merge mode does NOT mean "merge through any conflict."
+
+### Merging a deep stacked tree: prefer one integration branch over N re-targets
+
+The per-PR rebase-and-merge above is right for a short stack landing incrementally as it's reviewed. For a **whole tree landing at once** at run-complete (a Merge Captain merging 8–12 stacked PRs together), assembling one integration branch is cleaner and safer:
+
+- **Cut `integration/<run>` off `main`, merge the feature branches into it in dependency order, validate the *assembled* tree once, then open a single `integration/<run> → main` PR.** One reviewed merge instead of N interleaved rebases.
+- **A stacked tree's leaf tips usually cover the whole set.** If C branched off B off A, merging C alone brings A+B+C. Identify the leaf tips, merge only those, then verify every expected file/feature is present (`ls` the modules, grep the registration lines, check the hard constraints).
+- **A squash-merged parent is NOT an ancestor of its children.** Once any PR squash-merges to `main`, `git merge-base --is-ancestor <child> main` returns false even though the content is there, and child PRs show phantom/duplicate diffs. Don't gate logic on ancestry after a squash; let the integration branch's 3-way merge resolve the duplicated content (identical changes auto-resolve; real conflicts resolve by the take-both-additive pattern — keep every ticket's work).
+- **Gate the merge on validating the assembled tree, not the individual PRs.** Per-ticket fixture tests can all pass while the integration breaks on the real dataset. (Substrate wiki run: GATE-1 caught a real output-truncation bug only visible compiling over the live corpus, fixed in the integration branch before the single merge to main.)
+
+When the tree lands this way, close the individual PRs with a "merged via integration/<run>" comment and mark each ticket `done`; record the integration merge SHA in `agents.md`.
 
 ## Orchestrator-as-captain (degraded mode, last resort)
 


### PR DESCRIPTION
## Problem (from a live two-agent test)

The mailbox dispatcher is **per-workspace** and only resolves recipient names within the sending workspace. Sending `--to Reviewer` from a surface in workspace A, when "Reviewer" lives in workspace B, produced:

```
{"event":"received","from":"Builder","to":"Reviewer"}
{"event":"resolved","recipients":[]}   ← recipient not found
{"event":"cleaned"}                     ← message silently discarded
```

The sender got a valid ULID back and **no error**. The message vanished. Same-workspace delivery worked perfectly.

## Fix 1 — cross-workspace routing

- **`MailboxGlobalResolver`** (pure, injected enumeration): resolves a recipient name against every live surface in the instance, **local-first** — a match in the sender's own workspace wins (same-workspace behavior is unchanged); otherwise the single workspace that has the name receives it; a name in >1 other workspace is *ambiguous*; no match is *unresolved*.
- **`mailbox.resolve` socket method** backed by `AppDelegate.mailboxAddressableSurfaces()`, which reads the same `SurfaceMetadataStore` `title` the local resolver uses, so global resolution matches local resolution exactly.
- **`c11 mailbox send`** calls `mailbox.resolve` and writes the envelope into the **recipient's** workspace outbox, so that workspace's own dispatcher delivers it locally — same delivery engine, different outbox.

**Collision rule:** local-first; a bare name in multiple workspaces is rejected as *ambiguous* with the candidate workspaces listed. Disambiguate with `--to-workspace <ref>` (a workspace UUID or `workspace:*`). Multiple same-named surfaces *within one* workspace still fan out to all (unchanged).

## Fix 2 — stop the silent drop

- **Dispatcher:** a well-formed envelope whose `to` matches no live surface is now quarantined (`_rejected/<id>.msg` + `.err` sidecar + `rejected` event), mirroring validation failures — never silently `cleaned`.
- **CLI:** `c11 mailbox send` exits non-zero with a human-readable error when the recipient is unresolved or ambiguous. If the socket is unreachable, send falls back to the sender's own workspace and the dispatcher rejection is the backstop.

## Tests (c11LogicTests — safe locally, green)

- Rewrote the unknown-recipient dispatcher test to assert non-silent rejection (rejected dir + sidecar + `received→resolved→rejected`, no `cleaned`).
- Added `MailboxGlobalResolverTests`: local-first wins, duplicate-local fan-out, cross-workspace unique, unknown → unresolved, multi-workspace → ambiguous, qualifier disambiguates, qualifier-miss → unresolved.
- `xcodebuild -scheme c11-logic ... test` (mailbox slices) and `c11-cli build` both succeed.

## Coordinated relaunch required

The dispatcher runs in-process, so this only takes effect after a rebuild + relaunch. **Not done here** (would nuke the operator's live session). When ready: `./scripts/reload.sh --tag mbx` and validate two real agents in two workspaces (cross-workspace deliver, collision → ambiguous error, unknown → non-zero `unresolved`), then merge.

Docs (`docs/c11-mailbox-guide.md`) + `c11` skill updated; installed skill synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)