### PR TITLE
fix(socket): stop the claude-hook flood from wedging the main thread (C11-156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [0.55.0] - 2026-06-30
 
-Tooling + hardening release. Headline: **`c11 tree --report` — a one-command, human-readable Markdown snapshot of your whole fleet** (every workspace's layout plus each surface's title, agent, live status, and description), built for "save the state before I close c11" handoffs. Alongside it: a workspace-navigation latch fix and socket-collision hardening so parallel c11 instances don't stomp each other's IPC socket.
+Tooling + hardening release. Headline: **`c11 tree --report` — a one-command, human-readable Markdown snapshot of your whole fleet** (every workspace's layout plus each surface's title, agent, live status, and description), built for "save the state before I close c11" handoffs. Alongside it: a fix for a main-thread hang that could beachball c11 under a heavy multi-agent fleet, a workspace-navigation latch fix, and socket-collision hardening so parallel c11 instances don't stomp each other's IPC socket.
 
 ### Added
 
@@ -16,6 +16,7 @@ Tooling + hardening release. Headline: **`c11 tree --report` — a one-command, 
 
 ### Fixed
 
+- **c11 no longer beachballs under a heavy multi-agent fleet.** Every Claude Code hook (one `c11 claude-hook` per tool call, per agent) ran its sidebar/notification socket commands on the GUI main thread, so a fleet of agents — or a crash-restore that resumed them all at once — could saturate the main thread and freeze the UI for tens of seconds. Those status/notification commands now ack off the main thread and apply asynchronously, the redundant per-hook workspace probe is gone, and agent resumes are staggered on restore. ([#296](https://github.com/Stage-11-Agentics/c11/pull/296)) (C11-156) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
 - **Workspace Previous/Next navigation no longer latches on the first workspace.** A selection latch could trap navigation on the first workspace; the Prev/Next controls release correctly now. ([#269](https://github.com/Stage-11-Agentics/c11/pull/269)) — thanks [@ajroberts0417](https://github.com/ajroberts0417)!
 - **Parallel c11 instances no longer stomp each other's IPC socket.** The control socket is namespaced per bundle, so a second instance binding its socket can't unlink a live peer's out from under it. (C11-155) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
 

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -15604,6 +15604,18 @@ struct CMUXCLI {
     }
 
     private func resolveWorkspaceIdForClaudeHook(_ raw: String?, client: SocketClient) throws -> String {
+        // C11-156: when the hook carries an explicit workspace UUID (the common
+        // case — c11 exports CMUX_WORKSPACE_ID into every hook process), trust
+        // it directly. `resolveWorkspaceId` short-circuits a UUID with zero
+        // socket calls, but the existence-probe below added a main-thread
+        // `surface.list` round-trip to EVERY hook invocation — a dominant
+        // contributor to the hook-flood main-thread hang. A stale UUID is
+        // harmless: downstream status/notify commands no-op on a missing
+        // workspace, and falling back to the *current* focused workspace would
+        // wrongly retarget another workspace's sidebar.
+        if let raw, !raw.isEmpty, isUUID(raw) {
+            return raw
+        }
         if let raw, !raw.isEmpty, let candidate = try? resolveWorkspaceId(raw, client: client) {
             let probe = try? client.sendV2(method: "surface.list", params: ["workspace_id": candidate])
             if probe != nil {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -48,6 +48,18 @@ enum SessionPersistencePolicy {
     /// queue semantics.
     static let agentRestartDelay: TimeInterval = 2.5
 
+    /// C11-156: per-agent spacing applied on top of `agentRestartDelay` when a
+    /// restore resumes more than one agent. Without it, every restored agent's
+    /// resume command is typed in the same main-queue turn, so N agents boot
+    /// and fire their SessionStart hooks (each a `conversation.push` +
+    /// `set_agent_pid` socket round-trip onto the main thread) simultaneously —
+    /// a thundering herd that, on a multi-agent workspace, beachballs the app
+    /// right after a crash-restore (observed: a fresh process stalled 44s on
+    /// resume; see ~/Library/Logs/c11/hang.log). Spreading the resumes by this
+    /// interval flattens that burst. The Nth agent resumes at
+    /// `agentRestartDelay + N * agentRestartStagger`.
+    static let agentRestartStagger: TimeInterval = 0.35
+
     private static func envFlagEnabled(_ name: String) -> Bool {
         guard let raw = ProcessInfo.processInfo.environment[name] else { return false }
         switch raw.trimmingCharacters(in: .whitespaces).lowercased() {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1919,6 +1919,27 @@ class TerminalController {
         "agent_kick",
     ]
 
+    // C11-156: fire-and-forget sidebar/notification telemetry the Claude Code
+    // hook integration issues at tool-call frequency. Each `c11 claude-hook`
+    // process (one per tool call, per agent) ends up calling these; their
+    // handlers return a bare "OK" the caller discards (`_ = try? sendV1Command`)
+    // and mutate only sidebar/notification model state. The default policy
+    // runs them under `DispatchQueue.main.sync`, so every hook blocks a
+    // socket-worker thread on the main queue. Under a multi-agent fleet — or a
+    // crash-restore mass-resume — that serialized main-sync backlog starves
+    // the run loop and beachballs the app (the 44s stall captured in
+    // ~/Library/Logs/c11/hang.log). Unlike `socketWorkerV1Commands` these
+    // don't need an off-main parse + explicit selector: we ack "OK" off-main
+    // immediately and re-enter the EXISTING handler via `main.async`, so there
+    // is zero logic duplication and the CLI never piles up blocked processes
+    // while the run loop drains status writes cooperatively.
+    private nonisolated static let asyncAckV1Commands: Set<String> = [
+        "set_status",
+        "clear_notifications",
+        "set_agent_pid",
+        "notify_target",
+    ]
+
     private nonisolated static func executionPolicy(forV2Method method: String) -> SocketCommandExecutionPolicy {
         if socketWorkerV2Methods.contains(method) {
             return .socketWorker
@@ -1986,12 +2007,36 @@ class TerminalController {
             return response
         }
 
+        if let response = asyncAckResponseIfNeeded(for: command) {
+            return response
+        }
+
         if Thread.isMainThread {
             return MainActor.assumeIsolated { self.processCommand(command) }
         }
         return DispatchQueue.main.sync {
             MainActor.assumeIsolated { self.processCommand(command) }
         }
+    }
+
+    /// C11-156: ack a fire-and-forget telemetry command off-main and apply its
+    /// mutation via `main.async`, instead of blocking a socket-worker thread on
+    /// `DispatchQueue.main.sync`. Returns nil for anything not in
+    /// `asyncAckV1Commands` (and for v2/JSON requests) so the dispatcher falls
+    /// through to its normal path. The existing `@MainActor` handler is reused
+    /// verbatim — only the scheduling changes — so behaviour is identical
+    /// except that the caller is acked before the mutation lands, which is safe
+    /// precisely because these handlers return a bare "OK" the hook discards.
+    private nonisolated func asyncAckResponseIfNeeded(for command: String) -> String? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("{") else { return nil }
+        let head = trimmed.split(separator: " ", maxSplits: 1).first.map(String.init)?.lowercased() ?? ""
+        guard Self.asyncAckV1Commands.contains(head) else { return nil }
+
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated { _ = self.processCommand(command) }
+        }
+        return "OK"
     }
 
     /// v1 telemetry worker entry. Parses head and args off-main, checks the

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -384,13 +384,17 @@ extension Workspace {
             commands.append((panelId: panelSnapshot.id, command: command))
         }
         guard !commands.isEmpty else { return }
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + SessionPersistencePolicy.agentRestartDelay
-        ) { [weak self] in
-            guard let self else { return }
-            for (panelId, command) in commands {
-                guard let terminalPanel = self.panels[panelId] as? TerminalPanel else {
-                    continue
+        // C11-156: stagger resumes (see scheduleAgentRestart) so the legacy
+        // path doesn't herd either.
+        let base = SessionPersistencePolicy.agentRestartDelay
+        let stagger = SessionPersistencePolicy.agentRestartStagger
+        for (index, (panelId, command)) in commands.enumerated() {
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + base + Double(index) * stagger
+            ) { [weak self] in
+                guard let self,
+                      let terminalPanel = self.panels[panelId] as? TerminalPanel else {
+                    return
                 }
                 TextBoxSubmit.send(command, via: terminalPanel.surface)
             }
@@ -509,12 +513,17 @@ extension Workspace {
     ) {
         let plans = pendingRestartPlans(from: snapshot, registry: registry)
         guard !plans.isEmpty else { return }
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + SessionPersistencePolicy.agentRestartDelay
-        ) { [weak self] in
-            guard let self else { return }
-            for (panelId, action) in plans {
-                self.executeResumeAction(action, on: panelId)
+        // C11-156: stagger the resumes so N agents don't all boot in the same
+        // main-queue turn and fire their SessionStart hooks at once (the
+        // mass-resume thundering herd that beachballs the app). Each agent
+        // resumes one `agentRestartStagger` after the previous.
+        let base = SessionPersistencePolicy.agentRestartDelay
+        let stagger = SessionPersistencePolicy.agentRestartStagger
+        for (index, (panelId, action)) in plans.enumerated() {
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + base + Double(index) * stagger
+            ) { [weak self] in
+                self?.executeResumeAction(action, on: panelId)
             }
         }
     }

--- a/tests_v2/test_v1_handler_main_self_deadlock.py
+++ b/tests_v2/test_v1_handler_main_self_deadlock.py
@@ -193,6 +193,11 @@ def test_v1_main_sync_handlers_return_ok(socket_path: str) -> None:
         ("report_pwd /tmp --tab=" + ws_id, lambda r: r.startswith("OK")),
         ("report_git_branch main --tab=" + ws_id, lambda r: r.startswith("OK")),
         ("clear_git_branch --tab=" + ws_id, lambda r: r.startswith("OK")),
+        # C11-156: the Claude-hook fire-and-forget commands now route through
+        # the async-ack tier (ack OK off-main, apply via main.async). They must
+        # still return OK and leave the listener up under the same dispatcher.
+        ("clear_notifications --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("set_agent_pid claude_code 99999 --tab=" + ws_id, lambda r: r.startswith("OK")),
     ]
 
     try:


### PR DESCRIPTION
## What & why

Prod c11 beachballed ~60s under a multi-agent fleet and had to be force-quit (2026-06-30). This was a **main-thread hang, not a crash** — no `.ips`, because a force-quit of a hung app produces none.

The in-app hang watchdog confirms it. `~/Library/Logs/c11/hang.log`:
- The **relaunched** process stalled **44.5s** on crash-restore (`hang.begin … stalledMs=42916`, recovered on its own) — a **crash-loop recurrence**.
- That instance hung **15+ times in the prior ~16h**, several for 25–30s.
- Every captured main-thread stack is the idle run loop (`__CFRunLoopRun`) → throughput saturation, not a single blocking handler.

### Root cause
c11's Claude Code hook integration fires `c11 claude-hook <event>` **per tool call, per agent** (`PreToolUse`, `UserPromptSubmit`, `Stop`, `SessionStart`, `Notification`, `SessionEnd`). Each invocation issues several socket round-trips — `resolve` + `set_status` / `clear_notifications` / `set_agent_pid` / `notify_target` / `conversation.push` — and **every one runs on the GUI main thread** via `processCommandUsingSocketExecutionPolicy` → `DispatchQueue.main.sync` (`TerminalController.swift`). None of the hook commands are in the off-main worker allowlists, so main-thread load scales linearly with agent count. A crash-restore that resumes **every agent at once** is a thundering herd that saturates the run loop and beachballs the app. CLI calls blocked on the wedged socket lived ~20s each, piling up processes.

**Not fixed in 0.55 before this PR** — `release/v0.55.0`'s off-main allowlists were byte-identical to HEAD. 0.55's other socket work (C11-155) is the unrelated bind-time socket-stomp bug. This is a sharper, reproduced instance of **C11-139 §B** (main-thread socket freezes), which only listed single-handler-blocks-30s cases, not this high-frequency hook-flood mode.

## The fix (three layers, all built on the existing C11-26 off-main design)

1. **Async-ack tier** (`Sources/TerminalController.swift`). The four fire-and-forget hook commands ack `OK` **off-main** and apply their mutation via `DispatchQueue.main.async`, reusing the **existing `@MainActor` handlers verbatim** (zero logic duplication). The socket-worker thread no longer blocks on the main queue; the CLI stops piling up blocked processes; the run loop drains status writes cooperatively. Safe because the hook discards the result, and FIFO ordering on the serial main queue preserves set-then-read semantics.
2. **CLI round-trip elimination** (`CLI/c11.swift`). `resolveWorkspaceIdForClaudeHook` trusts an explicit workspace UUID (the common case via `CMUX_WORKSPACE_ID`) and drops the per-hook `surface.list` existence probe. A UUID short-circuits with zero socket calls, so the resolve phase now does **no** socket round-trips on the hot path.
3. **Resume stagger** (`Sources/Workspace.swift`, `Sources/SessionPersistence.swift`). `scheduleAgentRestart{,Legacy}` space resumed agents by `agentRestartStagger` (0.35s) instead of typing every resume command in one main-queue turn — flattening the `SessionStart`→`conversation.push` herd on crash-restore.

**Net:** a `pre-tool-use` hook drops from **~6 main-thread `main.sync` round-trips → 0 resolve calls + 2 off-main async-acked mutations**.

## Testing
- `c11` (app) + `c11-cli` build green (Debug, isolated DerivedData).
- `c11-logic` suite green (0 failures).
- Extends `tests_v2/test_v1_handler_main_self_deadlock.py` to probe `clear_notifications` + `set_agent_pid` through the dispatcher (must return `OK` and keep the listener up). Set-then-read is already guarded by `test_status_entry_persistence.py` (FIFO ordering preserved).
- Full socket (`tests_v2`) + host suites run in CI.

## Notes
- Targets `release/v0.55.0` so the fix ships in 0.55. Retarget to `main` if the team prefers the release to cut from main.
- The currently-running prod instance (0.53.0) is left as-is per operator (stable enough until this lands).
- Scope intentionally tight: `set_progress`/`clear_status`/`clear_progress` share the same fire-and-forget shape and are candidates for the same async-ack treatment in a follow-up if shell-telemetry load ever warrants it.

Closes C11-156. Related: C11-139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
