### PR TITLE
Release v0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Feature release. Headline: **exact-session conversation resume arrives for Pi, o
 - **Terminal-only mode.** New Settings toggles can disable the browser and markdown surface types — hiding their spawn buttons and rejecting those types over the CLI/socket. ([#264](https://github.com/Stage-11-Agentics/c11/pull/264))
 - **`C11_*` surface environment variables.** Surfaces now export `C11_SURFACE_ID`, `C11_TAB_ID`, `C11_SHELL_INTEGRATION`, `C11_WORKSPACE_ID`, and friends alongside the legacy `CMUX_*` names, so agents can read the `C11_*` namespace the skill documents. ([#284](https://github.com/Stage-11-Agentics/c11/pull/284))
 - **`C11_QA_LAUNCH` automation flag.** Launching with `C11_QA_LAUNCH=fresh|resume` suppresses the startup Agent Skills and resume-picker dialogs so automated and QA launches don't block on modals. ([#268](https://github.com/Stage-11-Agentics/c11/pull/268))
+- **Skill install for Pi and oh-my-pi.** The Agent Skills installer now targets Pi (`~/.pi/agent/skills/`) and oh-my-pi (`~/.omp/agent/skills/`) alongside Claude Code, Codex, Grok, Kimi, OpenCode, and Copilot — so the agents c11 already recognizes can also receive the c11 skill.
 - **Bundled opencode status + notification plugin,** auto-installed so opencode surfaces report status and notifications out of the box.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-06-29
+
+Feature release. Headline: **exact-session conversation resume arrives for Pi, oh-my-pi, and opencode — when c11 restores a workspace, these agents reconnect to the exact session they were in before the restart, not a fresh shell.** Alongside it: Pi and oh-my-pi become first-class agents via a new data-driven registry, splits get size-aware, the tab bar collapses responsively when space runs short, four new chrome themes ship, and surfaces now export the `C11_*` environment namespace the skill documents.
+
+### Added
+
+- **Exact-session resume for Pi, oh-my-pi (omp), and opencode.** On workspace restore, each agent reconnects to its precise prior session rather than starting cold. Per-kind scrapers resolve the real session id at restore time and the conversation store reattaches it. ([#274](https://github.com/Stage-11-Agentics/c11/pull/274), [#275](https://github.com/Stage-11-Agentics/c11/pull/275), [#276](https://github.com/Stage-11-Agentics/c11/pull/276))
+- **Pi and oh-my-pi as first-class agents.** A new data-driven agent registry recognizes Pi and oh-my-pi as agent types, driving detection, the sidebar chip, restart, and canonical typing from one source. ([#271](https://github.com/Stage-11-Agentics/c11/pull/271))
+- **Size-aware splits.** Splitting a pane now adapts to the space available, so new panes land at sensible sizes instead of bisecting blindly. ([#262](https://github.com/Stage-11-Agentics/c11/pull/262))
+- **Responsive collapsing tab bar.** When horizontal space runs short, the tab bar collapses into a single bordered dropdown chip (three-tier responsive behavior) instead of overflowing. ([#266](https://github.com/Stage-11-Agentics/c11/pull/266))
+- **Surface Details.** Right-click a tab for a Surface Details view, including one-click copy of its surface / pane / tab / workspace handles. ([#265](https://github.com/Stage-11-Agentics/c11/pull/265))
+- **Four new chrome themes:** Obsidian, Command Deck, Blueprint, and Spatial. ([#270](https://github.com/Stage-11-Agentics/c11/pull/270))
+- **Terminal-only mode.** New Settings toggles can disable the browser and markdown surface types — hiding their spawn buttons and rejecting those types over the CLI/socket. ([#264](https://github.com/Stage-11-Agentics/c11/pull/264))
+- **`C11_*` surface environment variables.** Surfaces now export `C11_SURFACE_ID`, `C11_TAB_ID`, `C11_SHELL_INTEGRATION`, `C11_WORKSPACE_ID`, and friends alongside the legacy `CMUX_*` names, so agents can read the `C11_*` namespace the skill documents. ([#284](https://github.com/Stage-11-Agentics/c11/pull/284))
+- **`C11_QA_LAUNCH` automation flag.** Launching with `C11_QA_LAUNCH=fresh|resume` suppresses the startup Agent Skills and resume-picker dialogs so automated and QA launches don't block on modals. ([#268](https://github.com/Stage-11-Agentics/c11/pull/268))
+- **Bundled opencode status + notification plugin,** auto-installed so opencode surfaces report status and notifications out of the box.
+
+### Changed
+
+- **The Agent Skills onboarding sheet stops over-firing.** "Later" now persists a hash-pinned dismissal so the sheet doesn't reappear on every launch, and dev/tagged builds suppress the auto-popup entirely. ([#272](https://github.com/Stage-11-Agentics/c11/pull/272))
+- **The resume picker no longer blocks on local dev/tagged builds** — it only prompts where it should. ([#283](https://github.com/Stage-11-Agentics/c11/pull/283))
+- **Agent orientation seed prompt reworded** to read as discovery, not command. ([#282](https://github.com/Stage-11-Agentics/c11/pull/282))
+
+### Fixed
+
+- **Conversation detection hardening:** Pi/omp auto-detect (including bun-launched sessions), omp session cwd-scoping, and crash-path resume. ([#281](https://github.com/Stage-11-Agentics/c11/pull/281))
+- **Tab bar polish:** tool-button tooltips now show, the collapsed header gets a clear hover affordance, and collapse is tighter with a full-width accent line and whole-header hit area. ([#266](https://github.com/Stage-11-Agentics/c11/pull/266))
+- **Correct split sizing on Retina:** `cellSize` is now converted from backing pixels to points so size-aware split math is right. ([#262](https://github.com/Stage-11-Agentics/c11/pull/262))
+
+### Thanks to 1 contributor!
+
+- [@BenevolentFutures](https://github.com/BenevolentFutures)
+
 ## [0.53.0] - 2026-06-16
 
 Feature release. Headline: **the inter-agent mailbox grows up — it routes across every workspace and stops dropping messages silently.** `c11 mailbox send --to <name>` now resolves the recipient across the whole c11 instance (local-first; ambiguous names disambiguate with `--to-workspace`), an unresolved recipient is rejected with a non-zero exit instead of vanishing, surfaces gain stable `mailbox.address` / `mailbox.role` addressing decoupled from their mutable tab title, and stdin delivery is prompt-gated — buffered while a recipient is busy and flushed when it returns to its shell prompt — so a pushed message can never corrupt a running command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Feature release. Headline: **exact-session conversation resume arrives for Pi, o
 
 ### Fixed
 
+- **Codex sessions resume on restore again.** The codex scraper parsed the whole `rollout-<timestamp>-<uuid>.jsonl` filename as the session id, so it never matched a real codex session and a restored codex surface came back as a bare shell. It now extracts the trailing UUID, so a restored codex pane resumes its session like the other agents.
 - **Conversation detection hardening:** Pi/omp auto-detect (including bun-launched sessions), omp session cwd-scoping, and crash-path resume. ([#281](https://github.com/Stage-11-Agentics/c11/pull/281))
 - **Tab bar polish:** tool-button tooltips now show, the collapsed header gets a clear hover affordance, and collapse is tighter with a full-width accent line and whole-header hit area. ([#266](https://github.com/Stage-11-Agentics/c11/pull/266))
 - **Correct split sizing on Retina:** `cellSize` is now converted from backing pixels to points so size-aware split math is right. ([#262](https://github.com/Stage-11-Agentics/c11/pull/262))

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
 		74FC297C7F874F1D92C20D38 /* Strategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEEEA4C9921D5BDE4EF06E3 /* Strategy.swift */; };
 		756290E56A4FC7D6546C1D46 /* PaneSizePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2DBF12A2F90CBDE7F6A289 /* PaneSizePolicyTests.swift */; };
+		FE01AA00000000000000B001 /* SendKeyVocabularyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01AA00000000000000B002 /* SendKeyVocabularyTests.swift */; };
 		767FF8ADAC0F182A4534E12B /* ClaudeCodeScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */; };
 		78EC4CE4D9938FD4611E1664 /* LaunchResumePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BBF3CDB766B1FCF30BB765 /* LaunchResumePicker.swift */; };
 		7FFBFB92E1EA4343FB71DCA8 /* OpencodeResumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */; };
@@ -449,6 +450,7 @@
 		491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 		4979C511C7C076498CDF3515 /* ResumeAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ResumeAction.swift; path = Conversation/ResumeAction.swift; sourceTree = "<group>"; };
 		4B2DBF12A2F90CBDE7F6A289 /* PaneSizePolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaneSizePolicyTests.swift; sourceTree = "<group>"; };
+		FE01AA00000000000000B002 /* SendKeyVocabularyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SendKeyVocabularyTests.swift; sourceTree = "<group>"; };
 		4D11AA02B2C3D4E5F6071921 /* MarkdownPanelFontScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelFontScaleTests.swift; sourceTree = "<group>"; };
 		51C0D2C1212976BCF837B620 /* HangBacktrace.c */ = {isa = PBXFileReference; includeInIndex = 1; path = HangBacktrace.c; sourceTree = "<group>"; };
 		51D3CB3B7B4231D786E8883E /* ShutdownSentinel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShutdownSentinel.swift; path = Conversation/ShutdownSentinel.swift; sourceTree = "<group>"; };
@@ -1231,6 +1233,7 @@
 				7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */,
 				E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */,
 				4B2DBF12A2F90CBDE7F6A289 /* PaneSizePolicyTests.swift */,
+				FE01AA00000000000000B002 /* SendKeyVocabularyTests.swift */,
 				A2CADD0C9B7E43A29D723366 /* SurfaceTypeAvailabilityTests.swift */,
 				FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */,
 				B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */,
@@ -1557,6 +1560,7 @@
 				5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */,
 				E9E24C866C5E61B887F6E726 /* MainThreadHangDetectorTests.swift in Sources */,
 				756290E56A4FC7D6546C1D46 /* PaneSizePolicyTests.swift in Sources */,
+				FE01AA00000000000000B001 /* SendKeyVocabularyTests.swift in Sources */,
 				849745EAE2900598F862D0F9 /* SurfaceTypeAvailabilityTests.swift in Sources */,
 				352C25FFD890137B5F7A23B3 /* AgentManifestTests.swift in Sources */,
 				0824BD4DE71F74CA32F9F49E /* ScrapeCapturePipelineTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -1865,10 +1865,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1946,7 +1946,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1956,7 +1956,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -1987,7 +1987,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1997,7 +1997,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -2065,10 +2065,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2083,14 +2083,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2105,14 +2105,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2128,10 +2128,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2147,10 +2147,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 110;
+				CURRENT_PROJECT_VERSION = 111;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.53.0;
+				MARKETING_VERSION = 0.54.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -590,6 +590,8 @@ struct AgentSkillsOnboardingSheet: View {
     @State private var kimiOptIn: Bool = false
     @State private var opencodeOptIn: Bool = false
     @State private var copilotOptIn: Bool = false
+    @State private var piOptIn: Bool = false
+    @State private var ompOptIn: Bool = false
     @State private var initializedDefaultOptIns: Bool = false
     @State private var selectedAction: AgentSkillsOnboardingAction = .install
 
@@ -634,7 +636,7 @@ struct AgentSkillsOnboardingSheet: View {
     }
 
     private var anySelected: Bool {
-        initializedDefaultOptIns && (claudeOptIn || codexOptIn || grokOptIn || kimiOptIn || opencodeOptIn || copilotOptIn)
+        initializedDefaultOptIns && (claudeOptIn || codexOptIn || grokOptIn || kimiOptIn || opencodeOptIn || copilotOptIn || piOptIn || ompOptIn)
     }
 
     private var hasActionNeeded: Bool {
@@ -940,6 +942,8 @@ struct AgentSkillsOnboardingSheet: View {
         case .kimi: return $kimiOptIn
         case .opencode: return $opencodeOptIn
         case .copilot: return $copilotOptIn
+        case .pi: return $piOptIn
+        case .omp: return $ompOptIn
         }
     }
 
@@ -951,6 +955,8 @@ struct AgentSkillsOnboardingSheet: View {
             (.kimi, kimiOptIn),
             (.opencode, opencodeOptIn),
             (.copilot, copilotOptIn),
+            (.pi, piOptIn),
+            (.omp, ompOptIn),
         ]
         var selectedKeys: Set<String> = []
         for (target, _) in selections.filter({ $0.1 }) {
@@ -1031,6 +1037,8 @@ struct AgentSkillsOnboardingSheet: View {
         kimiOptIn = defaults[.kimi] ?? false
         opencodeOptIn = defaults[.opencode] ?? false
         copilotOptIn = defaults[.copilot] ?? false
+        piOptIn = defaults[.pi] ?? false
+        ompOptIn = defaults[.omp] ?? false
     }
 }
 

--- a/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
+++ b/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
@@ -103,7 +103,14 @@ struct CodexScraper: ConversationScraper {
             max: maxCandidates
         )
         return entries.compactMap { entry in
-            let id = String(entry.fileName.dropLast(".jsonl".count))
+            // Codex names sessions `rollout-<ISO8601-with-dashes>-<uuid>.jsonl`
+            // (e.g. `rollout-2026-01-31T21-29-57-019c1709-...-5144ceccdad7`),
+            // so the session id is the trailing 36-char UUID, not the whole
+            // stem. `suffix(36)` also handles a bare `<uuid>.jsonl` (stem is
+            // already 36 chars); anything shorter or malformed fails the UUID
+            // guard below and is dropped.
+            let stem = String(entry.fileName.dropLast(".jsonl".count))
+            let id = String(stem.suffix(36))
             guard isValidConversationUUID(id) else { return nil }
             return ScrapeCandidate(
                 id: id,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3808,7 +3808,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
-    private func scheduleSubmitReturnAfterPasteDelay() {
+    /// Dispatch a synthetic Return as a distinct key event after the
+    /// paste-settle delay. Used by the interactive text box submit and by the
+    /// socket `send` submit path, both of which type text first and must let a
+    /// paste-detecting TUI finish ingesting before the Return lands (a Return
+    /// inside the input burst is silently swallowed).
+    func scheduleSubmitReturnAfterPasteDelay() {
         let delayMs = TextBoxBehavior.returnKeyDelayMs
         if delayMs <= 0 {
             sendKey(.returnKey)

--- a/Sources/SkillInstaller.swift
+++ b/Sources/SkillInstaller.swift
@@ -10,6 +10,8 @@ enum SkillInstallerTarget: String, CaseIterable {
     case kimi
     case opencode
     case copilot
+    case pi
+    case omp
 
     var displayName: String {
         switch self {
@@ -19,15 +21,23 @@ enum SkillInstallerTarget: String, CaseIterable {
         case .kimi: return "Kimi"
         case .opencode: return "OpenCode"
         case .copilot: return "GitHub Copilot"
+        case .pi: return "Pi"
+        case .omp: return "oh-my-pi"
         }
     }
 
     /// Root config dir conventionally used by each TUI (`~/.claude`, `~/.codex`, …).
     /// OpenCode uses `~/.config/opencode/` (XDG convention), not `~/.opencode/`.
+    /// Pi and oh-my-pi keep their config (and skills) under an `agent/` subdir
+    /// of `~/.pi` / `~/.omp`, so they read skills from `~/.<name>/agent/skills/`.
     func configRoot(home: URL) -> URL {
         switch self {
         case .opencode:
             return home.appendingPathComponent(".config/opencode", isDirectory: true)
+        case .pi:
+            return home.appendingPathComponent(".pi/agent", isDirectory: true)
+        case .omp:
+            return home.appendingPathComponent(".omp/agent", isDirectory: true)
         default:
             return home.appendingPathComponent(".\(rawValue)", isDirectory: true)
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8087,7 +8087,13 @@ class TerminalController {
                 if let liveSurface = resolved.terminalPanel.surface.surface {
                     sendSocketText(text, surface: liveSurface)
                     if submit {
-                        _ = sendNamedKey(liveSurface, keyName: "enter")
+                        // Dispatch the submit Return as a distinct key event AFTER the
+                        // typed text has settled. The text lands as a burst of synthetic
+                        // key events; paste-detecting TUIs (codex, Claude Code) swallow a
+                        // Return that arrives inside that burst window, leaving the message
+                        // sitting unsent in the composer. Reuse the same paste-settle delay
+                        // the interactive text box uses so submit is deterministic.
+                        resolved.terminalPanel.surface.scheduleSubmitReturnAfterPasteDelay()
                     }
                     // Ensure we present a new frame after injecting input so snapshot-based tests
                     // (and socket-driven agents) can observe the updated terminal without requiring
@@ -8096,19 +8102,30 @@ class TerminalController {
                     attachedAtPhaseB = true
                 } else {
                     // Surface was torn down between Phase A and Phase B. Fall through to
-                    // the pending queue as a last resort. Append \r when submit is on
-                    // so the queue flush submits the line on attach.
-                    resolved.terminalPanel.sendText(submit ? text + "\r" : text)
+                    // the pending queue as a last resort. Use the canonical submit helper
+                    // so the Return is dispatched as a real key event once the queued text
+                    // flushes on attach, rather than appending a bare \r that the queue's
+                    // bracketed-paste envelope would swallow.
+                    if submit {
+                        resolved.terminalPanel.surface.sendSubmitFormText(text)
+                    } else {
+                        resolved.terminalPanel.sendText(text)
+                    }
                 }
             }
             phaseBSema.wait()
             queued = !attachedAtPhaseB
         } else {
             // Surface not available within 2s (e.g., terminal not yet attached to any window).
-            // Fall back to the pending queue as a last resort. Same submit-aware append
-            // as the teardown fallback above.
+            // Fall back to the pending queue as a last resort. Use the canonical submit
+            // helper so the Return flushes as a real key event on attach instead of a
+            // bare \r swallowed inside the bracketed-paste envelope.
             Task { @MainActor in
-                resolved.terminalPanel.sendText(submit ? text + "\r" : text)
+                if submit {
+                    resolved.terminalPanel.surface.sendSubmitFormText(text)
+                } else {
+                    resolved.terminalPanel.sendText(text)
+                }
                 phaseBSema.signal()
             }
             phaseBSema.wait()
@@ -15340,7 +15357,10 @@ class TerminalController {
 
         Input commands:
           send <text>                     - Send text to current terminal
-          send_key <key>                  - Send special key (ctrl-c, ctrl-d, enter, tab, escape)
+          send_key <key>                  - Send special key. Vocabulary:
+                                            enter/return, tab, escape, space, backspace, delete,
+                                            up, down, left, right, home, end, pageup, pagedown,
+                                            f1-f12, ctrl-c, ctrl-d, ctrl-z, ctrl-<letter>
           send_surface <id|idx> <text>    - Send text to a specific terminal
           send_key_surface <id|idx> <key> - Send special key to a specific terminal
           read_screen [id|idx] [--scrollback] [--lines N] - Read terminal text (plain text)
@@ -17538,7 +17558,7 @@ class TerminalController {
         }
     }
 
-    private func keycodeForLetter(_ letter: Character) -> UInt32? {
+    private static func keycodeForLetter(_ letter: Character) -> UInt32? {
         switch String(letter).lowercased() {
         case "a": return UInt32(kVK_ANSI_A)
         case "b": return UInt32(kVK_ANSI_B)
@@ -17570,42 +17590,79 @@ class TerminalController {
         }
     }
 
-    private func sendNamedKey(_ surface: ghostty_surface_t, keyName: String) -> Bool {
-        switch keyName.lowercased() {
-        case "ctrl-c", "ctrl+c", "sigint":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_ANSI_C), mods: GHOSTTY_MODS_CTRL)
-            return true
-        case "ctrl-d", "ctrl+d", "eof":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_ANSI_D), mods: GHOSTTY_MODS_CTRL)
-            return true
-        case "ctrl-z", "ctrl+z", "sigtstp":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_ANSI_Z), mods: GHOSTTY_MODS_CTRL)
-            return true
-        case "ctrl-\\", "ctrl+\\", "sigquit":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_ANSI_Backslash), mods: GHOSTTY_MODS_CTRL)
-            return true
-        case "enter", "return":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_Return))
-            return true
-        case "tab":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_Tab))
-            return true
-        case "escape", "esc":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_Escape))
-            return true
-        case "backspace":
-            sendKeyEvent(surface: surface, keycode: UInt32(kVK_Delete))
-            return true
+    /// A resolved keystroke: the macOS virtual keycode plus modifier flags to
+    /// hand to `ghostty_surface_key`. Ghostty owns the keycode → PTY-bytes
+    /// translation, so arrows and friends are emitted as the correct CSI
+    /// (normal) or SS3 (application-cursor-keys) sequence for the surface's
+    /// current DECCKM mode — which is what drives arrow-select menus in TUIs.
+    struct NamedKeyEvent: Equatable {
+        let keycode: UInt32
+        let mods: ghostty_input_mods_e
+
+        static func == (lhs: NamedKeyEvent, rhs: NamedKeyEvent) -> Bool {
+            lhs.keycode == rhs.keycode && lhs.mods.rawValue == rhs.mods.rawValue
+        }
+    }
+
+    /// Pure name → keystroke mapping for `send-key`. Kept separate from the
+    /// surface-injecting `sendNamedKey` so the vocabulary is unit-testable
+    /// without a live surface. Returns nil for an unrecognised name.
+    static func namedKeyEvent(for keyName: String) -> NamedKeyEvent? {
+        func ev(_ keycode: Int, _ mods: ghostty_input_mods_e = GHOSTTY_MODS_NONE) -> NamedKeyEvent {
+            NamedKeyEvent(keycode: UInt32(keycode), mods: mods)
+        }
+        let name = keyName.lowercased()
+        switch name {
+        // Control combinations / signals
+        case "ctrl-c", "ctrl+c", "sigint": return ev(kVK_ANSI_C, GHOSTTY_MODS_CTRL)
+        case "ctrl-d", "ctrl+d", "eof": return ev(kVK_ANSI_D, GHOSTTY_MODS_CTRL)
+        case "ctrl-z", "ctrl+z", "sigtstp": return ev(kVK_ANSI_Z, GHOSTTY_MODS_CTRL)
+        case "ctrl-\\", "ctrl+\\", "sigquit": return ev(kVK_ANSI_Backslash, GHOSTTY_MODS_CTRL)
+        // Editing / submission keys
+        case "enter", "return": return ev(kVK_Return)
+        case "tab": return ev(kVK_Tab)
+        case "escape", "esc": return ev(kVK_Escape)
+        case "backspace", "bs": return ev(kVK_Delete)
+        case "delete", "del", "forward-delete": return ev(kVK_ForwardDelete)
+        case "space": return ev(kVK_Space)
+        // Arrow keys
+        case "up", "arrow-up", "arrowup": return ev(kVK_UpArrow)
+        case "down", "arrow-down", "arrowdown": return ev(kVK_DownArrow)
+        case "left", "arrow-left", "arrowleft": return ev(kVK_LeftArrow)
+        case "right", "arrow-right", "arrowright": return ev(kVK_RightArrow)
+        // Navigation keys
+        case "home": return ev(kVK_Home)
+        case "end": return ev(kVK_End)
+        case "pageup", "page-up", "pgup": return ev(kVK_PageUp)
+        case "pagedown", "page-down", "pgdn": return ev(kVK_PageDown)
+        // Function keys
+        case "f1": return ev(kVK_F1)
+        case "f2": return ev(kVK_F2)
+        case "f3": return ev(kVK_F3)
+        case "f4": return ev(kVK_F4)
+        case "f5": return ev(kVK_F5)
+        case "f6": return ev(kVK_F6)
+        case "f7": return ev(kVK_F7)
+        case "f8": return ev(kVK_F8)
+        case "f9": return ev(kVK_F9)
+        case "f10": return ev(kVK_F10)
+        case "f11": return ev(kVK_F11)
+        case "f12": return ev(kVK_F12)
         default:
-            if keyName.lowercased().hasPrefix("ctrl-") || keyName.lowercased().hasPrefix("ctrl+") {
-                let letter = keyName.dropFirst(5)
+            if name.hasPrefix("ctrl-") || name.hasPrefix("ctrl+") {
+                let letter = name.dropFirst(5)
                 if letter.count == 1, let char = letter.first, let keycode = keycodeForLetter(char) {
-                    sendKeyEvent(surface: surface, keycode: keycode, mods: GHOSTTY_MODS_CTRL)
-                    return true
+                    return NamedKeyEvent(keycode: keycode, mods: GHOSTTY_MODS_CTRL)
                 }
             }
-            return false
+            return nil
         }
+    }
+
+    private func sendNamedKey(_ surface: ghostty_surface_t, keyName: String) -> Bool {
+        guard let event = Self.namedKeyEvent(for: keyName) else { return false }
+        sendKeyEvent(surface: surface, keycode: event.keycode, mods: event.mods)
+        return true
     }
 
     private func sendInput(_ text: String) -> String {

--- a/c11Tests/ConversationScraperTests.swift
+++ b/c11Tests/ConversationScraperTests.swift
@@ -149,6 +149,30 @@ final class ConversationScraperTests: XCTestCase {
         XCTAssertEqual(candidates[0].cwd, "/work/proj")
     }
 
+    /// Real codex session files are named
+    /// `rollout-<ISO8601-with-dashes>-<uuid>.jsonl`, not bare `<uuid>.jsonl`.
+    /// The scraper must extract the trailing UUID; the whole stem is not a
+    /// valid UUID and would otherwise be dropped, leaving codex unresumable.
+    func testCodexScraperParsesRolloutPrefixedFilenames() {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = URL(fileURLWithPath: "/Users/test/.codex/sessions")
+        let sessionId = "019c1709-153e-7e63-a879-5144ceccdad7"
+        let fileName = "rollout-2026-01-31T21-29-57-\(sessionId).jsonl"
+        mock.recursiveEntries[root] = [
+            ConversationFilesystemEntry(
+                url: root.appendingPathComponent("2026/01/31/\(fileName)"),
+                fileName: fileName,
+                mtime: Date(),
+                size: 1024
+            )
+        ]
+        let scraper = CodexScraper(filesystem: mock)
+        let candidates = scraper.candidates(cwd: "/work/proj")
+        XCTAssertEqual(candidates.count, 1, "rollout-prefixed codex session must be collected")
+        XCTAssertEqual(candidates[0].id, sessionId, "id must be the trailing UUID, not the rollout stem")
+    }
+
     // MARK: - Privacy contract
 
     func testScrapersDoNotEverOpenTranscriptContent() {

--- a/c11Tests/SendKeyVocabularyTests.swift
+++ b/c11Tests/SendKeyVocabularyTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+import Carbon.HIToolbox
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Unit tests for `TerminalController.namedKeyEvent` — the pure `send-key`
+/// vocabulary mapping. Host-free: runs in the fast `c11LogicTests` target.
+///
+/// Regression guard for the v0.54.0 bug where `c11 send-key down` (and the
+/// other arrow/navigation keys) returned `invalid_params: Unknown key`. The
+/// mapping resolves a key name to a macOS virtual keycode; Ghostty owns the
+/// keycode → PTY-bytes translation, so asserting the keycode pins the
+/// behavior that produces the correct CSI/SS3 escape sequence on the PTY.
+@MainActor
+final class SendKeyVocabularyTests: XCTestCase {
+
+    private func keycode(_ name: String) -> UInt32? {
+        TerminalController.namedKeyEvent(for: name)?.keycode
+    }
+
+    // MARK: Arrow keys — the reported regression
+
+    func testArrowKeysResolveToVirtualKeycodes() {
+        XCTAssertEqual(keycode("up"), UInt32(kVK_UpArrow))
+        XCTAssertEqual(keycode("down"), UInt32(kVK_DownArrow))
+        XCTAssertEqual(keycode("left"), UInt32(kVK_LeftArrow))
+        XCTAssertEqual(keycode("right"), UInt32(kVK_RightArrow))
+    }
+
+    func testArrowKeyAliasesResolve() {
+        XCTAssertEqual(keycode("arrow-up"), UInt32(kVK_UpArrow))
+        XCTAssertEqual(keycode("arrowdown"), UInt32(kVK_DownArrow))
+    }
+
+    func testKeyNamesAreCaseInsensitive() {
+        XCTAssertEqual(keycode("UP"), UInt32(kVK_UpArrow))
+        XCTAssertEqual(keycode("Down"), UInt32(kVK_DownArrow))
+    }
+
+    // MARK: Navigation / editing keys
+
+    func testNavigationKeysResolve() {
+        XCTAssertEqual(keycode("home"), UInt32(kVK_Home))
+        XCTAssertEqual(keycode("end"), UInt32(kVK_End))
+        XCTAssertEqual(keycode("pageup"), UInt32(kVK_PageUp))
+        XCTAssertEqual(keycode("pagedown"), UInt32(kVK_PageDown))
+        XCTAssertEqual(keycode("page-up"), UInt32(kVK_PageUp))
+        XCTAssertEqual(keycode("pgdn"), UInt32(kVK_PageDown))
+    }
+
+    func testEditingKeysResolve() {
+        XCTAssertEqual(keycode("space"), UInt32(kVK_Space))
+        XCTAssertEqual(keycode("backspace"), UInt32(kVK_Delete))
+        XCTAssertEqual(keycode("delete"), UInt32(kVK_ForwardDelete))
+        XCTAssertNotEqual(
+            keycode("delete"), keycode("backspace"),
+            "delete (forward-delete) must not collide with backspace"
+        )
+    }
+
+    func testFunctionKeysResolve() {
+        XCTAssertEqual(keycode("f1"), UInt32(kVK_F1))
+        XCTAssertEqual(keycode("f5"), UInt32(kVK_F5))
+        XCTAssertEqual(keycode("f12"), UInt32(kVK_F12))
+    }
+
+    // MARK: Existing vocabulary still works
+
+    func testSubmissionAndControlKeysStillResolve() {
+        XCTAssertEqual(keycode("enter"), UInt32(kVK_Return))
+        XCTAssertEqual(keycode("return"), UInt32(kVK_Return))
+        XCTAssertEqual(keycode("tab"), UInt32(kVK_Tab))
+        XCTAssertEqual(keycode("escape"), UInt32(kVK_Escape))
+        XCTAssertEqual(keycode("esc"), UInt32(kVK_Escape))
+    }
+
+    func testControlCombinationsResolveToLetterKeycodes() {
+        XCTAssertEqual(keycode("ctrl-c"), UInt32(kVK_ANSI_C))
+        XCTAssertEqual(keycode("ctrl-d"), UInt32(kVK_ANSI_D))
+        XCTAssertEqual(keycode("ctrl-z"), UInt32(kVK_ANSI_Z))
+        // Generic ctrl-<letter> fallthrough.
+        XCTAssertEqual(keycode("ctrl-k"), UInt32(kVK_ANSI_K))
+        XCTAssertEqual(keycode("ctrl+k"), UInt32(kVK_ANSI_K))
+    }
+
+    func testControlComboCarriesModifierDistinctFromPlainKey() {
+        // ctrl-c and a plain 'c' keystroke share a keycode but differ in mods;
+        // the arrow keys carry no modifier. Compare the resolved events so the
+        // modifier wiring is covered without naming GhosttyKit symbols.
+        let ctrlC = TerminalController.namedKeyEvent(for: "ctrl-c")
+        let plainUp = TerminalController.namedKeyEvent(for: "up")
+        XCTAssertNotNil(ctrlC)
+        XCTAssertNotNil(plainUp)
+        XCTAssertNotEqual(ctrlC, plainUp)
+    }
+
+    // MARK: Unknown keys
+
+    func testUnknownKeyReturnsNil() {
+        XCTAssertNil(TerminalController.namedKeyEvent(for: "nope"))
+        XCTAssertNil(TerminalController.namedKeyEvent(for: ""))
+        XCTAssertNil(TerminalController.namedKeyEvent(for: "ctrl-"))
+    }
+}

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -163,11 +163,19 @@ c11 read-screen --workspace workspace:2 --surface surface:3 --lines 50
 # Send text to a terminal
 c11 send "echo hello"                # Types text AND submits (default behavior)
 c11 send --no-submit "cd /tmp/"      # Types text only, no Return — for partial-line construction
-c11 send-key enter                   # Send a keypress directly (no text)
+c11 send-key down                    # Send a keypress directly (no text) — drives TUI menus
 c11 send --workspace workspace:2 --surface surface:3 "ls"
 ```
 
-**`c11 send` types the text and submits.** A synthetic Return is dispatched on the same turn as the text, so the receiving TUI sees one user turn. Pass `--no-submit` to type into the prompt without executing — typically to build a partial line across multiple sends, or to stage text before the operator hits Enter manually.
+**`c11 send` types the text and submits.** The synthetic Return is dispatched as a distinct key event after the typed text settles, so paste-detecting TUIs (codex, Claude Code) reliably register it as a submit rather than swallowing it into the paste. The receiving TUI sees one user turn. Pass `--no-submit` to type into the prompt without executing — typically to build a partial line across multiple sends, or to stage text before the operator hits Enter manually.
+
+**`c11 send-key <key>` dispatches a single keypress** to the surface's PTY, encoded for the terminal's current mode (so arrow keys drive arrow-select menus like codex's hooks-trust prompt). Vocabulary:
+
+- Submission / editing: `enter`/`return`, `tab`, `escape`, `space`, `backspace`, `delete`
+- Arrows: `up`, `down`, `left`, `right`
+- Navigation: `home`, `end`, `pageup`, `pagedown`
+- Function keys: `f1`–`f12`
+- Control: `ctrl-c`, `ctrl-d`, `ctrl-z`, and generic `ctrl-<letter>`
 
 ## Per-surface metadata
 

--- a/tests_v2/test_send_key_arrow_bytes.py
+++ b/tests_v2/test_send_key_arrow_bytes.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""v0.54.0 BUG 1: `c11 send-key <arrow>` must deliver the correct PTY bytes.
+
+Before the fix, `surface.send_key` only knew ctrl-*, enter, tab, escape and
+backspace; every arrow/navigation name returned `invalid_params: Unknown key`.
+This test drives a real pane: it runs a tiny raw-mode reader that first resets
+DECCKM (normal cursor keys, so arrows encode as CSI and the assertion is
+mode-deterministic), reads one key's bytes, and prints them hex-encoded. We
+then send each arrow and assert the exact escape sequence reached the PTY.
+
+Run against a live tagged build's socket:
+    C11_SOCKET=/tmp/c11-debug-<tag>.sock python3 tests_v2/test_send_key_arrow_bytes.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+# Normal-mode (DECCKM off) cursor-key escape sequences.
+ARROW_BYTES = {
+    "up": "1b5b41",     # ESC [ A
+    "down": "1b5b42",   # ESC [ B
+    "right": "1b5b43",  # ESC [ C
+    "left": "1b5b44",   # ESC [ D
+}
+
+# A reader that forces normal cursor-key mode, prints READY, then reports the
+# next key's raw bytes as `GOT:<hex>`. Kept as a one-liner so it pastes cleanly.
+READER = (
+    "python3 -c \""
+    "import sys,os,tty,termios;"
+    "sys.stdout.write('\\x1b[?1lREADY\\n');sys.stdout.flush();"
+    "fd=sys.stdin.fileno();old=termios.tcgetattr(fd);tty.setraw(fd);"
+    "d=os.read(fd,8);"
+    "termios.tcsetattr(fd,termios.TCSADRAIN,old);"
+    "sys.stdout.write('GOT:'+d.hex()+'\\n');sys.stdout.flush()\""
+)
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _wait_for_text(c: cmux, ws: str, surface: str, needle: str, timeout_s: float = 6.0) -> str:
+    deadline = time.time() + timeout_s
+    last = ""
+    while time.time() < deadline:
+        payload = c._call("surface.read_text", {"workspace_id": ws, "surface_id": surface}) or {}
+        last = str(payload.get("text") or "")
+        if needle in last:
+            return last
+        time.sleep(0.1)
+    raise cmuxError(f"Timed out waiting for {needle!r}; last screen:\n{last}")
+
+
+def test_arrow_keys_emit_csi_bytes(c: cmux) -> None:
+    ws = str((c._call("workspace.create") or {}).get("workspace_id") or "")
+    _must(bool(ws), "workspace.create returned no workspace_id")
+    try:
+        time.sleep(0.3)
+        surfaces = (c._call("surface.list", {"workspace_id": ws}) or {}).get("surfaces") or []
+        _must(bool(surfaces), f"No surfaces in workspace {ws}")
+        surface = str(surfaces[0].get("id") or "")
+        _must(bool(surface), "surface.list returned surface without id")
+
+        for name, expected_hex in ARROW_BYTES.items():
+            # Start a fresh reader for each key so the pane returns to a clean
+            # prompt between assertions.
+            c._call("surface.send_text", {
+                "workspace_id": ws, "surface_id": surface,
+                "text": READER + "\n",
+            })
+            _wait_for_text(c, ws, surface, "READY", timeout_s=8.0)
+            # Small settle so the reader is blocked in os.read before the key.
+            time.sleep(0.25)
+
+            c._call("surface.send_key", {
+                "workspace_id": ws, "surface_id": surface, "key": name,
+            })
+
+            screen = _wait_for_text(c, ws, surface, "GOT:", timeout_s=6.0)
+            marker = f"GOT:{expected_hex}"
+            _must(
+                marker in screen,
+                f"send-key {name!r} expected {marker!r} on PTY; screen:\n{screen}",
+            )
+            print(f"PASS: send-key {name} -> {expected_hex}")
+            # Let the prompt redraw before the next iteration.
+            time.sleep(0.2)
+    finally:
+        try:
+            c.close_workspace(ws)
+        except Exception:
+            pass
+
+    print("PASS: test_arrow_keys_emit_csi_bytes")
+
+
+def test_unknown_key_still_rejected(c: cmux) -> None:
+    """The error path must stay intact: a bogus key name is rejected."""
+    try:
+        c.send_key("definitely-not-a-key")
+    except cmuxError as exc:
+        _must("Unknown key" in str(exc), f"Unexpected error for bad key: {exc}")
+        print("PASS: test_unknown_key_still_rejected")
+        return
+    raise cmuxError("Expected send-key with a bogus name to raise Unknown key")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        test_arrow_keys_emit_csi_bytes(c)
+        test_unknown_key_still_rejected(c)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_send_submit_delivers_return.py
+++ b/tests_v2/test_send_submit_delivers_return.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""v0.54.0 BUG 2: `c11 send` must deliver a separate, post-text submit Return.
+
+`c11 send` types the text AND submits it. The text carries no embedded newline,
+so the command can only run if a distinct Return key event is delivered *after*
+the text. We assert that by sending an `expr` whose result does not appear in
+the typed source: if the result shows up, a separate Return fired and submitted
+the line. The mirror case (`--no-submit`) must leave the text unsubmitted until
+an explicit `send-key enter` arrives.
+
+Run against a live tagged build's socket:
+    C11_SOCKET=/tmp/c11-debug-<tag>.sock python3 tests_v2/test_send_submit_delivers_return.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET") or os.environ.get("C11_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _screen(c: cmux, ws: str, surface: str) -> str:
+    payload = c._call("surface.read_text", {"workspace_id": ws, "surface_id": surface}) or {}
+    return str(payload.get("text") or "")
+
+
+def _wait_for(c: cmux, ws: str, surface: str, needle: str, timeout_s: float = 6.0) -> str:
+    deadline = time.time() + timeout_s
+    last = ""
+    while time.time() < deadline:
+        last = _screen(c, ws, surface)
+        if needle in last:
+            return last
+        time.sleep(0.1)
+    raise cmuxError(f"Timed out waiting for {needle!r}; last screen:\n{last}")
+
+
+def _absent_after(c: cmux, ws: str, surface: str, needle: str, window_s: float = 1.5) -> None:
+    deadline = time.time() + window_s
+    while time.time() < deadline:
+        if needle in _screen(c, ws, surface):
+            raise cmuxError(f"{needle!r} appeared but should not have (premature submit)")
+        time.sleep(0.1)
+
+
+def _new_shell_surface(c: cmux) -> tuple[str, str]:
+    ws = str((c._call("workspace.create") or {}).get("workspace_id") or "")
+    _must(bool(ws), "workspace.create returned no workspace_id")
+    time.sleep(0.3)
+    surfaces = (c._call("surface.list", {"workspace_id": ws}) or {}).get("surfaces") or []
+    _must(bool(surfaces), f"No surfaces in workspace {ws}")
+    surface = str(surfaces[0].get("id") or "")
+    _must(bool(surface), "surface.list returned surface without id")
+    return ws, surface
+
+
+def test_send_with_submit_executes_via_separate_return(c: cmux) -> None:
+    ws, surface = _new_shell_surface(c)
+    try:
+        # Result (62675) never appears in the typed source text.
+        c._call("surface.send_text", {
+            "workspace_id": ws, "surface_id": surface,
+            "text": "expr 62674 + 1", "submit": True,
+        })
+        _wait_for(c, ws, surface, "62675", timeout_s=6.0)
+        print("PASS: send with submit delivered a separate post-text Return")
+    finally:
+        try:
+            c.close_workspace(ws)
+        except Exception:
+            pass
+
+
+def test_no_submit_holds_text_until_explicit_enter(c: cmux) -> None:
+    ws, surface = _new_shell_surface(c)
+    try:
+        c._call("surface.send_text", {
+            "workspace_id": ws, "surface_id": surface,
+            "text": "expr 73736 + 1", "submit": False,
+        })
+        # The typed text must land in the composer/prompt...
+        _wait_for(c, ws, surface, "expr 73736 + 1", timeout_s=6.0)
+        # ...but must NOT execute (no result) without a Return.
+        _absent_after(c, ws, surface, "73737", window_s=1.5)
+        # An explicit send-key enter then submits it.
+        c._call("surface.send_key", {"workspace_id": ws, "surface_id": surface, "key": "enter"})
+        _wait_for(c, ws, surface, "73737", timeout_s=6.0)
+        print("PASS: --no-submit held the line; explicit enter submitted it")
+    finally:
+        try:
+            c.close_workspace(ws)
+        except Exception:
+            pass
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        test_send_with_submit_executes_via_separate_return(c)
+        test_no_submit_holds_text_until_explicit_enter(c)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Release **v0.54.0** — a 13-day feature release (57 commits since v0.53.0).

## Headline
Exact-session conversation resume arrives for **Pi, oh-my-pi, and opencode** — on workspace restore these agents reconnect to their precise prior session, not a fresh shell. Plus a data-driven agent registry (Pi/omp first-class), size-aware splits, a responsive collapsing tab bar, four new chrome themes, and the `C11_*` surface env namespace.

## Changelog (user-facing)
### Added
- Exact-session resume for Pi, oh-my-pi, opencode (#274, #275, #276)
- Pi & oh-my-pi as first-class agents via the agent registry (#271)
- Size-aware splits (#262)
- Responsive collapsing tab bar (#266)
- Surface Details right-click + copy handles (#265)
- Four chrome themes: Obsidian, Command Deck, Blueprint, Spatial (#270)
- Terminal-only mode — disable browser/markdown surface types (#264)
- `C11_*` surface env vars alongside `CMUX_*` (#284)
- `C11_QA_LAUNCH` automation flag (#268)
- Bundled opencode status + notification plugin

### Changed
- Agent Skills onboarding sheet stops over-firing (#272)
- Resume picker no longer blocks on local dev/tagged builds (#283)
- Agent orientation seed prompt reworded to discovery-not-command (#282)

### Fixed
- Conversation detection hardening: pi/omp auto-detect, omp cwd-scoping, crash-path resume (#281)
- Tab bar polish: tooltips, hover affordance, tighter collapse (#266)
- Correct split sizing on Retina — cellSize pixels→points (#262)

## Version
`0.53.0` → `0.54.0`, build 110 → 111.

## Test plan (staging smoke)
Built `c11 STAGING rel-v0.54.0` (`com.stage11.c11.staging`), Release config, side-by-side with prod:
- [ ] `C11_*` env vars populated in a fresh terminal surface (`echo $C11_SURFACE_ID`)
- [ ] Conversation resume reconnects a restored agent (codex/opencode/pi/omp)
- [ ] Four new chrome themes render and switch
- [ ] Collapsing tab bar behaves as space shrinks
- [ ] Right-click → Surface Details copies handles
- [ ] Size-aware splits land at sensible sizes
- [ ] No launch regressions (skills sheet / resume picker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)