### PR TITLE
feat(conversation): live scrape-capture pipeline — wire scrapers into restore (C11-152)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */; };
 		06D1536ABCF81C2938399DAB /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 		076B1D5338134A1CD69B5467 /* TCCPrimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */; };
+		0824BD4DE71F74CA32F9F49E /* ScrapeCapturePipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */; };
 		0C8D60FC511085983B359106 /* DefaultAgentResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */; };
 		0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */; };
 		100913C268BE26DBACE5A563 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */; };
@@ -45,6 +46,7 @@
 		46044A577BB8C602B02EF327 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6068E3FCA0467699A1ADD6FD /* Cocoa.framework */; };
 		46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
 		47C976CFA2AD3633C427D15D /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
+		48D1A7FA449F78DFC0148E27 /* ConversationScraperRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BFB0FCD7F3834654919F820 /* ConversationScraperRegistry.swift */; };
 		4A5A1F18E3F574F301890675 /* StdinHandlerFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7112BF1A1B2C3D4E5F60718 /* StdinHandlerFormattingTests.swift */; };
 		4BF73AE4358BED37E9D90771 /* WorkspaceApplyChromeScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */; };
 		4D11AA01B2C3D4E5F6071920 /* MarkdownPanelFontScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D11AA02B2C3D4E5F6071921 /* MarkdownPanelFontScaleTests.swift */; };
@@ -85,10 +87,12 @@
 		82BBB769071BCA11F1484D56 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 		849745EAE2900598F862D0F9 /* SurfaceTypeAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CADD0C9B7E43A29D723366 /* SurfaceTypeAvailabilityTests.swift */; };
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
+		8574E0DF636A7359989C51A4 /* ConversationScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */; };
 		864B59A6AAF8E002451F50CB /* ThemedValueParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F008 /* ThemedValueParserTests.swift */; };
 		8B6BA07B09D5E9E01F141A44 /* BrowserChromeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F01C /* BrowserChromeSnapshotTests.swift */; };
 		8B85A633AA2D415C37FD4727 /* ShutdownSentinel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D3CB3B7B4231D786E8883E /* ShutdownSentinel.swift */; };
 		8C1F311B2760FEE15B8DFD2F /* MailboxEnvelopeValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7107BF1A1B2C3D4E5F60718 /* MailboxEnvelopeValidationTests.swift */; };
+		8FAB47C9F34672F10BB37D41 /* ScrapeCapturePipeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */; };
 		90204B2AA277D990B450D7E9 /* AgentManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */; };
 		9267DDD60A813FBEF3F59F99 /* MailboxDispatcherGCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7113BF1A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift */; };
 		928593E0CB8B058E6599C4A4 /* StrategyRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B59DC588DFAF89D0678B39 /* StrategyRegistry.swift */; };
@@ -422,6 +426,7 @@
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
 		0AC6B52BF66E258E170A6B92 /* c11LogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11LogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
+		14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/ScrapeCapturePipeline.swift; sourceTree = "<group>"; };
 		14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePullRequestSidebarTests.swift; sourceTree = "<group>"; };
 		14C14C792CC3845B19215A4A /* WorkspaceConversationResumeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceConversationResumeTests.swift; sourceTree = "<group>"; };
 		1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManualUnreadTests.swift; sourceTree = "<group>"; };
@@ -456,6 +461,7 @@
 		96951AF465673123431D362B /* ConversationStoreFailureModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationStoreFailureModeTests.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
+		9BFB0FCD7F3834654919F820 /* ConversationScraperRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/Scrapers/ConversationScraperRegistry.swift; sourceTree = "<group>"; };
 		A2CADD0C9B7E43A29D723366 /* SurfaceTypeAvailabilityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceTypeAvailabilityTests.swift; sourceTree = "<group>"; };
 		A5001000 /* c11.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = c11.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5001011 /* c11App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = c11App.swift; sourceTree = "<group>"; };
@@ -584,8 +590,10 @@
 		A8C9388437A24EE58C8AAA71 /* Ref.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Ref.swift; path = Conversation/Ref.swift; sourceTree = "<group>"; };
 		AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClaudeCodeScraper.swift; path = Conversation/Scrapers/ClaudeCodeScraper.swift; sourceTree = "<group>"; };
 		AE1C8E6BE23CECF1DA9531BA /* Codex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codex.swift; path = Conversation/Strategies/Codex.swift; sourceTree = "<group>"; };
+		B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrapeCapturePipelineTests.swift; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
+		B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/Scrapers/ConversationScraper.swift; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
 		B9000001A1B2C3D4E5F60719 /* c11.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = c11.swift; sourceTree = "<group>"; };
@@ -1043,6 +1051,9 @@
 				0095C3D72A7722FFA42A7ED1 /* PaneSizePolicy.swift */,
 				8FF3E8B8443DEA778BA817BB /* SurfaceTypeAvailability.swift */,
 				C28AE9F41DE55AB88CAE431D /* AgentManifest.swift */,
+				B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */,
+				9BFB0FCD7F3834654919F820 /* ConversationScraperRegistry.swift */,
+				14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1201,6 +1212,7 @@
 				4B2DBF12A2F90CBDE7F6A289 /* PaneSizePolicyTests.swift */,
 				A2CADD0C9B7E43A29D723366 /* SurfaceTypeAvailabilityTests.swift */,
 				FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */,
+				B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1523,6 +1535,7 @@
 				756290E56A4FC7D6546C1D46 /* PaneSizePolicyTests.swift in Sources */,
 				849745EAE2900598F862D0F9 /* SurfaceTypeAvailabilityTests.swift in Sources */,
 				352C25FFD890137B5F7A23B3 /* AgentManifestTests.swift in Sources */,
+				0824BD4DE71F74CA32F9F49E /* ScrapeCapturePipelineTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1696,6 +1709,9 @@
 				27AE9B7E020D938C6013B312 /* PaneSizePolicy.swift in Sources */,
 				B56F0F5D50E43946F0510B03 /* SurfaceTypeAvailability.swift in Sources */,
 				F3561BE21E032B0AB6FC9DFE /* AgentManifest.swift in Sources */,
+				8574E0DF636A7359989C51A4 /* ConversationScraper.swift in Sources */,
+				48D1A7FA449F78DFC0148E27 /* ConversationScraperRegistry.swift in Sources */,
+				8FAB47C9F34672F10BB37D41 /* ScrapeCapturePipeline.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3236,6 +3236,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // (TODO 0.46.0 / v1.1 in WorkspaceSnapshotConversationBridge).
         if let snapshot, !ConversationStorePolicy.isDisabled {
             WorkspaceSnapshotConversationBridge.seedFromSnapshot(snapshot)
+            // C11-152: live scrape-capture seam. Now that the store is seeded,
+            // run the per-kind scrapers for each restored terminal surface and
+            // resolve real session ids via each strategy's `capture`, applying
+            // scrape-derived refs to the store. This is the missing runtime
+            // call site for the scrape rail — it lights up codex resume (and
+            // future pi/omp). Runs BEFORE the `--no-resume` / dirty-reclassify
+            // branches below so those still win when they apply. `Task.detached`
+            // breaks `@MainActor` isolation so the actor work runs while this
+            // method blocks on the bounded wait (mirrors the seed/reclassify
+            // neighbours).
+            let scrapeContexts = ScrapeCaptureContext.contexts(from: snapshot)
+            if !scrapeContexts.isEmpty {
+                let pipeline = ScrapeCapturePipeline(scrapers: .v1(), strategies: .v1)
+                let sema = DispatchSemaphore(value: 0)
+                Task.detached(priority: .userInitiated) {
+                    await ConversationStore.shared.runScrapeCapture(
+                        contexts: scrapeContexts,
+                        pipeline: pipeline
+                    )
+                    sema.signal()
+                }
+                _ = sema.wait(timeout: .now() + 1.0)
+            }
         }
         // C11-131: `c11 app restart --no-resume` left a one-shot sentinel.
         // Honor it by forcing every seeded ref to .unknown so the restore

--- a/Sources/Conversation/ScrapeCapturePipeline.swift
+++ b/Sources/Conversation/ScrapeCapturePipeline.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Per-surface restore context the scrape-capture pipeline consumes. Built
+/// from the session snapshot at launch (`contexts(from:)`); one entry per
+/// terminal panel whose `terminal_type` metadata declares an agent kind.
+struct ScrapeCaptureContext: Sendable, Equatable {
+    /// `panel.id.uuidString` — the surface id the store keys on.
+    let surfaceId: String
+    /// The agent kind, from the panel's `terminal_type` metadata. Pairs the
+    /// surface with a scraper + strategy of the same `kind`.
+    let kind: String
+    /// The panel's working directory, used by cwd-filtering strategies.
+    let cwd: String?
+    /// Optional mtime floor. Nil at a cold restore (the snapshot doesn't
+    /// carry live activity); present when a caller knows the last activity.
+    let lastActivityTimestamp: Date?
+
+    init(
+        surfaceId: String,
+        kind: String,
+        cwd: String? = nil,
+        lastActivityTimestamp: Date? = nil
+    ) {
+        self.surfaceId = surfaceId
+        self.kind = kind
+        self.cwd = cwd
+        self.lastActivityTimestamp = lastActivityTimestamp
+    }
+
+    /// Build contexts from a loaded session snapshot. Walks every terminal
+    /// panel across all windows/workspaces; keeps only those whose
+    /// `terminal_type` metadata resolves to a non-empty kind (nothing else
+    /// has a scraper to run). `directory` becomes `cwd`.
+    static func contexts(from snapshot: AppSessionSnapshot) -> [ScrapeCaptureContext] {
+        var result: [ScrapeCaptureContext] = []
+        for window in snapshot.windows {
+            for ws in window.tabManager.workspaces {
+                for panel in ws.panels {
+                    guard panel.type == .terminal else { continue }
+                    guard let kind = terminalType(of: panel), !kind.isEmpty else { continue }
+                    let cwd = panel.directory.flatMap { $0.isEmpty ? nil : $0 }
+                    result.append(ScrapeCaptureContext(
+                        surfaceId: panel.id.uuidString,
+                        kind: kind,
+                        cwd: cwd
+                    ))
+                }
+            }
+        }
+        return result
+    }
+
+    /// Read the panel's declared `terminal_type` metadata value (a `.string`).
+    private static func terminalType(of panel: SessionPanelSnapshot) -> String? {
+        guard let metadata = panel.metadata else { return nil }
+        guard case .string(let raw)? = metadata[SurfaceMetadataKeyName.terminalType] else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+/// The live scrape-capture pipeline — the connective tissue between the
+/// pull rail (`ConversationScraper`) and the per-kind `ConversationStrategy`.
+///
+/// This is the seam the architecture finding identified as missing: scrapers
+/// produce `[ScrapeCandidate]`, strategies know how to `capture` candidates
+/// into a `ConversationRef`, but nothing connected the two at runtime, so
+/// codex (and any future scrape-primary kind: pi, omp) never resolved a real
+/// session id at restore. The pipeline closes that gap.
+///
+/// Pure by design: it performs no store mutation and no I/O of its own beyond
+/// invoking the injected scrapers (whose filesystem is itself injected). The
+/// actor-isolated apply step lives on `ConversationStore.runScrapeCapture`.
+struct ScrapeCapturePipeline: Sendable {
+    let scrapers: ConversationScraperRegistry
+    let strategies: ConversationStrategyRegistry
+
+    init(
+        scrapers: ConversationScraperRegistry,
+        strategies: ConversationStrategyRegistry = .v1
+    ) {
+        self.scrapers = scrapers
+        self.strategies = strategies
+    }
+
+    /// For each context, run its kind's scraper, hand the candidates (plus the
+    /// surface's existing wrapper-claim / push, so claim-time + cwd filters
+    /// keep working) to the strategy's `capture`, and collect the result IFF
+    /// it is a genuinely scrape-derived ref (`capturedVia == .scrape`).
+    ///
+    /// Forwarding only `.scrape` provenance is the safety property: a strategy
+    /// that merely echoes back the wrapper-claim placeholder (no disk match)
+    /// or returns a hook-sourced ref produces nothing to apply, so the store
+    /// is never written with a placeholder — or a regression — via the scrape
+    /// path. Pure: never touches the store. Results are in input order.
+    func captureRefs(
+        contexts: [ScrapeCaptureContext],
+        existing: [String: SurfaceConversations]
+    ) -> [(surfaceId: String, ref: ConversationRef)] {
+        var result: [(surfaceId: String, ref: ConversationRef)] = []
+        for context in contexts {
+            guard let scraper = scrapers.scraper(forKind: context.kind) else { continue }
+            guard let strategy = strategies.strategy(forKind: context.kind) else { continue }
+
+            let candidates = scraper.candidates(cwd: context.cwd)
+
+            // Route the existing active ref into the right input slot so the
+            // strategy's filters (claim-time floor, push-wins) behave exactly
+            // as they do on the live path.
+            let active = existing[context.surfaceId]?.active
+            let wrapperClaim = active?.capturedVia == .wrapperClaim ? active : nil
+            let push = (active != nil && active?.capturedVia != .wrapperClaim) ? active : nil
+
+            let inputs = ConversationStrategyInputs(
+                surfaceId: context.surfaceId,
+                cwd: context.cwd,
+                lastActivityTimestamp: context.lastActivityTimestamp,
+                wrapperClaim: wrapperClaim,
+                push: push,
+                scrapeCandidates: candidates
+            )
+
+            guard let ref = strategy.capture(inputs: inputs) else { continue }
+            // Only apply genuinely scrape-derived refs (see doc comment).
+            guard ref.capturedVia == .scrape else { continue }
+            result.append((surfaceId: context.surfaceId, ref: ref))
+        }
+        return result
+    }
+}

--- a/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
+++ b/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
@@ -15,7 +15,7 @@ import Foundation
 ///   used by crash-recovery verification lives on the strategy
 ///   (`ClaudeCodeStrategy.transcriptExists`); this scraper is the bounded
 ///   top-N pull-fallback seam.
-struct ClaudeCodeScraper: Sendable {
+struct ClaudeCodeScraper: ConversationScraper {
     let kind: String = "claude-code"
     static let defaultMaxCandidates: Int = 16
 
@@ -70,7 +70,7 @@ struct ClaudeCodeScraper: Sendable {
 ///
 /// Codex filenames are `<uuid>.jsonl`; the scraper recovers the session id
 /// from the filename without parsing content.
-struct CodexScraper: Sendable {
+struct CodexScraper: ConversationScraper {
     let kind: String = "codex"
     static let defaultMaxCandidates: Int = 16
 

--- a/Sources/Conversation/Scrapers/ConversationScraper.swift
+++ b/Sources/Conversation/Scrapers/ConversationScraper.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A per-kind, bounded, metadata-only session scraper.
+///
+/// Conformers walk a TUI's on-disk session store and return the most-recent
+/// candidates by mtime. They are the **pull rail** half of the live
+/// scrape-capture pipeline (`ScrapeCapturePipeline`): the scraper produces
+/// `[ScrapeCandidate]`, the per-kind `ConversationStrategy.capture` turns
+/// those into a resolved `ConversationRef`.
+///
+/// **Privacy contract** (see the architecture doc §"Privacy contract for
+/// scrape"): conformers read metadata only — filename + mtime + size. The
+/// filename carries the session id. Transcript bytes are never opened,
+/// copied, or logged.
+///
+/// `ClaudeCodeScraper` and `CodexScraper` are the built-in conformers;
+/// downstream kinds (pi, omp) add their own scraper and register it in
+/// `ConversationScraperRegistry.v1`.
+protocol ConversationScraper: Sendable {
+    /// Stable kind identifier. Matches `ConversationStrategy.kind` and
+    /// `ConversationRef.kind` (e.g. `"claude-code"`, `"codex"`, `"pi"`,
+    /// `"omp"`). The pipeline uses this to pair a scraper with its strategy.
+    var kind: String { get }
+
+    /// Bounded top-N candidates, newest-first by mtime. When `cwd` is
+    /// provided it is stamped onto each returned candidate so the strategy's
+    /// cwd filter (e.g. `CodexStrategy.capture`) can apply. Returns an empty
+    /// array when the kind's session store doesn't exist on this machine.
+    func candidates(cwd: String?) -> [ScrapeCandidate]
+}

--- a/Sources/Conversation/Scrapers/ConversationScraperRegistry.swift
+++ b/Sources/Conversation/Scrapers/ConversationScraperRegistry.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Hardcoded enum-shaped registry of `ConversationScraper`s, mirroring
+/// `ConversationStrategyRegistry`. We are not building a plugin system —
+/// adding a new kind is one scraper file plus an entry in `v1`.
+///
+/// Stored as an immutable map keyed by `kind`; lookups are O(1). The
+/// filesystem dependency is injected at construction so the production
+/// registry uses `DefaultConversationFilesystem` and tests pass a mock.
+struct ConversationScraperRegistry: Sendable {
+    private let scrapers: [String: any ConversationScraper]
+
+    init(scrapers: [any ConversationScraper]) {
+        var map: [String: any ConversationScraper] = [:]
+        for scraper in scrapers {
+            map[scraper.kind] = scraper
+        }
+        self.scrapers = map
+    }
+
+    func scraper(forKind kind: String) -> (any ConversationScraper)? {
+        scrapers[kind]
+    }
+
+    func contains(kind: String) -> Bool {
+        scrapers[kind] != nil
+    }
+
+    var allKinds: [String] {
+        Array(scrapers.keys).sorted()
+    }
+
+    /// Default registry: every built-in kind that keeps an on-disk session
+    /// store the pull rail can read. claude-code (push-primary, scrape is the
+    /// crash-recovery fallback) and codex (scrape-primary). Downstream kinds
+    /// (pi, omp) append their scraper here — that single edit is all the
+    /// scrape rail needs to light them up, given a matching strategy in
+    /// `ConversationStrategyRegistry.v1`.
+    static func v1(
+        filesystem: ConversationFilesystem = DefaultConversationFilesystem()
+    ) -> ConversationScraperRegistry {
+        ConversationScraperRegistry(scrapers: [
+            ClaudeCodeScraper(filesystem: filesystem),
+            CodexScraper(filesystem: filesystem)
+        ])
+    }
+}

--- a/Sources/Conversation/Store.swift
+++ b/Sources/Conversation/Store.swift
@@ -144,13 +144,35 @@ extension ConversationStore {
         return reconcile(surfaceId: surfaceId, candidate: ref) ?? ref
     }
 
-    /// Apply a scrape result. Same reconciliation rule as `push`.
+    /// Apply a scrape result. Same reconciliation rule as `push`. This is
+    /// the canonical write entry for the live scrape-capture pipeline and the
+    /// name downstream kinds (pi, omp) build against.
     @discardableResult
-    func recordScrape(
+    func applyScrape(
         surfaceId: String,
         ref: ConversationRef
     ) -> ConversationRef {
         return reconcile(surfaceId: surfaceId, candidate: ref) ?? ref
+    }
+
+    /// Live scrape-capture driver. Runs the pure `ScrapeCapturePipeline`
+    /// against the current store contents (so claim-time / push filters see
+    /// the seeded refs), then applies each scrape-derived ref under actor
+    /// isolation. Returns what was applied, for diagnostics.
+    ///
+    /// This is the runtime call the architecture finding identified as
+    /// missing: it is the single place that connects scrapers → strategies →
+    /// store at restore, lighting up codex (and future pi/omp) resume.
+    @discardableResult
+    func runScrapeCapture(
+        contexts: [ScrapeCaptureContext],
+        pipeline: ScrapeCapturePipeline
+    ) -> [(surfaceId: String, ref: ConversationRef)] {
+        let captured = pipeline.captureRefs(contexts: contexts, existing: bySurface)
+        for (surfaceId, ref) in captured {
+            applyScrape(surfaceId: surfaceId, ref: ref)
+        }
+        return captured
     }
 
     /// Mark the surface's active ref as tombstoned. Operator-initiated

--- a/c11Tests/ScrapeCapturePipelineTests.swift
+++ b/c11Tests/ScrapeCapturePipelineTests.swift
@@ -1,0 +1,228 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Tests for the C11-152 live scrape-capture pipeline — the seam that wires
+/// scrapers into restore so a `ScrapeCandidate` becomes a resumable ref.
+///
+/// Member of the **`c11LogicTests`** target only, so it runs on the safe
+/// `c11-logic` scheme. All mocks are declared locally (the host-target
+/// `ConversationScraperTests.MockFS` is not reachable from this target).
+final class ScrapeCapturePipelineTests: XCTestCase {
+
+    // MARK: - Local mocks (logic-target-local; do not borrow host-target helpers)
+
+    /// A stub scraper that returns preset candidates regardless of cwd, but
+    /// stamps the passed cwd onto each (mirroring the real scrapers).
+    struct MockScraper: ConversationScraper {
+        let kind: String
+        let preset: [ScrapeCandidate]
+        func candidates(cwd: String?) -> [ScrapeCandidate] {
+            preset.map {
+                ScrapeCandidate(id: $0.id, filePath: $0.filePath, mtime: $0.mtime, size: $0.size, cwd: cwd ?? $0.cwd)
+            }
+        }
+    }
+
+    private let codexId = "abc12345-ef67-890a-bcde-f0123456789a"
+    private let codexId2 = "eee22222-2222-3333-4444-555566667777"
+
+    private func candidate(_ id: String, mtime: Date, cwd: String? = nil) -> ScrapeCandidate {
+        ScrapeCandidate(id: id, filePath: "/Users/test/.codex/sessions/\(id).jsonl", mtime: mtime, size: 1024, cwd: cwd)
+    }
+
+    // MARK: - Case 1: end-to-end acceptance (the gate)
+
+    func testSingleCodexCandidateBecomesResumableTypeCommand() {
+        let surfaceId = UUID().uuidString
+        let cwd = "/work/proj"
+        let now = Date()
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "codex", preset: [candidate(codexId, mtime: now)])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "codex", cwd: cwd)]
+
+        let captured = pipeline.captureRefs(contexts: contexts, existing: [:])
+        XCTAssertEqual(captured.count, 1)
+        let ref = captured[0].ref
+        XCTAssertEqual(captured[0].surfaceId, surfaceId)
+        XCTAssertEqual(ref.kind, "codex")
+        XCTAssertEqual(ref.id, codexId)
+        XCTAssertEqual(ref.capturedVia, .scrape)
+        XCTAssertEqual(ref.state, .alive)
+
+        // The applied ref resumes to a typeCommand.
+        let action = CodexStrategy().resume(ref: ref)
+        guard case let .typeCommand(text, submit) = action else {
+            return XCTFail("expected .typeCommand, got \(action)")
+        }
+        XCTAssertEqual(text, "codex resume '\(codexId)'")
+        XCTAssertTrue(submit)
+    }
+
+    // MARK: - Case 2: ambiguous codex → skip
+
+    func testAmbiguousCodexCandidatesYieldUnknownAndSkip() {
+        let surfaceId = UUID().uuidString
+        let cwd = "/work/proj"
+        let now = Date()
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "codex", preset: [
+                candidate(codexId, mtime: now),
+                candidate(codexId2, mtime: now.addingTimeInterval(-10))
+            ])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "codex", cwd: cwd)]
+
+        let captured = pipeline.captureRefs(contexts: contexts, existing: [:])
+        XCTAssertEqual(captured.count, 1)
+        XCTAssertEqual(captured[0].ref.state, .unknown)
+        if case .skip = CodexStrategy().resume(ref: captured[0].ref) {
+            // expected
+        } else {
+            XCTFail("ambiguous ref must skip resume")
+        }
+    }
+
+    // MARK: - Case 3: no regression — a seeded claude hook ref is preserved
+
+    func testClaudeHookRefIsNotOverwrittenByScrapePath() {
+        let surfaceId = UUID().uuidString
+        let claudeId = "11111111-2222-3333-4444-555566667777"
+        // A live hook ref already in the store for this surface.
+        let hookRef = ConversationRef(
+            kind: "claude-code", id: claudeId, placeholder: false, cwd: "/work/proj",
+            capturedAt: Date(), capturedVia: .hook, state: .suspended
+        )
+        let existing = [surfaceId: SurfaceConversations(active: hookRef, history: [])]
+        // Scraper would surface a DIFFERENT (stale) top-by-mtime transcript.
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "claude-code", preset: [candidate(codexId, mtime: Date())])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "claude-code", cwd: "/work/proj")]
+
+        // capture() returns the push (hook) ref unchanged (capturedVia==.hook),
+        // which the pipeline filters out — nothing scrape-derived to apply.
+        let captured = pipeline.captureRefs(contexts: contexts, existing: existing)
+        XCTAssertTrue(captured.isEmpty, "hook ref must not be displaced via the scrape path")
+    }
+
+    // MARK: - Case 4: injectable filesystem / empty output leaves store unchanged
+
+    func testEmptyScraperOutputProducesNoRefs() {
+        let surfaceId = UUID().uuidString
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "codex", preset: [])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "codex", cwd: "/work/proj")]
+        XCTAssertTrue(pipeline.captureRefs(contexts: contexts, existing: [:]).isEmpty)
+    }
+
+    func testKindWithoutRegisteredScraperIsSkipped() {
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "codex", preset: [candidate(codexId, mtime: Date())])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        // "pi" has no scraper registered here → skipped, no crash.
+        let contexts = [ScrapeCaptureContext(surfaceId: UUID().uuidString, kind: "pi", cwd: "/work/proj")]
+        XCTAssertTrue(pipeline.captureRefs(contexts: contexts, existing: [:]).isEmpty)
+    }
+
+    // MARK: - Case 5: runScrapeCapture actor driver round-trips through the store
+
+    func testRunScrapeCaptureAppliesRefToStoreAndRoundTripsToResume() async {
+        let surfaceId = UUID().uuidString
+        let cwd = "/work/proj"
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "codex", preset: [candidate(codexId, mtime: Date())])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "codex", cwd: cwd)]
+
+        let store = ConversationStore()
+        let applied = await store.runScrapeCapture(contexts: contexts, pipeline: pipeline)
+        XCTAssertEqual(applied.count, 1)
+
+        // The store's active ref for the surface is now the scraped, resumable ref.
+        let active = await store.active(for: surfaceId)
+        XCTAssertNotNil(active)
+        XCTAssertEqual(active?.id, codexId)
+        XCTAssertEqual(active?.capturedVia, .scrape)
+        guard let active, case let .typeCommand(text, _) = CodexStrategy().resume(ref: active) else {
+            return XCTFail("store ref must resume to a typeCommand")
+        }
+        XCTAssertEqual(text, "codex resume '\(codexId)'")
+    }
+
+    // MARK: - Case 6: ScrapeCaptureContext.contexts(from:) extraction
+
+    func testContextsExtractedFromSnapshotTerminalPanelsOnly() {
+        let codexPanelId = UUID()
+        let kindlessPanelId = UUID()
+
+        // Codex terminal panel: extracted.
+        let codexPanel = makeTerminalPanel(
+            id: codexPanelId, directory: "/work/proj",
+            metadata: [SurfaceMetadataKeyName.terminalType: .string("codex")]
+        )
+        // Terminal panel with no terminal_type metadata: skipped.
+        let kindlessPanel = makeTerminalPanel(id: kindlessPanelId, directory: "/tmp", metadata: nil)
+        // Browser panel (non-terminal): skipped.
+        let browserPanel = makeBrowserPanel(id: UUID())
+
+        let snapshot = makeSnapshot(panels: [codexPanel, kindlessPanel, browserPanel])
+        let contexts = ScrapeCaptureContext.contexts(from: snapshot)
+
+        XCTAssertEqual(contexts.count, 1)
+        XCTAssertEqual(contexts[0].surfaceId, codexPanelId.uuidString)
+        XCTAssertEqual(contexts[0].kind, "codex")
+        XCTAssertEqual(contexts[0].cwd, "/work/proj")
+    }
+
+    // MARK: - Snapshot builders
+
+    private func makeTerminalPanel(
+        id: UUID, directory: String?, metadata: [String: PersistedJSONValue]?
+    ) -> SessionPanelSnapshot {
+        SessionPanelSnapshot(
+            id: id, type: .terminal, title: "T", customTitle: nil, directory: directory,
+            isPinned: false, isManuallyUnread: false, gitBranch: nil, listeningPorts: [],
+            ttyName: nil, terminal: nil, browser: nil, markdown: nil,
+            metadata: metadata, metadataSources: nil, surfaceConversations: nil
+        )
+    }
+
+    private func makeBrowserPanel(id: UUID) -> SessionPanelSnapshot {
+        SessionPanelSnapshot(
+            id: id, type: .browser, title: "B", customTitle: nil, directory: nil,
+            isPinned: false, isManuallyUnread: false, gitBranch: nil, listeningPorts: [],
+            ttyName: nil, terminal: nil, browser: nil, markdown: nil,
+            metadata: [SurfaceMetadataKeyName.terminalType: .string("codex")],
+            metadataSources: nil, surfaceConversations: nil
+        )
+    }
+
+    private func makeSnapshot(panels: [SessionPanelSnapshot]) -> AppSessionSnapshot {
+        let workspace = SessionWorkspaceSnapshot(
+            id: UUID(), processTitle: "Terminal", customTitle: nil, customColor: nil,
+            isPinned: false, currentDirectory: "/tmp", focusedPanelId: nil,
+            layout: .pane(SessionPaneLayoutSnapshot(panelIds: panels.map(\.id), selectedPanelId: nil)),
+            panels: panels, statusEntries: [], logEntries: [], progress: nil, gitBranch: nil
+        )
+        let window = SessionWindowSnapshot(
+            frame: nil, display: nil,
+            tabManager: SessionTabManagerSnapshot(selectedWorkspaceIndex: 0, workspaces: [workspace]),
+            sidebar: SessionSidebarSnapshot(isVisible: true, selection: .tabs, width: 240)
+        )
+        return AppSessionSnapshot(version: SessionSnapshotSchema.currentVersion,
+                                  createdAt: Date().timeIntervalSince1970, windows: [window])
+    }
+}

--- a/c11Tests/WorkspaceConversationResumeTests.swift
+++ b/c11Tests/WorkspaceConversationResumeTests.swift
@@ -75,7 +75,7 @@ final class WorkspaceConversationResumeTests: XCTestCase {
             state: .unknown,
             diagnosticReason: "ambiguous: 2 candidates; chose newest"
         )
-        await ConversationStore.shared.recordScrape(surfaceId: surfaceId, ref: ref)
+        await ConversationStore.shared.applyScrape(surfaceId: surfaceId, ref: ref)
         let snapshot = makeSnapshot(panels: [
             makePanelSnapshot(id: panelId, type: .terminal, metadata: nil)
         ])


### PR DESCRIPTION
## C11-152 — Live scrape-capture pipeline (the missing restore seam)

The scrape rail (`Sources/Conversation/Scrapers/`) existed as a unit-tested seam with **0 live call sites** — nothing invoked scrapers at restore, so codex (and any future scrape-primary kind) never resolved a real session id and `resume()` only ever saw a placeholder. This PR builds the missing connective tissue.

**Phase B foundation. Blocks C11-153 (pi) + C11-154 (omp)** — they import against the public seam below.

### New public seam (additive)
- `ConversationScraper` protocol; `ClaudeCodeScraper`/`CodexScraper` conform.
- `ConversationScraperRegistry` (+ `v1(filesystem:)`), mirrors the strategy registry.
- `ScrapeCaptureContext` + `ScrapeCapturePipeline` — pure orchestrator: per-kind scraper → `strategy.capture`, forwarding only `.scrape`-provenance refs.
- `ConversationStore.applyScrape` (renamed from `recordScrape`) + `runScrapeCapture` actor driver.

### Live call site
`AppDelegate.prepareStartupSessionSnapshotIfNeeded` runs the pipeline after `seedFromSnapshot` and **before** the `--no-resume` / dirty-reclassify branches (so those still win), via the established `Task.detached` + 1s-semaphore pattern.

### No claude/codex resume regression
A seeded hook ref is returned by `capture` as `.hook` and filtered out (scrape path can't displace it); claude scrape-only refs stay `.unknown` → skip; codex single unambiguous cwd+mtime match → `.alive` → `codex resume '<uuid>'` (the intended new capability).

### Tests / validation
- `c11Tests/ScrapeCapturePipelineTests.swift` (c11LogicTests target only; local mocks): 7 cases incl. the end-to-end `ScrapeCandidate → applyScrape → resume .typeCommand` round-trip, ambiguity-skip, hook-ref-preserved, and `contexts(from:)` extraction. **Green.**
- `ConversationCrashRecoveryTests` regression guard: 14 green.
- `xcodebuild -scheme c11 build`: **BUILD SUCCEEDED**.
- Full observed live-agent exact-session resume is owned by the consuming tickets C11-153/154 (BUILDPLAN Phase B step 5) — rationale in the validation artifact.

### Notes
- `recordScrape`→`applyScrape` rename touches one host-target caller (`c11Tests/WorkspaceConversationResumeTests.swift`); that edit is CI-verified per the no-local-host-test rule.
- pbxproj: 3 product files → `c11`, 1 test → `c11LogicTests` only (single-membership verified); `xcodebuild -list` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)