### PR TITLE
feat(surface-details): tab right-click Surface Details + copy surface handles

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5314,6 +5314,15 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.surfaceDetails",
+                title: constant(String(localized: "command.surfaceDetails.title", defaultValue: "Surface Details")),
+                subtitle: panelSubtitle,
+                keywords: ["surface", "details", "manifest", "metadata", "id", "number", "tab"],
+                when: { $0.bool(CommandPaletteContextKeys.hasFocusedPanel) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.closeTab",
                 title: constant(String(localized: "command.closeTab.title", defaultValue: "Close Tab")),
                 subtitle: constant(String(localized: "command.closeTab.subtitle", defaultValue: "Tab")),
@@ -5969,6 +5978,15 @@ struct ContentView: View {
             DispatchQueue.main.async {
                 _ = AppDelegate.shared?.openBrowserAndFocusAddressBar()
             }
+        }
+        registry.register(commandId: "palette.surfaceDetails") {
+            guard let workspace = tabManager.selectedWorkspace,
+                  let panelId = workspace.focusedPanelId,
+                  let panel = workspace.panels[panelId] else {
+                NSSound.beep()
+                return
+            }
+            workspace.showSurfaceDetails(for: panel)
         }
         registry.register(commandId: "palette.closeTab") {
             tabManager.closeCurrentPanelWithConfirmation()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6255,7 +6255,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             let manifestItem = menu.addItem(
                 withTitle: String(
                     localized: "surfaceManifest.menuItem",
-                    defaultValue: "Show surface manifest…"
+                    defaultValue: "Surface Details"
                 ),
                 action: #selector(showSurfaceManifest(_:)),
                 keyEquivalent: ""

--- a/Sources/SurfaceManifestView.swift
+++ b/Sources/SurfaceManifestView.swift
@@ -18,6 +18,24 @@ enum SurfaceManifestKind: String {
     }
 }
 
+/// Friendly handle refs (and a few human-relevant fields) for a surface,
+/// resolved by `TerminalController.surfaceHandleInfo(workspaceId:surfaceId:)`.
+/// This is the data the operator opens Surface Details to find — chiefly the
+/// `surface:N` / `tab:N` numbers, which are otherwise only reachable via the
+/// CLI.
+struct SurfaceHandleInfo {
+    let surfaceRef: String
+    let tabRef: String
+    let paneRef: String?
+    let workspaceRef: String
+    let windowRef: String?
+    let terminalType: String?
+    let tty: String?
+    let workingDirectory: String?
+    let url: String?
+    let filePath: String?
+}
+
 struct SurfaceManifestSnapshot {
     let metadata: [String: Any]
     let sources: [String: [String: Any]]
@@ -44,15 +62,19 @@ struct SurfaceManifestView: View {
     let workspaceId: UUID
     let surfaceId: UUID
     let kind: SurfaceManifestKind
+    let handle: SurfaceHandleInfo
 
     @State private var snapshot: SurfaceManifestSnapshot
-    @State private var copiedFlash: Bool = false
+    // Which field's Copy button most recently fired — flips that one button to
+    // "Copied" briefly. Only one row shows the confirmation at a time.
+    @State private var copiedField: String?
     @State private var copyResetWorkItem: DispatchWorkItem?
 
-    init(workspaceId: UUID, surfaceId: UUID, kind: SurfaceManifestKind) {
+    init(workspaceId: UUID, surfaceId: UUID, kind: SurfaceManifestKind, handle: SurfaceHandleInfo) {
         self.workspaceId = workspaceId
         self.surfaceId = surfaceId
         self.kind = kind
+        self.handle = handle
         _snapshot = State(initialValue: SurfaceManifestSnapshot.capture(workspaceId: workspaceId, surfaceId: surfaceId))
     }
 
@@ -64,8 +86,10 @@ struct SurfaceManifestView: View {
             Divider()
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {
-                    bodyJSON
+                    detailsSection
+                    jsonSection
                     sourcesDisclosure
+                    advancedDisclosure
                 }
                 .padding(16)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -75,23 +99,122 @@ struct SurfaceManifestView: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
         }
-        .frame(minWidth: 480, minHeight: 360)
+        .frame(minWidth: 520, minHeight: 400)
     }
 
+    // The handle refs are the headline — always-visible, each copyable, with
+    // surface:N rendered extra-large since it's the number the operator most
+    // often wants.
     private var header: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            row(
-                label: String(localized: "surfaceManifest.header.workspace", defaultValue: "Workspace"),
-                value: workspaceId.uuidString
+        VStack(alignment: .leading, spacing: 8) {
+            refRow(
+                label: String(localized: "surfaceManifest.ref.surface", defaultValue: "Surface"),
+                value: handle.surfaceRef,
+                field: "surface",
+                size: .extraLarge
             )
-            row(
-                label: String(localized: "surfaceManifest.header.surface", defaultValue: "Surface"),
-                value: surfaceId.uuidString
+            refRow(
+                label: String(localized: "surfaceManifest.ref.tab", defaultValue: "Tab"),
+                value: handle.tabRef,
+                field: "tab",
+                size: .prominent
             )
+            if let pane = handle.paneRef {
+                refRow(
+                    label: String(localized: "surfaceManifest.ref.pane", defaultValue: "Pane"),
+                    value: pane,
+                    field: "pane",
+                    size: .normal
+                )
+            }
+            refRow(
+                label: String(localized: "surfaceManifest.ref.workspace", defaultValue: "Workspace"),
+                value: handle.workspaceRef,
+                field: "workspace",
+                size: .normal
+            )
+            if let window = handle.windowRef {
+                refRow(
+                    label: String(localized: "surfaceManifest.ref.window", defaultValue: "Window"),
+                    value: window,
+                    field: "window",
+                    size: .normal
+                )
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private enum RefSize {
+        case normal, prominent, extraLarge
+
+        var fontSize: CGFloat {
+            switch self {
+            case .normal: return 11
+            case .prominent: return 13
+            case .extraLarge: return 22
+            }
+        }
+
+        var weight: Font.Weight {
+            switch self {
+            case .normal: return .regular
+            case .prominent: return .semibold
+            case .extraLarge: return .bold
+            }
+        }
+    }
+
+    private func refRow(label: String, value: String, field: String, size: RefSize) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(label)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+                .frame(width: 80, alignment: .leading)
+            Text(value)
+                .font(.system(size: size.fontSize, weight: size.weight, design: .monospaced))
+                .textSelection(.enabled)
+            Spacer(minLength: 8)
+            copyButton(field: field, value: value)
+        }
+    }
+
+    private var detailsSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
             row(
-                label: String(localized: "surfaceManifest.header.kind", defaultValue: "Kind"),
+                label: String(localized: "surfaceManifest.detail.type", defaultValue: "Type"),
                 value: kind.localizedLabel
             )
+            if let terminalType = handle.terminalType, !terminalType.isEmpty {
+                row(
+                    label: String(localized: "surfaceManifest.detail.terminalType", defaultValue: "Terminal type"),
+                    value: terminalType
+                )
+            }
+            if let tty = handle.tty, !tty.isEmpty {
+                row(
+                    label: String(localized: "surfaceManifest.detail.tty", defaultValue: "TTY"),
+                    value: tty
+                )
+            }
+            if let cwd = handle.workingDirectory, !cwd.isEmpty {
+                row(
+                    label: String(localized: "surfaceManifest.detail.directory", defaultValue: "Directory"),
+                    value: cwd
+                )
+            }
+            if let url = handle.url, !url.isEmpty {
+                row(
+                    label: String(localized: "surfaceManifest.detail.url", defaultValue: "URL"),
+                    value: url
+                )
+            }
+            if let file = handle.filePath, !file.isEmpty {
+                row(
+                    label: String(localized: "surfaceManifest.detail.file", defaultValue: "File"),
+                    value: file
+                )
+            }
             row(
                 label: String(localized: "surfaceManifest.header.capturedAt", defaultValue: "Captured"),
                 value: Self.timestampFormatter.string(from: snapshot.capturedAt)
@@ -113,6 +236,34 @@ struct SurfaceManifestView: View {
         }
     }
 
+    private func copyButton(field: String, value: String) -> some View {
+        Button {
+            copyValue(value, field: field)
+        } label: {
+            Text(copiedField == field
+                 ? String(localized: "surfaceManifest.copiedButton", defaultValue: "Copied")
+                 : String(localized: "surfaceManifest.copyButton.short", defaultValue: "Copy"))
+                .font(.system(size: 10, weight: .medium))
+        }
+        .buttonStyle(.borderless)
+        .foregroundColor(copiedField == field ? .secondary : .accentColor)
+    }
+
+    private var jsonSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(String(localized: "surfaceManifest.json.title", defaultValue: "Metadata (JSON)"))
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.secondary)
+                Spacer()
+                if !snapshot.metadata.isEmpty {
+                    copyButton(field: "json", value: snapshot.prettyJSON)
+                }
+            }
+            bodyJSON
+        }
+    }
+
     @ViewBuilder
     private var bodyJSON: some View {
         if snapshot.metadata.isEmpty {
@@ -125,6 +276,32 @@ struct SurfaceManifestView: View {
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    // Identifiers are advanced-only — collapsed by default, with a note
+    // steering toward the surface integer (surface:N) rather than the UUID.
+    private var advancedDisclosure: some View {
+        DisclosureGroup(String(localized: "surfaceManifest.advanced.disclosure", defaultValue: "Advanced — identifiers")) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(String(
+                    localized: "surfaceManifest.advanced.note",
+                    defaultValue: "Tip: copy the surface integer above (e.g. surface:75), not the UUID below."
+                ))
+                .font(.system(size: 10))
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                row(
+                    label: String(localized: "surfaceManifest.ids.surfaceUUID", defaultValue: "Surface UUID"),
+                    value: surfaceId.uuidString
+                )
+                row(
+                    label: String(localized: "surfaceManifest.ids.workspaceUUID", defaultValue: "Workspace UUID"),
+                    value: workspaceId.uuidString
+                )
+            }
+            .padding(.top, 6)
+        }
+        .font(.system(size: 12))
     }
 
     private var sourcesDisclosure: some View {
@@ -197,12 +374,6 @@ struct SurfaceManifestView: View {
 
     private var footer: some View {
         HStack {
-            Button(action: copyJSON) {
-                Text(copiedFlash
-                     ? String(localized: "surfaceManifest.copiedButton", defaultValue: "Copied")
-                     : String(localized: "surfaceManifest.copyButton", defaultValue: "Copy JSON"))
-            }
-            .disabled(snapshot.metadata.isEmpty)
             Button(action: refresh) {
                 Text(String(localized: "surfaceManifest.refreshButton", defaultValue: "Refresh"))
             }
@@ -210,15 +381,14 @@ struct SurfaceManifestView: View {
         }
     }
 
-    private func copyJSON() {
-        let payload = snapshot.prettyJSON
-        guard !payload.isEmpty else { return }
+    private func copyValue(_ value: String, field: String) {
+        guard !value.isEmpty else { return }
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(payload, forType: .string)
-        copiedFlash = true
+        pasteboard.setString(value, forType: .string)
+        copiedField = field
         copyResetWorkItem?.cancel()
-        let work = DispatchWorkItem { copiedFlash = false }
+        let work = DispatchWorkItem { copiedField = nil }
         copyResetWorkItem = work
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5, execute: work)
     }

--- a/Sources/SurfaceManifestViewerWindowController.swift
+++ b/Sources/SurfaceManifestViewerWindowController.swift
@@ -14,13 +14,14 @@ final class SurfaceManifestViewerWindowController: NSWindowController, NSWindowD
             backing: .buffered,
             defer: false
         )
-        panel.title = String(localized: "surfaceManifest.windowTitle", defaultValue: "Surface manifest")
+        panel.title = String(localized: "surfaceManifest.windowTitle", defaultValue: "Surface Details")
         panel.titleVisibility = .visible
         panel.isReleasedWhenClosed = false
         panel.identifier = NSUserInterfaceItemIdentifier("c11.surfaceManifestViewer.\(surfaceId.uuidString)")
         panel.center()
+        let handle = TerminalController.shared.surfaceHandleInfo(workspaceId: workspaceId, surfaceId: surfaceId)
         panel.contentView = NSHostingView(
-            rootView: SurfaceManifestView(workspaceId: workspaceId, surfaceId: surfaceId, kind: kind)
+            rootView: SurfaceManifestView(workspaceId: workspaceId, surfaceId: surfaceId, kind: kind, handle: handle)
         )
         AppDelegate.shared?.applyWindowDecorations(to: panel)
         super.init(window: panel)
@@ -49,5 +50,94 @@ final class SurfaceManifestViewerWindowController: NSWindowController, NSWindowD
 
     func windowWillClose(_ notification: Notification) {
         Self.openControllers.removeValue(forKey: surfaceId)
+    }
+}
+
+/// A small, non-activating transient HUD used to confirm a clipboard copy
+/// (e.g. "Copied surface:75") triggered from a context menu, where the menu
+/// closes before any inline feedback could show. Appears near the pointer and
+/// auto-dismisses. Does not steal focus.
+@MainActor
+final class CopyConfirmationHUD {
+    private static var panel: NSPanel?
+    private static var dismissWork: DispatchWorkItem?
+
+    static func show(message: String) {
+        let hud = panel ?? makePanel()
+        panel = hud
+
+        let host = NSHostingView(rootView: CopyConfirmationHUDView(message: message))
+        hud.contentView = host
+        hud.layoutIfNeeded()
+        var size = host.fittingSize
+        size.width = max(size.width, 96)
+        size.height = max(size.height, 36)
+
+        // Position just above the pointer, clamped to the active screen.
+        let mouse = NSEvent.mouseLocation
+        var origin = NSPoint(x: mouse.x - size.width / 2, y: mouse.y + 18)
+        if let screen = NSScreen.screens.first(where: { $0.frame.contains(mouse) }) ?? NSScreen.main {
+            let frame = screen.visibleFrame
+            origin.x = min(max(origin.x, frame.minX + 8), frame.maxX - size.width - 8)
+            origin.y = min(max(origin.y, frame.minY + 8), frame.maxY - size.height - 8)
+        }
+        hud.setFrame(NSRect(origin: origin, size: size), display: true)
+        hud.alphaValue = 1
+        hud.orderFrontRegardless()
+
+        dismissWork?.cancel()
+        let work = DispatchWorkItem { Self.dismiss() }
+        dismissWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9, execute: work)
+    }
+
+    private static func dismiss() {
+        guard let hud = panel else { return }
+        NSAnimationContext.runAnimationGroup({ ctx in
+            ctx.duration = 0.18
+            hud.animator().alphaValue = 0
+        }, completionHandler: {
+            hud.orderOut(nil)
+        })
+    }
+
+    private static func makePanel() -> NSPanel {
+        let p = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 160, height: 40),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        p.isFloatingPanel = true
+        p.level = .floating
+        p.hidesOnDeactivate = false
+        p.isReleasedWhenClosed = false
+        p.backgroundColor = .clear
+        p.isOpaque = false
+        p.hasShadow = true
+        p.ignoresMouseEvents = true
+        p.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .transient]
+        return p
+    }
+}
+
+private struct CopyConfirmationHUDView: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(Color(red: 0.96, green: 0.77, blue: 0.09))
+            Text(message)
+                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                .foregroundStyle(.white)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 9)
+        .background(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .fill(Color.black.opacity(0.82))
+        )
+        .fixedSize()
     }
 }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4048,6 +4048,80 @@ class TerminalController {
         return surfaceRef.replacingOccurrences(of: "surface:", with: "tab:")
     }
 
+    /// Cheap surface-ref-only lookup. Mints (or returns) just the `surface:N`
+    /// handle for a panel — a dictionary lookup, no pane/window/locate work.
+    /// Used by the bonsplit tab context menu's "Copy surface:N" item, which is
+    /// built per tab and must stay cheap. `@MainActor` like the ref maps.
+    func surfaceRefOnly(forSurfaceUUID surfaceId: UUID) -> String {
+        v2EnsureHandleRef(kind: .surface, uuid: surfaceId)
+    }
+
+    /// UI-facing handle lookup for the Surface Details panel.
+    ///
+    /// Mints (or returns) the friendly `surface:N` / `tab:N` / `pane:M` /
+    /// `workspace:X` / `window:Y` handles for a surface — the same numbers the
+    /// CLI (`c11 identify`, `c11 tree`) exposes — plus a few human-relevant
+    /// fields (tty, cwd, url, file). The operator opens this to answer "what
+    /// number is this surface?" without dropping to the CLI. Minting on demand
+    /// is intentional: a surface the CLI has never touched still gets a stable
+    /// handle the operator can paste into a command.
+    ///
+    /// `@MainActor`-confined like the rest of the v2 ref maps; safe to call
+    /// from UI (the panel is presented on the main actor).
+    func surfaceHandleInfo(workspaceId: UUID, surfaceId: UUID) -> SurfaceHandleInfo {
+        let surfaceRef = v2EnsureHandleRef(kind: .surface, uuid: surfaceId)
+        let tabRef = surfaceRef.replacingOccurrences(of: "surface:", with: "tab:")
+        let workspaceRef = v2EnsureHandleRef(kind: .workspace, uuid: workspaceId)
+
+        var paneRef: String?
+        var windowRef: String?
+        var tty: String?
+        var workingDirectory: String?
+        var url: String?
+        var filePath: String?
+
+        if let located = AppDelegate.shared?.locateSurface(surfaceId: surfaceId) {
+            windowRef = v2EnsureHandleRef(kind: .window, uuid: located.windowId)
+            if let ws = located.tabManager.tabs.first(where: { $0.id == located.workspaceId }) {
+                for paneId in ws.bonsplitController.allPaneIds
+                where ws.bonsplitController.tabs(inPane: paneId)
+                    .contains(where: { ws.panelIdFromSurfaceId($0.id) == surfaceId }) {
+                    paneRef = v2EnsureHandleRef(kind: .pane, uuid: paneId.id)
+                    break
+                }
+                tty = ws.surfaceTTYNames[surfaceId]
+                workingDirectory = ws.surfaceDirectories[surfaceId]
+                if let panel = ws.panels[surfaceId] {
+                    if let browser = panel as? BrowserPanel {
+                        url = browser.currentURL?.absoluteString
+                    }
+                    if let markdown = panel as? MarkdownPanel {
+                        filePath = markdown.filePath
+                    }
+                }
+            }
+        }
+
+        let (metadata, _) = SurfaceMetadataStore.shared.getMetadata(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId
+        )
+        let terminalType = metadata[MetadataKey.terminalType] as? String
+
+        return SurfaceHandleInfo(
+            surfaceRef: surfaceRef,
+            tabRef: tabRef,
+            paneRef: paneRef,
+            workspaceRef: workspaceRef,
+            windowRef: windowRef,
+            terminalType: terminalType,
+            tty: tty,
+            workingDirectory: workingDirectory,
+            url: url,
+            filePath: filePath
+        )
+    }
+
     private func v2RefreshKnownRefs() {
         guard let app = AppDelegate.shared else { return }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5836,6 +5836,10 @@ final class Workspace: Identifiable, ObservableObject {
         bonsplitController.onTabCloseRequest = { [weak self] tabId, _ in
             self?.markExplicitClose(surfaceId: tabId)
         }
+        bonsplitController.surfaceRefProvider = { [weak self] tabId in
+            guard let self, let panelId = self.panelIdFromSurfaceId(tabId) else { return nil }
+            return TerminalController.shared.surfaceRefOnly(forSurfaceUUID: panelId)
+        }
 
         // Set ourselves as delegate
         bonsplitController.delegate = self
@@ -11915,9 +11919,52 @@ extension Workspace: BonsplitDelegate {
         case .chooseCustomColor:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             promptCustomTabColor(panelId: panelId)
+        case .surfaceDetails:
+            showSurfaceDetails(forSurfaceId: tab.id)
+        case .copySurfaceRef:
+            copySurfaceRef(forSurfaceId: tab.id)
         @unknown default:
             break
         }
+    }
+
+    /// Copy the tab's `surface:N` handle to the clipboard and show a brief
+    /// confirmation HUD. Routed from the tab right-click menu's copy item.
+    func copySurfaceRef(forSurfaceId surfaceId: TabID) {
+        guard let panel = panel(for: surfaceId) else { return }
+        let ref = TerminalController.shared.surfaceRefOnly(forSurfaceUUID: panel.id)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(ref, forType: .string)
+        let copied = String(localized: "copyHUD.copiedPrefix", defaultValue: "Copied")
+        CopyConfirmationHUD.show(message: "\(copied) \(ref)")
+    }
+
+    /// Open the Surface Details panel for the surface backing a tab. Routed
+    /// from the tab right-click menu; the panel shows the `surface:N` /
+    /// `tab:N` handles plus the surface metadata manifest.
+    func showSurfaceDetails(forSurfaceId surfaceId: TabID) {
+        guard let panel = panel(for: surfaceId) else { return }
+        showSurfaceDetails(for: panel)
+    }
+
+    /// Open the Surface Details panel for a specific panel. Routed from the
+    /// command palette (which targets the focused panel directly).
+    func showSurfaceDetails(for panel: any Panel) {
+        let kind: SurfaceManifestKind
+        switch panel.panelType {
+        case .terminal:
+            kind = .terminal
+        case .browser:
+            kind = .browser
+        case .markdown:
+            kind = .markdown
+        }
+        SurfaceManifestViewerWindowController.show(
+            workspaceId: id,
+            surfaceId: panel.id,
+            kind: kind
+        )
     }
 
     func splitTabBar(_ controller: BonsplitController, didSelectTabColorPaletteEntry hex: String, for tab: Bonsplit.Tab, inPane pane: PaneID) {


### PR DESCRIPTION
## Surface Details on tab right-click

Right-clicking a tab now exposes a **Surface Details** panel and a **Copy `surface:N`** item. The surface/tab handle (`surface:75`, `tab:75`) was previously only reachable via the CLI; this surfaces it in the UI.

### Tab right-click menu
`Surface Details` → `Copy surface:N` → ─── → `Close Tab` → `Close Pane`
- **Copy surface:N** copies the handle and shows a brief "Copied surface:N" HUD near the cursor (`CopyConfirmationHUD`).
- **Surface Details** opens the panel (works for terminal / browser / markdown tabs).

### Surface Details panel
Reuses the existing surface-manifest window, extended to show the friendly handles:
- `surface:N` (**extra-large**), `tab:N`, `pane:M`, `workspace:X`, `window:Y` — each with a **Copy** button.
- `type`, `terminal_type`, `tty`, directory, url/file; the custom metadata JSON with its own **Copy**.
- UUIDs moved to a collapsed **"Advanced — identifiers"** disclosure (relabeled **Surface UUID / Workspace UUID**) with a note steering to the integer handle.

### Also
- **Command palette:** `Surface Details` entry (focused surface).
- Terminal-body `Show surface manifest…` renamed to **Surface Details** for consistency, routing to the same panel.

### Plumbing
- `TerminalController.surfaceHandleInfo` / `surfaceRefOnly` resolve + mint handles (same numbers the CLI mints).
- bonsplit (submodule, `2d08d42`): two new `TabContextAction`s (`surfaceDetails`, `copySurfaceRef`), a host `surfaceRefProvider` closure, and `surfaceRef` on `TabContextMenuState`. c11-specific; not for upstream.

### Validation
- Debug build green (no new warnings). Tagged build launched and exercised across terminal/browser/markdown surfaces; menu order + panel visuals signed off by operator.
- Follow-up: 6-locale translation pass for the new English strings (runtime falls back to English meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
