### PR TITLE
Mailbox: prompt-gated stdin delivery — buffer while busy, flush at prompt (C11-144)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -282,6 +282,8 @@
 		D710EBF0A1B2C3D4E5F60718 /* MailboxDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710EBF1A1B2C3D4E5F60718 /* MailboxDispatcher.swift */; };
 		D7110BF0A1B2C3D4E5F60718 /* MailboxHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7110BF1A1B2C3D4E5F60718 /* MailboxHandler.swift */; };
 		D7111BF0A1B2C3D4E5F60718 /* StdinMailboxHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7111BF1A1B2C3D4E5F60718 /* StdinMailboxHandler.swift */; };
+		C11144A0B0C0D0E0F0010002 /* MailboxStdinBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11144A0B0C0D0E0F0010001 /* MailboxStdinBuffer.swift */; };
+		C11144A0B0C0D0E0F0010004 /* MailboxStdinBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11144A0B0C0D0E0F0010003 /* MailboxStdinBufferTests.swift */; };
 		D7200BF0A1B2C3D4E5F60719 /* MailboxLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7100BF1A1B2C3D4E5F60718 /* MailboxLayout.swift */; };
 		D7202BF0A1B2C3D4E5F60719 /* MailboxIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7102BF1A1B2C3D4E5F60718 /* MailboxIO.swift */; };
 		D7203BF0A1B2C3D4E5F60719 /* MailboxULID.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7103BF1A1B2C3D4E5F60718 /* MailboxULID.swift */; };
@@ -659,6 +661,8 @@
 		D710FBF1A1B2C3D4E5F60718 /* MailboxDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxDispatcherTests.swift; sourceTree = "<group>"; };
 		D7110BF1A1B2C3D4E5F60718 /* MailboxHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxHandler.swift; sourceTree = "<group>"; };
 		D7111BF1A1B2C3D4E5F60718 /* StdinMailboxHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/StdinMailboxHandler.swift; sourceTree = "<group>"; };
+		C11144A0B0C0D0E0F0010001 /* MailboxStdinBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxStdinBuffer.swift; sourceTree = "<group>"; };
+		C11144A0B0C0D0E0F0010003 /* MailboxStdinBufferTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxStdinBufferTests.swift; sourceTree = "<group>"; };
 		D7112BF1A1B2C3D4E5F60718 /* StdinHandlerFormattingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StdinHandlerFormattingTests.swift; sourceTree = "<group>"; };
 		D7113BF1A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxDispatcherGCTests.swift; sourceTree = "<group>"; };
 		D7C11251A1B2C3D4E5F60718 /* SurfaceLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfaceLifecycle.swift; sourceTree = "<group>"; };
@@ -934,6 +938,7 @@
 				D710EBF1A1B2C3D4E5F60718 /* MailboxDispatcher.swift */,
 				D7110BF1A1B2C3D4E5F60718 /* MailboxHandler.swift */,
 				D7111BF1A1B2C3D4E5F60718 /* StdinMailboxHandler.swift */,
+				C11144A0B0C0D0E0F0010001 /* MailboxStdinBuffer.swift */,
 				A5008F12 /* SurfaceTitleBarView.swift */,
 				A5008F22 /* TitleFormatting.swift */,
 				A5001225 /* SocketControlSettings.swift */,
@@ -1145,6 +1150,7 @@
 				D710BBF1A1B2C3D4E5F60718 /* MailboxSurfaceResolverTests.swift */,
 				D710DBF1A1B2C3D4E5F60718 /* MailboxOutboxWatcherTests.swift */,
 				D710FBF1A1B2C3D4E5F60718 /* MailboxDispatcherTests.swift */,
+				C11144A0B0C0D0E0F0010003 /* MailboxStdinBufferTests.swift */,
 				D7112BF1A1B2C3D4E5F60718 /* StdinHandlerFormattingTests.swift */,
 				D7113BF1A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift */,
 				3BF9D5EC78046EDA9B54AC68 /* DefaultAgentConfigTests.swift */,
@@ -1422,6 +1428,7 @@
 				69DA05D60B975E4924059EE8 /* LegacyPrefsMigrationGateTests.swift in Sources */,
 				9267DDD60A813FBEF3F59F99 /* MailboxDispatcherGCTests.swift in Sources */,
 				6F3E766AEE928B3A98ADC170 /* MailboxDispatcherTests.swift in Sources */,
+				C11144A0B0C0D0E0F0010004 /* MailboxStdinBufferTests.swift in Sources */,
 				DBF8F51099CEF804B8023B5D /* MailboxDispatchLogTests.swift in Sources */,
 				8C1F311B2760FEE15B8DFD2F /* MailboxEnvelopeValidationTests.swift in Sources */,
 				BAE105919F0262DEA7D0DE0C /* MailboxIOTests.swift in Sources */,
@@ -1574,6 +1581,7 @@
 				D710EBF0A1B2C3D4E5F60718 /* MailboxDispatcher.swift in Sources */,
 				D7110BF0A1B2C3D4E5F60718 /* MailboxHandler.swift in Sources */,
 				D7111BF0A1B2C3D4E5F60718 /* StdinMailboxHandler.swift in Sources */,
+				C11144A0B0C0D0E0F0010002 /* MailboxStdinBuffer.swift in Sources */,
 				A5008F11 /* SurfaceTitleBarView.swift in Sources */,
 				A5008F21 /* TitleFormatting.swift in Sources */,
 				A5001226 /* SocketControlSettings.swift in Sources */,

--- a/Sources/Mailbox/MailboxDispatchLog.swift
+++ b/Sources/Mailbox/MailboxDispatchLog.swift
@@ -71,10 +71,24 @@ final class MailboxDispatchLog {
     ///   same as "real PTY write errno 5"; Stage 2 does not propagate
     ///   PTY write errors (follow-up; see plan risks).
     ///
+    /// C11-144 delivery-safety lifecycle (all emitted as `handler` events with
+    /// handler="stdin" so a buffered message's full path is visible in
+    /// `c11 mailbox trace <id>` — never a silent drop):
+    /// - `buffered`: recipient shell was busy (`commandRunning`/`unknown`);
+    ///   the framed block was queued to flush at the next prompt.
+    /// - `flushed`: a previously-buffered block was injected once the shell
+    ///   returned to `promptIdle`.
+    /// - `expired`: a buffered block aged past the freshness window before the
+    ///   shell went idle; dropped from the buffer (the filesystem inbox +
+    ///   `recv --drain` floor still holds it).
+    /// - `evicted`: a buffered block was dropped because the per-surface buffer
+    ///   cap was exceeded (oldest-first; inbox floor still holds it).
+    ///
     /// The previously-declared `.epipe` variant was never produced and
     /// was removed in review cycle 1 rework.
     enum HandlerOutcome: String {
         case ok, timeout, eio, closed
+        case buffered, flushed, expired, evicted
     }
 
     // MARK: - File I/O

--- a/Sources/Mailbox/MailboxDispatcher.swift
+++ b/Sources/Mailbox/MailboxDispatcher.swift
@@ -147,6 +147,31 @@ final class MailboxDispatcher {
         gcTimer = nil
     }
 
+    /// C11-144: append a `handler` event for a buffered-stdin lifecycle step
+    /// (`flushed`/`expired`/`evicted`) that happens *outside* the normal
+    /// handler-invocation path — i.e. when the recipient shell transitions back
+    /// to a prompt and `Workspace` flushes its buffer, or when an entry is
+    /// dropped. The `buffered` event itself is logged inline by the dispatcher
+    /// when the handler returns `.buffered`. Routed through the log's own queue;
+    /// safe to call from the main actor (the log append is async).
+    func logStdinLifecycle(
+        id: String,
+        recipient: String,
+        outcome: MailboxDispatchLog.HandlerOutcome,
+        bytes: Int? = nil
+    ) {
+        log.append(
+            .handler(
+                id: id,
+                recipient: recipient,
+                handler: "stdin",
+                outcome: outcome,
+                bytes: bytes,
+                elapsedMs: nil
+            )
+        )
+    }
+
     // MARK: - Stale-tmp GC
 
     /// Deletes dot-prefixed `.tmp` files in `_outbox/` older than

--- a/Sources/Mailbox/MailboxStdinBuffer.swift
+++ b/Sources/Mailbox/MailboxStdinBuffer.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Per-surface buffer + gating decision for `stdin` mailbox delivery (C11-144).
+///
+/// Pasting a framed `<c11-msg>` block straight into a recipient PTY is only
+/// safe when that PTY is sitting at a shell prompt. If a foreground command is
+/// running (a build, `vim`, a REPL — anything in raw or cooked mode that owns
+/// stdin), the paste corrupts that program's input stream. This type gates the
+/// push on c11's already-tracked `PanelShellActivityState`:
+///
+///   - `.promptIdle`     → inject now (safe).
+///   - `.commandRunning` → buffer; flush when the shell returns to the prompt.
+///   - `.unknown`        → buffer (conservative; never corrupt on a guess).
+///
+/// **Doorbell, not delivery.** The dispatcher always copies the envelope into
+/// the recipient's filesystem inbox *before* invoking this handler, and the
+/// receiver-pull cadence (`c11 mailbox recv --drain` at turn boundaries) is the
+/// durable floor. So buffered entries that never flush — e.g. a long-lived
+/// agent TUI that stays `.commandRunning` for hours and is delivered via pull
+/// instead — are not lost. That floor is what lets the freshness window below
+/// drop stale entries rather than dump them onto a bare shell.
+///
+/// **Pure and clock-injected.** No PTY, no `Workspace` instance, no ambient
+/// clock — `now` is supplied by the caller — so the gating/buffer/flush logic
+/// is deterministically unit-testable without a live terminal. All mutation in
+/// production happens on the main actor (the dispatcher's writer hop and the
+/// shell-state transition both land on main), so this is a plain value type
+/// with no internal locking.
+struct MailboxStdinBuffer {
+
+    /// One queued framed block awaiting a safe moment to inject. `block` is the
+    /// fully-formatted, XML-escaped `<c11-msg>` string; `id`/`recipientName`
+    /// are carried so the flush path can log a coherent `handler` event for
+    /// `c11 mailbox trace`.
+    struct Entry: Equatable {
+        let id: String
+        let recipientName: String
+        let block: String
+        let bufferedAt: Date
+    }
+
+    enum Decision: Equatable {
+        case injectNow
+        case buffer
+    }
+
+    /// Result of draining one surface's queue at a `→ .promptIdle` transition.
+    struct FlushResult: Equatable {
+        /// Entries young enough to inject, in FIFO order.
+        var fresh: [Entry]
+        /// Entries older than `freshnessWindow` — dropped from the buffer (the
+        /// inbox + `recv --drain` floor still owns them) rather than injected.
+        var expired: [Entry]
+    }
+
+    /// Max queued entries per surface. A broadcast storm into a busy surface
+    /// can't grow the buffer without bound; the oldest is evicted (and the
+    /// inbox floor still holds it). Generous: real handoff traffic is sparse.
+    static let perSurfaceCap = 64
+
+    /// Entries older than this at flush time are expired, not injected.
+    ///
+    /// This is the mechanism that separates the two `.commandRunning` regimes:
+    /// a build or `vim` edit runs for seconds-to-minutes, so its buffered
+    /// messages flush cleanly when it ends; an agent TUI runs for hours, so by
+    /// the time it exits to a bare shell its buffered messages are stale and
+    /// drop instead of pasting `<c11-msg>` junk onto the prompt (they were
+    /// already delivered via the pull floor). 10 minutes comfortably covers
+    /// normal foreground commands while staying well under an agent session.
+    static let freshnessWindow: TimeInterval = 600
+
+    private var queues: [UUID: [Entry]] = [:]
+
+    /// Inject-now vs buffer, purely from the recipient's shell activity state.
+    static func decide(state: Workspace.PanelShellActivityState) -> Decision {
+        switch state {
+        case .promptIdle:
+            return .injectNow
+        case .commandRunning, .unknown:
+            return .buffer
+        }
+    }
+
+    /// Append an entry to a surface's FIFO queue. Returns the evicted entry if
+    /// the per-surface cap was exceeded (oldest dropped), else `nil`.
+    @discardableResult
+    mutating func enqueue(surfaceId: UUID, entry: Entry) -> Entry? {
+        var queue = queues[surfaceId] ?? []
+        queue.append(entry)
+        var evicted: Entry?
+        if queue.count > Self.perSurfaceCap {
+            evicted = queue.removeFirst()
+        }
+        queues[surfaceId] = queue
+        return evicted
+    }
+
+    /// Remove and partition a surface's queue for flushing at a
+    /// `→ .promptIdle` transition. Fresh entries (FIFO) are for injection;
+    /// expired entries are for drop+log. Clears the surface's queue entirely.
+    mutating func drainForFlush(surfaceId: UUID, now: Date) -> FlushResult {
+        guard let queue = queues[surfaceId], !queue.isEmpty else {
+            return FlushResult(fresh: [], expired: [])
+        }
+        queues.removeValue(forKey: surfaceId)
+        var fresh: [Entry] = []
+        var expired: [Entry] = []
+        for entry in queue {
+            if now.timeIntervalSince(entry.bufferedAt) <= Self.freshnessWindow {
+                fresh.append(entry)
+            } else {
+                expired.append(entry)
+            }
+        }
+        return FlushResult(fresh: fresh, expired: expired)
+    }
+
+    /// Drop a surface's queue outright (surface closed). Returns any entries
+    /// that were pending so the caller can log the drop; the inbox floor still
+    /// holds them for `recv --drain`.
+    @discardableResult
+    mutating func removeSurface(_ surfaceId: UUID) -> [Entry] {
+        queues.removeValue(forKey: surfaceId) ?? []
+    }
+
+    /// Prune queues for surfaces no longer present (mirrors the metadata prune
+    /// the socket fast-path runs).
+    mutating func retainOnly(surfaceIds: Set<UUID>) {
+        queues = queues.filter { surfaceIds.contains($0.key) }
+    }
+
+    func pendingCount(surfaceId: UUID) -> Int {
+        queues[surfaceId]?.count ?? 0
+    }
+
+    var isEmpty: Bool {
+        queues.values.allSatisfy { $0.isEmpty }
+    }
+}

--- a/Sources/Mailbox/StdinMailboxHandler.swift
+++ b/Sources/Mailbox/StdinMailboxHandler.swift
@@ -43,10 +43,22 @@ final class StdinMailboxHandler: MailboxHandler {
     /// writer (see plan risks, Stage 2 P0 #5/#6). Until that lands,
     /// "real PTY write failure → dispatcher log" is not a Stage 2
     /// contract.
-    typealias Writer = @MainActor (_ surfaceId: UUID, _ bytes: String) -> WriteOutcome
+    /// The envelope `id` and resolved `recipientName` are threaded through so
+    /// the writer can buffer the block (C11-144) and the flush path can later
+    /// log a coherent `handler` event keyed on the same id/recipient.
+    typealias Writer = @MainActor (
+        _ surfaceId: UUID,
+        _ envelopeId: String,
+        _ recipientName: String,
+        _ bytes: String
+    ) -> WriteOutcome
 
     enum WriteOutcome: Equatable {
         case ok(bytes: Int)
+        /// C11-144: recipient shell was busy, so the block was queued to flush
+        /// at the next prompt instead of injected now. Still a delivery, logged
+        /// as `buffered` rather than dropped.
+        case buffered(bytes: Int)
         case surfaceNotFound
         case surfaceNotTerminal
     }
@@ -87,14 +99,17 @@ final class StdinMailboxHandler: MailboxHandler {
                 Int(Date().timeIntervalSince(start) * 1000)
             }
 
+            let envelopeId = envelope.id
             Task {
                 let outcome: WriteOutcome = await MainActor.run {
-                    writer(surfaceId, block)
+                    writer(surfaceId, envelopeId, surfaceName, block)
                 }
                 let result: MailboxDispatcher.HandlerInvocationResult
                 switch outcome {
                 case .ok(let bytes):
                     result = .init(outcome: .ok, bytes: bytes, elapsedMs: elapsedMs())
+                case .buffered(let bytes):
+                    result = .init(outcome: .buffered, bytes: bytes, elapsedMs: elapsedMs())
                 case .surfaceNotFound, .surfaceNotTerminal:
                     result = .init(outcome: .closed, bytes: 0, elapsedMs: elapsedMs())
                 }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5357,6 +5357,10 @@ final class Workspace: Identifiable, ObservableObject {
         return formatter
     }()
     private var panelShellActivityStates: [UUID: PanelShellActivityState] = [:]
+    /// C11-144: per-surface queue of framed `<c11-msg>` blocks that arrived
+    /// while the recipient shell was busy. Flushed when the surface returns to
+    /// `.promptIdle` (see `flushBufferedMailboxStdin`). Main-actor-confined.
+    private var mailboxStdinBuffer = MailboxStdinBuffer()
     /// PIDs associated with agent status entries (e.g. claude_code), keyed by status key.
     /// Used for stale-session detection: if the PID is dead, the status entry is cleared.
     var agentPIDs: [String: pid_t] = [:]
@@ -5917,16 +5921,14 @@ final class Workspace: Identifiable, ObservableObject {
         dispatcher.registerHandler(name: "silent") { _, _, _ in
             .init(outcome: .ok)
         }
-        let stdinHandler = StdinMailboxHandler { [weak self] surfaceId, text in
+        let stdinHandler = StdinMailboxHandler { [weak self] surfaceId, envelopeId, recipientName, text in
             guard let self else { return .surfaceNotFound }
-            guard let panel = self.panels[surfaceId] else {
-                return .surfaceNotFound
-            }
-            guard let terminalPanel = panel as? TerminalPanel else {
-                return .surfaceNotTerminal
-            }
-            TextBoxSubmit.send(text, via: terminalPanel.surface)
-            return .ok(bytes: text.utf8.count)
+            return self.deliverOrBufferMailboxStdin(
+                surfaceId: surfaceId,
+                envelopeId: envelopeId,
+                recipientName: recipientName,
+                block: text
+            )
         }
         dispatcher.registerHandler(
             name: "stdin",
@@ -5934,6 +5936,82 @@ final class Workspace: Identifiable, ObservableObject {
         )
         dispatcher.start()
         mailboxDispatcher = dispatcher
+    }
+
+    /// C11-144 delivery safety: decide whether to inject a framed `<c11-msg>`
+    /// block into the recipient PTY now or buffer it. Runs on the main actor
+    /// (the handler's writer hop). Pasting into a PTY that has a foreground
+    /// command running (a build, `vim`, a REPL) corrupts that program's stdin,
+    /// so we gate on the recipient's already-tracked `PanelShellActivityState`:
+    /// `.promptIdle` injects immediately; `.commandRunning`/`.unknown` buffer
+    /// the block to flush at the next prompt. The dispatcher has already copied
+    /// the envelope into the recipient's filesystem inbox, so a buffered (or
+    /// even dropped) block is still reachable via `c11 mailbox recv --drain`.
+    func deliverOrBufferMailboxStdin(
+        surfaceId: UUID,
+        envelopeId: String,
+        recipientName: String,
+        block: String
+    ) -> StdinMailboxHandler.WriteOutcome {
+        guard let panel = panels[surfaceId] else { return .surfaceNotFound }
+        guard let terminalPanel = panel as? TerminalPanel else { return .surfaceNotTerminal }
+
+        let state = panelShellActivityStates[surfaceId] ?? .unknown
+        switch MailboxStdinBuffer.decide(state: state) {
+        case .injectNow:
+            TextBoxSubmit.send(block, via: terminalPanel.surface)
+            return .ok(bytes: block.utf8.count)
+        case .buffer:
+            let entry = MailboxStdinBuffer.Entry(
+                id: envelopeId,
+                recipientName: recipientName,
+                block: block,
+                bufferedAt: Date()
+            )
+            if let evicted = mailboxStdinBuffer.enqueue(surfaceId: surfaceId, entry: entry) {
+                mailboxDispatcher?.logStdinLifecycle(
+                    id: evicted.id,
+                    recipient: evicted.recipientName,
+                    outcome: .evicted
+                )
+            }
+            return .buffered(bytes: block.utf8.count)
+        }
+    }
+
+    /// C11-144: flush any buffered `<c11-msg>` blocks for a surface that just
+    /// returned to `.promptIdle`. Fresh entries are injected in FIFO order;
+    /// stale ones (older than the buffer's freshness window) are dropped — they
+    /// were already delivered via the inbox/pull floor, and pasting them onto a
+    /// now-bare shell after a long-lived foreground process exited would only
+    /// produce junk. Each step is logged to the dispatch log so the message's
+    /// full lifecycle stays visible in `c11 mailbox trace`.
+    private func flushBufferedMailboxStdin(surfaceId: UUID) {
+        let flush = mailboxStdinBuffer.drainForFlush(surfaceId: surfaceId, now: Date())
+        guard !flush.fresh.isEmpty || !flush.expired.isEmpty else { return }
+
+        for entry in flush.expired {
+            mailboxDispatcher?.logStdinLifecycle(
+                id: entry.id,
+                recipient: entry.recipientName,
+                outcome: .expired
+            )
+        }
+
+        guard !flush.fresh.isEmpty else { return }
+        // The surface could have changed type/closed between buffering and the
+        // transition; if it's no longer a terminal, the entries are already
+        // drained and the inbox floor still holds them.
+        guard let terminalPanel = panels[surfaceId] as? TerminalPanel else { return }
+        for entry in flush.fresh {
+            TextBoxSubmit.send(entry.block, via: terminalPanel.surface)
+            mailboxDispatcher?.logStdinLifecycle(
+                id: entry.id,
+                recipient: entry.recipientName,
+                outcome: .flushed,
+                bytes: entry.block.utf8.count
+            )
+        }
     }
 
     func refreshSplitButtonTooltips() {
@@ -6645,6 +6723,11 @@ final class Workspace: Identifiable, ObservableObject {
             "panel=\(panelId.uuidString.prefix(5)) from=\(previousState.rawValue) to=\(state.rawValue)"
         )
 #endif
+        // C11-144: a recipient returning to its prompt is the safe moment to
+        // inject any blocks that were buffered while it was busy.
+        if state == .promptIdle {
+            flushBufferedMailboxStdin(surfaceId: panelId)
+        }
     }
 
     func panelNeedsConfirmClose(panelId: UUID, fallbackNeedsConfirmClose: Bool) -> Bool {
@@ -7194,6 +7277,7 @@ final class Workspace: Identifiable, ObservableObject {
         surfaceListeningPorts = surfaceListeningPorts.filter { validSurfaceIds.contains($0.key) }
         surfaceTTYNames = surfaceTTYNames.filter { validSurfaceIds.contains($0.key) }
         panelShellActivityStates = panelShellActivityStates.filter { validSurfaceIds.contains($0.key) }
+        mailboxStdinBuffer.retainOnly(surfaceIds: validSurfaceIds)
         panelPullRequests = panelPullRequests.filter { validSurfaceIds.contains($0.key) }
         SurfaceMetadataStore.shared.pruneWorkspace(workspaceId: id, validSurfaceIds: validSurfaceIds)
         titleBarCollapsed = titleBarCollapsed.filter { validSurfaceIds.contains($0.key) }
@@ -11085,6 +11169,7 @@ extension Workspace: BonsplitDelegate {
         manualUnreadMarkedAt.removeValue(forKey: panelId)
         panelSubscriptions.removeValue(forKey: panelId)
         panelShellActivityStates.removeValue(forKey: panelId)
+        mailboxStdinBuffer.removeSurface(panelId)
         surfaceTTYNames.removeValue(forKey: panelId)
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
         titleBarCollapsed.removeValue(forKey: panelId)
@@ -11266,6 +11351,7 @@ extension Workspace: BonsplitDelegate {
                 manualUnreadPanelIds.remove(panelId)
                 panelSubscriptions.removeValue(forKey: panelId)
                 panelShellActivityStates.removeValue(forKey: panelId)
+                mailboxStdinBuffer.removeSurface(panelId)
                 surfaceTTYNames.removeValue(forKey: panelId)
                 surfaceListeningPorts.removeValue(forKey: panelId)
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)

--- a/c11Tests/MailboxDispatcherTests.swift
+++ b/c11Tests/MailboxDispatcherTests.swift
@@ -294,4 +294,46 @@ final class MailboxDispatcherTests: XCTestCase {
         // Exactly one full dispatch sequence.
         XCTAssertEqual(events, ["received", "resolved", "copied", "handler", "cleaned"])
     }
+
+    // MARK: - C11-144 stdin buffer/flush lifecycle logging
+
+    /// `logStdinLifecycle` is what makes the "never a silent drop" story
+    /// observable: blocks buffered while a recipient is busy, then flushed (or
+    /// expired/evicted) from the main-actor path, must still surface in
+    /// `c11 mailbox trace <id>` as `handler` events keyed on the same
+    /// id/recipient. This locks that contract without a live PTY.
+    func testLogStdinLifecycleEmitsTraceableHandlerEvents() throws {
+        let dispatcher = makeDispatcher(surfaces: [])
+
+        dispatcher.logStdinLifecycle(
+            id: "01K3A2B7X8PQRTVWYZ0123456J",
+            recipient: "watcher",
+            outcome: .flushed,
+            bytes: 42
+        )
+        dispatcher.logStdinLifecycle(
+            id: "01K3A2B7X8PQRTVWYZ0123456K",
+            recipient: "watcher",
+            outcome: .expired
+        )
+        dispatcher.logStdinLifecycle(
+            id: "01K3A2B7X8PQRTVWYZ0123456L",
+            recipient: "watcher",
+            outcome: .evicted
+        )
+        dispatcher.log.flush()
+
+        let handlerEvents = try readLog().filter { ($0["event"] as? String) == "handler" }
+        XCTAssertEqual(handlerEvents.count, 3)
+        for event in handlerEvents {
+            XCTAssertEqual(event["handler"] as? String, "stdin")
+            XCTAssertEqual(event["recipient"] as? String, "watcher")
+        }
+        XCTAssertEqual(handlerEvents.map { $0["outcome"] as? String }, ["flushed", "expired", "evicted"])
+        // Bytes are carried through when present, omitted otherwise.
+        let flushed = handlerEvents.first { ($0["outcome"] as? String) == "flushed" }
+        XCTAssertEqual(flushed?["bytes"] as? Int, 42)
+        let expired = handlerEvents.first { ($0["outcome"] as? String) == "expired" }
+        XCTAssertNil(expired?["bytes"])
+    }
 }

--- a/c11Tests/MailboxStdinBufferTests.swift
+++ b/c11Tests/MailboxStdinBufferTests.swift
@@ -1,0 +1,168 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Unit tests for the pure gating/buffer/flush logic behind C11-144's
+/// prompt-gated stdin delivery. No PTY, no Workspace instance — the clock is
+/// injected, so every decision is deterministic.
+final class MailboxStdinBufferTests: XCTestCase {
+
+    private func entry(
+        id: String = "01K3A2B7X8PQRTVWYZ0123456J",
+        recipient: String = "watcher",
+        block: String = "<c11-msg/>",
+        at: Date = Date(timeIntervalSince1970: 1_000)
+    ) -> MailboxStdinBuffer.Entry {
+        MailboxStdinBuffer.Entry(
+            id: id, recipientName: recipient, block: block, bufferedAt: at
+        )
+    }
+
+    // MARK: - decide()
+
+    func testDecideInjectsWhenPromptIdle() {
+        XCTAssertEqual(MailboxStdinBuffer.decide(state: .promptIdle), .injectNow)
+    }
+
+    func testDecideBuffersWhenCommandRunning() {
+        XCTAssertEqual(MailboxStdinBuffer.decide(state: .commandRunning), .buffer)
+    }
+
+    func testDecideBuffersWhenUnknown() {
+        XCTAssertEqual(MailboxStdinBuffer.decide(state: .unknown), .buffer)
+    }
+
+    // MARK: - enqueue / drain FIFO
+
+    func testBufferedEntriesFlushInFifoOrder() {
+        var buffer = MailboxStdinBuffer()
+        let surface = UUID()
+        let base = Date(timeIntervalSince1970: 1_000)
+        for i in 0..<3 {
+            buffer.enqueue(
+                surfaceId: surface,
+                entry: entry(id: "id-\(i)", block: "block-\(i)", at: base)
+            )
+        }
+        XCTAssertEqual(buffer.pendingCount(surfaceId: surface), 3)
+
+        let result = buffer.drainForFlush(surfaceId: surface, now: base.addingTimeInterval(1))
+        XCTAssertEqual(result.fresh.map(\.id), ["id-0", "id-1", "id-2"])
+        XCTAssertTrue(result.expired.isEmpty)
+        // Drained — queue is now empty.
+        XCTAssertEqual(buffer.pendingCount(surfaceId: surface), 0)
+        XCTAssertTrue(buffer.isEmpty)
+    }
+
+    func testDrainOfEmptySurfaceIsNoOp() {
+        var buffer = MailboxStdinBuffer()
+        let result = buffer.drainForFlush(surfaceId: UUID(), now: Date())
+        XCTAssertTrue(result.fresh.isEmpty)
+        XCTAssertTrue(result.expired.isEmpty)
+    }
+
+    func testQueuesAreIsolatedPerSurface() {
+        var buffer = MailboxStdinBuffer()
+        let a = UUID()
+        let b = UUID()
+        buffer.enqueue(surfaceId: a, entry: entry(id: "a0"))
+        buffer.enqueue(surfaceId: b, entry: entry(id: "b0"))
+        let drainA = buffer.drainForFlush(surfaceId: a, now: Date(timeIntervalSince1970: 1_001))
+        XCTAssertEqual(drainA.fresh.map(\.id), ["a0"])
+        // b untouched.
+        XCTAssertEqual(buffer.pendingCount(surfaceId: b), 1)
+    }
+
+    // MARK: - freshness window
+
+    func testStaleEntriesExpireRatherThanFlush() {
+        var buffer = MailboxStdinBuffer()
+        let surface = UUID()
+        let bufferedAt = Date(timeIntervalSince1970: 1_000)
+        buffer.enqueue(surfaceId: surface, entry: entry(id: "stale", at: bufferedAt))
+        buffer.enqueue(
+            surfaceId: surface,
+            entry: entry(id: "fresh", at: bufferedAt.addingTimeInterval(
+                MailboxStdinBuffer.freshnessWindow
+            ))
+        )
+
+        // Flush far enough out that the first entry is past the window but the
+        // second is exactly on the boundary (<= window → fresh).
+        let now = bufferedAt
+            .addingTimeInterval(MailboxStdinBuffer.freshnessWindow)
+            .addingTimeInterval(1)
+        let result = buffer.drainForFlush(surfaceId: surface, now: now)
+        XCTAssertEqual(result.expired.map(\.id), ["stale"])
+        XCTAssertEqual(result.fresh.map(\.id), ["fresh"])
+    }
+
+    func testEntryExactlyAtWindowBoundaryIsFresh() {
+        var buffer = MailboxStdinBuffer()
+        let surface = UUID()
+        let bufferedAt = Date(timeIntervalSince1970: 1_000)
+        buffer.enqueue(surfaceId: surface, entry: entry(id: "edge", at: bufferedAt))
+        let now = bufferedAt.addingTimeInterval(MailboxStdinBuffer.freshnessWindow)
+        let result = buffer.drainForFlush(surfaceId: surface, now: now)
+        XCTAssertEqual(result.fresh.map(\.id), ["edge"])
+        XCTAssertTrue(result.expired.isEmpty)
+    }
+
+    // MARK: - per-surface cap eviction
+
+    func testCapEvictsOldestAndReportsIt() {
+        var buffer = MailboxStdinBuffer()
+        let surface = UUID()
+        let base = Date(timeIntervalSince1970: 1_000)
+        var evictions: [String] = []
+        for i in 0...MailboxStdinBuffer.perSurfaceCap {
+            if let evicted = buffer.enqueue(
+                surfaceId: surface,
+                entry: entry(id: "id-\(i)", at: base)
+            ) {
+                evictions.append(evicted.id)
+            }
+        }
+        // One over the cap → exactly one eviction, the oldest.
+        XCTAssertEqual(evictions, ["id-0"])
+        XCTAssertEqual(buffer.pendingCount(surfaceId: surface), MailboxStdinBuffer.perSurfaceCap)
+
+        let result = buffer.drainForFlush(surfaceId: surface, now: base.addingTimeInterval(1))
+        XCTAssertEqual(result.fresh.first?.id, "id-1")
+        XCTAssertEqual(result.fresh.count, MailboxStdinBuffer.perSurfaceCap)
+    }
+
+    func testEnqueueUnderCapDoesNotEvict() {
+        var buffer = MailboxStdinBuffer()
+        let surface = UUID()
+        let evicted = buffer.enqueue(surfaceId: surface, entry: entry())
+        XCTAssertNil(evicted)
+    }
+
+    // MARK: - removeSurface / retainOnly
+
+    func testRemoveSurfaceReturnsPendingAndClears() {
+        var buffer = MailboxStdinBuffer()
+        let surface = UUID()
+        buffer.enqueue(surfaceId: surface, entry: entry(id: "x0"))
+        buffer.enqueue(surfaceId: surface, entry: entry(id: "x1"))
+        let dropped = buffer.removeSurface(surface)
+        XCTAssertEqual(dropped.map(\.id), ["x0", "x1"])
+        XCTAssertEqual(buffer.pendingCount(surfaceId: surface), 0)
+    }
+
+    func testRetainOnlyPrunesAbsentSurfaces() {
+        var buffer = MailboxStdinBuffer()
+        let keep = UUID()
+        let drop = UUID()
+        buffer.enqueue(surfaceId: keep, entry: entry(id: "k"))
+        buffer.enqueue(surfaceId: drop, entry: entry(id: "d"))
+        buffer.retainOnly(surfaceIds: [keep])
+        XCTAssertEqual(buffer.pendingCount(surfaceId: keep), 1)
+        XCTAssertEqual(buffer.pendingCount(surfaceId: drop), 0)
+    }
+}

--- a/c11Tests/StdinHandlerFormattingTests.swift
+++ b/c11Tests/StdinHandlerFormattingTests.swift
@@ -139,7 +139,7 @@ final class StdinHandlerFormattingTests: XCTestCase {
             id: "01K3A2B7X8PQRTVWYZ0123456J",
             ts: "2026-04-23T10:15:42Z"
         )
-        let handler = StdinMailboxHandler(writer: { _, bytes in
+        let handler = StdinMailboxHandler(writer: { _, _, _, bytes in
             .ok(bytes: bytes.utf8.count)
         })
         let surfaceId = UUID()
@@ -152,6 +152,64 @@ final class StdinHandlerFormattingTests: XCTestCase {
         XCTAssertGreaterThan(result.bytes ?? 0, 0)
     }
 
+    /// C11-144: when the writer buffers (recipient shell busy), `deliver` must
+    /// report `.buffered` with the byte count — a delivery, not a drop.
+    func testDeliverReportsBufferedWhenWriterBuffers() async throws {
+        let envelope = try MailboxEnvelope.build(
+            from: "builder",
+            to: "watcher",
+            body: "buffered hello",
+            id: "01K3A2B7X8PQRTVWYZ0123456J",
+            ts: "2026-04-23T10:15:42Z"
+        )
+        let handler = StdinMailboxHandler(writer: { _, _, _, bytes in
+            .buffered(bytes: bytes.utf8.count)
+        })
+        let result = await handler.deliver(
+            envelope: envelope,
+            to: UUID(),
+            surfaceName: "watcher"
+        )
+        XCTAssertEqual(result.outcome, .buffered)
+        XCTAssertGreaterThan(result.bytes ?? 0, 0)
+    }
+
+    /// The writer receives the envelope id and resolved recipient name so the
+    /// buffer/flush path can log a coherent `handler` event for that id.
+    func testDeliverPassesEnvelopeIdAndRecipientToWriter() async throws {
+        let envelope = try MailboxEnvelope.build(
+            from: "builder",
+            to: "watcher",
+            body: "hi",
+            id: "01K3A2B7X8PQRTVWYZ0123456J",
+            ts: "2026-04-23T10:15:42Z"
+        )
+        actor Captured {
+            var id: String?
+            var recipient: String?
+            func set(id: String, recipient: String) {
+                self.id = id
+                self.recipient = recipient
+            }
+        }
+        let captured = Captured()
+        let handler = StdinMailboxHandler(writer: { _, envelopeId, recipientName, bytes in
+            Task { await captured.set(id: envelopeId, recipient: recipientName) }
+            return .ok(bytes: bytes.utf8.count)
+        })
+        _ = await handler.deliver(
+            envelope: envelope,
+            to: UUID(),
+            surfaceName: "watcher"
+        )
+        // Allow the capture Task to run.
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let id = await captured.id
+        let recipient = await captured.recipient
+        XCTAssertEqual(id, "01K3A2B7X8PQRTVWYZ0123456J")
+        XCTAssertEqual(recipient, "watcher")
+    }
+
     func testDeliverReportsClosedWhenSurfaceNotFound() async throws {
         let envelope = try MailboxEnvelope.build(
             from: "builder",
@@ -160,7 +218,7 @@ final class StdinHandlerFormattingTests: XCTestCase {
             id: "01K3A2B7X8PQRTVWYZ0123456J",
             ts: "2026-04-23T10:15:42Z"
         )
-        let handler = StdinMailboxHandler(writer: { _, _ in .surfaceNotFound })
+        let handler = StdinMailboxHandler(writer: { _, _, _, _ in .surfaceNotFound })
         let result = await handler.deliver(
             envelope: envelope,
             to: UUID(),
@@ -178,7 +236,7 @@ final class StdinHandlerFormattingTests: XCTestCase {
             ts: "2026-04-23T10:15:42Z"
         )
         let handler = StdinMailboxHandler(
-            writer: { _, _ in
+            writer: { _, _, _, _ in
                 // Simulate a hang that exceeds the timeout deadline.
                 Thread.sleep(forTimeInterval: 0.6)
                 return .ok(bytes: 0)
@@ -217,7 +275,7 @@ final class StdinHandlerFormattingTests: XCTestCase {
         // Thread.sleep blocks that thread for the whole interval — exactly
         // the scenario the reporting-bound documentation describes.
         let handler = StdinMailboxHandler(
-            writer: { _, _ in
+            writer: { _, _, _, _ in
                 Thread.sleep(forTimeInterval: 5.0)
                 return .ok(bytes: 0)
             },

--- a/docs/c11-mailbox-guide.md
+++ b/docs/c11-mailbox-guide.md
@@ -60,10 +60,13 @@ c11 mailbox send --to watcher --body "build green sha=abc"
 # In surface "watcher":
 c11 set-title "watcher"
 c11 set-metadata mailbox.delivery stdin   # opt in to PTY injection
-# The framed block lands in the PTY automatically the next time builder sends.
+# The framed block lands in the PTY the next time builder sends — at a shell
+# prompt it injects immediately; if watcher is mid-command it buffers and
+# flushes at the next prompt (see "Prompt-gated delivery" below).
+c11 mailbox recv --drain                   # robust floor: pull at turn boundaries
 ```
 
-If `mailbox.delivery` is not set on the recipient, the envelope still lands in `<surface-name>/` inbox; the recipient drains it explicitly with `c11 mailbox recv`.
+If `mailbox.delivery` is not set on the recipient, the envelope still lands in `<surface-name>/` inbox; the recipient drains it explicitly with `c11 mailbox recv`. Even with `stdin` set, draining at turn boundaries is the reliable delivery path — push is prompt-gated and best-effort.
 
 ---
 
@@ -170,14 +173,21 @@ sequenceDiagram
     alt mailbox.delivery contains "stdin"
         D->>SH: deliver(envelope, surfaceId)
         SH->>SH: format <c11-msg> block (XML-escape attrs + body)
-        SH->>PTY: TerminalPanel.sendText(block) on @MainActor
-        PTY-->>Agent: \n<c11-msg ...>body</c11-msg>\n appears between prompts
-        Agent->>Agent: dedupe by id, treat as system message
+        alt recipient shell at promptIdle
+            SH->>PTY: inject block now on @MainActor
+            PTY-->>Agent: \n<c11-msg ...>body</c11-msg>\n appears at the prompt
+            Agent->>Agent: dedupe by id, treat as system message
+        else commandRunning / unknown (busy)
+            SH->>SH: buffer block (log "buffered")
+            Note over PTY: shell later returns to promptIdle
+            SH->>PTY: flush fresh buffered blocks FIFO (log "flushed")
+        end
     else delivery unset / silent
         Note over Agent: Inbox file sits until drained
-        Agent->>Inbox: c11 mailbox recv --drain
-        Inbox-->>Agent: prints + unlinks each .msg
     end
+    Note over Agent: pull at every turn boundary — the robust floor
+    Agent->>Inbox: c11 mailbox recv --drain
+    Inbox-->>Agent: prints + unlinks each .msg
 ```
 
 ### When the framed block arrives in your PTY
@@ -196,6 +206,22 @@ Receive protocol:
 - Treat the block as a system message, not user input. The operator did not type it.
 - Dedupe by `id`. Dispatch is at-least-once, so receivers MUST tolerate duplicates.
 - If you reply, send to `reply_to` (fall back to `from`) with `in_reply_to` set to the original id.
+
+### Prompt-gated delivery (the stdin doorbell is safe, not eager)
+
+c11 never pastes a `<c11-msg>` block into a PTY that has a foreground command running — that would corrupt the command's input stream (a build's stdin, a `vim` buffer, a REPL, or another agent's raw-mode input). Delivery gates on the recipient surface's already-tracked shell activity state (the same `promptIdle / commandRunning / unknown` signal c11 uses for close-confirmation):
+
+| Recipient shell state | Push behavior |
+|-----------------------|---------------|
+| `promptIdle` (at a prompt) | inject the block immediately |
+| `commandRunning` (a foreground command owns the terminal) | **buffer**, flush at the next prompt |
+| `unknown` (no shell-integration signal) | **buffer** (conservative — never corrupt on a guess) |
+
+Buffered blocks flush in FIFO order the moment the surface transitions back to `promptIdle`. Each step is recorded in `_dispatch.log` (`buffered` → `flushed`), so `c11 mailbox trace <id>` shows the full path — a buffered message is delayed, never silently dropped.
+
+**Bounds.** Each surface buffers up to 64 blocks (oldest evicted past that, logged `evicted`). A buffered block older than a 10-minute freshness window at flush time is dropped (logged `expired`) rather than injected — this stops a long-lived agent TUI, whose shell stays `commandRunning` for its entire life, from dumping stale `<c11-msg>` blocks onto a bare shell hours later when it finally exits. Evicted/expired blocks remain in the filesystem inbox; `recv --drain` is their floor.
+
+**Why you still pull.** Because a live agent keeps its shell `commandRunning`, stdin push into a busy agent typically buffers and may never flush in time. The filesystem inbox copy is written *before* any push is attempted, so `c11 mailbox recv --drain` at every turn boundary is the delivery path that always works. Treat stdin push as a best-effort doorbell; treat the pull cadence as the contract.
 
 ### Explicit inbox drain
 
@@ -323,7 +349,14 @@ Newline-delimited JSON, one event per line, append-only. Every event carries an 
 | `gc`        | `temp_files_removed`                                                |
 | `replayed`  | `id` (declared in the event enum; not emitted in Stage 2)           |
 
-Handler outcomes: `ok`, `timeout`, `eio`, `closed`. (`epipe` was declared in early drafts and removed in P0 #6 because nothing emits it.) `timeout` is a reporting bound, not a runtime cancellation: the dispatcher logs after 2 s and moves on, but the handler closure may still be running.
+Handler outcomes: `ok`, `timeout`, `eio`, `closed`, plus the C11-144 stdin delivery-safety lifecycle `buffered`, `flushed`, `expired`, `evicted` (all emitted as `handler` events with `handler = "stdin"`, so a buffered message's full path is traceable). (`epipe` was declared in early drafts and removed in P0 #6 because nothing emits it.) `timeout` is a reporting bound, not a runtime cancellation: the dispatcher logs after 2 s and moves on, but the handler closure may still be running.
+
+| stdin outcome | Meaning |
+|---------------|---------|
+| `buffered`    | recipient shell was busy; block queued to flush at the next prompt |
+| `flushed`     | a previously-buffered block was injected once the shell went idle |
+| `expired`     | a buffered block aged past the freshness window; dropped (inbox floor holds it) |
+| `evicted`     | a buffered block dropped because the per-surface cap was exceeded (inbox floor holds it) |
 
 ```bash
 c11 mailbox tail                              # follow log as it grows

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -470,7 +470,7 @@ This section is the agent-facing quick-reference. The full guide (filesystem lay
 
 ### The framed block you'll see in your PTY
 
-When another surface sends you a message and your surface's `mailbox.delivery` contains `stdin`, a block like this appears between prompts:
+When another surface sends you a message and your surface's `mailbox.delivery` contains `stdin`, a block like this appears **at a shell prompt** (delivery is prompt-gated — see below):
 
 ```
 <c11-msg from="builder" id="01K3A2B7X8PQRTVWYZ0123456J" ts="2026-04-23T10:15:42Z" to="watcher">
@@ -521,13 +521,23 @@ See [`Resources/bin/c11-mailbox-send-bash-example.sh`](../../Resources/bin/c11-m
 
 ### Receiving
 
-- **If your `mailbox.delivery` includes `stdin`:** the framed block arrives in your PTY automatically. No poll, no sync.
-- **Otherwise:** drain the inbox explicitly.
+**Pull at every turn boundary — this is the robust floor.** Regardless of your delivery mode, run `c11 mailbox recv --drain` at the top of each turn (or every few turns in a long autonomous loop). The filesystem inbox is the durable queue; `stdin` push is only a best-effort doorbell layered on top. Pulling is the one delivery path that always works — it does not depend on your shell being idle, on push being enabled, or on shell-integration reporting your state.
 
 ```bash
-c11 mailbox recv --drain    # list + print + unlink (default)
+c11 mailbox recv --drain    # list + print + unlink (default) — run at turn boundaries
 c11 mailbox recv --peek     # list + print only
 ```
+
+- **If your `mailbox.delivery` includes `stdin`:** a framed block *also* appears in your PTY, but **only when you're at a shell prompt** (delivery is prompt-gated, below). While you're running a command or a live agent owns the terminal, pushes are buffered, not injected — so the pull cadence above is what actually delivers them in time.
+- **Otherwise:** the pull cadence is your only delivery path; do not skip it.
+
+#### Prompt-gated delivery (why push can lag)
+
+c11 will not paste a `<c11-msg>` block into a PTY that has a foreground command running — doing so would corrupt that command's input (a build, `vim`, a REPL, or another agent's raw-mode stdin). It gates on the recipient surface's shell activity:
+
+- **At a shell prompt (`promptIdle`)** → the block is injected immediately.
+- **A command is running (`commandRunning`) or state is `unknown`** → the block is **buffered** and flushed when the surface next returns to its prompt. A buffered message is still delivered and logged (`c11 mailbox trace <id>` shows `buffered` → `flushed`), never silently dropped.
+- A long-lived agent TUI keeps its shell in `commandRunning` for its whole life, so push into a busy agent may never flush before it goes stale. **That is exactly why you pull** — `recv --drain` reads the inbox copy that was written before any push was attempted.
 
 **Opting in to stdin delivery.** Stdin delivery is per-recipient and off by default. Set `mailbox.delivery` on the surface that should auto-receive — it is a **comma-separated string** (not a JSON array), and the only handlers registered today are `stdin` and `silent`:
 


### PR DESCRIPTION
## C11-144 — Mailbox delivery safety: prompt-gated stdin injection + receiver-pull cadence

Operator's top concern from the Trident mailbox review (§8). The stdin handler pasted a framed `<c11-msg>` block into the recipient PTY and dispatched Return unconditionally — unsafe when a foreground command owns the terminal (a build, `vim`, a REPL, another agent's raw-mode stdin), corrupting that program's input.

### Layer 1 — prompt-gated injection + buffer/flush
Gate the push on the recipient's already-tracked `PanelShellActivityState` (the same `promptIdle / commandRunning / unknown` signal close-confirmation reads — no new lifecycle hook):

- **`promptIdle`** → inject now
- **`commandRunning` / `unknown`** → **buffer** the block; flush FIFO when the surface next returns to `promptIdle`

**Where the logic lives:** a new pure value type `MailboxStdinBuffer` (no PTY, no `Workspace`, clock injected) holds the per-surface FIFO and the inject-vs-buffer decision, so the gating/buffer/flush logic is deterministically unit-testable. **Where the buffer lives:** main-actor-confined state on `Workspace` (`mailboxStdinBuffer`), mutated only from the handler's writer hop and the `updatePanelShellActivityState` transition — both already on main, so no locks. Flush is wired into the existing `→ promptIdle` transition.

**Bounds & safety:** per-surface cap (64, oldest evicted) + a 600 s freshness window (stale entries dropped at flush rather than dumped onto a bare shell — a live agent TUI keeps its shell `commandRunning` for its whole life, so its buffer is stale by the time it exits). The dispatcher always copies the envelope to the filesystem inbox **before** any push, so buffered/evicted/expired blocks are never lost — they remain reachable via `recv --drain`. New dispatch-log outcomes `buffered`/`flushed`/`expired`/`evicted` keep the full lifecycle visible in `c11 mailbox trace` — never a silent drop.

### Layer 2 — receiver-pull cadence (the delivery contract)
`skills/c11/SKILL.md` now tells agents to `c11 mailbox recv --drain` at every turn boundary as the robust floor, with a prompt-gating explainer; `docs/c11-mailbox-guide.md` documents the buffer/flush behavior, bounds, outcomes, and updated receive diagram. Installed skill synced (HARD RULE).

### Tests
- `MailboxStdinBufferTests` (new): `decide()` per state, FIFO drain, per-surface isolation, freshness-window expiry incl. exact boundary, cap eviction, `removeSurface`/`retainOnly`, empty-drain no-op.
- `StdinHandlerFormattingTests` extended for the `.buffered` outcome + widened writer signature.
- `MailboxDispatcherTests` + a `logStdinLifecycle` round-trip test locking the trace-visibility contract.
- `c11LogicTests` green; mailbox regression suite green.

### Live validation (tagged `c11-144` build, prod untouched)
Drove the real dispatcher end-to-end. Confirmed: idle → immediate inject (`ok`); busy → `buffered`, no inject; `→ promptIdle` → FIFO `flushed`; gated send into open `vim` left it **pristine**; a **raw ungated push** into the same `vim` **corrupted** it (chars eaten as commands, dropped into `-- INSERT --`).

**This settles the Claude-vs-Gemini split empirically:** ungated PTY push into a busy raw-mode recipient *is* unsafe (Gemini right); the prompt-gate fixes it. Full transcripts + dispatch-log evidence in the ticket's `validation` artifact.

### Pre-existing infra finding (not this PR's code; follow-up recommended)
In the test build, `CMUX_TAB_ID` is exported as the **surface** UUID, but `report_shell_state`'s scope resolver reads `--tab` as the **workspace** UUID — so the shell integration's automatic state reports are silently dropped and state stays `unknown`. With state `unknown` the gate buffers everything (safe; no corruption) and delivery falls to the Layer-2 pull floor. So Layer 1 is fundamentally a **safety** mechanism and Layer 2 is the **delivery** contract — exactly how the docs frame it ("doorbell, not delivery"). Recommend a separate ticket to fix the `CMUX_TAB_ID` export (or resolve panels by surface UUID) so the bare-shell/build/vim push-flush path works without manual scope.

### Scope
Stayed within the existing PTY-delivery mechanism made safe by gating; did **not** build an out-of-band control socket (explicitly out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
