### PR TITLE
feat(tree): `c11 tree --report` — human-readable fleet snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+### Added
+
+- **`c11 tree --report` — human-readable fleet snapshot.** A new flag on `tree` (alias `--markdown`) emits a Markdown report of what every agent is doing: per workspace, the pane layout (position percentages) and, for each surface, its canonical title, agent type + model, live status/role, description, mailbox address, and browser URL — closed by a summary table. Unlike `workspace export-blueprint` (a layout *template* that drops live metadata), this is the legible status artifact for "save the state before I close c11" / handoffs. Defaults to every window/workspace; narrow with `--window`/`--workspace`. `--out <path>` writes the Markdown to a file instead of stdout. Built entirely on the existing `system.tree` + `surface.get_metadata` socket calls, so it works against any running instance.
+
 ## [0.53.0] - 2026-06-16
 
 Feature release. Headline: **the inter-agent mailbox grows up — it routes across every workspace and stops dropping messages silently.** `c11 mailbox send --to <name>` now resolves the recipient across the whole c11 instance (local-first; ambiguous names disambiguate with `--to-workspace`), an unresolved recipient is rejected with a non-zero exit instead of vanishing, surfaces gain stable `mailbox.address` / `mailbox.role` addressing decoupled from their mutable tab title, and stdin delivery is prompt-gated — buffered while a recipient is busy and flushed when it returns to its shell prompt — so a pushed message can never corrupt a running command.

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -8301,9 +8301,14 @@ struct CMUXCLI {
               --no-layout                   Suppress the floor plan unconditionally
               --canvas-cols <N>             Override the floor-plan canvas width (default: auto, min 40)
               --json                        Structured JSON output (layout in `layout`/`content_area` keys)
+              --report                      Human-readable Markdown snapshot: layout + each surface's
+                                            manifest (title, agent, status, description). Alias: --markdown.
+                                            Defaults to every window/workspace; narrow with --window/--workspace.
+              --out <path>                  With --report, write the Markdown to a file instead of stdout
 
             Default scope: the caller's current workspace. Use --window for the
             pre-M8 behavior (current window, all workspaces); --all for every window.
+            (`--report` defaults to --all unless you pass an explicit scope.)
 
             Note: `layout.split_path` is recomputed on every call from the live
             split tree — it is NOT a stable identifier. A pane's split_path will
@@ -8326,6 +8331,8 @@ struct CMUXCLI {
               c11 tree --all
               c11 tree --workspace workspace:2
               c11 --json tree --all
+              c11 tree --report
+              c11 tree --report --out ~/c11-fleet-$(date +%F).md
             """
         case "focus-pane":
             return """
@@ -12239,6 +12246,11 @@ struct CMUXCLI {
         /// Floor plan: nil = default per scope, true = force on, false = force off.
         let layoutOverride: Bool?
         let canvasColsOverride: Int?
+        /// `--report`/`--markdown`: emit a human-readable Markdown fleet snapshot
+        /// (layout + per-surface manifest) instead of the ASCII tree.
+        let report: Bool
+        /// `--out <path>`: write the report to a file instead of stdout.
+        let outPath: String?
     }
 
     private struct TreePath {
@@ -12256,11 +12268,199 @@ struct CMUXCLI {
     ) throws {
         let options = try parseTreeCommandOptions(commandArgs)
         let payload = try buildTreePayload(options: options, client: client)
+        if options.report {
+            try emitFleetReport(payload: payload, options: options, client: client)
+            return
+        }
         if jsonOutput || options.jsonOutput {
             print(jsonString(formatIDs(payload, mode: idFormat)))
         } else {
             print(renderTreeText(payload: payload, options: options, idFormat: idFormat))
         }
+    }
+
+    // MARK: - Fleet report (`c11 tree --report`)
+
+    /// Build a human-readable Markdown snapshot of the tree payload, enriched
+    /// with each surface's manifest, and either print it or write it to a file.
+    private func emitFleetReport(
+        payload: [String: Any],
+        options: TreeCommandOptions,
+        client: SocketClient
+    ) throws {
+        let metadata = fetchFleetMetadata(payload: payload, client: client)
+        let markdown = renderFleetReport(
+            payload: payload,
+            metadata: metadata,
+            generatedAt: ISO8601DateFormatter().string(from: Date())
+        )
+        guard let outRaw = options.outPath else {
+            print(markdown)
+            return
+        }
+        let resolved = resolvePath(outRaw)
+        do {
+            try FileManager.default.createDirectory(
+                at: URL(fileURLWithPath: resolved).deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data(markdown.utf8).write(to: URL(fileURLWithPath: resolved))
+        } catch {
+            throw CLIError(message: "tree --report: failed to write \(resolved): \(error)")
+        }
+        print("OK fleet-report path=\(resolved) bytes=\(markdown.utf8.count)")
+    }
+
+    /// One `surface.get_metadata` call per surface in the payload, keyed by the
+    /// surface's short ref. Failures degrade to an empty manifest for that
+    /// surface rather than aborting the whole report.
+    private func fetchFleetMetadata(
+        payload: [String: Any],
+        client: SocketClient
+    ) -> [String: [String: Any]] {
+        var out: [String: [String: Any]] = [:]
+        for win in (payload["windows"] as? [[String: Any]] ?? []) {
+            for ws in (win["workspaces"] as? [[String: Any]] ?? []) {
+                let wsRef = ws["ref"] as? String
+                for pane in (ws["panes"] as? [[String: Any]] ?? []) {
+                    for surf in (pane["surfaces"] as? [[String: Any]] ?? []) {
+                        guard let sRef = surf["ref"] as? String else { continue }
+                        var params: [String: Any] = ["surface_id": sRef]
+                        if let wsRef { params["workspace_id"] = wsRef }
+                        if let resp = try? client.sendV2(method: "surface.get_metadata", params: params),
+                           let md = resp["metadata"] as? [String: Any] {
+                            out[sRef] = md
+                        }
+                    }
+                }
+            }
+        }
+        return out
+    }
+
+    private func renderFleetReport(
+        payload: [String: Any],
+        metadata: [String: [String: Any]],
+        generatedAt: String
+    ) -> String {
+        let windows = payload["windows"] as? [[String: Any]] ?? []
+        var wsCount = 0
+        var surfCount = 0
+        for win in windows {
+            let wss = win["workspaces"] as? [[String: Any]] ?? []
+            wsCount += wss.count
+            for ws in wss {
+                for pane in (ws["panes"] as? [[String: Any]] ?? []) {
+                    surfCount += (pane["surfaces"] as? [[String: Any]])?.count ?? 0
+                }
+            }
+        }
+
+        var out = "# c11 Fleet Snapshot\n\n"
+        out += "_Generated \(generatedAt) · "
+        out += "\(windows.count) \(plural(windows.count, "window")) · "
+        out += "\(wsCount) \(plural(wsCount, "workspace")) · "
+        out += "\(surfCount) \(plural(surfCount, "surface"))_\n"
+
+        var summaryRows: [String] = []
+        for (wi, win) in windows.enumerated() {
+            let wss = win["workspaces"] as? [[String: Any]] ?? []
+            out += "\n## Window \(wi + 1)\n"
+            for ws in wss {
+                let wsTitle = (ws["title"] as? String) ?? "(untitled)"
+                let wsRef = (ws["ref"] as? String) ?? "?"
+                let panes = ws["panes"] as? [[String: Any]] ?? []
+                let sCount = panes.reduce(0) { $0 + (($1["surfaces"] as? [[String: Any]])?.count ?? 0) }
+                out += "\n### \(wsTitle) (\(wsRef)) — "
+                out += "\(panes.count) \(plural(panes.count, "pane")), "
+                out += "\(sCount) \(plural(sCount, "surface"))\n"
+                summaryRows.append("| \(wi + 1) | \(mdCell(wsTitle)) | \(panes.count) | \(sCount) |")
+                for pane in panes {
+                    let pRef = (pane["ref"] as? String) ?? "?"
+                    let pos = panePositionLabel(pane)
+                    out += "\n**Pane** \(pRef)\(pos.isEmpty ? "" : " — \(pos)")\n"
+                    for surf in (pane["surfaces"] as? [[String: Any]] ?? []) {
+                        out += renderSurfaceLine(surf, metadata: metadata)
+                    }
+                }
+            }
+        }
+
+        out += "\n## Summary\n\n"
+        out += "| Window | Workspace | Panes | Surfaces |\n"
+        out += "|---|---|---|---|\n"
+        out += summaryRows.joined(separator: "\n")
+        out += "\n"
+        return out
+    }
+
+    private func renderSurfaceLine(
+        _ surf: [String: Any],
+        metadata: [String: [String: Any]]
+    ) -> String {
+        let sRef = (surf["ref"] as? String) ?? "?"
+        let md = metadata[sRef] ?? [:]
+        // Prefer the canonical manifest title; the tree's title can be a stale
+        // auto-title.
+        let title = (md["title"] as? String) ?? (surf["title"] as? String) ?? "(untitled)"
+        let kind = (surf["type"] as? String) ?? "terminal"
+
+        var chips: [String] = []
+        if let t = md["terminal_type"] as? String, !t.isEmpty { chips.append(t) }
+        if let m = md["model"] as? String, !m.isEmpty { chips.append(m) }
+        if let st = (md["status"] as? String) ?? (md["lifecycle_state"] as? String), !st.isEmpty {
+            chips.append(st)
+        }
+        if let role = md["role"] as? String, !role.isEmpty { chips.append("role=\(role)") }
+
+        var marker = ""
+        if (surf["here"] as? Bool) == true { marker = " ← here" }
+        else if (surf["focused"] as? Bool) == true { marker = " ← focused" }
+
+        var line = "- **\(mdInline(title))** (\(sRef))"
+        if kind != "terminal" { line += " · _\(kind)_" }
+        if !chips.isEmpty { line += " — `\(chips.joined(separator: " · "))`" }
+        line += marker + "\n"
+
+        if kind == "browser", let url = surf["url"] as? String, !url.isEmpty {
+            line += "  - \(url)\n"
+        }
+        if let desc = md["description"] as? String, !desc.isEmpty {
+            line += "  - \(desc.replacingOccurrences(of: "\n", with: " "))\n"
+        }
+        if let addr = md["mailbox.address"] as? String, !addr.isEmpty {
+            line += "  - mailbox: `\(addr)`\n"
+        }
+        return line
+    }
+
+    /// `H a–b% · V c–d%` derived from the pane's percent rect; empty when the
+    /// layout block is absent.
+    private func panePositionLabel(_ pane: [String: Any]) -> String {
+        guard let layout = pane["layout"] as? [String: Any],
+              let pct = layout["percent"] as? [String: Any],
+              let h = pct["H"] as? [Any], h.count == 2,
+              let v = pct["V"] as? [Any], v.count == 2 else { return "" }
+        func pctInt(_ x: Any) -> Int {
+            let d = (x as? Double) ?? Double("\(x)") ?? 0
+            return Int((d * 100).rounded())
+        }
+        return "H \(pctInt(h[0]))–\(pctInt(h[1]))% · V \(pctInt(v[0]))–\(pctInt(v[1]))%"
+    }
+
+    private func plural(_ n: Int, _ word: String) -> String {
+        n == 1 ? word : "\(word)s"
+    }
+
+    /// Escape a value for a Markdown table cell (pipes + newlines).
+    private func mdCell(_ s: String) -> String {
+        s.replacingOccurrences(of: "|", with: "\\|")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+
+    /// Escape a value used inside inline emphasis (`**…**`).
+    private func mdInline(_ s: String) -> String {
+        s.replacingOccurrences(of: "\n", with: " ")
     }
 
     private func parseTreeCommandOptions(_ args: [String]) throws -> TreeCommandOptions {
@@ -12274,13 +12474,19 @@ struct CMUXCLI {
             throw CLIError(message: "tree requires --canvas-cols <N>")
         }
 
+        let (outOpt, rem2) = parseOption(rem1, name: "--out")
+        if rem2.contains("--out") {
+            throw CLIError(message: "tree requires --out <path>")
+        }
+
         var includeAll = false
         var includeWindow = false
         var jsonOutput = false
         var layoutForceOn = false
         var layoutForceOff = false
+        var report = false
         var remaining: [String] = []
-        for arg in rem1 {
+        for arg in rem2 {
             switch arg {
             case "--all":
                 includeAll = true
@@ -12292,13 +12498,15 @@ struct CMUXCLI {
                 layoutForceOff = true
             case "--json":
                 jsonOutput = true
+            case "--report", "--markdown":
+                report = true
             default:
                 remaining.append(arg)
             }
         }
 
         if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-            throw CLIError(message: "tree: unknown flag '\(unknown)'. Known flags: --all --window --workspace <id|ref|index> --layout --no-layout --canvas-cols <N> --json")
+            throw CLIError(message: "tree: unknown flag '\(unknown)'. Known flags: --all --window --workspace <id|ref|index> --layout --no-layout --canvas-cols <N> --json --report [--out <path>]")
         }
         if let extra = remaining.first {
             throw CLIError(message: "tree: unexpected argument '\(extra)'")
@@ -12327,6 +12535,10 @@ struct CMUXCLI {
             scope = .all
         } else if includeWindow {
             scope = .window
+        } else if report && workspaceOpt == nil {
+            // A fleet report is cross-workspace by default; narrow it with an
+            // explicit --window or --workspace.
+            scope = .all
         } else {
             // Default and --workspace both produce a single workspace in the response.
             scope = .workspace
@@ -12363,7 +12575,9 @@ struct CMUXCLI {
             workspaceHandle: workspaceOpt,
             jsonOutput: jsonOutput,
             layoutOverride: layoutOverride,
-            canvasColsOverride: canvasOverride
+            canvasColsOverride: canvasOverride,
+            report: report,
+            outPath: outOpt
         )
     }
 

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -679,6 +679,30 @@ c11 app restart --no-resume          # restore layout, but type nothing into pan
 
 **Crash resume.** After an unclean exit (kill, panic, power loss) c11 relaunches, restores layout, and verifies each Claude conversation against the transcript it keeps at `~/.claude/projects/<cwd-slug>/<id>.jsonl` (stat only — bytes are never read). A verified transcript resumes in place; a missing one is skipped with a clear diagnostic. Sessions you ended with `/exit` are never auto-resumed.
 
+### Human-readable fleet snapshot (what every agent is doing)
+
+Three artifacts answer three different questions — don't confuse them:
+
+| The operator wants… | Use | Output |
+|---|---|---|
+| To reopen later with layout + agents restored | `c11 state save` (whole app) or `c11 snapshot` (one workspace) | JSON, for the machine |
+| A reusable layout *template* to respawn on demand | `c11 workspace export-blueprint --name <n> --format md` | markdown **layout only** — drops descriptions, roles, status, mailbox |
+| A legible report of *what every agent is doing* across all workspaces | `c11 tree --report` | narrative markdown, for a human |
+
+When the operator says **"save a snapshot of what everything is doing"** / "write down the state before I close c11" / "what's the state of the whole fleet" — that's the third row:
+
+```bash
+c11 tree --report                       # fleet-wide markdown to stdout
+c11 tree --report --out ~/c11-fleet-$(date +%F).md   # …or written to a file
+c11 tree --workspace <ref> --report     # narrow to one workspace (or --window)
+```
+
+`--report` (alias `--markdown`) joins the layout from `system.tree` with each surface's manifest, emitting per workspace: the pane layout (position %) and, per surface, the canonical title, agent type + model, live status/role, the `description` ("why it's open"), mailbox address, and any browser URL — closed by a summary table. It defaults to **every** window/workspace. Note it is *not* the blueprint exporter: blueprints are layout templates that deliberately drop the live metadata that makes a status report useful.
+
+Pair it with a `c11 state save` when the goal is to close c11 — the report is the legible record, `state save` is the machine-restore checkpoint — and offer to `open` the file.
+
+> **Older binary without `--report`?** Compose the same report by hand: `c11 tree --all --json` for geometry + titles, then one `c11 get-metadata --workspace <ws> --surface <surf>` per surface for the descriptions/roles/status, rendered into one dated markdown file.
+
 ## Conversation primitives
 
 c11 0.44.0+ owns a first-class **conversation store**: each surface hosts at most one active `ConversationRef` keyed by an opaque, per-kind id, persisted across c11 restarts. Per-TUI strategies (Claude Code, Codex, Opencode, Kimi today) capture and resume conversations using whatever signals each TUI exposes — hooks where available, on-disk file scrape as fallback.

--- a/tests_v2/test_tree_report.py
+++ b/tests_v2/test_tree_report.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""`c11 tree --report` — human-readable Markdown fleet snapshot.
+
+Covers:
+  - test_report_structure        header, generated line, panes, summary table
+  - test_report_defaults_to_all  no scope flag => every workspace in the window
+  - test_report_out_file         --out writes the markdown to a file
+  - test_report_workspace_scope  --workspace narrows to a single workspace
+  - test_report_markdown_alias   --markdown is an alias for --report
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError  # type: ignore[import]
+from tree_test_helpers import (
+    SOCKET_PATH,
+    find_cli_binary,
+    run_cli,
+)
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _run_report(cli: str, extra_args=None):
+    args = ["tree", "--report"] + (extra_args or [])
+    _, stdout, _ = run_cli(cli, args)
+    return stdout
+
+
+def _heading_count(markdown: str) -> int:
+    return sum(1 for line in markdown.splitlines() if line.startswith("### "))
+
+
+def test_report_structure(c: cmux, cli: str) -> None:
+    if len(c.list_workspaces()) < 2:
+        c.new_workspace()
+        time.sleep(0.2)
+
+    md = _run_report(cli)
+    _must(md.startswith("# c11 Fleet Snapshot"), f"report must start with the title header; got: {md[:60]!r}")
+    _must("_Generated " in md, "report must carry a `_Generated ...` line")
+    for token in ("window", "workspace", "surface"):
+        _must(token in md, f"generated line should mention {token!r}")
+    _must("**Pane**" in md, "report must list panes")
+    _must("## Summary" in md, "report must end with a Summary section")
+    _must("| Window | Workspace | Panes | Surfaces |" in md, "report must contain the summary table header")
+    print("PASS: test_report_structure")
+
+
+def test_report_defaults_to_all(c: cmux, cli: str) -> None:
+    """No scope flag => fleet-wide (every workspace in the window, >= 2)."""
+    if len(c.list_workspaces()) < 2:
+        c.new_workspace()
+        time.sleep(0.2)
+    expected = len(c.list_workspaces())
+
+    md = _run_report(cli)
+    headings = _heading_count(md)
+    _must(
+        headings >= expected,
+        f"--report should default to all workspaces (>= {expected}); got {headings} workspace headings",
+    )
+    print(f"PASS: test_report_defaults_to_all (headings={headings} expected>={expected})")
+
+
+def test_report_out_file(cli: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        out_path = os.path.join(tmp, "nested", "fleet.md")
+        rc, stdout, _ = run_cli(cli, ["tree", "--report", "--out", out_path])
+        _must(rc == 0, f"--out should succeed; rc={rc}")
+        _must("OK fleet-report path=" in stdout, f"--out should print an OK line; got: {stdout!r}")
+        _must(os.path.isfile(out_path), f"--out should create {out_path}")
+        content = Path(out_path).read_text(encoding="utf-8")
+        _must(content.startswith("# c11 Fleet Snapshot"), "written file must contain the report")
+    print("PASS: test_report_out_file")
+
+
+def test_report_workspace_scope(c: cmux, cli: str) -> None:
+    """`--workspace <id> --report` narrows to exactly one workspace."""
+    workspaces = c.list_workspaces()
+    if len(workspaces) < 2:
+        c.new_workspace()
+        time.sleep(0.2)
+        workspaces = c.list_workspaces()
+    target_id = workspaces[-1][1]  # (index, id, title, selected)
+
+    md = _run_report(cli, ["--workspace", target_id])
+    headings = _heading_count(md)
+    _must(headings == 1, f"--workspace --report should render exactly 1 workspace, got {headings}")
+    print("PASS: test_report_workspace_scope")
+
+
+def test_report_markdown_alias(cli: str) -> None:
+    _, stdout, _ = run_cli(cli, ["tree", "--markdown"])
+    _must(stdout.startswith("# c11 Fleet Snapshot"), "--markdown should alias --report")
+    print("PASS: test_report_markdown_alias")
+
+
+def main() -> int:
+    cli = find_cli_binary()
+    with cmux(SOCKET_PATH) as c:
+        c.activate_app()
+        test_report_structure(c, cli)
+        test_report_defaults_to_all(c, cli)
+        test_report_out_file(cli)
+        test_report_workspace_scope(c, cli)
+        test_report_markdown_alias(cli)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds **`c11 tree --report`** (alias `--markdown`) — a human-readable Markdown snapshot of *what every agent is doing* across the whole fleet.

Per workspace it emits the pane layout (position %) and, for each surface: canonical title, agent type + model, live status/role, the `description` ("why it's open"), mailbox address, and any browser URL — closed by a summary table.

```
c11 tree --report                      # fleet-wide markdown to stdout
c11 tree --report --out ~/fleet.md     # …or to a file
c11 tree --workspace <ref> --report    # narrow to one workspace (or --window)
```

## Why

There were already three persistence systems but none produced a legible cross-workspace *status* report:
- `c11 state save` / `c11 snapshot` — JSON, for machine restore.
- `c11 workspace export-blueprint --format md` — a layout **template** that *deliberately drops* descriptions/roles/status/mailbox.

So "save a snapshot of what everything is doing before I close c11" / handoffs / fleet status sweeps had no first-class command — agents hand-assembled it from `tree` + `get-metadata`. This makes it one command.

## How

- Built entirely on the existing `system.tree` + `surface.get_metadata` socket calls — **no app-side changes**, so it works against any running instance.
- `--report` defaults scope to all-workspaces (narrow with `--window`/`--workspace`); `--out <path>` writes to a file; renderer + per-surface metadata fetch live in `CLI/c11.swift`.
- Prefers each surface's canonical manifest `title` over the tree's (which can be a stale auto-title).

## Testing

- **Live-validated** against a real running 9-workspace / 44-surface instance: report, `--out` (with nested dir creation + byte count), `--workspace` narrowing, `--markdown` alias, and the summary table all verified.
- `tests_v2/test_tree_report.py` (auto-discovered by `run-tests-v2.sh`): structure, all-workspace default, `--out` file write, single-workspace scope, `--markdown` alias.
- `c11-cli` target builds clean (`xcodebuild -scheme c11-cli`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)