### PR TITLE
fix(sidebar): release Previous/Next Workspace button latch that traps selection on first workspace

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10805,6 +10805,18 @@ private struct WorkspaceArrowButton: View {
                         stopRepeat()
                     }
             )
+            .onChange(of: isDisabled) {
+                // The press action mutates the selected workspace, which can rebuild
+                // this view mid-gesture and cause DragGesture.onEnded to be dropped —
+                // leaving `isPressed` stuck true and the auto-repeat Timer orphaned, so
+                // the sidebar keeps walking selection back to the first/last workspace.
+                // Reaching the first/last workspace disables the button; use that as a
+                // reliable signal to release the latch and cancel the repeat.
+                if isDisabled {
+                    isPressed = false
+                    stopRepeat()
+                }
+            }
             .accessibilityLabel(accessibilityText)
             .accessibilityAddTraits(isDisabled ? .isStaticText : .isButton)
             .safeHelp(isDisabled ? "" : tooltipText)


### PR DESCRIPTION
## Problem

The **▲ Previous Workspace** button in the sidebar footer (`WorkspaceArrowButton`, the up-triangle in `WorkspaceNavRow`) latches "pressed" and never releases. While latched, workspace selection is repeatedly forced back to the first workspace, making multi-workspace navigation unusable until a full app restart. (The ▼ Next button has the symmetric failure toward the last workspace.)

Reported on c11 0.53.0 (110), macOS 14 (Apple Silicon).

### Repro
1. Click (or briefly press-and-hold) the ▲ button at the bottom-left of the sidebar.
2. The button stays visually active.
3. Selecting any other workspace immediately snaps selection back to the first (top) workspace.
4. Only restarting the app clears it.

## Root cause

`WorkspaceArrowButton` (`Sources/ContentView.swift`) is a press-and-hold auto-repeat control:

- `onChanged` sets `@State isPressed = true`, calls `action()`, and starts a repeating `Timer` (`startRepeat()`).
- Release depends on `DragGesture`'s `.onEnded`.

The press's own `action()` (Previous Workspace → `selectPreviousTab`) changes the selected workspace, which re-renders the sidebar **mid-gesture**. `DragGesture.onEnded` can then be dropped (a known SwiftUI behavior when the view is rebuilt during the gesture), so `isPressed` stays `true` and the repeat `Timer` is never invalidated.

The orphaned `Timer` keeps calling "previous workspace" every 0.12s. `goToPreviousWorkspace` no-ops at the first workspace (`guard !isFirstWorkspace`), so it parks selection there; any manual selection of another workspace is walked straight back to the first by the next tick. That is the observed "snaps to first workspace" symptom.

(Secondary: `startRepeat()`'s timer closure captures the struct's frozen `self`, so its `!self.isDisabled` guard reads a stale value; only the live `@State isPressed` actually gates the repeat.)

## Fix

Release the latch and cancel the repeat when the button becomes disabled — i.e. when selection reaches the first/last workspace. `isDisabled` is recomputed by the parent on every selection change, so `onChange(of: isDisabled)` fires reliably through normal view updates regardless of whether `onEnded` was delivered:

```swift
.onChange(of: isDisabled) {
    if isDisabled {
        isPressed = false
        stopRepeat()
    }
}
```

This terminates the runaway repeat at the boundary it's heading toward (first for ▲, last for ▼), clears `isPressed`, and lets the next timer tick's live `isPressed` guard stop as well.

## Notes / testing

- Minimal, targeted change to a single view; no behavior change for a normal click or in-range press-and-hold.
- I was **not** able to run a full local build (Ghostty xcframework / Zig toolchain isn't set up in my environment), so this is verified by source inspection and by matching the existing `onChange(of:)` usage in the file (e.g. `ContentView.swift:2101`). A maintainer build/QA pass on the press-and-hold path would be appreciated.
- A more aggressive variant could also release on hover-exit (`onHover`), but I kept this minimal to avoid changing press-and-hold ergonomics.

Against `main` @ `95a5b72`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
