### PR TITLE
Release v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-06-16
+
+Feature release. Headline: **the inter-agent mailbox grows up — it routes across every workspace and stops dropping messages silently.** `c11 mailbox send --to <name>` now resolves the recipient across the whole c11 instance (local-first; ambiguous names disambiguate with `--to-workspace`), an unresolved recipient is rejected with a non-zero exit instead of vanishing, surfaces gain stable `mailbox.address` / `mailbox.role` addressing decoupled from their mutable tab title, and stdin delivery is prompt-gated — buffered while a recipient is busy and flushed when it returns to its shell prompt — so a pushed message can never corrupt a running command.
+
+### Added
+
+- **Cross-workspace mailbox routing.** `c11 mailbox send --to <name>` resolves the recipient across every workspace in the instance, local-first: a match in your own workspace wins, otherwise the one other workspace holding that name receives it. If the name lives in more than one other workspace the send fails *ambiguous* — disambiguate with `--to-workspace <ref>`. ([#251](https://github.com/Stage-11-Agentics/c11/pull/251))
+- **Stable mailbox addressing (`mailbox.address` / `mailbox.role`).** Addressing is decoupled from the surface's mutable title, so renaming a tab no longer changes who a message routes to. ([#253](https://github.com/Stage-11-Agentics/c11/pull/253))
+
+### Changed
+
+- **The mailbox no longer drops messages silently.** A recipient that matches no live surface anywhere is rejected with a non-zero `unresolved` exit instead of vanishing; the cross-workspace seam emits a loud socket fallback and a global trace (`c11 mailbox trace <id>` now finds a message wherever it was dispatched), and a `content_type` cap bounds envelope bodies. ([#251](https://github.com/Stage-11-Agentics/c11/pull/251), [#252](https://github.com/Stage-11-Agentics/c11/pull/252))
+
+### Fixed
+
+- **Prompt-gated stdin delivery (C11-144).** c11 no longer pastes a framed `<c11-msg>` block into a PTY that has a foreground command running, where it would corrupt a build, REPL, or another agent's raw-mode stdin. The push is buffered while the recipient is busy and flushed when the surface returns to its shell prompt; buffered messages are still delivered and logged (`buffered` → `flushed`), never dropped. ([#254](https://github.com/Stage-11-Agentics/c11/pull/254))
+
+### Thanks to 1 contributor!
+
+- [@BenevolentFutures](https://github.com/BenevolentFutures)
+
+### Built and shipped by
+
+Stage 11 Agentics. Operator:agent, fused.
+
 ## [0.52.0] - 2026-06-14
 
 Feature release. Headline: **two new coding agents and a hang catcher** — GitHub Copilot CLI and Grok Build join as first-class c11 agents with full conversation-store resume wiring, and a real-time main-thread hang monitor now suspends the stalled thread, captures its stack off-thread, and reports to a local log plus Sentry/PostHog (on by default in Release). Alongside it: a batch of resume/reliability fixes (crash-resume, browser-freeze, inspector divider hit-test), a markdown-pane live-reload and font-zoom pass, and a consistent white-outline selection signal in the sidebar.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -1787,10 +1787,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1868,7 +1868,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1878,7 +1878,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1909,7 +1909,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1919,7 +1919,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -1987,10 +1987,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2005,14 +2005,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2027,14 +2027,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2050,10 +2050,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2069,10 +2069,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 109;
+				CURRENT_PROJECT_VERSION = 110;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.52.0;
+				MARKETING_VERSION = 0.53.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Release v0.53.0

Feature release. Headline: **the inter-agent mailbox goes cross-workspace and stops dropping messages silently.**

### Changelog

**Added**
- Cross-workspace mailbox routing — `c11 mailbox send --to <name>` resolves across every workspace (local-first; `--to-workspace` to disambiguate). (#251)
- Stable mailbox addressing (`mailbox.address` / `mailbox.role`) decoupled from the mutable tab title. (#253)

**Changed**
- The mailbox no longer drops messages silently — unresolved recipient → non-zero `unresolved` exit, loud socket fallback, global `mailbox trace`, `content_type` cap. (#251, #252)

**Fixed**
- Prompt-gated stdin delivery (C11-144) — buffer while the recipient is busy, flush at the prompt; never corrupts a running command, never silently dropped. (#254)

### Test plan (smoke on tagged build, release/v0.53.0 source)

- [x] Cross-workspace send delivers (alpha ws1 → bravo ws2)
- [x] Unresolved recipient rejected with non-zero exit (no silent drop)
- [x] `mailbox trace` resolves cross-workspace (received→resolved→copied→cleaned)
- [x] Stable address routes after a tab rename; old title no longer resolves
- [x] Buffer-while-busy: `handler stdin outcome=buffered` while recipient busy
- [x] Durable non-drop: `recv --drain` retrieves all buffered messages
- [ ] stdin push flush-into-PTY: needs a 30s visual check on the foreground staging app (not exercisable in a backgrounded CLI harness; pull floor verified)

Note (follow-up, not a blocker): renaming a surface orphans *undrained* mail in the old-name inbox dir — inbox storage is keyed by title; #253 decoupled routing but not storage.

### Thanks to 1 contributor!

- [@BenevolentFutures](https://github.com/BenevolentFutures)
