### PR TITLE
feat(conversation): omp exact-session resume (OmpScraper + OmpStrategy) (C11-154)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
 		20A2EC594F0DF1560BB0E28E /* ClaudeCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1299AE998DF9F78A383294 /* ClaudeCode.swift */; };
 		20F7EACAFF3B4C7AFBE0D063 /* WorkspaceLayoutExecutorAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */; };
+		24E7BF80A6D38962748D9509 /* OmpScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B94CA7E57E1FD8FFF1217B /* OmpScraper.swift */; };
 		27AE9B7E020D938C6013B312 /* PaneSizePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0095C3D72A7722FFA42A7ED1 /* PaneSizePolicy.swift */; };
 		2A1AAF5C5915A2960E874202 /* PaneMetadataPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7012BF1A1B2C3D4E5F60718 /* PaneMetadataPersistenceTests.swift */; };
 		2BA0A65D723C9E1F886F326D /* AgentRestartRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8009BF1A1B2C3D4E5F60718 /* AgentRestartRegistryTests.swift */; };
@@ -92,6 +93,7 @@
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
 		8574E0DF636A7359989C51A4 /* ConversationScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */; };
 		864B59A6AAF8E002451F50CB /* ThemedValueParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F008 /* ThemedValueParserTests.swift */; };
+		88C381A879AAF75295A60C34 /* Omp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F0DED724227677C7B8512 /* Omp.swift */; };
 		8B6BA07B09D5E9E01F141A44 /* BrowserChromeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F01C /* BrowserChromeSnapshotTests.swift */; };
 		8B85A633AA2D415C37FD4727 /* ShutdownSentinel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D3CB3B7B4231D786E8883E /* ShutdownSentinel.swift */; };
 		8C1F311B2760FEE15B8DFD2F /* MailboxEnvelopeValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7107BF1A1B2C3D4E5F60718 /* MailboxEnvelopeValidationTests.swift */; };
@@ -280,6 +282,7 @@
 		D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
 		D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */ = {isa = PBXBuildFile; fileRef = D1BEF00001A1B2C3D4E5F719 /* open */; };
 		D3A97DA994E2DA451F6020CF /* DefaultAgentConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B62D2ECDC52E5244D9C6E3 /* DefaultAgentConfig.swift */; };
+		D49911F30C44874C90103A16 /* OmpConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D79AA02822FFBE8B15FA2B6 /* OmpConversationTests.swift */; };
 		D533F2133EFFE99386F805B0 /* StatusEntryPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D700ABF1A1B2C3D4E5F60718 /* StatusEntryPersistenceTests.swift */; };
 		D7001BF0A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7001BF1A1B2C3D4E5F60718 /* SurfaceTitleBarRenderTests.swift */; };
 		D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */; };
@@ -436,6 +439,7 @@
 		14C14C792CC3845B19215A4A /* WorkspaceConversationResumeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceConversationResumeTests.swift; sourceTree = "<group>"; };
 		1AF4B917D915F1E0B37511F0 /* OpencodeScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpencodeScraper.swift; path = Conversation/Scrapers/OpencodeScraper.swift; sourceTree = "<group>"; };
 		1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManualUnreadTests.swift; sourceTree = "<group>"; };
+		287F0DED724227677C7B8512 /* Omp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Omp.swift; path = Conversation/Strategies/Omp.swift; sourceTree = "<group>"; };
 		3536E1F26D365D81206EFAAC /* SnapshotBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SnapshotBridge.swift; path = Conversation/SnapshotBridge.swift; sourceTree = "<group>"; };
 		3566F50A753107233CC16743 /* DefaultAgentResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentResolver.swift; sourceTree = "<group>"; };
 		36B9B8C3641F9801C6A45757 /* ConversationStrategyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationStrategyTests.swift; sourceTree = "<group>"; };
@@ -462,6 +466,7 @@
 		7DEEEA4C9921D5BDE4EF06E3 /* Strategy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Strategy.swift; path = Conversation/Strategy.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* c11UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
+		8D79AA02822FFBE8B15FA2B6 /* OmpConversationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OmpConversationTests.swift; path = OmpConversationTests.swift; sourceTree = "<group>"; };
 		8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentResolverTests.swift; sourceTree = "<group>"; };
 		8FF3E8B8443DEA778BA817BB /* SurfaceTypeAvailability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceTypeAvailability.swift; sourceTree = "<group>"; };
 		93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWorkspaceTitleTests.swift; sourceTree = "<group>"; };
@@ -750,6 +755,7 @@
 		DH022BF1A1B2C3D4E5F60718 /* CLIResolutionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIResolutionSnapshotTests.swift; sourceTree = "<group>"; };
 		DH023BF1A1B2C3D4E5F60718 /* TerminalControllerTelemetryWorkerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerTelemetryWorkerTests.swift; sourceTree = "<group>"; };
 		E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
+		E1B94CA7E57E1FD8FFF1217B /* OmpScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OmpScraper.swift; path = Conversation/Scrapers/OmpScraper.swift; sourceTree = "<group>"; };
 		E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThreadHangDetectorTests.swift; sourceTree = "<group>"; };
 		E25359D87534E2AF54EA0E5F /* SurfaceActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceActivityTests.swift; sourceTree = "<group>"; };
 		E2BDE4F4D562EC49C639CF86 /* Kimi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Kimi.swift; path = Conversation/Strategies/Kimi.swift; sourceTree = "<group>"; };
@@ -1067,6 +1073,8 @@
 				1AF4B917D915F1E0B37511F0 /* OpencodeScraper.swift */,
 				BB265ECF45AC4D4930FA9B22 /* PiScraper.swift */,
 				AE86A069B4ECE7503CE20B95 /* Pi.swift */,
+				E1B94CA7E57E1FD8FFF1217B /* OmpScraper.swift */,
+				287F0DED724227677C7B8512 /* Omp.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1228,6 +1236,7 @@
 				B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */,
 				C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */,
 				6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */,
+				8D79AA02822FFBE8B15FA2B6 /* OmpConversationTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1553,6 +1562,7 @@
 				0824BD4DE71F74CA32F9F49E /* ScrapeCapturePipelineTests.swift in Sources */,
 				7FFBFB92E1EA4343FB71DCA8 /* OpencodeResumeTests.swift in Sources */,
 				E123B16B00B33A73F7527FF1 /* PiConversationTests.swift in Sources */,
+				D49911F30C44874C90103A16 /* OmpConversationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1732,6 +1742,8 @@
 				80AB58969BB8EC6059C099DA /* OpencodeScraper.swift in Sources */,
 				18C7A8A92E1BA2E2177EC159 /* PiScraper.swift in Sources */,
 				E883012FE2EFF094545647F6 /* Pi.swift in Sources */,
+				24E7BF80A6D38962748D9509 /* OmpScraper.swift in Sources */,
+				88C381A879AAF75295A60C34 /* Omp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -247,12 +247,15 @@ struct AgentRegistry: Sendable {
             detectNodeArgsSubstrings: ["@oh-my-pi/"],
             iconAsset: nil,
             sfSymbolFallback: "o.circle",
-            // No confirmed resume flag (TUI `/resume` only); launches fresh.
-            // Exact-session resume via a JSONL scraper (~/.omp/agent/sessions/)
-            // is a tracked follow-up.
+            // Exact-session resume via the conversation rail: `OmpScraper`
+            // (JSONL metadata over ~/.omp/agent/sessions/) feeds `OmpStrategy`,
+            // which emits `omp --resume='<id>'`. No fixed-command fallback
+            // exists for the legacy `resume` path (the TUI offers `/resume`
+            // only), so `resume` stays `.none` while the strategy owns exact
+            // resume — same split as the codex row.
             resume: .none,
             isCanonicalTerminalType: true,
-            hasConversationStrategy: false
+            hasConversationStrategy: true
         ),
         AgentManifest(
             kind: "custom",

--- a/Sources/Conversation/Scrapers/ConversationScraperRegistry.swift
+++ b/Sources/Conversation/Scrapers/ConversationScraperRegistry.swift
@@ -42,7 +42,8 @@ struct ConversationScraperRegistry: Sendable {
         ConversationScraperRegistry(scrapers: [
             ClaudeCodeScraper(filesystem: filesystem),
             CodexScraper(filesystem: filesystem),
-            PiScraper(filesystem: filesystem)
+            PiScraper(filesystem: filesystem),
+            OmpScraper(filesystem: filesystem)
         ])
     }
 }

--- a/Sources/Conversation/Scrapers/OmpScraper.swift
+++ b/Sources/Conversation/Scrapers/OmpScraper.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Bounded filesystem I/O over `~/.omp/agent/sessions/`, where oh-my-pi
+/// (`omp`) stores per-cwd transcripts as
+/// `<cwd-slug>/<ts>_<uuid>.jsonl` alongside a sibling `<ts>_<uuid>/`
+/// directory of per-session `*.log` files.
+///
+/// **Privacy contract** (see architecture doc §"Privacy contract for scrape"):
+/// reads metadata only — filename + mtime + size. The session id is the
+/// trailing UUID in the filename. Transcript bytes are NEVER opened, copied,
+/// or logged.
+///
+/// Scope:
+/// - At most `maxCandidates` (default 16) most-recent transcripts by mtime.
+/// - Filename pattern: `<ts>_<uuid>.jsonl`. The timestamp uses dashes, so the
+///   single `_` separates it from the UUID; the id is the substring after the
+///   **last** `_` with `.jsonl` stripped.
+/// - The id is a UUIDv7 (`019f0b94-be86-7000-…`), but still 8-4-4-4-12 hex, so
+///   `isValidConversationUUID` (the shared v4-grammar check) accepts it.
+/// - The per-session `*.log` files live in a sibling directory with no
+///   `.jsonl` extension, so the recursive walker's `extensionFilter: "jsonl"`
+///   excludes them for free — no extra filtering needed here.
+struct OmpScraper: ConversationScraper {
+    let kind: String = "omp"
+    static let defaultMaxCandidates: Int = 16
+
+    /// Filesystem dependency. Tests pass a mock that produces fixture
+    /// session-storage layouts without touching the real `~/.omp/`.
+    let filesystem: ConversationFilesystem
+    let maxCandidates: Int
+
+    init(
+        filesystem: ConversationFilesystem = DefaultConversationFilesystem(),
+        maxCandidates: Int = OmpScraper.defaultMaxCandidates
+    ) {
+        self.filesystem = filesystem
+        self.maxCandidates = maxCandidates
+    }
+
+    /// Resolve `~/.omp/agent/sessions/`. Returns nil if HOME isn't set.
+    func sessionsRoot() -> URL? {
+        guard let home = filesystem.homeDirectory else { return nil }
+        return home
+            .appendingPathComponent(".omp", isDirectory: true)
+            .appendingPathComponent("agent", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    /// Top-N candidates by mtime. Empty list when the directory doesn't exist
+    /// (omp never ran on this machine). Walks the cwd-slug subdirectories
+    /// recursively because transcripts are nested one level under
+    /// `<cwd-slug>/`. The `jsonl` extension filter drops the sibling
+    /// `*.log` subdir files.
+    func candidates(cwd: String? = nil) -> [ScrapeCandidate] {
+        guard let root = sessionsRoot() else { return [] }
+        let entries = filesystem.listSessionsRecursivelyByMtime(
+            root,
+            extensionFilter: "jsonl",
+            max: maxCandidates
+        )
+        return entries.compactMap { entry in
+            // `<ts>_<uuid>.jsonl` → drop extension, take the substring after
+            // the LAST underscore. Reject filenames without a `_`.
+            let stem = String(entry.fileName.dropLast(".jsonl".count))
+            guard let underscore = stem.lastIndex(of: "_") else { return nil }
+            let id = String(stem[stem.index(after: underscore)...])
+            guard isValidConversationUUID(id) else { return nil }
+            return ScrapeCandidate(
+                id: id,
+                filePath: entry.url.path,
+                mtime: entry.mtime,
+                size: entry.size,
+                cwd: cwd
+            )
+        }
+    }
+}

--- a/Sources/Conversation/Strategies/Omp.swift
+++ b/Sources/Conversation/Strategies/Omp.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Pull-primary strategy for oh-my-pi (`omp`). Like codex, omp exposes no
+/// session-id injection flag and no SessionStart hook; the scraper resolves
+/// the real id from `~/.omp/agent/sessions/<cwd-slug>/<ts>_<uuid>.jsonl`
+/// (id = the trailing UUIDv7), filtered by cwd, mtime ≥ wrapper-claim time,
+/// and mtime ≥ surface `lastActivityTimestamp`.
+///
+/// Ambiguity policy (mirrors `CodexStrategy`): when more than one candidate
+/// matches the surface filter, return a ref with `state = .unknown`,
+/// `placeholder = false`, `id = most-plausible-candidate`, and a
+/// diagnosticReason like `"ambiguous: 3 candidates; chose newest"`.
+/// `resume()` returns `.skip(reason: "ambiguous")` for state=.unknown so
+/// neither pane resumes the other's session and the operator is asked to
+/// disambiguate via `c11 conversation clear --surface <id>`.
+///
+/// Id grammar: UUIDv7 (8-4-4-4-12 hex; the scraper parses it out of the
+/// `<ts>_<uuid>.jsonl` filename, so `resume`/`capture` receive a clean id).
+struct OmpStrategy: ConversationStrategy {
+    let kind: String = "omp"
+
+    init() {}
+
+    func capture(inputs: ConversationStrategyInputs) -> ConversationRef? {
+        // Filter the candidates by what we know about the surface.
+        let activityFloor = inputs.lastActivityTimestamp
+        let claimTime = inputs.wrapperClaim?.capturedAt
+        let cwd = inputs.cwd
+
+        let filtered = inputs.scrapeCandidates.filter { candidate in
+            // cwd must match the surface's cwd if both are known.
+            if let cwd, let candCwd = candidate.cwd, cwd != candCwd {
+                return false
+            }
+            if let claimTime, candidate.mtime < claimTime {
+                return false
+            }
+            if let activityFloor, candidate.mtime < activityFloor {
+                return false
+            }
+            return isValidConversationUUID(candidate.id)
+        }
+
+        if filtered.isEmpty {
+            // No live signal. Return wrapper-claim placeholder if we have it.
+            return inputs.wrapperClaim
+        }
+        // Sort newest-first; deterministic within the strategy.
+        let sorted = filtered.sorted { $0.mtime > $1.mtime }
+        let chosen = sorted[0]
+        if sorted.count > 1 {
+            return ConversationRef(
+                kind: kind,
+                id: chosen.id,
+                placeholder: false,
+                cwd: chosen.cwd ?? cwd,
+                capturedAt: chosen.mtime,
+                capturedVia: .scrape,
+                state: .unknown,
+                diagnosticReason: "ambiguous: \(sorted.count) candidates; chose newest"
+            )
+        }
+        return ConversationRef(
+            kind: kind,
+            id: chosen.id,
+            placeholder: false,
+            cwd: chosen.cwd ?? cwd,
+            capturedAt: chosen.mtime,
+            capturedVia: .scrape,
+            state: .alive,
+            diagnosticReason: "matched cwd + mtime after claim"
+        )
+    }
+
+    func resume(ref: ConversationRef) -> ResumeAction {
+        guard !ref.placeholder else {
+            return .skip(reason: "placeholder; no omp session resolved yet")
+        }
+        switch ref.state {
+        case .unknown:
+            return .skip(reason: "ambiguous")
+        case .tombstoned, .unsupported:
+            return .skip(reason: "state=\(ref.state.rawValue) not auto-resumable")
+        case .alive, .suspended:
+            break
+        }
+        guard isValidConversationUUID(ref.id) else {
+            return .skip(reason: "invalid id grammar")
+        }
+        let quoted = conversationShellQuote(ref.id)
+        // Specific id, not a `--last`-style flag — the whole point of the
+        // exact-resume rail is restoring *this* surface's session.
+        let text = "omp --resume=\(quoted)"
+        return .typeCommand(text: text, submitWithReturn: true)
+    }
+
+    func isValidId(_ id: String) -> Bool {
+        isValidConversationUUID(id)
+    }
+}

--- a/Sources/Conversation/StrategyRegistry.swift
+++ b/Sources/Conversation/StrategyRegistry.swift
@@ -40,7 +40,8 @@ struct ConversationStrategyRegistry: Sendable {
             OpencodeStrategy(),
             KimiStrategy(),
             GitHubCopilotStrategy(),
-            PiStrategy()
+            PiStrategy(),
+            OmpStrategy()
         ])
     }()
 }

--- a/c11Tests/OmpConversationTests.swift
+++ b/c11Tests/OmpConversationTests.swift
@@ -1,0 +1,241 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Pure tests for `OmpScraper` and `OmpStrategy` (oh-my-pi exact-session
+/// resume) against a mock filesystem. Lives in the host-free `c11LogicTests`
+/// target so it runs under the `c11-logic` scheme without launching a c11
+/// DEV.app. Mirrors the `MockFS` shape used by `ConversationScraperTests`.
+final class OmpConversationTests: XCTestCase {
+
+    // MARK: - Mock filesystem
+
+    final class MockFS: ConversationFilesystem, @unchecked Sendable {
+        var home: URL?
+        var directoryEntries: [URL: [ConversationFilesystemEntry]] = [:]
+        var recursiveEntries: [URL: [ConversationFilesystemEntry]] = [:]
+        var existingPaths: Set<String> = []
+
+        var homeDirectory: URL? { home }
+
+        func fileExists(atPath path: String) -> Bool {
+            existingPaths.contains(path)
+        }
+
+        func listDirectoryByMtime(_ directory: URL, max: Int) -> [ConversationFilesystemEntry] {
+            Array((directoryEntries[directory] ?? []).prefix(max))
+        }
+
+        func listSessionsRecursivelyByMtime(
+            _ root: URL,
+            extensionFilter: String,
+            max: Int
+        ) -> [ConversationFilesystemEntry] {
+            Array((recursiveEntries[root] ?? [])
+                .filter { $0.fileName.hasSuffix("." + extensionFilter) }
+                .prefix(max))
+        }
+    }
+
+    // omp's real id grammar: a UUIDv7 (version nibble 7) in 8-4-4-4-12 hex.
+    private let v7Id = "019f0b94-be86-7000-bf88-d9b6dcae2616"
+    private let v7Id2 = "019f0ab6-19f2-7000-88f8-5c62ba55bc76"
+
+    /// Build the sessions-root key exactly as `OmpScraper.sessionsRoot()` does
+    /// (chained `appendingPathComponent(isDirectory: true)`), so the MockFS
+    /// dictionary lookup keyed on this URL matches the scraper's lookup. A flat
+    /// `URL(fileURLWithPath:)` would differ by a trailing slash and miss.
+    private func sessionsRoot(_ home: URL) -> URL {
+        home.appendingPathComponent(".omp", isDirectory: true)
+            .appendingPathComponent("agent", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+    }
+
+    private func ompEntry(
+        slug: String, fileName: String, mtime: Date, size: Int64, root: URL
+    ) -> ConversationFilesystemEntry {
+        ConversationFilesystemEntry(
+            url: root.appendingPathComponent(slug).appendingPathComponent(fileName),
+            fileName: fileName,
+            mtime: mtime,
+            size: size
+        )
+    }
+
+    // MARK: - Scraper
+
+    func testOmpScraperParsesUUIDv7AfterLastUnderscore() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot(mock.home!)
+        let now = Date()
+        mock.recursiveEntries[root] = [
+            ompEntry(slug: "-work-proj",
+                     fileName: "2026-06-28T00-15-25-318Z_\(v7Id).jsonl",
+                     mtime: now, size: 1024, root: root),
+            ompEntry(slug: "-other-proj",
+                     fileName: "2026-06-27T20-12-14-194Z_\(v7Id2).jsonl",
+                     mtime: now.addingTimeInterval(-60), size: 2048, root: root)
+        ]
+        let scraper = OmpScraper(filesystem: mock)
+        let candidates = scraper.candidates(cwd: "/work/proj")
+        XCTAssertEqual(candidates.count, 2)
+        XCTAssertEqual(candidates[0].id, v7Id, "id is the UUID after the last underscore")
+        XCTAssertEqual(candidates[1].id, v7Id2)
+        XCTAssertEqual(candidates[0].cwd, "/work/proj", "passed cwd is stamped onto candidates")
+    }
+
+    func testOmpScraperRejectsNonUUIDAndNoUnderscoreFilenames() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot(mock.home!)
+        mock.recursiveEntries[root] = [
+            // valid
+            ompEntry(slug: "-work", fileName: "2026-06-28T00-00-00-000Z_\(v7Id).jsonl",
+                     mtime: Date(), size: 10, root: root),
+            // trailing segment after last `_` is not a UUID
+            ompEntry(slug: "-work", fileName: "2026-06-28T00-00-00-000Z_garbage.jsonl",
+                     mtime: Date(), size: 10, root: root),
+            // no underscore at all → rejected
+            ompEntry(slug: "-work", fileName: "noUnderscore.jsonl",
+                     mtime: Date(), size: 10, root: root)
+        ]
+        let scraper = OmpScraper(filesystem: mock)
+        let candidates = scraper.candidates()
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates[0].id, v7Id)
+    }
+
+    func testOmpScraperExcludesLogSiblingsViaExtensionFilter() {
+        // The recursive walker only surfaces `.jsonl`; the per-session
+        // `*.log` files in the sibling subdir never reach the scraper. We
+        // model that by including a `.log` entry and asserting it's filtered.
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot(mock.home!)
+        mock.recursiveEntries[root] = [
+            ompEntry(slug: "-work", fileName: "2026-06-28T00-00-00-000Z_\(v7Id).jsonl",
+                     mtime: Date(), size: 10, root: root),
+            ompEntry(slug: "-work/2026-06-28T00-00-00-000Z_\(v7Id)",
+                     fileName: "1.bash-original.log",
+                     mtime: Date(), size: 10, root: root)
+        ]
+        let scraper = OmpScraper(filesystem: mock)
+        let candidates = scraper.candidates()
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertEqual(candidates[0].id, v7Id)
+    }
+
+    func testOmpScraperEmptyWhenDirectoryMissing() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        // No recursiveEntries keyed for the sessions root.
+        let scraper = OmpScraper(filesystem: mock)
+        XCTAssertTrue(scraper.candidates().isEmpty)
+    }
+
+    // MARK: - Strategy
+
+    private func candidate(id: String, mtime: Date, cwd: String?) -> ScrapeCandidate {
+        ScrapeCandidate(id: id, filePath: "/p/\(id).jsonl", mtime: mtime, size: 1, cwd: cwd)
+    }
+
+    func testOmpCaptureSingleCandidateMarksAlive() {
+        let strategy = OmpStrategy()
+        let claimTime = Date().addingTimeInterval(-100)
+        let inputs = ConversationStrategyInputs(
+            surfaceId: "surface:1",
+            cwd: "/work/proj",
+            lastActivityTimestamp: claimTime,
+            wrapperClaim: ConversationRef(
+                kind: "omp", id: "placeholder", placeholder: true,
+                cwd: "/work/proj", capturedAt: claimTime,
+                capturedVia: .wrapperClaim, state: .alive),
+            scrapeCandidates: [
+                candidate(id: v7Id, mtime: Date(), cwd: "/work/proj")
+            ])
+        let ref = strategy.capture(inputs: inputs)
+        XCTAssertEqual(ref?.id, v7Id)
+        XCTAssertEqual(ref?.state, .alive)
+        XCTAssertFalse(ref?.placeholder ?? true)
+    }
+
+    func testOmpResumeEmitsResumeFlagWithSpecificId() {
+        let strategy = OmpStrategy()
+        let ref = ConversationRef(
+            kind: "omp", id: v7Id, placeholder: false,
+            cwd: "/work/proj", capturedAt: Date(),
+            capturedVia: .scrape, state: .alive)
+        guard case .typeCommand(let text, let submit) = strategy.resume(ref: ref) else {
+            XCTFail("expected typeCommand"); return
+        }
+        XCTAssertEqual(text, "omp --resume='\(v7Id)'")
+        XCTAssertTrue(text.contains(v7Id), "must resume the specific id, not a --last-style flag")
+        XCTAssertTrue(submit)
+    }
+
+    func testOmpAmbiguousCandidatesSkipResume() {
+        let strategy = OmpStrategy()
+        let claimTime = Date().addingTimeInterval(-100)
+        let now = Date()
+        let inputs = ConversationStrategyInputs(
+            surfaceId: "surface:1",
+            cwd: "/work/proj",
+            lastActivityTimestamp: claimTime,
+            wrapperClaim: ConversationRef(
+                kind: "omp", id: "placeholder", placeholder: true,
+                cwd: "/work/proj", capturedAt: claimTime,
+                capturedVia: .wrapperClaim, state: .alive),
+            scrapeCandidates: [
+                candidate(id: v7Id, mtime: now, cwd: "/work/proj"),
+                candidate(id: v7Id2, mtime: now.addingTimeInterval(-5), cwd: "/work/proj")
+            ])
+        let ref = strategy.capture(inputs: inputs)
+        XCTAssertEqual(ref?.state, .unknown, "ambiguity ⇒ unknown")
+        XCTAssertEqual(ref?.id, v7Id, "chose newest")
+        XCTAssertTrue(ref?.diagnosticReason?.contains("ambiguous") ?? false)
+        guard case .skip(let reason) = strategy.resume(ref: ref!) else {
+            XCTFail("ambiguous ref must not auto-resume"); return
+        }
+        XCTAssertEqual(reason, "ambiguous")
+    }
+
+    func testOmpResumeSkipsPlaceholder() {
+        let strategy = OmpStrategy()
+        let ref = ConversationRef(
+            kind: "omp", id: v7Id, placeholder: true,
+            cwd: nil, capturedAt: Date(),
+            capturedVia: .wrapperClaim, state: .alive)
+        guard case .skip = strategy.resume(ref: ref) else {
+            XCTFail("placeholder must skip"); return
+        }
+    }
+
+    func testOmpResumeSkipsInvalidId() {
+        let strategy = OmpStrategy()
+        let ref = ConversationRef(
+            kind: "omp", id: "not-a-uuid", placeholder: false,
+            cwd: nil, capturedAt: Date(),
+            capturedVia: .scrape, state: .alive)
+        guard case .skip = strategy.resume(ref: ref) else {
+            XCTFail("invalid id must skip"); return
+        }
+    }
+
+    func testOmpIsValidIdAcceptsUUIDv7() {
+        let strategy = OmpStrategy()
+        XCTAssertTrue(strategy.isValidId(v7Id))
+        XCTAssertFalse(strategy.isValidId("nope"))
+    }
+
+    // MARK: - Registry wiring
+
+    func testOmpRegisteredInBothV1Registries() {
+        XCTAssertTrue(ConversationStrategyRegistry.v1.contains(kind: "omp"))
+        XCTAssertTrue(ConversationScraperRegistry.v1().contains(kind: "omp"))
+    }
+}


### PR DESCRIPTION
## What

Lights up **exact-session resume for the oh-my-pi (`omp`) TUI** on C11-152's live
scrape-capture pipeline, mirroring the codex scrape-primary pattern.

- **`OmpScraper`** — bounded, metadata-only walk of `~/.omp/agent/sessions/` for
  `*.jsonl`. Session id is the UUIDv7 after the last `_` in `<ts>_<uuid>.jsonl`;
  the `jsonl` extension filter naturally excludes the sibling per-session `*.log`
  subdir files. Validated via `isValidConversationUUID` (v7 fits the 8-4-4-4-12
  grammar unchanged).
- **`OmpStrategy`** — cloned from `CodexStrategy`: cwd + mtime capture filter and
  the `>1`-candidate ambiguity policy (`state=.unknown` ⇒ resume `.skip`, never a
  wrong-session resume). `resume()` emits `omp --resume='<id>'` (verified against
  the binary: `omp -r, --resume=<value>`).
- Registered `OmpStrategy` in `ConversationStrategyRegistry.v1` and `OmpScraper`
  in `ConversationScraperRegistry.v1`; flipped the omp manifest
  `hasConversationStrategy` → `true` in the **same commit**
  (`AgentManifestTests.testConversationStrategyPresenceParity` enforces it).

## Tests
19 `c11-logic` tests green: 11 `OmpConversationTests` (scraper parse/filter/empty/
cwd-stamp; strategy alive/resume-specific-id/ambiguous-skip/placeholder-skip/
invalid-skip/validId-v7; both-registry wiring) + 8 `AgentManifestTests` parity.

## Live validation — OBSERVED PASS
Tagged build, real on-disk omp session in a clean dedicated cwd. After a clean
quit→`--qa resume` cycle, the restored omp surface auto-relaunched omp showing its
**"Welcome back!"** resume banner, and `c11 conversation get` reported
`{can_resume: true, kind: "omp", id: "019f111a-…" (exact), state: "alive",
captured_via: "scrape", diagnostic: "matched cwd + mtime after claim"}`.

## Review
Headless `lattice code-review` returns a vacuous empty-diff (resolves against
`LATTICE_ROOT`, the main checkout — MV-flagged tooling gap), so review was done
own-reviewer on `origin/main...HEAD`: **PASS, no Critical/Major**.

## Two findings (follow-ups, not blockers for this rail)
1. **Detection gap (out of scope, affects pi too):** bun-installed omp runs as
   `bun /path/omp` → `ps comm`=`bun`, which matches neither `detectComms:["omp"]`
   nor the `node`-gated `detectNodeArgsSubstrings:["@oh-my-pi/"]`, so
   `AgentDetector` tags `terminal_type="unknown"` and the rail won't fire
   out-of-the-box. `AgentDetector` is the sole writer of `terminal_type` (no
   spawn-time tag). Validation injected `terminal_type=omp` to exercise this
   ticket's rail. The identical gap hits pi (C11-153). Recommend a dedicated
   ticket to teach `AgentDetector` the `bun` runtime / shim basename.
2. **cwd filter is a documented no-op**, so `OmpScraper` walks all slugs; with >1
   omp session on disk, restore correctly hits the safe ambiguity-skip. The
   deferred cwd-slug-scoped walk (lossless, unique to omp's layout) is the real
   precision enhancement.

## Merge ordering
Branched on C11-152's pipeline; **rebased onto `origin/main`** (which now carries
both C11-152 #273 and C11-151 #274). pbxproj adds 3 file refs only (no gem
reformat churn); rebase via the `xcodeproj` gem if a sibling PR lands first.

C11-154.