### PR TITLE
feat(conversation): pi exact-session resume — PiScraper + PiStrategy (C11-153)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		14D792EBB09AC36ADFF389EC /* ShutdownSentinelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37B204EF50A2AF07D922EFFA /* ShutdownSentinelTests.swift */; };
 		1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */; };
 		176BB8C7A69033D4F4671809 /* MailboxOutboxWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710DBF1A1B2C3D4E5F60718 /* MailboxOutboxWatcherTests.swift */; };
+		18C7A8A92E1BA2E2177EC159 /* PiScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB265ECF45AC4D4930FA9B22 /* PiScraper.swift */; };
 		1A1EC322E65B74DEDAAD08A5 /* DefaultAgentConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF9D5EC78046EDA9B54AC68 /* DefaultAgentConfigTests.swift */; };
 		1BA5C5B28E1CE348469E1778 /* MetadataStoreRevisionCounterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7009BF1A1B2C3D4E5F60718 /* MetadataStoreRevisionCounterTests.swift */; };
 		1D57711F82EF7A25FB6FEA23 /* Codex.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE1C8E6BE23CECF1DA9531BA /* Codex.swift */; };
@@ -339,6 +340,7 @@
 		DH020BF0A1B2C3D4E5F60719 /* CLIResolutionSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH020BF1A1B2C3D4E5F60718 /* CLIResolutionSnapshot.swift */; };
 		DH021BF0A1B2C3D4E5F60719 /* DoctorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH021BF1A1B2C3D4E5F60719 /* DoctorCommand.swift */; };
 		E1000000A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */; };
+		E123B16B00B33A73F7527FF1 /* PiConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */; };
 		E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */; };
 		E2010D80CDA99F910358E34E /* HealthSentinelParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH013BF1A1B2C3D4E5F60718 /* HealthSentinelParserTests.swift */; };
 		E22B7F896B34E302923449BF /* ConversationRefTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81492660FA7D00E8115BD46 /* ConversationRefTests.swift */; };
@@ -346,6 +348,7 @@
 		E6C1381837332D3B253A0C42 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 		E7E728D3008386FFA3E28065 /* WorkspacePullRequestSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14A7DC53B9CA33BE2A421711 /* WorkspacePullRequestSidebarTests.swift */; };
 		E81B5FA9C3AF8FAB6C10C623 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
+		E883012FE2EFF094545647F6 /* Pi.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE86A069B4ECE7503CE20B95 /* Pi.swift */; };
 		E9E24C866C5E61B887F6E726 /* MainThreadHangDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */; };
 		EAD9B00B1CD68D5F1C61CEDF /* ConversationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B9B8C3641F9801C6A45757 /* ConversationStrategyTests.swift */; };
 		EC224F7B0F7E77A981DFEC5A /* StateDirectoryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */; };
@@ -450,6 +453,7 @@
 		6068E3FCA0467699A1ADD6FD /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
 		660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationCrashRecoveryTests.swift; path = ConversationCrashRecoveryTests.swift; sourceTree = "<group>"; };
+		6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PiConversationTests.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
 		76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentProjectConfig.swift; sourceTree = "<group>"; };
 		7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentDetectorTests.swift; sourceTree = "<group>"; };
@@ -593,6 +597,7 @@
 		A8C9388437A24EE58C8AAA71 /* Ref.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Ref.swift; path = Conversation/Ref.swift; sourceTree = "<group>"; };
 		AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClaudeCodeScraper.swift; path = Conversation/Scrapers/ClaudeCodeScraper.swift; sourceTree = "<group>"; };
 		AE1C8E6BE23CECF1DA9531BA /* Codex.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Codex.swift; path = Conversation/Strategies/Codex.swift; sourceTree = "<group>"; };
+		AE86A069B4ECE7503CE20B95 /* Pi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/Strategies/Pi.swift; sourceTree = "<group>"; };
 		B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrapeCapturePipelineTests.swift; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
@@ -608,6 +613,7 @@
 		B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceCmdDUITests.swift; sourceTree = "<group>"; };
 		B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWindowConfirmDialogUITests.swift; sourceTree = "<group>"; };
+		BB265ECF45AC4D4930FA9B22 /* PiScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/Scrapers/PiScraper.swift; sourceTree = "<group>"; };
 		BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOrderingTests.swift; sourceTree = "<group>"; };
 		BE61F2503F50546EC21A9868 /* HangBacktrace.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HangBacktrace.h; sourceTree = "<group>"; };
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
@@ -1059,6 +1065,8 @@
 				9BFB0FCD7F3834654919F820 /* ConversationScraperRegistry.swift */,
 				14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */,
 				1AF4B917D915F1E0B37511F0 /* OpencodeScraper.swift */,
+				BB265ECF45AC4D4930FA9B22 /* PiScraper.swift */,
+				AE86A069B4ECE7503CE20B95 /* Pi.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1219,6 +1227,7 @@
 				FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */,
 				B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */,
 				C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */,
+				6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1543,6 +1552,7 @@
 				352C25FFD890137B5F7A23B3 /* AgentManifestTests.swift in Sources */,
 				0824BD4DE71F74CA32F9F49E /* ScrapeCapturePipelineTests.swift in Sources */,
 				7FFBFB92E1EA4343FB71DCA8 /* OpencodeResumeTests.swift in Sources */,
+				E123B16B00B33A73F7527FF1 /* PiConversationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1720,6 +1730,8 @@
 				48D1A7FA449F78DFC0148E27 /* ConversationScraperRegistry.swift in Sources */,
 				8FAB47C9F34672F10BB37D41 /* ScrapeCapturePipeline.swift in Sources */,
 				80AB58969BB8EC6059C099DA /* OpencodeScraper.swift in Sources */,
+				18C7A8A92E1BA2E2177EC159 /* PiScraper.swift in Sources */,
+				E883012FE2EFF094545647F6 /* Pi.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -228,12 +228,14 @@ struct AgentRegistry: Sendable {
             detectNodeArgsSubstrings: ["@earendil-works/pi"],
             iconAsset: nil,
             sfSymbolFallback: "p.circle",
-            // `pi -c` continues the most recent session in cwd (best-effort,
-            // same shape as codex --last). Exact-session resume via a JSONL
-            // scraper (~/.pi/agent/sessions/) is a tracked follow-up.
+            // `pi -c` continues the most recent session in cwd (best-effort
+            // phase-1 fallback, same shape as codex --last). Exact-session
+            // resume is handled by the scrape rail: `PiScraper` +
+            // `PiStrategy` resolve a specific `~/.pi/agent/sessions/` id and
+            // type `pi --session '<id>'`.
             resume: .fixed("pi -c\n"),
             isCanonicalTerminalType: true,
-            hasConversationStrategy: false
+            hasConversationStrategy: true
         ),
         AgentManifest(
             kind: "omp",

--- a/Sources/Conversation/Scrapers/ConversationScraperRegistry.swift
+++ b/Sources/Conversation/Scrapers/ConversationScraperRegistry.swift
@@ -41,7 +41,8 @@ struct ConversationScraperRegistry: Sendable {
     ) -> ConversationScraperRegistry {
         ConversationScraperRegistry(scrapers: [
             ClaudeCodeScraper(filesystem: filesystem),
-            CodexScraper(filesystem: filesystem)
+            CodexScraper(filesystem: filesystem),
+            PiScraper(filesystem: filesystem)
         ])
     }
 }

--- a/Sources/Conversation/Scrapers/PiScraper.swift
+++ b/Sources/Conversation/Scrapers/PiScraper.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+/// Bounded filesystem I/O over `~/.pi/agent/sessions/`, where pi stores
+/// per-cwd transcripts as `<cwd-slug>/<ISO-ts>_<uuid>.jsonl`.
+///
+/// **Privacy contract** (see architecture doc §"Privacy contract for scrape"):
+/// reads metadata only — filename + mtime + size. Filename carries the session
+/// id. Transcript bytes are NEVER opened, copied, or logged.
+///
+/// Two divergences from `ClaudeCodeScraper`/`CodexScraper`:
+///
+/// 1. **Filename grammar.** pi's filename is `<ISO-ts>_<uuid>.jsonl`, not
+///    `<uuid>.jsonl`. The ISO timestamp (`2026-06-27T21-35-42-003Z`) uses
+///    dashes/`T`/`Z` and contains no `_`, so the session id is the substring
+///    after the **last** `_` of the filename stem. `isValidConversationUUID`
+///    rejects anything that isn't an 8-4-4-4-12 hex UUID (pi mints UUIDv7,
+///    which is that shape), so a filename with no `_` or a non-UUID tail is
+///    dropped.
+///
+/// 2. **cwd-scoped lookup.** pi stores sessions under a **per-cwd slug
+///    directory** (`~/.pi/agent/sessions/<slug>/`) and resolves sessions by
+///    cwd itself. Unlike codex, pi has no wrapper-claim time floor and no
+///    SessionStart hook, so a whole-tree top-N scrape would return candidates
+///    from every project and `PiStrategy.capture` would see them all as
+///    ambiguous (its cwd filter can't help once every candidate is stamped
+///    with the surface cwd). To make the cwd actually narrow — so exact
+///    resume can fire — when a `cwd` is known the scraper scopes its walk to
+///    that cwd's slug directory (pi's own model). With no `cwd` it falls back
+///    to the whole-tree top-N (best-effort, e.g. a surface with no recorded
+///    directory).
+struct PiScraper: ConversationScraper {
+    let kind: String = "pi"
+    static let defaultMaxCandidates: Int = 16
+
+    /// Filesystem dependency. Tests pass a mock that produces fixture
+    /// session-storage layouts without touching the real `~/.pi/`.
+    let filesystem: ConversationFilesystem
+    let maxCandidates: Int
+
+    init(
+        filesystem: ConversationFilesystem = DefaultConversationFilesystem(),
+        maxCandidates: Int = PiScraper.defaultMaxCandidates
+    ) {
+        self.filesystem = filesystem
+        self.maxCandidates = maxCandidates
+    }
+
+    /// Resolve `~/.pi/agent/sessions/`. Returns nil if HOME isn't set.
+    func sessionsRoot() -> URL? {
+        guard let home = filesystem.homeDirectory else { return nil }
+        return home
+            .appendingPathComponent(".pi", isDirectory: true)
+            .appendingPathComponent("agent", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    /// pi's per-cwd session-directory name. Mirrors pi's encoding exactly
+    /// (`@earendil-works/pi-coding-agent` `migrations.js`):
+    /// `"--" + cwd.drop(leading "/" or "\") with [/\\:] -> "-" + "--"`. Note
+    /// pi does NOT map `.` (unlike Claude's project slug), so dots are kept.
+    static func sessionSlug(forCwd cwd: String) -> String {
+        var stripped = Substring(cwd)
+        if let first = stripped.first, first == "/" || first == "\\" {
+            stripped = stripped.dropFirst()
+        }
+        let mapped = String(stripped.map { ($0 == "/" || $0 == "\\" || $0 == ":") ? "-" : $0 })
+        return "--\(mapped)--"
+    }
+
+    /// Top-N candidates by mtime. Empty list when the session store (or the
+    /// cwd's slug directory) doesn't exist. When `cwd` is known, lists just
+    /// that cwd's slug directory (sessions live directly under it, one level
+    /// deep); otherwise walks the whole tree recursively.
+    func candidates(cwd: String? = nil) -> [ScrapeCandidate] {
+        guard let root = sessionsRoot() else { return [] }
+        let entries: [ConversationFilesystemEntry]
+        if let cwd, !cwd.isEmpty {
+            let slugDir = root.appendingPathComponent(
+                Self.sessionSlug(forCwd: cwd), isDirectory: true
+            )
+            entries = filesystem.listDirectoryByMtime(slugDir, max: maxCandidates)
+        } else {
+            entries = filesystem.listSessionsRecursivelyByMtime(
+                root, extensionFilter: "jsonl", max: maxCandidates
+            )
+        }
+        return entries.compactMap { entry in
+            // `listDirectoryByMtime` returns every file in the slug dir, so
+            // filter the extension here (the recursive lister already did).
+            guard entry.fileName.hasSuffix(".jsonl") else { return nil }
+            let stem = String(entry.fileName.dropLast(".jsonl".count))
+            // Session id is the substring after the last `_`; the ISO
+            // timestamp before it contains no `_`.
+            guard let underscore = stem.lastIndex(of: "_") else { return nil }
+            let id = String(stem[stem.index(after: underscore)...])
+            guard isValidConversationUUID(id) else { return nil }
+            return ScrapeCandidate(
+                id: id,
+                filePath: entry.url.path,
+                mtime: entry.mtime,
+                size: entry.size,
+                cwd: cwd
+            )
+        }
+    }
+}

--- a/Sources/Conversation/Strategies/Pi.swift
+++ b/Sources/Conversation/Strategies/Pi.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Scrape-primary strategy for pi. pi exposes no SessionStart hook and no
+/// session-id injection flag, so the wrapper never mints a placeholder; the
+/// `PiScraper` resolves the real id from `~/.pi/agent/sessions/**/<ts>_<uuid>.jsonl`
+/// filtered by cwd, mtime ≥ wrapper-claim time, and mtime ≥ surface
+/// `lastActivityTimestamp`. (In production pi has no claim rail, so the
+/// empty-candidates branch returns the absent `wrapperClaim` — i.e. `nil` —
+/// and capture is driven entirely by the scrape rail.)
+///
+/// Ambiguity policy (mirrors `CodexStrategy`): when more than one candidate
+/// matches the surface filter, return ref with `state = .unknown`,
+/// `placeholder = false`, `id = most-plausible-candidate`, and a
+/// diagnosticReason like `"ambiguous: 3 candidates; chose newest"`. `resume()`
+/// returns `.skip(reason: "ambiguous")` for state=.unknown so neither pane
+/// resumes the other's session and the operator is asked to disambiguate via
+/// `c11 conversation clear --surface <id>`.
+///
+/// Id grammar: UUID (pi session filenames carry a UUIDv7 after the last `_`;
+/// `isValidConversationUUID` accepts the 8-4-4-4-12 hex shape).
+struct PiStrategy: ConversationStrategy {
+    let kind: String = "pi"
+
+    init() {}
+
+    func capture(inputs: ConversationStrategyInputs) -> ConversationRef? {
+        // Filter the candidates by what we know about the surface.
+        let activityFloor = inputs.lastActivityTimestamp
+        let claimTime = inputs.wrapperClaim?.capturedAt
+        let cwd = inputs.cwd
+
+        let filtered = inputs.scrapeCandidates.filter { candidate in
+            // cwd must match the surface's cwd if both are known.
+            if let cwd, let candCwd = candidate.cwd, cwd != candCwd {
+                return false
+            }
+            if let claimTime, candidate.mtime < claimTime {
+                return false
+            }
+            if let activityFloor, candidate.mtime < activityFloor {
+                return false
+            }
+            return isValidConversationUUID(candidate.id)
+        }
+
+        if filtered.isEmpty {
+            // No live signal. pi has no wrapper-claim rail, so this is `nil`
+            // in production; return it for parity with the codex mirror.
+            return inputs.wrapperClaim
+        }
+        // Sort newest-first; deterministic within the strategy.
+        let sorted = filtered.sorted { $0.mtime > $1.mtime }
+        let chosen = sorted[0]
+        if sorted.count > 1 {
+            return ConversationRef(
+                kind: kind,
+                id: chosen.id,
+                placeholder: false,
+                cwd: chosen.cwd ?? cwd,
+                capturedAt: chosen.mtime,
+                capturedVia: .scrape,
+                state: .unknown,
+                diagnosticReason: "ambiguous: \(sorted.count) candidates; chose newest"
+            )
+        }
+        return ConversationRef(
+            kind: kind,
+            id: chosen.id,
+            placeholder: false,
+            cwd: chosen.cwd ?? cwd,
+            capturedAt: chosen.mtime,
+            capturedVia: .scrape,
+            state: .alive,
+            diagnosticReason: "matched cwd + mtime after claim"
+        )
+    }
+
+    func resume(ref: ConversationRef) -> ResumeAction {
+        guard !ref.placeholder else {
+            return .skip(reason: "placeholder; no pi session resolved yet")
+        }
+        switch ref.state {
+        case .unknown:
+            return .skip(reason: "ambiguous")
+        case .tombstoned, .unsupported:
+            return .skip(reason: "state=\(ref.state.rawValue) not auto-resumable")
+        case .alive, .suspended:
+            break
+        }
+        guard isValidConversationUUID(ref.id) else {
+            return .skip(reason: "invalid id grammar")
+        }
+        let quoted = conversationShellQuote(ref.id)
+        // Specific id, not `pi -c`. Exact-session resume is the whole point.
+        let text = "pi --session \(quoted)"
+        return .typeCommand(text: text, submitWithReturn: true)
+    }
+
+    func isValidId(_ id: String) -> Bool {
+        isValidConversationUUID(id)
+    }
+}

--- a/Sources/Conversation/StrategyRegistry.swift
+++ b/Sources/Conversation/StrategyRegistry.swift
@@ -39,7 +39,8 @@ struct ConversationStrategyRegistry: Sendable {
             GrokStrategy(),
             OpencodeStrategy(),
             KimiStrategy(),
-            GitHubCopilotStrategy()
+            GitHubCopilotStrategy(),
+            PiStrategy()
         ])
     }()
 }

--- a/c11Tests/PiConversationTests.swift
+++ b/c11Tests/PiConversationTests.swift
@@ -1,0 +1,309 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Pure tests for `PiScraper` + `PiStrategy` (C11-153 pi exact-session resume).
+///
+/// Member of the **`c11LogicTests`** target only, so it runs on the safe
+/// `c11-logic` scheme. All mocks are declared locally — the host-target
+/// `ConversationScraperTests.MockFS` is not reachable from this target
+/// (mirrors `ScrapeCapturePipelineTests`).
+final class PiConversationTests: XCTestCase {
+
+    // MARK: - Local mocks (logic-target-local; do not borrow host-target helpers)
+
+    final class MockFS: ConversationFilesystem, @unchecked Sendable {
+        var home: URL?
+        var recursiveEntries: [URL: [ConversationFilesystemEntry]] = [:]
+        var directoryEntries: [URL: [ConversationFilesystemEntry]] = [:]
+        var existingPaths: Set<String> = []
+
+        var homeDirectory: URL? { home }
+        func fileExists(atPath path: String) -> Bool { existingPaths.contains(path) }
+        func listDirectoryByMtime(_ directory: URL, max: Int) -> [ConversationFilesystemEntry] {
+            Array((directoryEntries[directory] ?? [])
+                .sorted { $0.mtime > $1.mtime }
+                .prefix(max))
+        }
+        func listSessionsRecursivelyByMtime(
+            _ root: URL,
+            extensionFilter: String,
+            max: Int
+        ) -> [ConversationFilesystemEntry] {
+            Array((recursiveEntries[root] ?? [])
+                .filter { $0.fileName.hasSuffix("." + extensionFilter) }
+                .prefix(max))
+        }
+    }
+
+    private func entry(_ dir: URL, _ name: String, mtime: Date, size: Int64 = 1024) -> ConversationFilesystemEntry {
+        ConversationFilesystemEntry(
+            url: dir.appendingPathComponent(name), fileName: name, mtime: mtime, size: size
+        )
+    }
+
+    // A real pi filename shape: `<ISO-ts>_<uuidv7>.jsonl`. The timestamp has
+    // no `_`, so the id is the substring after the last `_`.
+    private let piUUID = "019f0b02-83b3-7c97-b12c-05946daccc84"
+    private let piUUID2 = "019f0b53-537e-75da-a487-10737b50b4e3"
+    private func piFileName(ts: String, uuid: String) -> String { "\(ts)_\(uuid).jsonl" }
+
+    /// Build the sessions-root URL exactly as `PiScraper.sessionsRoot()` does
+    /// (three `isDirectory: true` appends), so the `MockFS` dictionary key
+    /// matches the URL the scraper looks up — URL equality is construction-
+    /// sensitive, so a single `".pi/agent/sessions"` component would not match.
+    private func sessionsRoot(_ home: String) -> URL {
+        URL(fileURLWithPath: home)
+            .appendingPathComponent(".pi", isDirectory: true)
+            .appendingPathComponent("agent", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    // MARK: - PiScraper
+
+    func testPiScraperExtractsUUIDAfterLastUnderscore() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot("/Users/test")
+        let slug = root.appendingPathComponent("--Users-test-proj--")
+        let name = piFileName(ts: "2026-06-27T21-35-42-003Z", uuid: piUUID)
+        mock.recursiveEntries[root] = [
+            ConversationFilesystemEntry(
+                url: slug.appendingPathComponent(name),
+                fileName: name,
+                mtime: Date(),
+                size: 4096
+            )
+        ]
+        let scraper = PiScraper(filesystem: mock)
+        let candidates = scraper.candidates()
+        XCTAssertEqual(candidates.count, 1)
+        // The id is the UUID, NOT the timestamp-prefixed stem.
+        XCTAssertEqual(candidates[0].id, piUUID)
+    }
+
+    func testPiScraperRecursivelyReturnsTopByMtime() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot("/Users/test")
+        let slugA = root.appendingPathComponent("--Users-test-a--")
+        let slugB = root.appendingPathComponent("--Users-test-b--")
+        let nameNew = piFileName(ts: "2026-06-27T23-03-58-078Z", uuid: piUUID2)
+        let nameOld = piFileName(ts: "2026-06-27T21-35-42-003Z", uuid: piUUID)
+        let now = Date()
+        mock.recursiveEntries[root] = [
+            ConversationFilesystemEntry(
+                url: slugB.appendingPathComponent(nameNew),
+                fileName: nameNew, mtime: now, size: 2048
+            ),
+            ConversationFilesystemEntry(
+                url: slugA.appendingPathComponent(nameOld),
+                fileName: nameOld, mtime: now.addingTimeInterval(-3600), size: 1024
+            )
+        ]
+        let candidates = PiScraper(filesystem: mock).candidates()
+        XCTAssertEqual(candidates.map(\.id), [piUUID2, piUUID])
+    }
+
+    func testPiScraperRejectsNonUUIDTailAndNoUnderscore() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot("/Users/test")
+        let slug = root.appendingPathComponent("--Users-test-proj--")
+        let valid = piFileName(ts: "2026-06-27T21-35-42-003Z", uuid: piUUID)
+        mock.recursiveEntries[root] = [
+            // valid
+            ConversationFilesystemEntry(
+                url: slug.appendingPathComponent(valid),
+                fileName: valid, mtime: Date(), size: 1024
+            ),
+            // tail after last `_` is not a UUID
+            ConversationFilesystemEntry(
+                url: slug.appendingPathComponent("2026-06-27T21-35-42-003Z_not-a-uuid.jsonl"),
+                fileName: "2026-06-27T21-35-42-003Z_not-a-uuid.jsonl",
+                mtime: Date(), size: 50
+            ),
+            // no underscore at all (whole stem is not a UUID)
+            ConversationFilesystemEntry(
+                url: slug.appendingPathComponent("plainname.jsonl"),
+                fileName: "plainname.jsonl", mtime: Date(), size: 50
+            )
+        ]
+        let candidates = PiScraper(filesystem: mock).candidates()
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates[0].id, piUUID)
+    }
+
+    func testPiScraperEmptyWhenDirMissing() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        // No recursiveEntries keyed for the sessions root.
+        XCTAssertTrue(PiScraper(filesystem: mock).candidates().isEmpty)
+    }
+
+    /// Slug encoding mirrors pi exactly: strip leading `/`, map `/ \ :` → `-`,
+    /// wrap in `--…--`. Dots are preserved (pi does not map `.`).
+    func testPiSessionSlugMatchesPiEncoding() {
+        XCTAssertEqual(
+            PiScraper.sessionSlug(forCwd: "/Users/atin/Projects/Gregorovich"),
+            "--Users-atin-Projects-Gregorovich--"
+        )
+        XCTAssertEqual(
+            PiScraper.sessionSlug(forCwd: "/work/my.proj"),
+            "--work-my.proj--"  // dot preserved
+        )
+    }
+
+    /// When a cwd is known, the scraper scopes to that cwd's slug directory and
+    /// stamps the surface cwd onto the candidate.
+    func testPiScraperScopesToCwdSlugDirectory() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot("/Users/test")
+        let cwd = "/work/proj"
+        let slugDir = root.appendingPathComponent(PiScraper.sessionSlug(forCwd: cwd), isDirectory: true)
+        let name = piFileName(ts: "2026-06-27T21-35-42-003Z", uuid: piUUID)
+        mock.directoryEntries[slugDir] = [entry(slugDir, name, mtime: Date())]
+        let candidates = PiScraper(filesystem: mock).candidates(cwd: cwd)
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates[0].id, piUUID)
+        XCTAssertEqual(candidates[0].cwd, cwd)
+    }
+
+    /// The narrowing is real: a session in a DIFFERENT cwd's slug dir is not
+    /// returned when scraping for this cwd — even if it is newer. This is what
+    /// lets exact resume fire on a machine with many pi sessions (pi has no
+    /// wrapper-claim floor to narrow by, unlike codex).
+    func testPiScraperDoesNotLeakSessionsFromOtherCwds() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot("/Users/test")
+        let mineDir = root.appendingPathComponent(PiScraper.sessionSlug(forCwd: "/work/mine"), isDirectory: true)
+        let otherDir = root.appendingPathComponent(PiScraper.sessionSlug(forCwd: "/work/other"), isDirectory: true)
+        let now = Date()
+        mock.directoryEntries[mineDir] = [
+            entry(mineDir, piFileName(ts: "2026-06-27T21-35-42-003Z", uuid: piUUID), mtime: now.addingTimeInterval(-3600))
+        ]
+        // Newer session, but in a different cwd's dir — must be invisible.
+        mock.directoryEntries[otherDir] = [
+            entry(otherDir, piFileName(ts: "2026-06-27T23-03-58-078Z", uuid: piUUID2), mtime: now)
+        ]
+        let candidates = PiScraper(filesystem: mock).candidates(cwd: "/work/mine")
+        XCTAssertEqual(candidates.map(\.id), [piUUID], "only the matching cwd's session is returned")
+    }
+
+    func testPiScraperEmptyWhenCwdSlugDirMissing() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        // No directoryEntries keyed for the cwd's slug dir.
+        XCTAssertTrue(PiScraper(filesystem: mock).candidates(cwd: "/work/proj").isEmpty)
+    }
+
+    // MARK: - PiStrategy / pipeline end-to-end
+
+    private func candidate(_ id: String, mtime: Date, cwd: String? = nil) -> ScrapeCandidate {
+        ScrapeCandidate(
+            id: id,
+            filePath: "/Users/test/.pi/agent/sessions/--slug--/2026-06-27T21-35-42-003Z_\(id).jsonl",
+            mtime: mtime, size: 1024, cwd: cwd
+        )
+    }
+
+    /// The gate: a single pi candidate resolves through the pipeline into a
+    /// scrape-derived, alive ref that resumes via `pi --session '<uuid>'`.
+    func testPiSingleCandidateResumesExactSession() {
+        let surfaceId = UUID().uuidString
+        let now = Date()
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "pi", preset: [candidate(piUUID, mtime: now)])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "pi", cwd: "/work/proj")]
+
+        let captured = pipeline.captureRefs(contexts: contexts, existing: [:])
+        XCTAssertEqual(captured.count, 1)
+        let ref = captured[0].ref
+        XCTAssertEqual(captured[0].surfaceId, surfaceId)
+        XCTAssertEqual(ref.kind, "pi")
+        XCTAssertEqual(ref.id, piUUID)
+        XCTAssertEqual(ref.capturedVia, .scrape)
+        XCTAssertEqual(ref.state, .alive)
+
+        let action = PiStrategy().resume(ref: ref)
+        guard case let .typeCommand(text, submit) = action else {
+            return XCTFail("expected .typeCommand, got \(action)")
+        }
+        XCTAssertEqual(text, "pi --session '\(piUUID)'")
+        XCTAssertTrue(submit)
+    }
+
+    /// Two candidates for the same surface → `.unknown`, and `resume` skips
+    /// so neither pane steals the other's session.
+    func testPiAmbiguousCandidatesYieldUnknownAndSkip() {
+        let surfaceId = UUID().uuidString
+        let now = Date()
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "pi", preset: [
+                candidate(piUUID, mtime: now),
+                candidate(piUUID2, mtime: now.addingTimeInterval(-30))
+            ])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "pi", cwd: "/work/proj")]
+
+        let captured = pipeline.captureRefs(contexts: contexts, existing: [:])
+        XCTAssertEqual(captured.count, 1)
+        let ref = captured[0].ref
+        XCTAssertEqual(ref.state, .unknown)
+        XCTAssertEqual(ref.id, piUUID, "newest-first chosen for the diagnostic id")
+
+        if case .skip = PiStrategy().resume(ref: ref) {
+            // expected
+        } else {
+            XCTFail("ambiguous ref must skip")
+        }
+    }
+
+    /// pi has no wrapper-claim rail in production, so this state is only
+    /// reachable via future wiring — construct the placeholder directly and
+    /// assert resume skips it.
+    func testPiPlaceholderRefSkips() {
+        let ref = ConversationRef(
+            kind: "pi",
+            id: piUUID,
+            placeholder: true,
+            capturedVia: .wrapperClaim,
+            state: .alive
+        )
+        if case let .skip(reason) = PiStrategy().resume(ref: ref) {
+            XCTAssertTrue(reason.contains("placeholder"))
+        } else {
+            XCTFail("placeholder ref must skip")
+        }
+    }
+
+    func testPiStrategyValidatesUUIDGrammar() {
+        let s = PiStrategy()
+        XCTAssertTrue(s.isValidId(piUUID))
+        XCTAssertFalse(s.isValidId("not-a-uuid"))
+        XCTAssertFalse(s.isValidId(""))
+    }
+
+    // MARK: - Local stub scraper
+
+    /// Returns preset candidates regardless of cwd, stamping the passed cwd
+    /// onto each (mirrors the real scrapers). Local to this target.
+    struct MockScraper: ConversationScraper {
+        let kind: String
+        let preset: [ScrapeCandidate]
+        func candidates(cwd: String?) -> [ScrapeCandidate] {
+            preset.map {
+                ScrapeCandidate(id: $0.id, filePath: $0.filePath, mtime: $0.mtime, size: $0.size, cwd: cwd ?? $0.cwd)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## C11-153 — pi exact-session resume (PiScraper + PiStrategy)

Lights up **exact-session** resume for `pi` on C11-152's live scrape-capture pipeline (Phase B, pi). Adds the two missing per-kind pieces plus registration; PiStrategy mirrors `CodexStrategy`'s scrape-primary + ambiguity policy.

### What's in
- **`PiScraper`** — bounded, stat-only lookup of pi's session store. pi filenames are `<ISO-ts>_<uuid>.jsonl`; the timestamp has no `_`, so the id is the substring after the **last** `_` (UUIDv7, accepted by `isValidConversationUUID`'s 8-4-4-4-12 hex grammar).
- **`PiStrategy`** — `resume` types `pi --session '<id>'` for an alive ref; skips on ambiguous / placeholder / invalid grammar. Faithful `CodexStrategy` mirror.
- Registered in `ConversationScraperRegistry.v1` + `ConversationStrategyRegistry.v1`; `pi` manifest `hasConversationStrategy` flipped `true` in the **same commit** (the `AgentManifestTests.testConversationStrategyPresenceParity` golden test enforces this). Manifest's phase-1 `pi -c` fallback unchanged.

### Deviation from the approved plan (flagged for reviewers)
`PiScraper` does **cwd-scoped lookup**, not a literal `CodexScraper` whole-tree mirror. Codex narrows candidates via its wrapper-claim time floor; **pi has no wrapper and no hook, so no floor at all** — a whole-tree mirror makes every restore on a real machine ambiguous → skip, so pi would *never* positively resume (fails the "live pi resumes exact session" acceptance). When a cwd is known the scraper scopes to pi's per-cwd slug dir (`~/.pi/agent/sessions/<slug>/`); slug encoding mirrors pi's own `migrations.js` exactly (`"--" + cwd.drop-leading-slash with [/\\:]→"-" + "--"`, dots preserved) and is unit-tested. PiStrategy stays a faithful codex mirror; the refinement is scraper-only and reversible.

### Validation
- **Unit (safe `c11-logic` scheme):** 12 `PiConversationTests` + 8 `AgentManifestTests` (parity) green.
- **Live exact-session resume (tagged build):** launched `pi` (session `019f1116-a8d7-70d5-bc9e-0c91c1050a08` in `~/c11-153-pi-live`), quit, relaunched with resume. Snapshot's pi panel had `active=None`; after restore `c11 conversation list --json` showed `{kind:pi, id:019f1116…, state:alive, captured_via:"scrape", diagnostic_reason:"matched cwd + mtime after claim"}` — resolved by PiScraper+PiStrategy at restore → `pi --session '<id>'`. The restored pi surface re-rendered the exact prior session. (Lattice C11-153 validation artifact has the full transcript.)

### Notes
- Based on `main` (C11-152 #273 and C11-151 #274 already merged); no merge-order dependency.
- pbxproj edits via the `xcodeproj` gem — gate on `xcodebuild -list` + target membership, not the line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
