### PR TITLE
Mailbox: de-silence cross-workspace seam (P0 hardening)

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -16807,12 +16807,13 @@ extension CMUXCLI {
         // exist, instead of dropping the message into an outbox where no
         // dispatcher will ever resolve it. `to` is guaranteed non-nil here
         // (topic-only sends were rejected above).
-        let targetWorkspaceId = try resolveMailboxTargetWorkspace(
+        let resolution = try resolveMailboxTargetWorkspace(
             client: client,
             to: to ?? "",
             senderWorkspaceId: workspaceId,
             qualifier: toWorkspace
         )
+        let targetWorkspaceId = resolution.workspaceId
 
         let stateURL = try MailboxLayout.defaultStateURL()
         let outboxURL = MailboxLayout.outboxURL(state: stateURL, workspaceId: targetWorkspaceId)
@@ -16826,6 +16827,26 @@ extension CMUXCLI {
         )
         let data = try envelope.encode()
         try MailboxIO.atomicWrite(data: data, to: targetURL)
+
+        // The recipient could not be resolved across workspaces (c11
+        // unreachable). The envelope was written best-effort to the sender's
+        // own workspace — a same-workspace recipient still gets it, otherwise
+        // the dispatcher rejects it. Either way the operator must know the send
+        // was unverified, so fail loud and non-zero instead of printing the id
+        // as if it succeeded.
+        if !resolution.verified {
+            var message = String(
+                localized: "mailbox.cli.error.unverified-send",
+                defaultValue: "c11 unreachable: wrote envelope %@ to your own workspace but could not verify recipient \"%@\" across workspaces. If the recipient is not in your workspace the message will be rejected — run `c11 mailbox trace %@` to confirm delivery."
+            )
+            // Fill the three %@ placeholders left-to-right: id, recipient, id.
+            for value in [envelope.id, to ?? "", envelope.id] {
+                if let range = message.range(of: "%@") {
+                    message.replaceSubrange(range, with: value)
+                }
+            }
+            throw CLIError(message: message)
+        }
 
         if jsonOutput {
             print(jsonString([
@@ -16853,7 +16874,7 @@ extension CMUXCLI {
         to: String,
         senderWorkspaceId: UUID,
         qualifier: String?
-    ) throws -> UUID {
+    ) throws -> (workspaceId: UUID, verified: Bool) {
         var params: [String: Any] = [
             "to": to,
             "sender_workspace_id": senderWorkspaceId.uuidString
@@ -16866,9 +16887,12 @@ extension CMUXCLI {
         do {
             payload = try client.sendV2(method: "mailbox.resolve", params: params)
         } catch {
-            // Socket unreachable (or an older app without mailbox.resolve):
-            // preserve same-workspace delivery rather than failing the send.
-            return senderWorkspaceId
+            // Socket unreachable (or an older app without mailbox.resolve): we
+            // cannot resolve across workspaces. Fall back to the sender's own
+            // workspace so a same-workspace recipient still gets the message,
+            // but flag it `verified: false` so the caller warns loudly and
+            // exits non-zero — an unverified send must not look like success.
+            return (senderWorkspaceId, false)
         }
 
         switch payload["resolution"] as? String {
@@ -16879,7 +16903,7 @@ extension CMUXCLI {
             else {
                 throw CLIError(message: "mailbox.resolve returned an invalid target workspace")
             }
-            return id
+            return (id, true)
         case "ambiguous":
             let candidates = (payload["candidates"] as? [[String: Any]]) ?? []
             throw CLIError(message: mailboxAmbiguityMessage(to: to, candidates: candidates))
@@ -16973,21 +16997,43 @@ extension CMUXCLI {
                 )
             )
         }
-        let (workspaceId, _) = try resolveMailboxCaller(
-            client: client,
-            fromOverride: nil,
-            surfaceOverride: nil
-        )
+        // Trace globally: a cross-workspace send is dispatched in the
+        // *recipient's* workspace, so its delivery/rejection events land in
+        // that workspace's `_dispatch.log`, not the sender's. Scanning every
+        // workspace's log (the envelope id is an instance-unique ULID) makes a
+        // message followable wherever it routed. No socket call — trace works
+        // even when the socket is unreachable, which is exactly when you need
+        // to diagnose a stuck send.
         let stateURL = try MailboxLayout.defaultStateURL()
-        let logURL = MailboxLayout.dispatchLogURL(state: stateURL, workspaceId: workspaceId)
-        guard let text = try? String(contentsOf: logURL, encoding: .utf8) else {
-            return
-        }
+        let workspacesRoot = stateURL.appendingPathComponent(
+            MailboxLayout.workspacesDirectoryName,
+            isDirectory: true
+        )
         let needle = "\"\(id)\""
-        for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
-            if line.contains(needle) {
-                print(String(line))
+        var matches: [(ts: String, line: String)] = []
+        let workspaceDirs = (try? FileManager.default.contentsOfDirectory(
+            at: workspacesRoot,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        for workspaceDir in workspaceDirs {
+            guard let workspaceId = UUID(uuidString: workspaceDir.lastPathComponent) else {
+                continue
             }
+            let logURL = MailboxLayout.dispatchLogURL(state: stateURL, workspaceId: workspaceId)
+            guard let text = try? String(contentsOf: logURL, encoding: .utf8) else { continue }
+            for line in text.split(separator: "\n", omittingEmptySubsequences: true)
+            where line.contains(needle) {
+                let lineStr = String(line)
+                let ts = (try? JSONSerialization.jsonObject(with: Data(lineStr.utf8)))
+                    .flatMap { ($0 as? [String: Any])?["ts"] as? String } ?? ""
+                matches.append((ts, lineStr))
+            }
+        }
+        // ISO-8601 UTC timestamps sort lexically into chronological order, so a
+        // string sort merges events from multiple workspace logs correctly.
+        matches.sort { $0.ts < $1.ts }
+        for match in matches {
+            print(match.line)
         }
     }
 

--- a/Sources/Mailbox/MailboxEnvelope.swift
+++ b/Sources/Mailbox/MailboxEnvelope.swift
@@ -18,6 +18,9 @@ struct MailboxEnvelope: Equatable {
     static let schemaVersion = 1
     static let maxBodyBytes = 4096
     static let maxStringFieldBytes = 256
+    /// `content_type` has a tighter cap than the generic string fields
+    /// (`maxLength: 128` in `spec/mailbox-envelope.v1.schema.json`).
+    static let maxContentTypeBytes = 128
     static let ulidPattern = #"^[0-9A-HJKMNP-TV-Z]{26}$"#
     static let topicPattern = #"^[A-Za-z0-9_][A-Za-z0-9_.\-]*$"#
     static let timestampPattern = #"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$"#
@@ -86,6 +89,7 @@ struct MailboxEnvelope: Equatable {
         case wrongVersionValue(Int)
         case emptyString(String)
         case stringTooLong(field: String, bytes: Int)
+        case contentTypeTooLong(bytes: Int)
         case invalidULID(field: String, value: String)
         case invalidTimestamp(String)
         case invalidTopic(String)
@@ -112,6 +116,8 @@ struct MailboxEnvelope: Equatable {
                 return "field '\(f)' must be a non-empty string"
             case .stringTooLong(let f, let bytes):
                 return "field '\(f)' exceeds \(maxStringFieldBytes)-byte cap (was \(bytes))"
+            case .contentTypeTooLong(let bytes):
+                return "field 'content_type' exceeds \(maxContentTypeBytes)-byte cap (was \(bytes))"
             case .invalidULID(let f, let v):
                 return "field '\(f)' is not a Crockford base32 ULID: \(v)"
             case .invalidTimestamp(let v):
@@ -230,7 +236,11 @@ struct MailboxEnvelope: Equatable {
         }
 
         if let raw = dict["content_type"] {
-            _ = try requireNonEmptyString(raw, field: "content_type")
+            let contentType = try requireNonEmptyString(raw, field: "content_type")
+            let bytes = contentType.utf8.count
+            if bytes > maxContentTypeBytes {
+                throw Error.contentTypeTooLong(bytes: bytes)
+            }
         }
 
         if let raw = dict["ext"] {

--- a/c11Tests/MailboxEnvelopeValidationTests.swift
+++ b/c11Tests/MailboxEnvelopeValidationTests.swift
@@ -90,6 +90,27 @@ final class MailboxEnvelopeValidationTests: XCTestCase {
         XCTAssertEqual(envelope.ext?["trace_id"] as? String, "abc-123")
     }
 
+    // MARK: - content_type byte cap (schema maxLength: 128)
+
+    func testContentTypeAt128BytesAccepted() throws {
+        let okType = String(repeating: "a", count: 128)
+        let envelope = try MailboxEnvelope.build(
+            from: "builder", to: "watcher", body: "hi", contentType: okType
+        )
+        XCTAssertEqual(envelope.contentType, okType)
+    }
+
+    func testContentTypeOver128BytesRejected() throws {
+        let longType = String(repeating: "a", count: 129)
+        XCTAssertThrowsError(
+            try MailboxEnvelope.build(
+                from: "builder", to: "watcher", body: "hi", contentType: longType
+            )
+        ) { error in
+            XCTAssertEqual(error as? MailboxEnvelope.Error, .contentTypeTooLong(bytes: 129))
+        }
+    }
+
     // MARK: - Invalid fixtures (one per documented rule)
 
     func testInvalidMissingVersion() throws {

--- a/docs/c11-mailbox-guide.md
+++ b/docs/c11-mailbox-guide.md
@@ -392,7 +392,7 @@ c11 mailbox inbox-dir --surface watcher        # someone else's inbox
 c11 mailbox surface-name                       # caller's resolved title
 c11 mailbox new-id                             # fresh ULID for raw-file writers
 c11 mailbox tail                               # follow _dispatch.log
-c11 mailbox trace <id>                         # all log lines mentioning <id>
+c11 mailbox trace <id>                         # all log lines for <id>, across every workspace
 ls "$(c11 mailbox outbox-dir)/../_rejected"    # what bounced and why
 ```
 

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -542,7 +542,7 @@ Writing the value as JSON (e.g. `--type json --value '["stdin"]'`) is the canoni
 ### Debugging
 
 ```bash
-c11 mailbox trace 01K3A2B7X8PQRTVWYZ0123456J   # pretty-print dispatch events for one id
+c11 mailbox trace 01K3A2B7X8PQRTVWYZ0123456J   # dispatch events for one id, across all workspaces (a cross-workspace send logs in the recipient's workspace)
 c11 mailbox tail                                # follow _dispatch.log as it grows
 c11 mailbox outbox-dir                          # absolute path of your outbox
 c11 mailbox inbox-dir                           # absolute path of your inbox


### PR DESCRIPTION
P0 hardening from the nine-instance Trident review of the mailbox feature. All three close silent-failure / observability gaps on the cross-workspace path shipped in #251.

## 1. Global `mailbox trace` (top consensus failure mode)
A cross-workspace send is dispatched in the **recipient's** workspace, so its delivery/rejection events land in *that* workspace's `_dispatch.log` — but `trace` read only the **caller's** log, returning empty for every cross-workspace send (undiagnosable silent loss, flagged by both critical reviewers + code-confirmed). `trace <id>` now scans every workspace's dispatch log (the id is an instance-unique ULID) and merges matches chronologically. It also **no longer calls the socket**, so it works even when the socket is unreachable — exactly when you need to diagnose a stuck send.

## 2. Loud socket-down fallback
When the socket is unreachable the CLI can't resolve across workspaces; it fell back to the sender's outbox and **exited 0**, so an undeliverable cross-workspace send looked like success. It now writes best-effort to the sender's workspace (a same-workspace recipient still gets it) but **exits non-zero** with a clear message naming the envelope id and the `trace` command. An unverified send never masquerades as delivered.

## 3. Enforce `content_type` 128-byte cap
Schema declares `content_type` maxLength 128 but `validate` never enforced it (every other string field is capped). Added a dedicated `contentTypeTooLong` error with an accurate message.

## Not addressed here (by design)
- **TOCTOU race (critical #1):** subsumed by the planned stable-addressing work + the existing post-#251 reject backstop — no separate fix needed.
- Larger workstreams (stable addressing, delivery safety, liveness) are being filed as Lattice tickets, not in this PR.

## Tests
`content_type` at-128 accepted / over-128 rejected (c11LogicTests, green). `c11-cli` builds. Docs + c11 skill updated (trace is global); skill synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)