### PR TITLE
fix(conversation): pi/omp auto-detect (bun) + omp cwd-scoping + crash-path resume (C11-155, C11-156)

### DIFF
--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -222,11 +222,24 @@ final class AgentDetector: @unchecked Sendable {
             return manifest.kind
         }
 
-        // Node-wrapped CLIs: comm truncated to `node`, match via args substring.
-        if c == "node" {
+        // JS/TS-runtime-wrapped CLIs: comm is the runtime (node/bun/deno) and
+        // the agent identity lives in the args. Two invocation shapes:
+        //  - module path (`node …/@anthropic-ai/claude-code/cli.js`) → match a
+        //    distinctive args substring.
+        //  - shim/symlink (`bun /Users/x/.bun/bin/omp`, `node /Users/x/.bun/bin/pi`)
+        //    → the module path isn't in argv, but the invoked script's basename
+        //    is the agent's binary name. (Matching only the *last* path
+        //    component avoids false positives from mid-path directory names.)
+        if c == "node" || c == "bun" || c == "deno" {
             for manifest in AgentRegistry.shared.all
             where manifest.detectNodeArgsSubstrings.contains(where: { a.contains($0) }) {
                 return manifest.kind
+            }
+            for token in a.split(separator: " ") {
+                let base = String(token.split(separator: "/").last ?? token)
+                for manifest in AgentRegistry.shared.all where manifest.detectComms.contains(base) {
+                    return manifest.kind
+                }
             }
         }
 

--- a/Sources/Conversation/Scrapers/OmpScraper.swift
+++ b/Sources/Conversation/Scrapers/OmpScraper.swift
@@ -46,19 +46,48 @@ struct OmpScraper: ConversationScraper {
             .appendingPathComponent("sessions", isDirectory: true)
     }
 
-    /// Top-N candidates by mtime. Empty list when the directory doesn't exist
-    /// (omp never ran on this machine). Walks the cwd-slug subdirectories
-    /// recursively because transcripts are nested one level under
-    /// `<cwd-slug>/`. The `jsonl` extension filter drops the sibling
-    /// `*.log` subdir files.
+    /// omp's per-cwd session-directory name. Verified against the real store:
+    /// the slug is the cwd with the home-directory prefix stripped and every
+    /// `/` mapped to `-`, e.g. `/Users/atin/Projects/Stage11/code/c11` →
+    /// `-Projects-Stage11-code-c11`. No lowercasing; existing dashes are
+    /// preserved. This differs from pi's full-path `--<…>--` convention, so it
+    /// is deliberately NOT a copy of `PiScraper.sessionSlug`.
+    static func sessionSlug(forCwd cwd: String, homeDirectory: URL?) -> String {
+        var path = cwd
+        if let home = homeDirectory?.path, path.hasPrefix(home) {
+            path = String(path.dropFirst(home.count))
+        }
+        return path.replacingOccurrences(of: "/", with: "-")
+    }
+
+    /// Top-N candidates by mtime. When `cwd` is known, scopes the walk to that
+    /// cwd's slug directory (omp stores `<slug>/<ts>_<uuid>.jsonl` one level
+    /// deep) so exact resume resolves *this* project's session rather than the
+    /// machine-wide newest. Without scoping every candidate is stamped with the
+    /// surface cwd, so `OmpStrategy`'s cwd filter cannot disambiguate and a
+    /// multi-project store either bleeds a foreign session or safe-skips. With
+    /// no `cwd`, falls back to the whole-tree top-N. The `.jsonl` suffix check
+    /// drops the sibling per-session `*.log` subdir files.
     func candidates(cwd: String? = nil) -> [ScrapeCandidate] {
         guard let root = sessionsRoot() else { return [] }
-        let entries = filesystem.listSessionsRecursivelyByMtime(
-            root,
-            extensionFilter: "jsonl",
-            max: maxCandidates
-        )
+        let entries: [ConversationFilesystemEntry]
+        if let cwd, !cwd.isEmpty {
+            let slugDir = root.appendingPathComponent(
+                Self.sessionSlug(forCwd: cwd, homeDirectory: filesystem.homeDirectory),
+                isDirectory: true
+            )
+            entries = filesystem.listDirectoryByMtime(slugDir, max: maxCandidates)
+        } else {
+            entries = filesystem.listSessionsRecursivelyByMtime(
+                root,
+                extensionFilter: "jsonl",
+                max: maxCandidates
+            )
+        }
         return entries.compactMap { entry in
+            // `listDirectoryByMtime` returns every entry in the slug dir
+            // (including the `<ts>_<uuid>/` log subdirs), so filter by suffix.
+            guard entry.fileName.hasSuffix(".jsonl") else { return nil }
             // `<ts>_<uuid>.jsonl` → drop extension, take the substring after
             // the LAST underscore. Reject filenames without a `_`.
             let stem = String(entry.fileName.dropLast(".jsonl".count))

--- a/Sources/Conversation/Strategies/Omp.swift
+++ b/Sources/Conversation/Strategies/Omp.swift
@@ -97,4 +97,19 @@ struct OmpStrategy: ConversationStrategy {
     func isValidId(_ id: String) -> Bool {
         isValidConversationUUID(id)
     }
+
+    /// Crash-recovery verification (stat-only): does a session file for
+    /// `ref.id` still exist on disk? Without this, `reclassifyAfterCrash`
+    /// forces the ref to `.unknown` (the protocol default returns nil) and
+    /// resume skips after a crash — the path that matters most for resume.
+    /// Reuses the cwd-scoped `OmpScraper`; never opens transcript bytes.
+    func transcriptExists(
+        for ref: ConversationRef,
+        filesystem: ConversationFilesystem
+    ) -> Bool? {
+        guard isValidConversationUUID(ref.id) else { return false }
+        return OmpScraper(filesystem: filesystem)
+            .candidates(cwd: ref.cwd)
+            .contains { $0.id == ref.id }
+    }
 }

--- a/Sources/Conversation/Strategies/Pi.swift
+++ b/Sources/Conversation/Strategies/Pi.swift
@@ -99,4 +99,19 @@ struct PiStrategy: ConversationStrategy {
     func isValidId(_ id: String) -> Bool {
         isValidConversationUUID(id)
     }
+
+    /// Crash-recovery verification (stat-only): does a session file for
+    /// `ref.id` still exist on disk? Without this, `reclassifyAfterCrash`
+    /// forces the ref to `.unknown` (the protocol default returns nil) and
+    /// resume skips after a crash — the path that matters most for resume.
+    /// Reuses the cwd-scoped `PiScraper`; never opens transcript bytes.
+    func transcriptExists(
+        for ref: ConversationRef,
+        filesystem: ConversationFilesystem
+    ) -> Bool? {
+        guard isValidConversationUUID(ref.id) else { return false }
+        return PiScraper(filesystem: filesystem)
+            .candidates(cwd: ref.cwd)
+            .contains { $0.id == ref.id }
+    }
 }

--- a/c11Tests/AgentDetectorTests.swift
+++ b/c11Tests/AgentDetectorTests.swift
@@ -53,4 +53,37 @@ final class AgentDetectorTests: XCTestCase {
         XCTAssertEqual(AgentDetector.classify(comm: "zsh", args: ""), "shell")
         XCTAssertEqual(AgentDetector.classify(comm: "-zsh", args: ""), "shell")
     }
+
+    // MARK: - Runtime shim invocations (C11-155: bun / node-symlink installs)
+
+    /// omp ships as a `#!/usr/bin/env bun` shim → runs as `comm=bun` with the
+    /// named binary in argv. The bun runtime branch + script-basename match it.
+    func testClassifyBunShimOmpReturnsOmp() {
+        XCTAssertEqual(
+            AgentDetector.classify(comm: "bun", args: "bun /Users/atin/.bun/bin/omp"),
+            "omp")
+    }
+
+    /// pi ships as a `#!/usr/bin/env node` shim; a node-shebang symlink reports
+    /// the symlink path in argv (not the module path), so the org-path substring
+    /// misses and the basename match is what classifies it.
+    func testClassifyNodeShimPiReturnsPi() {
+        XCTAssertEqual(
+            AgentDetector.classify(comm: "node", args: "node /Users/atin/.bun/bin/pi"),
+            "pi")
+    }
+
+    /// Module-path invocation still matches via the substring rail (here bun).
+    func testClassifyBunModulePathOmpReturnsOmp() {
+        let args = "bun /Users/atin/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/dist/cli.js"
+        XCTAssertEqual(AgentDetector.classify(comm: "bun", args: args), "omp")
+    }
+
+    /// Basename match keys on the LAST path component only, so a comm-named
+    /// mid-path directory ("pi" here) is not a false positive.
+    func testClassifyRuntimeBasenameIgnoresMidPathDirNames() {
+        XCTAssertEqual(
+            AgentDetector.classify(comm: "node", args: "node /Users/me/pi/app/server.js"),
+            "unknown")
+    }
 }

--- a/c11Tests/OmpConversationTests.swift
+++ b/c11Tests/OmpConversationTests.swift
@@ -82,11 +82,13 @@ final class OmpConversationTests: XCTestCase {
                      mtime: now.addingTimeInterval(-60), size: 2048, root: root)
         ]
         let scraper = OmpScraper(filesystem: mock)
-        let candidates = scraper.candidates(cwd: "/work/proj")
+        // No cwd → whole-tree recursive fallback (the cwd-scoped path is
+        // covered by testOmpScraperScopesToCwdSlugDirectory).
+        let candidates = scraper.candidates()
         XCTAssertEqual(candidates.count, 2)
         XCTAssertEqual(candidates[0].id, v7Id, "id is the UUID after the last underscore")
         XCTAssertEqual(candidates[1].id, v7Id2)
-        XCTAssertEqual(candidates[0].cwd, "/work/proj", "passed cwd is stamped onto candidates")
+        XCTAssertNil(candidates[0].cwd, "no cwd passed → not stamped")
     }
 
     func testOmpScraperRejectsNonUUIDAndNoUnderscoreFilenames() {
@@ -136,6 +138,63 @@ final class OmpConversationTests: XCTestCase {
         // No recursiveEntries keyed for the sessions root.
         let scraper = OmpScraper(filesystem: mock)
         XCTAssertTrue(scraper.candidates().isEmpty)
+    }
+
+    /// omp's slug strips the home prefix and maps `/`→`-` (verified against the
+    /// real store; differs from pi's full-path `--<…>--` convention).
+    func testOmpSessionSlugStripsHomeAndMapsSlashes() {
+        let home = URL(fileURLWithPath: "/Users/atin")
+        XCTAssertEqual(
+            OmpScraper.sessionSlug(forCwd: "/Users/atin/Projects/Stage11/code/c11", homeDirectory: home),
+            "-Projects-Stage11-code-c11")
+        XCTAssertEqual(
+            OmpScraper.sessionSlug(forCwd: "/Users/atin/Projects/GLM-UniHub", homeDirectory: home),
+            "-Projects-GLM-UniHub", "existing dashes + case preserved")
+        XCTAssertEqual(
+            OmpScraper.sessionSlug(forCwd: "/work/x", homeDirectory: home),
+            "-work-x", "cwd outside home → full path mapped")
+    }
+
+    /// When a cwd is known, scope to that cwd's slug dir, and filter sibling
+    /// `*.log` entries out by suffix (the slug-dir listing is unfiltered).
+    func testOmpScraperScopesToCwdSlugDirectory() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot(mock.home!)
+        let cwd = "/Users/test/work/mine"
+        let slugDir = root.appendingPathComponent(
+            OmpScraper.sessionSlug(forCwd: cwd, homeDirectory: mock.home), isDirectory: true)
+        let name = "2026-06-28T00-15-25-318Z_\(v7Id).jsonl"
+        mock.directoryEntries[slugDir] = [
+            ConversationFilesystemEntry(url: slugDir.appendingPathComponent(name), fileName: name, mtime: Date(), size: 1024),
+            ConversationFilesystemEntry(url: slugDir.appendingPathComponent("1.bash.log"), fileName: "1.bash.log", mtime: Date(), size: 10)
+        ]
+        let candidates = OmpScraper(filesystem: mock).candidates(cwd: cwd)
+        XCTAssertEqual(candidates.map(\.id), [v7Id], "scoped to cwd slug dir; .log filtered out")
+        XCTAssertEqual(candidates[0].cwd, cwd)
+    }
+
+    /// C11-156 regression: a newer session in a DIFFERENT project's slug dir
+    /// must not leak into this cwd's candidates (the cross-project bleed bug).
+    func testOmpScraperDoesNotLeakSessionsFromOtherCwds() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot(mock.home!)
+        let mineDir = root.appendingPathComponent(
+            OmpScraper.sessionSlug(forCwd: "/Users/test/mine", homeDirectory: mock.home), isDirectory: true)
+        let otherDir = root.appendingPathComponent(
+            OmpScraper.sessionSlug(forCwd: "/Users/test/other", homeDirectory: mock.home), isDirectory: true)
+        let now = Date()
+        let mineName = "2026-06-28T00-00-00-000Z_\(v7Id).jsonl"
+        let otherName = "2026-06-28T00-30-00-000Z_\(v7Id2).jsonl"
+        mock.directoryEntries[mineDir] = [
+            ConversationFilesystemEntry(url: mineDir.appendingPathComponent(mineName), fileName: mineName, mtime: now.addingTimeInterval(-3600), size: 1)
+        ]
+        mock.directoryEntries[otherDir] = [
+            ConversationFilesystemEntry(url: otherDir.appendingPathComponent(otherName), fileName: otherName, mtime: now, size: 1)
+        ]
+        let candidates = OmpScraper(filesystem: mock).candidates(cwd: "/Users/test/mine")
+        XCTAssertEqual(candidates.map(\.id), [v7Id], "only this cwd's session; newer foreign session not leaked")
     }
 
     // MARK: - Strategy
@@ -230,6 +289,27 @@ final class OmpConversationTests: XCTestCase {
         let strategy = OmpStrategy()
         XCTAssertTrue(strategy.isValidId(v7Id))
         XCTAssertFalse(strategy.isValidId("nope"))
+    }
+
+    /// Crash-recovery: `transcriptExists` confirms the session file is on disk
+    /// (cwd-scoped) so a crashed omp ref is promoted to `.suspended` and resumes
+    /// instead of being forced to `.unknown`.
+    func testOmpTranscriptExistsVerifiesSessionFileOnDisk() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot(mock.home!)
+        let cwd = "/Users/test/proj"
+        let slugDir = root.appendingPathComponent(
+            OmpScraper.sessionSlug(forCwd: cwd, homeDirectory: mock.home), isDirectory: true)
+        let name = "2026-06-28T00-15-25-318Z_\(v7Id).jsonl"
+        mock.directoryEntries[slugDir] = [
+            ConversationFilesystemEntry(url: slugDir.appendingPathComponent(name), fileName: name, mtime: Date(), size: 1)
+        ]
+        let strategy = OmpStrategy()
+        let present = ConversationRef(kind: "omp", id: v7Id, placeholder: false, cwd: cwd, capturedVia: .scrape, state: .suspended)
+        XCTAssertEqual(strategy.transcriptExists(for: present, filesystem: mock), true)
+        let absent = ConversationRef(kind: "omp", id: v7Id2, placeholder: false, cwd: cwd, capturedVia: .scrape, state: .suspended)
+        XCTAssertEqual(strategy.transcriptExists(for: absent, filesystem: mock), false)
     }
 
     // MARK: - Registry wiring

--- a/c11Tests/PiConversationTests.swift
+++ b/c11Tests/PiConversationTests.swift
@@ -293,6 +293,26 @@ final class PiConversationTests: XCTestCase {
         XCTAssertFalse(s.isValidId(""))
     }
 
+    /// Crash-recovery: `transcriptExists` confirms the session file is still on
+    /// disk (cwd-scoped) so `reclassifyAfterCrash` promotes the ref to
+    /// `.suspended` instead of forcing `.unknown` (which would skip resume).
+    func testPiTranscriptExistsVerifiesSessionFileOnDisk() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = sessionsRoot("/Users/test")
+        let cwd = "/work/proj"
+        let slugDir = root.appendingPathComponent(PiScraper.sessionSlug(forCwd: cwd), isDirectory: true)
+        let name = piFileName(ts: "2026-06-27T21-35-42-003Z", uuid: piUUID)
+        mock.directoryEntries[slugDir] = [entry(slugDir, name, mtime: Date())]
+        let strategy = PiStrategy()
+        let present = ConversationRef(kind: "pi", id: piUUID, placeholder: false, cwd: cwd, capturedVia: .scrape, state: .suspended)
+        XCTAssertEqual(strategy.transcriptExists(for: present, filesystem: mock), true)
+        let absent = ConversationRef(kind: "pi", id: piUUID2, placeholder: false, cwd: cwd, capturedVia: .scrape, state: .suspended)
+        XCTAssertEqual(strategy.transcriptExists(for: absent, filesystem: mock), false)
+        let bad = ConversationRef(kind: "pi", id: "nope", placeholder: false, cwd: cwd, capturedVia: .scrape, state: .suspended)
+        XCTAssertEqual(strategy.transcriptExists(for: bad, filesystem: mock), false)
+    }
+
     // MARK: - Local stub scraper
 
     /// Returns preset candidates regardless of cwd, stamping the passed cwd


### PR DESCRIPTION
Post-run review fixes for the exact-resume feature. pi/omp exact-resume shipped but was **unreachable for the real (bun) install**, and omp could resume the **wrong project's** session. Three fixes:

## C11-155 — bun/runtime detection (the gate)
`AgentDetector` only matched `comm=node`. pi ships as a node-shebang symlink (argv shows the symlink path, so the module-path substring missed) and omp as a `bun` shebang (`comm=bun`, no branch at all) → both classified `unknown` → no scraper → no resume, no chip. Now handles `node`/`bun`/`deno` and matches the invoked **script basename** (last path component only) alongside the module-path substring.

## C11-156 — omp cross-project bleed
`OmpScraper` walked the whole tree and only *stamped* the surface cwd onto candidates, defeating `OmpStrategy`'s cwd filter (self-comparison). It could attach to a **foreign project's** session, or safe-skip with several present. Now scopes to the cwd's slug dir (omp's verified `strip-$HOME, /→-` encoding, distinct from pi's), mirroring `PiScraper`.

## Crash-path resume (new finding, not previously ticketed)
pi/omp lacked `transcriptExists`, so `reclassifyAfterCrash` forced their refs to `.unknown` on a dirty restart → resume skipped (the path that matters most). Implemented for both (stat-only, via the cwd-scoped scraper) so a verified ref is promoted to `.suspended` and resumes after a crash.

## Tests
- Detector regression guards encoding the **real** invocations: `bun /…/.bun/bin/omp` → omp, `node /…/.bun/bin/pi` → pi, module-path → omp, and a mid-path-dir no-false-positive guard.
- The omp cross-cwd **no-leak** test that was missing (the gap that let C11-156 ship).
- Both `transcriptExists` paths (present → true, absent/invalid → false).
- Full `c11-logic` suite green (1115 tests, 0 failures). No new files → no pbxproj change.

Deferred (noted, not in this pass): opencode reserved-key dead plumbing, scraper-walk memoization (perf at scale), the shared trailing-`\n` regex anchor, codex `transcriptExists`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)