### PR TITLE
test(remote): de-flake relay-cleanup tests (5s -> 30s subprocess timeout)

### DIFF
--- a/c11Tests/WorkspaceRemoteConnectionTests.swift
+++ b/c11Tests/WorkspaceRemoteConnectionTests.swift
@@ -83,7 +83,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 "-c",
                 WorkspaceRemoteSessionController.remoteRelayMetadataCleanupScript(relayPort: 64008),
             ],
-            timeout: 5
+            timeout: 30  // generous hang-guard: the script is ms-fast; 5s flaked under CI WebProcess load
         )
 
         XCTAssertFalse(result.timedOut, result.stderr)
@@ -115,7 +115,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
                 "-c",
                 WorkspaceRemoteSessionController.remoteRelayMetadataCleanupScript(relayPort: 64009),
             ],
-            timeout: 5
+            timeout: 30  // generous hang-guard: the script is ms-fast; 5s flaked under CI WebProcess load
         )
 
         XCTAssertFalse(result.timedOut, result.stderr)


### PR DESCRIPTION
Both `testRemoteRelayMetadataCleanupScript*` tests shell out to `/bin/sh` for ms-fast file ops under a 5s wall-clock hang-guard. That 5s flaked on a loaded CI runner (WebProcess/RBS assertion storm from sibling browser-panel tests) and red-failed the #292 post-merge build gate; a no-change re-run passed. Widen the guard to 30s — the tests' correctness is timing-independent. No logic change.

Validated: CI (test-only literal change; the build gate runs these tests).