### PR TITLE
chore(agents): reword c11 orientation seed prompt to discovery-not-command

### DIFF
--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -276,4 +276,4 @@ struct AgentRegistry: Sendable {
 
 /// The orientation prompt typed into a freshly launched agent. Mirrors
 /// `AgentType.factoryInitialPrompt` for non-custom agents.
-let c11OrientPrompt = "you are operating inside a c11 workspace. load the skill."
+let c11OrientPrompt = "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it."

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -21,25 +21,25 @@ final class DefaultAgentConfigTests: XCTestCase {
     func testFactoryClaudeCommandIncludesDangerouslySkipPermissions() {
         let entry = AgentConfig.factory(for: .claudeCode)
         XCTAssertEqual(entry.command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
     func testFactoryCodexCommandIncludesYolo() {
         let entry = AgentConfig.factory(for: .codex)
         XCTAssertEqual(entry.command, "codex --yolo")
-        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
     func testFactoryGrokCommandIncludesAlwaysApprove() {
         let entry = AgentConfig.factory(for: .grok)
         XCTAssertEqual(entry.command, "grok --always-approve")
-        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
     func testFactoryGitHubCopilotCommandIncludesAllowAllAndAutopilot() {
         let entry = AgentConfig.factory(for: .githubCopilot)
         XCTAssertEqual(entry.command, "copilot --allow-all --autopilot")
-        XCTAssertEqual(entry.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
     func testAgentTypeGitHubCopilotRawValueIsKebabCase() {
@@ -180,7 +180,7 @@ final class DefaultAgentConfigTests: XCTestCase {
         let (store, _) = makeStore()
         XCTAssertEqual(store.current.defaultAgent, .claudeCode)
         XCTAssertEqual(store.current.config(for: .claudeCode).command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
     func testStoreReturnsFactoryOnGarbageData() {

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -18,7 +18,7 @@ final class DefaultAgentResolverTests: XCTestCase {
             projectConfig: nil
         )
         XCTAssertEqual(agent, .claudeCode)
-        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions 'you are operating inside a c11 workspace. load the skill.'")
+        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'")
     }
 
     func testProjectConfigDefaultAgentBeatsUserDefault() {
@@ -118,12 +118,12 @@ final class DefaultAgentResolverTests: XCTestCase {
     func testBuildCommandClaudeAppendsInitialPromptAsPositional() {
         let cfg = AgentConfig(
             command: "claude --dangerously-skip-permissions",
-            initialPrompt: "you are operating inside a c11 workspace. load the skill.",
+            initialPrompt: "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.",
             envOverridesText: ""
         )
         XCTAssertEqual(
             DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
-            "claude --dangerously-skip-permissions 'you are operating inside a c11 workspace. load the skill.'"
+            "claude --dangerously-skip-permissions 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
         )
     }
 
@@ -143,7 +143,7 @@ final class DefaultAgentResolverTests: XCTestCase {
         // Non-claude agents preserve the prompt in config but don't auto-append.
         let cfg = AgentConfig(
             command: "codex --yolo",
-            initialPrompt: "you are operating inside a c11 workspace. load the skill.",
+            initialPrompt: "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.",
             envOverridesText: ""
         )
         XCTAssertEqual(
@@ -222,11 +222,11 @@ final class DefaultAgentResolverTests: XCTestCase {
             projectConfig: nil
         )
         XCTAssertEqual(launch.bareCommand, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(launch.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+        XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
         // The baked form still ships on `command` for the A-button path.
         XCTAssertEqual(
             launch.command,
-            "claude --dangerously-skip-permissions 'you are operating inside a c11 workspace. load the skill.'"
+            "claude --dangerously-skip-permissions 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
         )
     }
 
@@ -260,7 +260,7 @@ final class DefaultAgentResolverTests: XCTestCase {
         XCTAssertEqual(launch.command, "codex --yolo")
         // The prompt is still surfaced for non-claude agents — the launch
         // delivery path is what differs (post-ready sendText vs positional).
-        XCTAssertEqual(launch.initialPrompt, "you are operating inside a c11 workspace. load the skill.")
+        XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
     func testBareCommandTrimsWhitespace() {


### PR DESCRIPTION
## What

Rewords the orientation seed prompt typed into every freshly launched agent.

Before: `you are operating inside a c11 workspace. load the skill.`
After:  `You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.`

## Why

Follow-up to the c11 skill slimming (749 → ~76 lines). With the skill now a thin orientation card rather than a 9k-word manual, the bootstrap message no longer needs to *command* a load — the skill's own `description` already triggers discovery when an agent is inside c11. The reworded line primes the agent's context less and reads as orientation rather than an instruction.

Single source of truth: `c11OrientPrompt` in `AgentManifest.swift` (used by all eight non-custom agents). Kept apostrophe-free so the claude-code positional-prompt path (single-quoted) stays shell-safe.

**Tradeoff (operator-chosen):** agents that don't load the skill won't auto-orient (name their tab / declare identity). The skill description still nudges loading inside c11, so most Claude agents will; this deliberately favors a lighter, non-commanding bootstrap.

## Tests

Updated the factory-default assertions in `DefaultAgentConfigTests` and `DefaultAgentResolverTests` (the `testBuildCommand*` literal-input pairs stay self-consistent). 51 tests green on `c11-logic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)