### PR TITLE
fix(skills): stop the Agent Skills onboarding sheet over-firing

### DIFF
--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -998,6 +998,16 @@ struct AgentSkillsOnboardingSheet: View {
     }
 
     private func installLater() {
+        // Persist a hash-pinned dismissal for every currently-offered row so
+        // "Later" survives app restarts and only re-surfaces when skill
+        // content actually changes — instead of re-prompting on the very next
+        // launch (the in-memory flag alone covers only this run). An empty
+        // selection records all offered rows.
+        let offered = model.rows.filter(\.detected).flatMap(\.packages)
+        AgentSkillsOnboarding.recordDismissalsForUncheckedRows(
+            offered: offered,
+            selectedKeys: []
+        )
         AgentSkillsOnboarding.markDismissedThisLaunch()
         onDismiss()
     }
@@ -1432,13 +1442,43 @@ enum AgentSkillsOnboarding {
         defaults.set(dict, forKey: dismissalsKey)
     }
 
+    /// Compile-time DEBUG flag surfaced as a value so the environment-driven
+    /// portion of `isLocalDevBuild` stays unit-testable — the logic test
+    /// target compiles DEBUG, so a bare `#if DEBUG` inside `isLocalDevBuild`
+    /// would force the gate `true` under test and hide the env branch.
+    static var isCompiledDebugBuild: Bool {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// True when the running app is a **local development build**: either a
+    /// Debug build, or a tagged `reload.sh --tag` / automation build (which
+    /// exports `CMUX_TAG`). Neither is ever true in a shipped Release without
+    /// a tag. Every local build rebundles edited skills, so the content-hash
+    /// re-offer would pop the onboarding sheet on essentially every launch for
+    /// the person *building* the skills; suppressing the auto-popup here ends
+    /// that treadmill while leaving end-user release behavior untouched. Only
+    /// the automatic `applicationDidBecomeActive` trigger is gated — the
+    /// operator can still open the sheet from Help / Settings.
+    static func isLocalDevBuild(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        isCompiledDebug: Bool = AgentSkillsOnboarding.isCompiledDebugBuild
+    ) -> Bool {
+        if isCompiledDebug { return true }
+        return SocketControlSettings.launchTag(environment: environment) != nil
+    }
+
     /// Should the onboarding sheet be offered on this launch?
     ///
     /// Order of suppression checks (cheapest first):
-    /// 1. Explicit `dontAskAgain` opt-out wins over everything.
-    /// 2. In-memory `_dismissedThisLaunch` covers the "Later" / window-close
+    /// 1. QA launch + local dev/tagged builds never auto-pop.
+    /// 2. Explicit `dontAskAgain` opt-out wins over everything.
+    /// 3. In-memory `_dismissedThisLaunch` covers the "Later" / window-close
     ///    paths for the current run.
-    /// 3. For each detected target × bundled skill that would otherwise
+    /// 4. For each detected target × bundled skill that would otherwise
     ///    offer, the persistent dismissal entry (if any) must match the
     ///    current bundled hash. A matching entry suppresses that row; a
     ///    mismatched entry (content drifted since dismissal) re-surfaces
@@ -1449,11 +1489,16 @@ enum AgentSkillsOnboarding {
         sourceDir: URL? = nil,
         defaults: UserDefaults = .standard,
         fileManager: FileManager = .default,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        isLocalDevBuild: Bool? = nil
     ) -> Bool {
         // QA launch (`C11_QA_LAUNCH`) suppresses the onboarding sheet so
         // automated runs reach a usable window with no modal in the way.
         if QALaunchPolicy.current(environment: environment).isActive { return false }
+        // Local dev / tagged builds rebundle edited skills on every compile,
+        // drifting the content hash and re-offering the sheet; suppress the
+        // auto-popup for the skill author. Release builds fall through.
+        if isLocalDevBuild ?? Self.isLocalDevBuild(environment: environment) { return false }
         if defaults.bool(forKey: dontAskAgainKey) { return false }
         if _dismissedThisLaunch { return false }
         let resolvedSource: URL

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -283,3 +283,132 @@ final class DefaultAgentConfigTests: XCTestCase {
         return URL(fileURLWithPath: url.resolvingSymlinksInPath().path, isDirectory: true)
     }
 }
+
+/// Gating logic for the Agent Skills onboarding/update sheet — the dialog that
+/// was over-firing for skill authors. Two fixes are covered:
+///   B. `isLocalDevBuild` suppresses the auto-popup on Debug / tagged builds.
+///   A. "Later" persists a hash-pinned dismissal for every offered row, so it
+///      survives restarts and only re-surfaces when skill content changes.
+final class AgentSkillsOnboardingGatingTests: XCTestCase {
+
+    // MARK: - Fix B: dev/tagged-build suppression
+
+    func testTaggedReleaseBuildCountsAsDev() {
+        // `reload.sh --tag` / automation exports CMUX_TAG; a Release build with
+        // a tag is still a developer build → suppress the auto-popup.
+        XCTAssertTrue(
+            AgentSkillsOnboarding.isLocalDevBuild(
+                environment: ["CMUX_TAG": "feat-foo"],
+                isCompiledDebug: false
+            )
+        )
+    }
+
+    func testUntaggedReleaseBuildIsNotDev() {
+        // The shipped end-user case: Release, no tag → the sheet must still
+        // be offered (function returns false = not a dev build).
+        XCTAssertFalse(
+            AgentSkillsOnboarding.isLocalDevBuild(environment: [:], isCompiledDebug: false)
+        )
+    }
+
+    func testWhitespaceTagDoesNotCountAsDev() {
+        // launchTag() trims to nil for blank values, so a stray empty CMUX_TAG
+        // must not flip a release build into dev-suppressed mode.
+        XCTAssertFalse(
+            AgentSkillsOnboarding.isLocalDevBuild(
+                environment: ["CMUX_TAG": "   "],
+                isCompiledDebug: false
+            )
+        )
+    }
+
+    func testDebugBuildAlwaysCountsAsDevRegardlessOfTag() {
+        XCTAssertTrue(
+            AgentSkillsOnboarding.isLocalDevBuild(environment: [:], isCompiledDebug: true)
+        )
+    }
+
+    @MainActor
+    func testShouldPresentSuppressedOnLocalDevBuild() throws {
+        let tmp = try makeTempDir()
+        let suite = "AgentSkillsGating-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        // Injected dev=true short-circuits before any source/dismissal work.
+        XCTAssertFalse(
+            AgentSkillsOnboarding.shouldPresent(
+                home: tmp,
+                sourceDir: tmp,
+                defaults: defaults,
+                environment: [:],
+                isLocalDevBuild: true
+            )
+        )
+    }
+
+    private func makeTempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AgentSkillsOnboardingGatingTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return URL(fileURLWithPath: url.resolvingSymlinksInPath().path, isDirectory: true)
+    }
+
+    // MARK: - Fix A: "Later" persists a hash-pinned dismissal
+
+    func testLaterRecordsHashPinnedDismissalForEveryOfferedRow() throws {
+        let suite = "AgentSkillsGating-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let offered = [
+            makeStatus(skill: "c11", state: .installedOutdated, hash: "h-c11"),
+            makeStatus(skill: "c11-browser", state: .notInstalled, hash: "h-browser"),
+            makeStatus(skill: "c11-markdown", state: .installedCurrent, hash: "h-current"),
+        ]
+
+        // Mirrors installLater(): empty selection → record every *offerable* row
+        // at its current bundled hash.
+        AgentSkillsOnboarding.recordDismissalsForUncheckedRows(
+            offered: offered,
+            selectedKeys: [],
+            defaults: defaults
+        )
+
+        let dismissals = AgentSkillsOnboarding.loadDismissals(defaults: defaults)
+        XCTAssertEqual(
+            dismissals[AgentSkillsOnboarding.dismissalKey(for: .claude, skillName: "c11")],
+            "h-c11"
+        )
+        XCTAssertEqual(
+            dismissals[AgentSkillsOnboarding.dismissalKey(for: .claude, skillName: "c11-browser")],
+            "h-browser"
+        )
+        // .installedCurrent is not offerable, so it must not be pinned.
+        XCTAssertNil(
+            dismissals[AgentSkillsOnboarding.dismissalKey(for: .claude, skillName: "c11-markdown")]
+        )
+    }
+
+    private func makeStatus(
+        skill: String,
+        target: SkillInstallerTarget = .claude,
+        state: SkillInstallerState,
+        hash: String
+    ) -> SkillInstallerPackageStatus {
+        SkillInstallerPackageStatus(
+            package: SkillInstallerPackage(
+                name: skill,
+                version: "1",
+                description: nil,
+                sourceDir: URL(fileURLWithPath: "/tmp/src/\(skill)", isDirectory: true)
+            ),
+            target: target,
+            destinationDir: URL(fileURLWithPath: "/tmp/dst/\(skill)", isDirectory: true),
+            state: state,
+            record: nil,
+            sourceContentHash: hash
+        )
+    }
+}

--- a/c11Tests/SocketControlPasswordStoreTests.swift
+++ b/c11Tests/SocketControlPasswordStoreTests.swift
@@ -947,7 +947,8 @@ final class AgentSkillsShouldPresentTests: XCTestCase {
         // otherwise present. But dontAskAgain is set.
         h.defaults.set(true, forKey: AgentSkillsOnboarding.dontAskAgainKey)
         XCTAssertFalse(AgentSkillsOnboarding.shouldPresent(
-            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default))
+            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default,
+            isLocalDevBuild: false))
     }
 
     func testDismissedEntryMatchingBundledHashSuppressesPresent() throws {
@@ -956,7 +957,8 @@ final class AgentSkillsShouldPresentTests: XCTestCase {
         let hash = try h.bundledHash(skillName: "foo")
         h.defaults.set(["claude.foo": hash], forKey: AgentSkillsOnboarding.dismissalsKey)
         XCTAssertFalse(AgentSkillsOnboarding.shouldPresent(
-            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default))
+            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default,
+            isLocalDevBuild: false))
     }
 
     func testDismissedEntryAgainstOldHashAllowsPresent() throws {
@@ -966,14 +968,16 @@ final class AgentSkillsShouldPresentTests: XCTestCase {
         defer { h.cleanup() }
         h.defaults.set(["claude.foo": "sha256:OBSOLETE"], forKey: AgentSkillsOnboarding.dismissalsKey)
         XCTAssertTrue(AgentSkillsOnboarding.shouldPresent(
-            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default))
+            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default,
+            isLocalDevBuild: false))
     }
 
     func testNoDetectedTargetsReturnsFalse() throws {
         let h = try makeHarness(skills: ["foo": "v1-content"], detect: false)
         defer { h.cleanup() }
         XCTAssertFalse(AgentSkillsOnboarding.shouldPresent(
-            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default))
+            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default,
+            isLocalDevBuild: false))
     }
 
     func testMissingPackageOnDetectedTargetReturnsTrue() throws {
@@ -981,7 +985,8 @@ final class AgentSkillsShouldPresentTests: XCTestCase {
         defer { h.cleanup() }
         // No dismissal entry → row offers → should present.
         XCTAssertTrue(AgentSkillsOnboarding.shouldPresent(
-            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default))
+            home: h.home, sourceDir: h.source, defaults: h.defaults, fileManager: .default,
+            isLocalDevBuild: false))
     }
 }
 


### PR DESCRIPTION
## Problem

The Agent Skills install/update onboarding sheet (`AgentSkillsOnboardingSheet`) is offered on **every** `applicationDidBecomeActive` and re-surfaces whenever a detected target's installed skill hash differs from the app's bundled hash. Within a launch it's well-guarded (`_dismissedThisLaunch` + the window `willClose` observer), so the problem is entirely **cross-launch**. Two gaps made it nag skill *authors* on nearly every launch:

1. **"Later" didn't persist.** `installLater()` only set the in-memory `_dismissedThisLaunch` flag, so it forgot across restarts and re-prompted on the next launch even when nothing had changed.
2. **Dev builds churn the hash.** Local/tagged builds rebundle edited skills on every compile, drifting the content hash and re-offering the sheet to the very person building the skills. With several agent targets detected (`~/.claude`, `~/.codex`, `~/.kimi`), one content change flips every row to outdated.

## Fix

**A — "Later" now persists.** `installLater()` records a hash-pinned dismissal for every currently-offered row (`recordDismissalsForUncheckedRows` with an empty selection). "Later" now means "not now, and stay quiet until skill content actually changes" — consistent with the v0.50.0 content-hash design already used by "Update selected". A genuine content change still re-surfaces the row exactly once.

**B — dev/tagged builds don't auto-pop.** `shouldPresent()` suppresses the auto-popup when `isLocalDevBuild()` is true (a Debug build, or any tagged `reload.sh`/automation build exporting `CMUX_TAG`), gated alongside the existing `C11_QA_LAUNCH` check. **End-user release behavior is unchanged** (untagged Release falls through); the operator can still open the sheet manually from Help / Settings — only the automatic `applicationDidBecomeActive` trigger is gated.

## Tests

`AgentSkillsOnboardingGatingTests` (in `c11LogicTests`, runs on the fast `c11-logic` scheme):
- `isLocalDevBuild` env logic — tagged Release = dev, untagged Release ≠ dev, whitespace tag ≠ dev, Debug = always dev.
- `shouldPresent` suppressed when `isLocalDevBuild` is true.
- "Later" records a hash-pinned dismissal for every *offerable* row and skips `.installedCurrent`.

All 6 pass locally (`xcodebuild -scheme c11-logic ... test`, `** TEST SUCCEEDED **`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)