### PR TITLE
feat(qa): C11_QA_LAUNCH flag to suppress startup dialogs for automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,8 @@ See `skills/c11-hotload/SKILL.md` for the full workflow — `reload.sh --tag` bu
 
 The one-liner: after any code change, `./scripts/reload.sh --tag <your-branch-slug>`. Never `open` an untagged `c11 DEV.app`.
 
+**QA / automation launch — suppress the startup dialogs.** A normal launch can block on two modals before the GUI is usable: the Agent Skills install/update sheet and the "Resume previous session?" picker. For automated/QA runs set `C11_QA_LAUNCH` (dual-read `CMUX_QA_LAUNCH`) to suppress both and make resume deterministic — `fresh` (or any non-`resume` value) starts clean, `resume` silently restores the prior session, unset is normal interactive behavior. It's read per-launch and never persisted. The tagged automation launcher exposes it as a flag: `./scripts/launch-tagged-automation.sh <tag> --qa [fresh|resume]`. Lives in `Sources/QALaunchPolicy.swift`; see `skills/c11-hotload/SKILL.md` for the full table.
+
 ## Diagnostics
 
 - **Portal lifecycle (C11-18):** launch c11 with `C11_PORTAL_DEBUG=1` (or `CMUX_PORTAL_DEBUG=1`) to write structured `bind`/`detach`/`sync.skip.orphan`/`sync.result`/`orphan.hide`/`geom.external` events to `/tmp/c11-portal.log` (override path with `C11_PORTAL_LOG`). The log truncates on first call after process start; one repro run per file. Drive churn with `scripts/repro-c11-18.sh [iterations]` and attach the log range covering the artifact to the C11-18 ticket.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		A5001544 /* AgentDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001545 /* AgentDetector.swift */; };
 		A5001601 /* SentryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001600 /* SentryHelper.swift */; };
 		A5001610 /* SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001611 /* SessionPersistence.swift */; };
+		A500DA01 /* QALaunchPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500DA02 /* QALaunchPolicy.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
 		A5001623 /* c11.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* c11.sdef */; };
 		A5001700 /* TextBoxInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001701 /* TextBoxInput.swift */; };
@@ -503,6 +504,7 @@
 		A5001545 /* AgentDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentDetector.swift; sourceTree = "<group>"; };
 		A5001600 /* SentryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHelper.swift; sourceTree = "<group>"; };
 		A5001611 /* SessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistence.swift; sourceTree = "<group>"; };
+		A500DA02 /* QALaunchPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QALaunchPolicy.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
 		A5001622 /* c11.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = c11.sdef; sourceTree = "<group>"; };
 		A5001701 /* TextBoxInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInput.swift; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
+				A500DA02 /* QALaunchPolicy.swift */,
 				A5005B01 /* BrandColors.swift */,
 				A5FA5701 /* FlashAppearance.swift */,
 				CC401001A1B2C3D4E5F60719 /* SkillInstaller.swift */,
@@ -1645,6 +1648,7 @@
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
+				A500DA01 /* QALaunchPolicy.swift in Sources */,
 				A5005B02 /* BrandColors.swift in Sources */,
 				A5FA5702 /* FlashAppearance.swift in Sources */,
 				CC401002A1B2C3D4E5F60719 /* SkillInstaller.swift in Sources */,

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -1448,8 +1448,12 @@ enum AgentSkillsOnboarding {
         home: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true),
         sourceDir: URL? = nil,
         defaults: UserDefaults = .standard,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
+        // QA launch (`C11_QA_LAUNCH`) suppresses the onboarding sheet so
+        // automated runs reach a usable window with no modal in the way.
+        if QALaunchPolicy.current(environment: environment).isActive { return false }
         if defaults.bool(forKey: dontAskAgainKey) { return false }
         if _dismissedThisLaunch { return false }
         let resolvedSource: URL

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3353,7 +3353,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // under `c11.launch.resumePolicy` (default `.ask`); `.always`
         // keeps the legacy "restore everything" behavior, `.never`
         // skips restore entirely.
-        let policy = LaunchResumePolicy.current()
+        //
+        // QA launch (`C11_QA_LAUNCH`) overrides that persisted policy for
+        // this launch only (never written back): `resume` → `.always`
+        // (silent restore), `fresh` → `.never` (skip). Both bypass the
+        // `.ask` picker so an automated run never blocks on the modal.
+        let policy: LaunchResumePolicy
+        switch QALaunchPolicy.current() {
+        case .on(.resume):
+            policy = .always
+        case .on(.fresh):
+            policy = .never
+        case .off:
+            policy = LaunchResumePolicy.current()
+        }
         if policy == .ask,
            let snapshot = startupSessionSnapshot,
            snapshot.windows.contains(where: { !$0.tabManager.workspaces.isEmpty }) {

--- a/Sources/QALaunchPolicy.swift
+++ b/Sources/QALaunchPolicy.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// QA / automation launch policy, parsed from the `C11_QA_LAUNCH`
+/// environment variable (dual-read `CMUX_QA_LAUNCH`).
+///
+/// A normal interactive launch can present two blocking dialogs before the
+/// operator reaches a usable window: the Agent Skills install/update
+/// onboarding sheet, and the "Resume previous session?" picker. Those are
+/// correct for humans but a nuisance for automated QA, which wants the GUI
+/// up with no modal in the way and a deterministic resume decision.
+///
+/// Setting `C11_QA_LAUNCH` to any non-empty value turns **QA mode** on:
+/// both dialogs are suppressed. The value selects the resume direction:
+///
+/// ```
+///   C11_QA_LAUNCH=fresh    QA mode, start clean (no session restore)
+///   C11_QA_LAUNCH=resume   QA mode, silently restore the prior session
+///   C11_QA_LAUNCH=<other>  QA mode, default: fresh
+///   (unset / empty)        normal interactive launch (both dialogs may show)
+/// ```
+///
+/// The variable is read fresh from the environment each launch and never
+/// persisted, so it can't leak into a later non-QA run the way a UserDefaults
+/// pref would. It is intentionally not gated to debug builds — nobody sets it
+/// in production, and gating would make it useless for QA against a release
+/// build.
+enum QALaunchPolicy: Equatable {
+    /// Whether the prior session is restored once QA mode is active.
+    enum Resume: Equatable {
+        case fresh
+        case resume
+    }
+
+    case off
+    case on(Resume)
+
+    /// Primary (authored) and legacy env var names. The c11 binary dual-reads
+    /// `C11_*` / `CMUX_*`; `C11_*` is canonical and wins when both are set.
+    static let primaryKey = "C11_QA_LAUNCH"
+    static let legacyKey = "CMUX_QA_LAUNCH"
+
+    static func current(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> QALaunchPolicy {
+        let raw = (environment[primaryKey] ?? environment[legacyKey] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return .off }
+        switch raw.lowercased() {
+        case "resume", "restore":
+            return .on(.resume)
+        default:
+            // Any other non-empty value (fresh, none, no, 0, 1, …) is QA mode
+            // with a clean slate. Default-fresh keeps automation deterministic:
+            // resume is the deliberate opt-in.
+            return .on(.fresh)
+        }
+    }
+
+    /// QA mode is active — suppress the skill-install and resume-session
+    /// dialogs.
+    var isActive: Bool {
+        if case .on = self { return true }
+        return false
+    }
+
+    /// QA mode is active and the prior session should be silently restored.
+    var shouldResume: Bool {
+        self == .on(.resume)
+    }
+
+    /// QA mode is active and the prior session should be skipped (clean slate).
+    var shouldStartFresh: Bool {
+        self == .on(.fresh)
+    }
+}

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -157,6 +157,14 @@ enum SessionRestorePolicy {
         arguments: [String] = CommandLine.arguments,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
+        // QA launch (`C11_QA_LAUNCH`) is the deterministic override: in QA
+        // mode the resume decision comes straight from the flag — load the
+        // snapshot iff resume was requested, regardless of args or test
+        // markers. This wins over everything below so QA runs are reproducible.
+        let qa = QALaunchPolicy.current(environment: environment)
+        if qa.isActive {
+            return qa.shouldResume
+        }
         if environment["CMUX_DISABLE_SESSION_RESTORE"] == "1" {
             return false
         }

--- a/c11Tests/SessionPersistenceTests.swift
+++ b/c11Tests/SessionPersistenceTests.swift
@@ -258,6 +258,72 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertFalse(shouldRestore)
     }
 
+    // MARK: - QA launch policy
+
+    func testQALaunchPolicyOffWhenUnset() {
+        XCTAssertEqual(QALaunchPolicy.current(environment: [:]), .off)
+        XCTAssertEqual(QALaunchPolicy.current(environment: ["C11_QA_LAUNCH": "  "]), .off)
+        XCTAssertFalse(QALaunchPolicy.current(environment: [:]).isActive)
+    }
+
+    func testQALaunchPolicyFreshForNonResumeValues() {
+        for value in ["fresh", "FRESH", "none", "0", "1", "yes", "clean"] {
+            let policy = QALaunchPolicy.current(environment: ["C11_QA_LAUNCH": value])
+            XCTAssertEqual(policy, .on(.fresh), "value=\(value)")
+            XCTAssertTrue(policy.isActive)
+            XCTAssertTrue(policy.shouldStartFresh)
+            XCTAssertFalse(policy.shouldResume)
+        }
+    }
+
+    func testQALaunchPolicyResumeValues() {
+        for value in ["resume", "RESUME", " restore ", "Resume"] {
+            let policy = QALaunchPolicy.current(environment: ["C11_QA_LAUNCH": value])
+            XCTAssertEqual(policy, .on(.resume), "value=\(value)")
+            XCTAssertTrue(policy.isActive)
+            XCTAssertTrue(policy.shouldResume)
+            XCTAssertFalse(policy.shouldStartFresh)
+        }
+    }
+
+    func testQALaunchPolicyDualReadsLegacyKeyButC11Wins() {
+        XCTAssertEqual(
+            QALaunchPolicy.current(environment: ["CMUX_QA_LAUNCH": "resume"]),
+            .on(.resume)
+        )
+        // C11_* is canonical and wins when both are present.
+        XCTAssertEqual(
+            QALaunchPolicy.current(environment: [
+                "C11_QA_LAUNCH": "fresh",
+                "CMUX_QA_LAUNCH": "resume",
+            ]),
+            .on(.fresh)
+        )
+    }
+
+    func testRestorePolicyFreshQALaunchSkipsRestore() {
+        // QA fresh: no snapshot load even though there are no explicit args.
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: ["/Applications/cmux.app/Contents/MacOS/cmux"],
+            environment: ["C11_QA_LAUNCH": "fresh"]
+        )
+        XCTAssertFalse(shouldRestore)
+    }
+
+    func testRestorePolicyResumeQALaunchForcesRestore() {
+        // QA resume wins even over markers that would normally skip restore
+        // (test detection, disable flag), so the resume decision is the flag's.
+        let shouldRestore = SessionRestorePolicy.shouldAttemptRestore(
+            arguments: ["/Applications/cmux.app/Contents/MacOS/cmux"],
+            environment: [
+                "C11_QA_LAUNCH": "resume",
+                "CMUX_DISABLE_SESSION_RESTORE": "1",
+                "XCTestConfigurationFilePath": "/tmp/xctest.xctestconfiguration",
+            ]
+        )
+        XCTAssertTrue(shouldRestore)
+    }
+
     func testSidebarWidthSanitizationClampsToPolicyRange() {
         XCTAssertEqual(
             SessionPersistencePolicy.sanitizedSidebarWidth(-20),

--- a/scripts/launch-tagged-automation.sh
+++ b/scripts/launch-tagged-automation.sh
@@ -7,6 +7,9 @@ Usage: ./scripts/launch-tagged-automation.sh <tag> [options]
 
 Options:
   --mode <mode>       Socket mode override. Default: automation
+  --qa [fresh|resume] QA launch: suppress the skill-install and resume-session
+                      dialogs (sets C11_QA_LAUNCH). Bare or "fresh" starts clean;
+                      "resume" silently restores the prior session. Default: fresh.
   --shell-log <path>  Set GHOSTTY_ZSH_INTEGRATION_LOG for shells in the tagged app.
   --wait-socket <s>   Wait for the tagged socket to appear. Default: 10
   --env KEY=VALUE     Extra environment variable to inject at launch. Repeatable.
@@ -43,6 +46,7 @@ TAG=""
 MODE="automation"
 SHELL_LOG=""
 WAIT_SOCKET="10"
+QA_LAUNCH=""
 EXTRA_ENV=()
 EXTRA_ENV_COUNT=0
 
@@ -55,6 +59,20 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       shift 2
+      ;;
+    --qa)
+      # Optional value: `--qa` / `--qa fresh` / `--qa resume`. A bare `--qa`
+      # (or anything that isn't an explicit resume direction) defaults fresh.
+      case "${2:-}" in
+        fresh|resume)
+          QA_LAUNCH="$2"
+          shift 2
+          ;;
+        *)
+          QA_LAUNCH="fresh"
+          shift 1
+          ;;
+      esac
       ;;
     --env)
       if [[ -z "${2:-}" ]]; then
@@ -138,6 +156,8 @@ OPEN_ENV=(
   -u CMUX_PORT_RANGE
   -u CMUX_DEBUG_LOG
   -u CMUX_BUNDLE_ID
+  -u C11_QA_LAUNCH
+  -u CMUX_QA_LAUNCH
   -u CMUX_SHELL_INTEGRATION
   -u CMUX_SHELL_INTEGRATION_DIR
   -u CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION
@@ -154,6 +174,9 @@ OPEN_ENV=(
   "CMUX_DEBUG_LOG=${LOG}"
 )
 
+if [[ -n "$QA_LAUNCH" ]]; then
+  OPEN_ENV+=("C11_QA_LAUNCH=${QA_LAUNCH}")
+fi
 if [[ "$EXTRA_ENV_COUNT" -gt 0 ]]; then
   for kv in "${EXTRA_ENV[@]}"; do
     OPEN_ENV+=("${kv}")
@@ -181,6 +204,9 @@ echo "socket: $SOCK"
 echo "c11d_socket: $DSOCK"
 echo "log: $LOG"
 echo "mode: $MODE"
+if [[ -n "$QA_LAUNCH" ]]; then
+  echo "qa_launch: $QA_LAUNCH"
+fi
 echo "socket_ready: $(if [[ -S "$SOCK" ]]; then echo yes; else echo no; fi)"
 if [[ -n "$SHELL_LOG" ]]; then
   echo "shell_log: $SHELL_LOG"

--- a/skills/c11-hotload/SKILL.md
+++ b/skills/c11-hotload/SKILL.md
@@ -56,6 +56,29 @@ xcodebuild -project GhosttyTabs.xcodeproj -scheme c11 -configuration Debug -dest
 
 A Release/staging build (`reloads.sh`, or a published `c11 STAGING …`) binds its **own** socket (e.g. `/tmp/c11-rel-<ver>.sock`) that a CLI running in a production-c11 shell cannot write to — the writes fail even with the path pointed at it. To run `c11` CLI or socket checks against such a build, run them from a terminal **inside that build**. For socket-level validation during development, prefer a tagged **Debug** build, whose socket is reachable from any shell via `C11_SOCKET=/tmp/c11-debug-<tag>.sock`.
 
+## QA / automation launch (suppress the startup dialogs)
+
+A normal launch can present two blocking dialogs before the GUI is usable: the **Agent Skills** install/update sheet and the **"Resume previous session?"** picker. For automated QA they're just modals in the way. The `C11_QA_LAUNCH` env var (dual-read `CMUX_QA_LAUNCH`) suppresses **both** and makes the resume decision deterministic:
+
+| `C11_QA_LAUNCH` | Skill sheet | Resume picker | Session |
+|---|---|---|---|
+| `fresh` (or any non-`resume` value) | suppressed | suppressed | clean slate, no restore |
+| `resume` | suppressed | suppressed | silently restores the prior session |
+| unset / empty | may show | may show | normal interactive launch |
+
+It's read fresh each launch and never persisted, so it can't leak into a later non-QA run. Default is **fresh** — automation usually wants a known-empty start; `resume` is the deliberate opt-in.
+
+```bash
+# Tagged automation launcher — dedicated flag:
+./scripts/launch-tagged-automation.sh <tag> --qa           # fresh (clean slate)
+./scripts/launch-tagged-automation.sh <tag> --qa resume    # restore prior session
+
+# Any other launch path — set the env var directly:
+C11_QA_LAUNCH=fresh open "/path/to/c11 DEV <tag>.app"
+```
+
+The launcher unsets any inherited `C11_QA_LAUNCH`/`CMUX_QA_LAUNCH` and only sets it when `--qa` is passed, so a stray value in your shell can't silently flip a normal run into QA mode.
+
 ## Rebuilding GhosttyKit
 
 When rebuilding `GhosttyKit.xcframework`, always use Release optimizations:


### PR DESCRIPTION
## Problem

Launching c11 for automated QA blocks on two modal dialogs before the GUI is usable:

1. **Agent Skills** install/update onboarding sheet
2. **"Resume previous session?"** picker

These are correct for a human on a normal launch but a recurring nuisance for programmatic/QA launches.

## Solution

A single env var **`C11_QA_LAUNCH`** (dual-read `CMUX_QA_LAUNCH`) that suppresses **both** dialogs and makes the resume decision deterministic:

| `C11_QA_LAUNCH` | Skill sheet | Resume picker | Session |
|---|---|---|---|
| `fresh` (or any non-`resume` value) | suppressed | suppressed | clean slate, no restore |
| `resume` | suppressed | suppressed | silently restores prior session |
| unset / empty | normal | normal | normal interactive launch |

Read fresh each launch and **never persisted**, so it can't leak into a later non-QA run the way a UserDefaults pref would. Default is **fresh** — automation wants a known-empty start; `resume` is the deliberate opt-in.

## How it's wired

- **`Sources/QALaunchPolicy.swift`** (new) — parses the env var; the single source of truth.
- **Skill dialog** — `AgentSkillsOnboarding.shouldPresent()` early-returns `false` in QA mode.
- **Resume picker + direction** — `attemptStartupSessionRestoreIfNeeded()` overrides the effective `LaunchResumePolicy` (`resume`→`.always`, `fresh`→`.never`) **without persisting**, bypassing the `.ask` picker.
- **Snapshot load** — `SessionRestorePolicy.shouldAttemptRestore()` loads the snapshot only when `resume`, so `fresh` is a true clean slate.
- **Launcher** — `scripts/launch-tagged-automation.sh` gains `--qa [fresh|resume]`, and unsets any inherited `C11_QA_LAUNCH`/`CMUX_QA_LAUNCH` so a stray shell value can't silently flip a normal run into QA mode.
- **Docs** — full table in the `c11-hotload` skill + a pointer in `CLAUDE.md`'s Local dev.

## Usage

```bash
./scripts/launch-tagged-automation.sh <tag> --qa           # fresh (clean slate)
./scripts/launch-tagged-automation.sh <tag> --qa resume    # restore prior session
# or any launch path:
C11_QA_LAUNCH=fresh open "/path/to/c11 DEV <tag>.app"
```

## Tests

6 logic tests in `SessionPersistenceTests` (c11-logic scheme): the parse table (fresh/resume/other/empty), `C11_*`-wins-over-`CMUX_*` dual-read, and the `shouldAttemptRestore` integration (QA `fresh` skips restore; QA `resume` forces it even past the disable/test-detection gates). All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
