### PR TITLE
fix(launch): don't block the resume picker on local dev builds

### DIFF
--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -1467,8 +1467,9 @@ enum AgentSkillsOnboarding {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         isCompiledDebug: Bool = AgentSkillsOnboarding.isCompiledDebugBuild
     ) -> Bool {
-        if isCompiledDebug { return true }
-        return SocketControlSettings.launchTag(environment: environment) != nil
+        // Single source of truth lives in SocketControlSettings (alongside
+        // launchTag / isDebugBuild); keeps the existing call sites + #272 tests.
+        SocketControlSettings.isLocalDevBuild(environment: environment, isDebugBuild: isCompiledDebug)
     }
 
     /// Should the onboarding sheet be offered on this launch?

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3380,16 +3380,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // QA launch (`C11_QA_LAUNCH`) overrides that persisted policy for
         // this launch only (never written back): `resume` → `.always`
         // (silent restore), `fresh` → `.never` (skip). Both bypass the
-        // `.ask` picker so an automated run never blocks on the modal.
-        let policy: LaunchResumePolicy
-        switch QALaunchPolicy.current() {
-        case .on(.resume):
-            policy = .always
-        case .on(.fresh):
-            policy = .never
-        case .off:
-            policy = LaunchResumePolicy.current()
-        }
+        // `.ask` picker so an automated run never blocks on the modal. A local
+        // dev / tagged build likewise bypasses the `.ask` picker (silent
+        // restore) so frequent rebuilds don't block on it — see
+        // `LaunchResumePicker.resolveEffectivePolicy`.
+        let policy = LaunchResumePicker.resolveEffectivePolicy(
+            qa: QALaunchPolicy.current(),
+            persisted: LaunchResumePolicy.current(),
+            isLocalDevBuild: SocketControlSettings.isLocalDevBuild()
+        )
         if policy == .ask,
            let snapshot = startupSessionSnapshot,
            snapshot.windows.contains(where: { !$0.tabManager.workspaces.isEmpty }) {

--- a/Sources/LaunchResumePicker.swift
+++ b/Sources/LaunchResumePicker.swift
@@ -80,6 +80,32 @@ enum LaunchResumePickerDecision {
 
 @MainActor
 enum LaunchResumePicker {
+    /// Resolve the effective resume policy for this launch.
+    ///
+    /// - QA launch (`C11_QA_LAUNCH`) overrides everything: `.on(.resume)` →
+    ///   `.always` (silent restore), `.on(.fresh)` → `.never` (skip).
+    /// - Otherwise the persisted policy applies — except that on a **local dev
+    ///   build** the default `.ask` becomes `.always` (silent restore), so a
+    ///   developer rebuilding c11 isn't blocked by the picker modal on every
+    ///   relaunch. An explicit `.always` / `.never` the operator set is always
+    ///   honored (a dev build never forces a restore the operator opted out of).
+    ///
+    /// `nonisolated` — pure value-logic with no main-actor needs, so it's
+    /// callable from the main-actor launch path and from off-main tests alike.
+    nonisolated static func resolveEffectivePolicy(
+        qa: QALaunchPolicy,
+        persisted: LaunchResumePolicy,
+        isLocalDevBuild: Bool
+    ) -> LaunchResumePolicy {
+        switch qa {
+        case .on(.resume): return .always
+        case .on(.fresh): return .never
+        case .off:
+            if persisted == .ask && isLocalDevBuild { return .always }
+            return persisted
+        }
+    }
+
     /// Present the picker as a sheet on `parentWindow` and call
     /// `completion` once the operator picks. When the snapshot has no
     /// workspaces (nothing to choose from), the picker is skipped and

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -376,6 +376,21 @@ struct SocketControlSettings {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    /// Whether the running app is a **local development build**: a Debug build,
+    /// or a tagged `reload.sh --tag` / automation build (`CMUX_TAG` set). Never
+    /// true in a shipped untagged Release. Single source of truth for
+    /// suppressing launch-time auto-dialogs (the Agent Skills onboarding sheet
+    /// and the resume picker) so the person rebuilding c11 isn't blocked by a
+    /// modal on every relaunch. `isDebugBuild` is injectable so the env branch
+    /// stays testable under the DEBUG-compiled logic-test target.
+    static func isLocalDevBuild(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        isDebugBuild: Bool = SocketControlSettings.isDebugBuild
+    ) -> Bool {
+        if isDebugBuild { return true }
+        return launchTag(environment: environment) != nil
+    }
+
     static func shouldBlockUntaggedDebugLaunch(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         bundleIdentifier: String? = Bundle.main.bundleIdentifier,

--- a/c11Tests/SocketControlSafetyTests.swift
+++ b/c11Tests/SocketControlSafetyTests.swift
@@ -43,3 +43,71 @@ final class SocketControlSafetyTests: XCTestCase {
         XCTAssertEqual(SocketControlSettings.migrateMode("cmux-only"), .c11Only)
     }
 }
+
+/// Shared "is this a local dev build?" gate used to suppress launch-time
+/// auto-dialogs (Agent Skills onboarding, resume picker) for the person
+/// rebuilding c11. `isDebugBuild` is injected so the env branch is exercised
+/// even though the logic-test target itself compiles DEBUG.
+final class SocketControlIsLocalDevBuildTests: XCTestCase {
+    func testTaggedReleaseBuildIsDev() {
+        XCTAssertTrue(SocketControlSettings.isLocalDevBuild(
+            environment: ["CMUX_TAG": "feat-foo"], isDebugBuild: false))
+    }
+
+    func testUntaggedReleaseBuildIsNotDev() {
+        XCTAssertFalse(SocketControlSettings.isLocalDevBuild(
+            environment: [:], isDebugBuild: false))
+    }
+
+    func testWhitespaceTagIsNotDev() {
+        XCTAssertFalse(SocketControlSettings.isLocalDevBuild(
+            environment: ["CMUX_TAG": "   "], isDebugBuild: false))
+    }
+
+    func testDebugBuildIsAlwaysDev() {
+        XCTAssertTrue(SocketControlSettings.isLocalDevBuild(
+            environment: [:], isDebugBuild: true))
+    }
+}
+
+/// `LaunchResumePicker.resolveEffectivePolicy` — QA launch overrides win; a
+/// local dev build replaces the default `.ask` picker with silent `.always`
+/// restore; an explicit operator policy is always honored.
+final class LaunchResumeGateTests: XCTestCase {
+    func testQAResumeForcesAlways() {
+        XCTAssertEqual(
+            LaunchResumePicker.resolveEffectivePolicy(qa: .on(.resume), persisted: .ask, isLocalDevBuild: false),
+            .always)
+    }
+
+    func testQAFreshForcesNever() {
+        XCTAssertEqual(
+            LaunchResumePicker.resolveEffectivePolicy(qa: .on(.fresh), persisted: .ask, isLocalDevBuild: false),
+            .never)
+    }
+
+    func testDevBuildTurnsAskIntoSilentAlways() {
+        XCTAssertEqual(
+            LaunchResumePicker.resolveEffectivePolicy(qa: .off, persisted: .ask, isLocalDevBuild: true),
+            .always)
+    }
+
+    func testReleaseBuildKeepsAskPicker() {
+        XCTAssertEqual(
+            LaunchResumePicker.resolveEffectivePolicy(qa: .off, persisted: .ask, isLocalDevBuild: false),
+            .ask)
+    }
+
+    func testExplicitNeverHonoredEvenOnDevBuild() {
+        // A dev build must not resurrect a session the operator opted out of.
+        XCTAssertEqual(
+            LaunchResumePicker.resolveEffectivePolicy(qa: .off, persisted: .never, isLocalDevBuild: true),
+            .never)
+    }
+
+    func testExplicitAlwaysHonored() {
+        XCTAssertEqual(
+            LaunchResumePicker.resolveEffectivePolicy(qa: .off, persisted: .always, isLocalDevBuild: false),
+            .always)
+    }
+}


### PR DESCRIPTION
## Problem

The "Resume previous session?" picker (`LaunchResumePicker`) is the sibling launch-time dialog to the Agent Skills onboarding sheet fixed in #272. It's suppressed under `C11_QA_LAUNCH` but **not** on dev builds — so a c11 developer running frequent `reload.sh --tag` builds gets the blocking modal on **every** relaunch (there's always a prior session to resume).

## Fix

- **Single source of truth for "is this a dev build":** `SocketControlSettings.isLocalDevBuild(environment:isDebugBuild:)`, living next to `launchTag` / `isDebugBuild`. `AgentSkillsOnboarding.isLocalDevBuild` now delegates to it — signature and #272 tests unchanged.
- **Testable policy seam:** `LaunchResumePicker.resolveEffectivePolicy(qa:persisted:isLocalDevBuild:)` (pure, `nonisolated`). QA launch overrides win; on a dev build the default `.ask` becomes silent `.always` restore; an explicit operator `.always`/`.never` is always honored (a dev build never resurrects a session the operator opted out of). `AppDelegate`'s inline switch now calls it.

End-user release behavior is unchanged: an untagged Release still shows the `.ask` picker exactly as before.

## Tests

`c11LogicTests`: `SocketControlIsLocalDevBuildTests` (tagged/untagged/whitespace/debug) and `LaunchResumeGateTests` (full `resolveEffectivePolicy` truth table). Green on `c11-logic`, and the #272 AgentSkills tests still pass through the delegation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)