### PR TITLE
Mailbox: stable addressing (mailbox.address/role, decouple from mutable title) [C11-143]

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 		D7106BF0A1B2C3D4E5F60718 /* MailboxEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7106BF1A1B2C3D4E5F60718 /* MailboxEnvelope.swift */; };
 		D7108BF0A1B2C3D4E5F60718 /* MailboxDispatchLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7108BF1A1B2C3D4E5F60718 /* MailboxDispatchLog.swift */; };
 		D710ABF0A1B2C3D4E5F60718 /* MailboxSurfaceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710ABF1A1B2C3D4E5F60718 /* MailboxSurfaceResolver.swift */; };
+		D710ADD0A1B2C3D4E5F60718 /* MailboxAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710ADD1A1B2C3D4E5F60718 /* MailboxAddress.swift */; };
 		D710CBF0A1B2C3D4E5F60718 /* MailboxOutboxWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710CBF1A1B2C3D4E5F60718 /* MailboxOutboxWatcher.swift */; };
 		D710EBF0A1B2C3D4E5F60718 /* MailboxDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710EBF1A1B2C3D4E5F60718 /* MailboxDispatcher.swift */; };
 		D7110BF0A1B2C3D4E5F60718 /* MailboxHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7110BF1A1B2C3D4E5F60718 /* MailboxHandler.swift */; };
@@ -652,6 +653,7 @@
 		D7108BF1A1B2C3D4E5F60718 /* MailboxDispatchLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxDispatchLog.swift; sourceTree = "<group>"; };
 		D7109BF1A1B2C3D4E5F60718 /* MailboxDispatchLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxDispatchLogTests.swift; sourceTree = "<group>"; };
 		D710ABF1A1B2C3D4E5F60718 /* MailboxSurfaceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxSurfaceResolver.swift; sourceTree = "<group>"; };
+		D710ADD1A1B2C3D4E5F60718 /* MailboxAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxAddress.swift; sourceTree = "<group>"; };
 		D710BBF1A1B2C3D4E5F60718 /* MailboxSurfaceResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxSurfaceResolverTests.swift; sourceTree = "<group>"; };
 		D710CBF1A1B2C3D4E5F60718 /* MailboxOutboxWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxOutboxWatcher.swift; sourceTree = "<group>"; };
 		D710DBF1A1B2C3D4E5F60718 /* MailboxOutboxWatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxOutboxWatcherTests.swift; sourceTree = "<group>"; };
@@ -930,6 +932,7 @@
 				D7106BF1A1B2C3D4E5F60718 /* MailboxEnvelope.swift */,
 				D7108BF1A1B2C3D4E5F60718 /* MailboxDispatchLog.swift */,
 				D710ABF1A1B2C3D4E5F60718 /* MailboxSurfaceResolver.swift */,
+				D710ADD1A1B2C3D4E5F60718 /* MailboxAddress.swift */,
 				D710CBF1A1B2C3D4E5F60718 /* MailboxOutboxWatcher.swift */,
 				D710EBF1A1B2C3D4E5F60718 /* MailboxDispatcher.swift */,
 				D7110BF1A1B2C3D4E5F60718 /* MailboxHandler.swift */,
@@ -1570,6 +1573,7 @@
 				D7106BF0A1B2C3D4E5F60718 /* MailboxEnvelope.swift in Sources */,
 				D7108BF0A1B2C3D4E5F60718 /* MailboxDispatchLog.swift in Sources */,
 				D710ABF0A1B2C3D4E5F60718 /* MailboxSurfaceResolver.swift in Sources */,
+				D710ADD0A1B2C3D4E5F60718 /* MailboxAddress.swift in Sources */,
 				D710CBF0A1B2C3D4E5F60718 /* MailboxOutboxWatcher.swift in Sources */,
 				D710EBF0A1B2C3D4E5F60718 /* MailboxDispatcher.swift in Sources */,
 				D7110BF0A1B2C3D4E5F60718 /* MailboxHandler.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4710,11 +4710,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     guard let name = metadata[MetadataKey.title] as? String, !name.isEmpty else {
                         continue
                     }
+                    // Stable identities (optional): the same `mailbox.*` keys
+                    // the per-workspace resolver reads, so global routing and
+                    // local delivery resolve a `to` identically.
+                    let address = metadata["mailbox.address"] as? String
+                    let role = metadata["mailbox.role"] as? String
                     result.append(
                         MailboxGlobalResolver.Surface(
                             workspaceId: workspace.id,
                             surfaceId: surfaceId,
-                            name: name
+                            name: name,
+                            address: address,
+                            role: role
                         )
                     )
                 }

--- a/Sources/Mailbox/MailboxAddress.swift
+++ b/Sources/Mailbox/MailboxAddress.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// A parsed mailbox recipient address.
+///
+/// The mailbox `to` field is an opaque string (envelope schema v1), so stable
+/// addressing rides entirely in how that string is *interpreted* — no schema
+/// change. A `to` value is one of three forms:
+///
+///   * `surface:<addr>` — match **only** surfaces whose `mailbox.address` equals
+///     `<addr>`. The stable, rename-proof handle an agent declares once.
+///   * `role:<name>` — match **only** surfaces whose `mailbox.role` equals
+///     `<name>`. Opt-in role addressing.
+///   * bare `<x>` — precedence resolution: `mailbox.address`, then `mailbox.role`,
+///     then `title`. Title is the fallback, so a send by display name keeps
+///     working unchanged for surfaces that declare no stable identity.
+///
+/// Both the cross-workspace resolver (`MailboxGlobalResolver`) and the
+/// per-workspace dispatcher (`MailboxSurfaceResolver` / `MailboxDispatcher`) run
+/// the same `MailboxMatcher.select` over this type, so global routing and local
+/// delivery always agree on who a `to` resolves to.
+enum MailboxAddress: Equatable {
+    /// `surface:<address>` — match `mailbox.address` exactly.
+    case surface(String)
+    /// `role:<name>` — match `mailbox.role` exactly.
+    case role(String)
+    /// Bare name — precedence: address, then role, then title.
+    case name(String)
+
+    static let surfacePrefix = "surface:"
+    static let rolePrefix = "role:"
+
+    /// Parse a raw `to` string. An empty value after a recognized prefix (e.g.
+    /// `surface:`) yields that scheme with an empty payload — which matches
+    /// nothing, the honest answer, rather than silently degrading to a bare name.
+    static func parse(_ raw: String) -> MailboxAddress {
+        if raw.hasPrefix(surfacePrefix) {
+            return .surface(String(raw.dropFirst(surfacePrefix.count)))
+        }
+        if raw.hasPrefix(rolePrefix) {
+            return .role(String(raw.dropFirst(rolePrefix.count)))
+        }
+        return .name(raw)
+    }
+}
+
+/// The keys a surface can be addressed by, in precedence order. Built from a
+/// surface's metadata at resolution time by whichever resolver is matching.
+struct MailboxIdentity: Equatable {
+    /// The `title` metadata — the display name and the inbox directory key.
+    let title: String?
+    /// `mailbox.address` — the stable, rename-proof handle.
+    let address: String?
+    /// `mailbox.role` — the opt-in role handle.
+    let role: String?
+
+    init(title: String?, address: String?, role: String?) {
+        self.title = MailboxIdentity.nonEmpty(title)
+        self.address = MailboxIdentity.nonEmpty(address)
+        self.role = MailboxIdentity.nonEmpty(role)
+    }
+
+    /// Treats empty strings as absent so a blank metadata value never matches a
+    /// blank `to` payload.
+    static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+/// Selects the subset of candidate surfaces that a parsed address resolves to,
+/// applying the address > role > title precedence for bare names. Pure and
+/// generic over the candidate type so both resolvers share one implementation.
+enum MailboxMatcher {
+
+    static func select<Item>(
+        _ address: MailboxAddress,
+        from items: [Item],
+        identity: (Item) -> MailboxIdentity
+    ) -> [Item] {
+        switch address {
+        case .surface(let target):
+            guard let target = MailboxIdentity.nonEmpty(target) else { return [] }
+            return items.filter { identity($0).address == target }
+        case .role(let target):
+            guard let target = MailboxIdentity.nonEmpty(target) else { return [] }
+            return items.filter { identity($0).role == target }
+        case .name(let target):
+            guard let target = MailboxIdentity.nonEmpty(target) else { return [] }
+            let byAddress = items.filter { identity($0).address == target }
+            if !byAddress.isEmpty { return byAddress }
+            let byRole = items.filter { identity($0).role == target }
+            if !byRole.isEmpty { return byRole }
+            return items.filter { identity($0).title == target }
+        }
+    }
+}

--- a/Sources/Mailbox/MailboxDispatcher.swift
+++ b/Sources/Mailbox/MailboxDispatcher.swift
@@ -312,7 +312,14 @@ final class MailboxDispatcher {
     ) -> [MailboxSurfaceResolver.SurfaceMetadata] {
         guard let to = envelope.to else { return [] }
         let all = resolver.surfacesWithMailboxMetadata()
-        return all.filter { $0.name == to }
+        // Same matcher the cross-workspace resolver uses, so local delivery
+        // agrees with global routing on who `to` resolves to (precedence
+        // address > role > title; `surface:`/`role:` qualifiers honored).
+        return MailboxMatcher.select(
+            MailboxAddress.parse(to),
+            from: all,
+            identity: { $0.identity }
+        )
     }
 
     // MARK: - Inbox copy

--- a/Sources/Mailbox/MailboxSurfaceResolver.swift
+++ b/Sources/Mailbox/MailboxSurfaceResolver.swift
@@ -36,6 +36,11 @@ struct MailboxSurfaceResolver {
     /// Returns all live surfaces whose `title` metadata equals `name`. In
     /// practice 0 or 1; we tolerate duplicates by returning a list and leave
     /// duplicate-warning logging to the dispatcher (design doc §2).
+    ///
+    /// Test-only helper: recipient routing resolves through
+    /// `MailboxMatcher.select` (see `MailboxDispatcher.resolveRecipients`),
+    /// which honors address > role > title precedence. This title-only lookup
+    /// has no production caller; it survives as a focused unit-test fixture.
     func surfaceIds(forName name: String) -> [UUID] {
         liveSurfaces().filter { surfaceId in
             surfaceName(for: surfaceId) == name

--- a/Sources/Mailbox/MailboxSurfaceResolver.swift
+++ b/Sources/Mailbox/MailboxSurfaceResolver.swift
@@ -103,6 +103,26 @@ struct MailboxSurfaceResolver {
             mailboxKeys["mailbox.retention_days"].flatMap { Int($0) }
         }
 
+        /// `mailbox.address` — the stable, rename-proof handle. Empty → nil.
+        var address: String? {
+            MailboxIdentity.nonEmpty(mailboxKeys["mailbox.address"])
+        }
+
+        /// `mailbox.role` — opt-in role handle. Empty → nil. Deliberately does
+        /// not fall back to the canonical `role` key: role addressing is
+        /// opt-in via `mailbox.role` so bare-name resolution stays identical
+        /// for the many surfaces that set `title` + canonical `role` but no
+        /// `mailbox.*` identity.
+        var role: String? {
+            MailboxIdentity.nonEmpty(mailboxKeys["mailbox.role"])
+        }
+
+        /// The address-precedence view (`title`/`address`/`role`) used by
+        /// `MailboxMatcher`.
+        var identity: MailboxIdentity {
+            MailboxIdentity(title: name, address: address, role: role)
+        }
+
         private func splitCommaSeparated(_ value: String?) -> [String] {
             guard let value, !value.isEmpty else { return [] }
             return value
@@ -144,11 +164,35 @@ struct MailboxSurfaceResolver {
 /// same-workspace duplicate names already behave.
 struct MailboxGlobalResolver {
 
-    /// One live, addressable surface anywhere in the instance.
+    /// One live, addressable surface anywhere in the instance. `name` is the
+    /// `title` (the display name and inbox key); `address`/`role` are the
+    /// optional stable identities a surface declares via `mailbox.address` /
+    /// `mailbox.role`. Defaulted to nil so existing call sites that only know
+    /// the title keep compiling.
     struct Surface: Equatable {
         let workspaceId: UUID
         let surfaceId: UUID
         let name: String
+        let address: String?
+        let role: String?
+
+        init(
+            workspaceId: UUID,
+            surfaceId: UUID,
+            name: String,
+            address: String? = nil,
+            role: String? = nil
+        ) {
+            self.workspaceId = workspaceId
+            self.surfaceId = surfaceId
+            self.name = name
+            self.address = MailboxIdentity.nonEmpty(address)
+            self.role = MailboxIdentity.nonEmpty(role)
+        }
+
+        var identity: MailboxIdentity {
+            MailboxIdentity(title: name, address: address, role: role)
+        }
     }
 
     enum Resolution: Equatable {
@@ -166,12 +210,21 @@ struct MailboxGlobalResolver {
     /// windows' workspaces.
     let surfaces: () -> [Surface]
 
+    /// `name` is the raw `to` string. It may be a bare name (precedence
+    /// address > role > title) or a qualifier form (`surface:<addr>` /
+    /// `role:<name>`) — see `MailboxAddress`. Workspace scoping is orthogonal:
+    /// the address selects *which surfaces*, the qualifier/local-first logic
+    /// selects *which workspace*.
     func resolve(
         name: String,
         senderWorkspaceId: UUID,
         workspaceQualifier: UUID? = nil
     ) -> Resolution {
-        let matches = surfaces().filter { $0.name == name }
+        let matches = MailboxMatcher.select(
+            MailboxAddress.parse(name),
+            from: surfaces(),
+            identity: { $0.identity }
+        )
 
         if let qualifier = workspaceQualifier {
             let scoped = matches.filter { $0.workspaceId == qualifier }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8764,7 +8764,11 @@ class TerminalController {
                         return .ok([
                             "resolution": "unresolved",
                             "candidates": self.mailboxCandidatePayload(
-                                surfaces.filter { $0.name == to }
+                                MailboxMatcher.select(
+                                    MailboxAddress.parse(to),
+                                    from: surfaces,
+                                    identity: { $0.identity }
+                                )
                             )
                         ])
                     }
@@ -8778,7 +8782,13 @@ class TerminalController {
                 workspaceQualifier: qualifierUUID
             )
 
-            let candidates = self.mailboxCandidatePayload(surfaces.filter { $0.name == to })
+            let candidates = self.mailboxCandidatePayload(
+                MailboxMatcher.select(
+                    MailboxAddress.parse(to),
+                    from: surfaces,
+                    identity: { $0.identity }
+                )
+            )
             switch resolution {
             case .unique(let workspaceId, let surfaceIds):
                 return .ok([

--- a/c11Tests/MailboxSurfaceResolverTests.swift
+++ b/c11Tests/MailboxSurfaceResolverTests.swift
@@ -140,6 +140,41 @@ final class MailboxSurfaceResolverTests: XCTestCase {
         let row = resolver.surfacesWithMailboxMetadata().first
         XCTAssertEqual(row?.mailboxKeys.keys.sorted(), ["mailbox.delivery"])
     }
+
+    // MARK: - Stable address / role identity (C11-143)
+
+    func testSurfaceMetadataExposesAddressAndRole() {
+        let s = seedSurface(
+            name: "builder-display",
+            extraMailbox: [
+                "mailbox.address": "01HSTABLEADDR",
+                "mailbox.role": "builder",
+            ]
+        )
+        let row = makeResolver(candidates: [s]).surfacesWithMailboxMetadata().first
+        XCTAssertEqual(row?.address, "01HSTABLEADDR")
+        XCTAssertEqual(row?.role, "builder")
+        XCTAssertEqual(
+            row?.identity,
+            MailboxIdentity(title: "builder-display", address: "01HSTABLEADDR", role: "builder")
+        )
+    }
+
+    func testSurfaceMetadataAddressAndRoleNilWhenUnset() {
+        let s = seedSurface(name: "title-only")
+        let row = makeResolver(candidates: [s]).surfacesWithMailboxMetadata().first
+        XCTAssertNil(row?.address)
+        XCTAssertNil(row?.role)
+        XCTAssertEqual(row?.identity, MailboxIdentity(title: "title-only", address: nil, role: nil))
+    }
+
+    func testSurfaceMetadataRoleDoesNotFallBackToCanonicalRole() {
+        // Canonical `role` is NOT a mailbox.* key — role addressing is opt-in
+        // via mailbox.role so bare-name resolution stays title-stable.
+        let s = seedSurface(name: "agent", extraMailbox: ["role": "reviewer"])
+        let row = makeResolver(candidates: [s]).surfacesWithMailboxMetadata().first
+        XCTAssertNil(row?.role)
+    }
 }
 
 /// Cross-workspace recipient resolution. Pure — drives `MailboxGlobalResolver`
@@ -152,6 +187,21 @@ final class MailboxGlobalResolverTests: XCTestCase {
 
     private func surface(_ ws: UUID, _ name: String) -> MailboxGlobalResolver.Surface {
         MailboxGlobalResolver.Surface(workspaceId: ws, surfaceId: UUID(), name: name)
+    }
+
+    private func surface(
+        _ ws: UUID,
+        title: String,
+        address: String? = nil,
+        role: String? = nil
+    ) -> MailboxGlobalResolver.Surface {
+        MailboxGlobalResolver.Surface(
+            workspaceId: ws,
+            surfaceId: UUID(),
+            name: title,
+            address: address,
+            role: role
+        )
     }
 
     private func resolver(_ surfaces: [MailboxGlobalResolver.Surface]) -> MailboxGlobalResolver {
@@ -236,5 +286,196 @@ final class MailboxGlobalResolverTests: XCTestCase {
             workspaceQualifier: wsC
         )
         XCTAssertEqual(resolution, .unresolved)
+    }
+
+    // MARK: - Stable address / role (C11-143)
+
+    func testBareNamePrefersAddressOverTitle() {
+        // wsA: one surface titled "delegator", a different one whose stable
+        // address is "delegator". A bare send to "delegator" must hit the
+        // address holder (precedence address > title), not the title holder.
+        let titled = surface(wsA, title: "delegator")
+        let addressed = surface(wsA, title: "delegator-display", address: "delegator")
+        let resolution = resolver([titled, addressed]).resolve(
+            name: "delegator",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [addressed.surfaceId]))
+    }
+
+    func testBareNamePrefersRoleOverTitle() {
+        let titled = surface(wsA, title: "builder")
+        let roled = surface(wsA, title: "builder-display", role: "builder")
+        let resolution = resolver([titled, roled]).resolve(
+            name: "builder",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [roled.surfaceId]))
+    }
+
+    func testBareNameAddressBeatsRole() {
+        let roled = surface(wsA, title: "r-display", role: "lead")
+        let addressed = surface(wsA, title: "a-display", address: "lead")
+        let resolution = resolver([roled, addressed]).resolve(
+            name: "lead",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [addressed.surfaceId]))
+    }
+
+    func testBareNameFallsBackToTitleWhenNoStableIdentity() {
+        // Back-compat: only titles set → identical to pre-C11-143 behavior.
+        let a = surface(wsA, title: "watcher")
+        let resolution = resolver([a]).resolve(name: "watcher", senderWorkspaceId: wsA)
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [a.surfaceId]))
+    }
+
+    func testSurfaceQualifierMatchesAddressOnly() {
+        // `surface:<addr>` resolves only by mailbox.address — a surface merely
+        // titled the same is NOT matched.
+        let titled = surface(wsA, title: "addr-1")
+        let addressed = surface(wsA, title: "real", address: "addr-1")
+        let resolution = resolver([titled, addressed]).resolve(
+            name: "surface:addr-1",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [addressed.surfaceId]))
+    }
+
+    func testRoleQualifierMatchesRoleOnly() {
+        let titled = surface(wsA, title: "delegator")
+        let roled = surface(wsA, title: "worker", role: "delegator")
+        let resolution = resolver([titled, roled]).resolve(
+            name: "role:delegator",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [roled.surfaceId]))
+    }
+
+    func testSurfaceQualifierAcrossWorkspaceIsAmbiguousWhenSplit() {
+        // Address routing still honors local-first / ambiguity. Two remote
+        // workspaces each hold the address → ambiguous (no local match).
+        let b = surface(wsB, title: "b", address: "shared-addr")
+        let c = surface(wsC, title: "c", address: "shared-addr")
+        let resolution = resolver([b, c]).resolve(
+            name: "surface:shared-addr",
+            senderWorkspaceId: wsA
+        )
+        guard case let .ambiguous(candidates) = resolution else {
+            return XCTFail("expected ambiguous, got \(resolution)")
+        }
+        XCTAssertEqual(Set(candidates.map(\.workspaceId)), [wsB, wsC])
+    }
+
+    func testRoleAddressLocalFirstWins() {
+        // Same role in local and remote workspace → local wins, unchanged
+        // local-first contract.
+        let local = surface(wsA, title: "a", role: "delegator")
+        let remote = surface(wsB, title: "b", role: "delegator")
+        let resolution = resolver([local, remote]).resolve(
+            name: "role:delegator",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unique(workspaceId: wsA, surfaceIds: [local.surfaceId]))
+    }
+
+    func testUnknownStableAddressIsUnresolved() {
+        let a = surface(wsA, title: "real", address: "addr-1")
+        let resolution = resolver([a]).resolve(
+            name: "surface:nope",
+            senderWorkspaceId: wsA
+        )
+        XCTAssertEqual(resolution, .unresolved)
+    }
+}
+
+/// Parser + precedence selector for stable addressing (C11-143). Pure — no
+/// store, no app.
+final class MailboxAddressTests: XCTestCase {
+
+    // MARK: - parse
+
+    func testParseSurfaceQualifier() {
+        XCTAssertEqual(MailboxAddress.parse("surface:01HABC"), .surface("01HABC"))
+    }
+
+    func testParseRoleQualifier() {
+        XCTAssertEqual(MailboxAddress.parse("role:delegator"), .role("delegator"))
+    }
+
+    func testParseBareName() {
+        XCTAssertEqual(MailboxAddress.parse("watcher"), .name("watcher"))
+    }
+
+    func testParseEmptyPayloadAfterPrefixIsHonored() {
+        // `surface:` with nothing after it parses as a surface address with an
+        // empty payload — which matches nothing, rather than degrading to a
+        // bare name that could match a real title.
+        XCTAssertEqual(MailboxAddress.parse("surface:"), .surface(""))
+        XCTAssertEqual(MailboxAddress.parse("role:"), .role(""))
+    }
+
+    func testParseNameContainingColonIsBareUnlessKnownScheme() {
+        XCTAssertEqual(MailboxAddress.parse("ci:status"), .name("ci:status"))
+    }
+
+    // MARK: - matcher precedence
+
+    private func id(_ title: String?, address: String? = nil, role: String? = nil) -> MailboxIdentity {
+        MailboxIdentity(title: title, address: address, role: role)
+    }
+
+    private func select(_ raw: String, _ ids: [MailboxIdentity]) -> [MailboxIdentity] {
+        MailboxMatcher.select(MailboxAddress.parse(raw), from: ids, identity: { $0 })
+    }
+
+    func testMatcherBareNamePrecedenceAddressFirst() {
+        let titled = id("x")
+        let addressed = id("display", address: "x")
+        let roled = id("display2", role: "x")
+        XCTAssertEqual(select("x", [titled, addressed, roled]), [addressed])
+    }
+
+    func testMatcherBareNameRoleBeforeTitle() {
+        let titled = id("x")
+        let roled = id("display", role: "x")
+        XCTAssertEqual(select("x", [titled, roled]), [roled])
+    }
+
+    func testMatcherBareNameTitleFallback() {
+        let titled = id("x")
+        XCTAssertEqual(select("x", [titled]), [titled])
+    }
+
+    func testMatcherSurfaceQualifierIgnoresTitleAndRole() {
+        let titled = id("addr")
+        let roled = id("display", role: "addr")
+        let addressed = id("display2", address: "addr")
+        XCTAssertEqual(select("surface:addr", [titled, roled, addressed]), [addressed])
+    }
+
+    func testMatcherRoleQualifierIgnoresTitleAndAddress() {
+        let titled = id("dele")
+        let addressed = id("display", address: "dele")
+        let roled = id("display2", role: "dele")
+        XCTAssertEqual(select("role:dele", [titled, addressed, roled]), [roled])
+    }
+
+    func testMatcherEmptyPayloadMatchesNothing() {
+        let addressed = id("display", address: "")
+        XCTAssertEqual(select("surface:", [addressed, id("x")]), [])
+    }
+
+    func testMatcherFansOutToAllSameAddress() {
+        let a = id("d1", address: "shared")
+        let b = id("d2", address: "shared")
+        XCTAssertEqual(select("surface:shared", [a, b]), [a, b])
+    }
+
+    func testMatcherBlankIdentityNeverMatchesBlankQuery() {
+        // A surface with an empty title/address is normalized to nil and must
+        // not match an (also empty) query.
+        let blank = id("", address: nil, role: nil)
+        XCTAssertEqual(select("surface:", [blank]), [])
     }
 }

--- a/docs/c11-mailbox-guide.md
+++ b/docs/c11-mailbox-guide.md
@@ -95,6 +95,8 @@ c11 mailbox send --to watcher                   --body "…"   # bare: address �
 
 These `surface:` / `role:` forms select *which surfaces* match; the workspace `--to-workspace` qualifier (below) is an orthogonal axis selecting *which workspace*. The envelope's `to` field stays an opaque string — no schema change — so the framed block a recipient sees carries whatever handle the sender used.
 
+`surface:` and `role:` are **reserved leading tokens** in `--to`: a value beginning with either is always parsed as that qualifier, never as a title. So a surface whose title literally starts with `surface:` or `role:` is not reachable by a bare `--to` (address it by its `mailbox.address`/`mailbox.role` instead). Any other colon stays part of a bare name — `--to ci:status` is a plain name.
+
 **Back-compat.** A surface with only a `title` is addressable by that title exactly as before. `mailbox.address` / `mailbox.role` are additive; the inbox directory is still keyed on the recipient's title.
 
 ---

--- a/docs/c11-mailbox-guide.md
+++ b/docs/c11-mailbox-guide.md
@@ -28,7 +28,7 @@ flowchart LR
 Two facts to internalize:
 
 1. **The filesystem is the contract.** The CLI is convenience over file I/O. Any process that can write a JSON file to a directory can send a message; any process that can list a directory can receive one. The `tests_v2/test_mailbox_parity.py` test asserts CLI sends and raw file writes produce byte-identical envelopes.
-2. **Surface name is the address.** The dispatcher resolves `to` by matching against each live surface's title (set with `c11 set-title` / `c11 rename-tab`). No title means unaddressable.
+2. **A surface is addressed by a stable handle, falling back to its name.** The resolver matches `to` with precedence **address → role → title** (see [Addressing](#addressing-stable-handles-and-the-title-fallback) below). A surface is addressable as long as it has a `title` (set with `c11 set-title` / `c11 rename-tab`); the optional `mailbox.address` / `mailbox.role` keys give it a rename-proof handle on top.
 
 ---
 
@@ -67,6 +67,38 @@ If `mailbox.delivery` is not set on the recipient, the envelope still lands in `
 
 ---
 
+## Addressing: stable handles and the title fallback
+
+A `--to` value resolves against three per-surface keys, in precedence order:
+
+| Precedence | Key | Set by | Notes |
+|-----------|-----|--------|-------|
+| 1 | `mailbox.address` | the surface, once at orientation | Stable, rename-proof handle. Survives every later `set-title` / `rename-tab`. |
+| 2 | `mailbox.role` | the surface, opt-in | Reach a surface by function (`delegator`, `orchestrator`). Only `mailbox.role` is consulted — the canonical `role` key is not. |
+| 3 | `title` | `set-title` / `rename-tab` | Display name. The fallback, so a bare-name send keeps working for surfaces that declare no stable identity. |
+
+**Why this exists.** The title is mutable, and the c11 orientation convention has every agent rename its tab as its first action. If peers address each other by title, the bus silently re-partitions the moment anyone renames. Declaring a `mailbox.address` at orientation gives a surface an identity that does not move when its display name does.
+
+```bash
+# Recipient, once at orientation:
+c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.address --value "delegator-c11-143" --type string
+c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.role    --value "delegator"         --type string  # optional
+```
+
+**Bare name vs qualifier forms.** A bare `--to <x>` walks the precedence chain (address, then role, then title). To target a specific key unambiguously — never falling back to the title — use a qualifier form:
+
+```bash
+c11 mailbox send --to surface:delegator-c11-143 --body "…"   # matches mailbox.address ONLY
+c11 mailbox send --to role:delegator            --body "…"   # matches mailbox.role ONLY
+c11 mailbox send --to watcher                   --body "…"   # bare: address → role → title
+```
+
+These `surface:` / `role:` forms select *which surfaces* match; the workspace `--to-workspace` qualifier (below) is an orthogonal axis selecting *which workspace*. The envelope's `to` field stays an opaque string — no schema change — so the framed block a recipient sees carries whatever handle the sender used.
+
+**Back-compat.** A surface with only a `title` is addressable by that title exactly as before. `mailbox.address` / `mailbox.role` are additive; the inbox directory is still keyed on the recipient's title.
+
+---
+
 ## Send flow
 
 ```mermaid
@@ -80,7 +112,7 @@ sequenceDiagram
     Note over B: framed <c11-msg> appears in PTY<br/>(or sits in inbox until drained)
 ```
 
-Under the hood the dispatcher validates the envelope against schema v1, resolves the recipient by surface title, copies into the recipient's inbox, and runs each registered delivery handler. Every state transition appends to `_dispatch.log` (NDJSON). Malformed envelopes land in `_rejected/` with a `.err` sidecar describing what failed. See [Internals: full send sequence](#internals-full-send-sequence) at the bottom for the complete step-by-step.
+Under the hood the dispatcher validates the envelope against schema v1, resolves the recipient by the address → role → title precedence (see [Addressing](#addressing-stable-handles-and-the-title-fallback)), copies into the recipient's inbox, and runs each registered delivery handler. Every state transition appends to `_dispatch.log` (NDJSON). Malformed envelopes land in `_rejected/` with a `.err` sidecar describing what failed. See [Internals: full send sequence](#internals-full-send-sequence) at the bottom for the complete step-by-step.
 
 ### Two equivalent send paths
 
@@ -100,7 +132,7 @@ Send flags accepted by the CLI:
 
 | Flag                  | Purpose                                                            |
 |-----------------------|--------------------------------------------------------------------|
-| `--to <surface>`      | Recipient surface name, in any workspace. Required in Stage 2 (topic-only rejected). |
+| `--to <surface>`      | Recipient handle, in any workspace. Bare name resolves address → role → title; `surface:<addr>` / `role:<name>` target one key. Required in Stage 2 (topic-only rejected). |
 | `--to-workspace <ref>`| Disambiguate a name that exists in more than one workspace. A workspace UUID or `workspace:*` ref. |
 | `--topic <token>`     | Dotted topic. Stored on the envelope; not used for routing yet.    |
 | `--body <text>`       | Inline body, ≤ 4096 bytes UTF-8.                                   |

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -464,9 +464,37 @@ the sub-agent's PR transitively requires another open PR to land first.
 
 ## Inter-agent messaging (mailbox)
 
-**c11 ships a mailbox primitive that routes across all workspaces.** Any agent in a surface can `c11 mailbox send --to <name>`; c11 resolves the recipient by surface name across every workspace in the instance, delivers into the recipient's inbox, and — for stdin-delivery recipients — writes a framed `<c11-msg>` block into the PTY. A recipient that matches no live surface is **rejected with a non-zero exit**, never silently dropped.
+**c11 ships a mailbox primitive that routes across all workspaces.** Any agent in a surface can `c11 mailbox send --to <name>`; c11 resolves the recipient across every workspace in the instance, delivers into the recipient's inbox, and — for stdin-delivery recipients — writes a framed `<c11-msg>` block into the PTY. A recipient that matches no live surface is **rejected with a non-zero exit**, never silently dropped.
 
 This section is the agent-facing quick-reference. The full guide (filesystem layout, sequence diagrams, schema reference, dispatch log shape, patterns, anti-patterns, Stage 2 limits) lives in [`docs/c11-mailbox-guide.md`](../../docs/c11-mailbox-guide.md).
+
+### Stable addressing — declare a `mailbox.address` once at orientation
+
+A `--to` value resolves with precedence **address → role → title**:
+
+1. `mailbox.address` — a stable handle the surface declares for itself.
+2. `mailbox.role` — an opt-in role handle (e.g. `delegator`, `orchestrator`).
+3. `title` — the display name; the fallback so a bare-name send keeps working.
+
+The title is **mutable** — the c11 orientation rule has you rename your tab as your first action, and operators rename tabs freely. If peers address you by title, every rename silently re-partitions the bus. So **declare a stable `mailbox.address` at orientation, before anyone needs to reach you**, and tell peers to send to that — it survives every later tab-rename:
+
+```bash
+# At orientation, once. Use a value that won't collide — your ULID, your
+# ticket id, or a role-scoped handle.
+c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.address --value "delegator-c11-143" --type string
+# Optional: also claim a role so peers can reach you by function.
+c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.role --value "delegator" --type string
+```
+
+Address a peer by its stable handle with the qualifier forms (which match **only** that key, never the title):
+
+```bash
+c11 mailbox send --to surface:delegator-c11-143 --body "PR open at #259"   # → mailbox.address
+c11 mailbox send --to role:orchestrator --body "blocked on a decision"     # → mailbox.role
+c11 mailbox send --to watcher --body "build green"                         # bare: address→role→title
+```
+
+Role addressing is opt-in: a surface is reachable by `role:<name>` only if it set `mailbox.role` (the canonical `role` key is not consulted, so bare-name sends to title-only surfaces are unchanged). Nothing breaks for surfaces that only set a title — they remain addressable by name exactly as before.
 
 ### The framed block you'll see in your PTY
 


### PR DESCRIPTION
## C11-143 — Mailbox stable addressing

Decouples a mailbox recipient's *address* from its mutable `title`. Previously a recipient was addressed solely by `title` — which the c11 orientation convention has every agent rename as its first action — so the bus silently re-partitioned the moment an agent renamed itself. This is the unanimous #1 mutation from the nine-instance Trident review of the mailbox feature.

### What changed
- **New shared addressing model** (`Sources/Mailbox/MailboxAddress.swift`): `MailboxAddress` parses a `to` string into `surface:<addr>` / `role:<name>` / bare-name; `MailboxMatcher.select` applies precedence **address → role → title**. Pure, generic, one tested place.
- **Both resolution layers route through the same matcher** — `MailboxGlobalResolver` (cross-workspace, CLI side via `mailbox.resolve`) and `MailboxDispatcher.resolveRecipients` (per-workspace, local delivery) — so global routing and local delivery can never disagree on who a `to` resolves to.
- `mailboxAddressableSurfaces()` and `v2MailboxResolve` carry/honor the new `mailbox.address` / `mailbox.role` keys (candidate payloads now reflect the matched set).
- **Skill + guide**: `skills/c11/SKILL.md` gains a "Stable addressing" section (declare `mailbox.address` once at orientation; `surface:`/`role:` forms); `docs/c11-mailbox-guide.md` gets a dedicated Addressing section with the precedence table. Installed skill synced via `scripts/sync-installed-skills.sh c11`.

### Precedence rule
A bare `--to <x>` resolves `mailbox.address`, then `mailbox.role`, then `title` (title is the fallback). The qualifier forms `--to surface:<addr>` / `--to role:<name>` match **only** that key, never the title. `surface:`/`role:` are reserved leading tokens; any other colon stays part of a bare name.

### Scope guards honored
- **No envelope schema change** — `to` stays an opaque string.
- **Inbox keying unchanged** (still title-keyed) — identity, not a routing rewrite.
- **Local-first / ambiguity routing unchanged.**
- **Back-compat**: role addressing is opt-in via `mailbox.role` (the canonical `role` key is *not* consulted), so bare-name resolution is identical for the many surfaces that set title + canonical role today; a title-only send works exactly as before.

### Tests
44 mailbox logic tests green under `c11-logic` (`MailboxAddressTests` for parse + matcher; `MailboxSurfaceResolverTests` / `MailboxGlobalResolverTests` extended for precedence, qualifier isolation, preserved local-first/ambiguity, and title fallback). CLI target builds clean.

### Live validation (tagged `c11-143` build, prod c11 untouched)
- Send `--to surface:addr-stable-143` before rename → delivered (stdin handler ok).
- Rename recipient title, send the **same** stable handle → still resolves and delivers. **Acceptance met.**
- Negative control: old title now unresolved (exit 1). Title fallback (new title) still resolves. `role:` addressing resolves; unknown role unresolved.

### Review
Headless `lattice code-review`: **PASS**. Two MINOR notes addressed in this branch (reserved-token doc line; test-only-helper marker); skill-sync note already done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
