### PR TITLE
fix(conversation): codex crash-path resume + accurate opencode reserved-key docs

### DIFF
--- a/Sources/Conversation/Strategies/Codex.swift
+++ b/Sources/Conversation/Strategies/Codex.swift
@@ -95,4 +95,21 @@ struct CodexStrategy: ConversationStrategy {
     func isValidId(_ id: String) -> Bool {
         isValidConversationUUID(id)
     }
+
+    /// Crash-recovery verification (stat-only): does a `rollout-<ts>-<uuid>.jsonl`
+    /// for `ref.id` still exist on disk? Without this, `reclassifyAfterCrash`
+    /// forces the ref to `.unknown` (the protocol default returns nil) and codex
+    /// resume skips after a crash. Codex filenames are date-nested with an
+    /// unknown timestamp, so an exact-path stat isn't constructable; reuse the
+    /// `CodexScraper` (which extracts the trailing UUID) and check membership.
+    /// Never opens transcript bytes.
+    func transcriptExists(
+        for ref: ConversationRef,
+        filesystem: ConversationFilesystem
+    ) -> Bool? {
+        guard isValidConversationUUID(ref.id) else { return false }
+        return CodexScraper(filesystem: filesystem)
+            .candidates(cwd: ref.cwd)
+            .contains { $0.id == ref.id }
+    }
 }

--- a/Sources/WorkspaceMetadataKeys.swift
+++ b/Sources/WorkspaceMetadataKeys.swift
@@ -38,23 +38,24 @@ public enum SurfaceMetadataKeyName {
     /// into the recorded directory before issuing `claude --resume`.
     public static let claudeSessionProjectDir = "claude.session_project_dir"
 
-    /// Surface-scoped session id written by the opencode `session.created`
-    /// plugin hook. Opencode session IDs are `ses_` + a 26-character
+    /// **Reserved namespace — not currently written by any production path.**
+    /// Opencode capture rides the plugin push rail (`session.created` →
+    /// `c11 conversation push`) and the SQLite scrape rail; both produce a
+    /// `ConversationRef` directly, and neither writes this metadata key. The
+    /// key + its `isValidOpencodeSessionId` grammar are kept reserved (and
+    /// validated at the store boundary) so a future opencode hook that records
+    /// the id has a safe, ready home — mirroring the live `claude.session_id`
+    /// wrapper rail. Opencode session IDs are `ses_` + a 26-character
     /// **base62** body (`[0-9A-Za-z]`), NOT UUIDs — see
-    /// `isValidOpencodeSessionId`. The `opencode.*` prefix mirrors the
-    /// `claude.*` reservation and does not collide with the C11-13
-    /// `mailbox.*` namespace.
+    /// `isValidOpencodeSessionId`. The `opencode.*` prefix does not collide
+    /// with the C11-13 `mailbox.*` namespace.
     public static let opencodeSessionId = "opencode.session_id"
 
-    /// Surface-scoped project directory the opencode session was created
-    /// in (its cwd at session start). Written alongside
-    /// `opencode.session_id` by the same hook. The pair is atomic for the
-    /// same reason `claude.session_project_dir` is: opencode resolves
-    /// session state relative to the launching cwd, so a session captured
-    /// in a worktree subdir cannot be resumed from its parent. Same
-    /// grammar as the claude project-dir key — validated via
-    /// `isValidOpencodeSessionProjectDir`, which delegates to the shared
-    /// `isValidClaudeSessionProjectDir`.
+    /// **Reserved namespace — not currently written by any production path**
+    /// (companion to `opencodeSessionId`; same rationale — capture rides the
+    /// plugin/scrape rails, not metadata keys). Same project-dir grammar as
+    /// the claude key, validated via `isValidOpencodeSessionProjectDir`, which
+    /// delegates to the shared `isValidClaudeSessionProjectDir`.
     public static let opencodeSessionProjectDir = "opencode.session_project_dir"
 
     /// Canonical `terminal_type` key (same literal as

--- a/c11Tests/ConversationCrashRecoveryTests.swift
+++ b/c11Tests/ConversationCrashRecoveryTests.swift
@@ -22,11 +22,16 @@ final class ConversationCrashRecoveryTests: XCTestCase {
     private final class MockFS: ConversationFilesystem, @unchecked Sendable {
         let home: URL?
         var existingPaths: Set<String> = []
+        var recursiveEntries: [URL: [ConversationFilesystemEntry]] = [:]
         init(home: String = "/Users/test") { self.home = URL(fileURLWithPath: home) }
         var homeDirectory: URL? { home }
         func fileExists(atPath path: String) -> Bool { existingPaths.contains(path) }
         func listDirectoryByMtime(_ d: URL, max: Int) -> [ConversationFilesystemEntry] { [] }
-        func listSessionsRecursivelyByMtime(_ r: URL, extensionFilter: String, max: Int) -> [ConversationFilesystemEntry] { [] }
+        func listSessionsRecursivelyByMtime(_ r: URL, extensionFilter: String, max: Int) -> [ConversationFilesystemEntry] {
+            Array((recursiveEntries[r] ?? [])
+                .filter { $0.fileName.hasSuffix("." + extensionFilter) }
+                .prefix(max))
+        }
     }
 
     private func mockFS(present ids: [String], cwd: String) -> MockFS {
@@ -87,6 +92,30 @@ final class ConversationCrashRecoveryTests: XCTestCase {
         let ref = ConversationRef(kind: "kimi", id: "real-id", cwd: cwd,
                                   capturedVia: .hook, state: .suspended)
         XCTAssertNil(KimiStrategy().transcriptExists(for: ref, filesystem: fs))
+    }
+
+    /// Codex resumes after a crash too: `transcriptExists` finds the
+    /// `rollout-<ts>-<uuid>.jsonl` on disk via the CodexScraper (which extracts
+    /// the trailing UUID), so the ref is promoted to `.suspended` rather than
+    /// forced `.unknown`. Exact-path stat isn't constructable (date-nested,
+    /// unknown timestamp), hence the scraper-membership check.
+    func testCodexTranscriptExistsViaScraper() {
+        let fs = MockFS()
+        let codexRoot = fs.home!
+            .appendingPathComponent(".codex", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        let name = "rollout-2025-11-18T16-49-19-\(uuidA).jsonl"
+        fs.recursiveEntries[codexRoot] = [
+            ConversationFilesystemEntry(
+                url: codexRoot.appendingPathComponent("2025/11/18").appendingPathComponent(name),
+                fileName: name, mtime: Date(), size: 1024)
+        ]
+        let present = ConversationRef(kind: "codex", id: uuidA, cwd: cwd,
+                                      capturedVia: .scrape, state: .suspended)
+        XCTAssertEqual(CodexStrategy().transcriptExists(for: present, filesystem: fs), true)
+        let absent = ConversationRef(kind: "codex", id: uuidB, cwd: cwd,
+                                     capturedVia: .scrape, state: .suspended)
+        XCTAssertEqual(CodexStrategy().transcriptExists(for: absent, filesystem: fs), false)
     }
 
     // MARK: - resume: suspended is resumable, unknown/tombstoned skip


### PR DESCRIPTION
Two follow-up nits from the exact-resume review. (Re-cut clean off `origin/main` — supersedes #288, which was accidentally based on a diverged local `main` that carried the pre-squash v0.54.0 release commits.)

## Codex crash-path resume
codex/pi/omp all lacked `transcriptExists`; pi/omp got it in #281, codex was the gap. Implemented `CodexStrategy.transcriptExists` via `CodexScraper` membership (codex files are date-nested `rollout-<ts>-<uuid>.jsonl`, no constructable exact path; the scraper extracts the trailing UUID). A crashed codex surface now promotes to `.suspended` and resumes instead of being forced to `.unknown`.

## Opencode reserved-key docs (the "dead plumbing" nit)
`opencode.session_id` / `.session_project_dir` are a reserved, validated namespace that no production path writes (capture rides the plugin push + SQLite scrape rails). Docs reworded from the misleading "written by the session.created hook" to "reserved-for-future, kept validated." Grammar validators stay live (used by `OpencodeScraper`/`OpencodeStrategy`). No behavior change. (Chose document-as-reserved over wire — a redundant 3rd rail — or delete — strips future-proofing + risks the base62 guard.)

## Tests
`testCodexTranscriptExistsViaScraper` (present/absent) via a recursive-capable mock; `c11-logic` CrashRecovery suite green.

Backlog (noted, not done): scraper-walk memoization (perf at scale), shared trailing-`\n` regex anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)