### PR TITLE
fix(socket): stop the claude-hook flood from wedging the main thread (C11-156) [main]

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -15604,6 +15604,18 @@ struct CMUXCLI {
     }
 
     private func resolveWorkspaceIdForClaudeHook(_ raw: String?, client: SocketClient) throws -> String {
+        // C11-156: when the hook carries an explicit workspace UUID (the common
+        // case — c11 exports CMUX_WORKSPACE_ID into every hook process), trust
+        // it directly. `resolveWorkspaceId` short-circuits a UUID with zero
+        // socket calls, but the existence-probe below added a main-thread
+        // `surface.list` round-trip to EVERY hook invocation — a dominant
+        // contributor to the hook-flood main-thread hang. A stale UUID is
+        // harmless: downstream status/notify commands no-op on a missing
+        // workspace, and falling back to the *current* focused workspace would
+        // wrongly retarget another workspace's sidebar.
+        if let raw, !raw.isEmpty, isUUID(raw) {
+            return raw
+        }
         if let raw, !raw.isEmpty, let candidate = try? resolveWorkspaceId(raw, client: client) {
             let probe = try? client.sendV2(method: "surface.list", params: ["workspace_id": candidate])
             if probe != nil {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -48,6 +48,18 @@ enum SessionPersistencePolicy {
     /// queue semantics.
     static let agentRestartDelay: TimeInterval = 2.5
 
+    /// C11-156: per-agent spacing applied on top of `agentRestartDelay` when a
+    /// restore resumes more than one agent. Without it, every restored agent's
+    /// resume command is typed in the same main-queue turn, so N agents boot
+    /// and fire their SessionStart hooks (each a `conversation.push` +
+    /// `set_agent_pid` socket round-trip onto the main thread) simultaneously —
+    /// a thundering herd that, on a multi-agent workspace, beachballs the app
+    /// right after a crash-restore (observed: a fresh process stalled 44s on
+    /// resume; see ~/Library/Logs/c11/hang.log). Spreading the resumes by this
+    /// interval flattens that burst. The Nth agent resumes at
+    /// `agentRestartDelay + N * agentRestartStagger`.
+    static let agentRestartStagger: TimeInterval = 0.35
+
     private static func envFlagEnabled(_ name: String) -> Bool {
         guard let raw = ProcessInfo.processInfo.environment[name] else { return false }
         switch raw.trimmingCharacters(in: .whitespaces).lowercased() {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1919,6 +1919,27 @@ class TerminalController {
         "agent_kick",
     ]
 
+    // C11-156: fire-and-forget sidebar/notification telemetry the Claude Code
+    // hook integration issues at tool-call frequency. Each `c11 claude-hook`
+    // process (one per tool call, per agent) ends up calling these; their
+    // handlers return a bare "OK" the caller discards (`_ = try? sendV1Command`)
+    // and mutate only sidebar/notification model state. The default policy
+    // runs them under `DispatchQueue.main.sync`, so every hook blocks a
+    // socket-worker thread on the main queue. Under a multi-agent fleet — or a
+    // crash-restore mass-resume — that serialized main-sync backlog starves
+    // the run loop and beachballs the app (the 44s stall captured in
+    // ~/Library/Logs/c11/hang.log). Unlike `socketWorkerV1Commands` these
+    // don't need an off-main parse + explicit selector: we ack "OK" off-main
+    // immediately and re-enter the EXISTING handler via `main.async`, so there
+    // is zero logic duplication and the CLI never piles up blocked processes
+    // while the run loop drains status writes cooperatively.
+    private nonisolated static let asyncAckV1Commands: Set<String> = [
+        "set_status",
+        "clear_notifications",
+        "set_agent_pid",
+        "notify_target",
+    ]
+
     private nonisolated static func executionPolicy(forV2Method method: String) -> SocketCommandExecutionPolicy {
         if socketWorkerV2Methods.contains(method) {
             return .socketWorker
@@ -1986,12 +2007,36 @@ class TerminalController {
             return response
         }
 
+        if let response = asyncAckResponseIfNeeded(for: command) {
+            return response
+        }
+
         if Thread.isMainThread {
             return MainActor.assumeIsolated { self.processCommand(command) }
         }
         return DispatchQueue.main.sync {
             MainActor.assumeIsolated { self.processCommand(command) }
         }
+    }
+
+    /// C11-156: ack a fire-and-forget telemetry command off-main and apply its
+    /// mutation via `main.async`, instead of blocking a socket-worker thread on
+    /// `DispatchQueue.main.sync`. Returns nil for anything not in
+    /// `asyncAckV1Commands` (and for v2/JSON requests) so the dispatcher falls
+    /// through to its normal path. The existing `@MainActor` handler is reused
+    /// verbatim — only the scheduling changes — so behaviour is identical
+    /// except that the caller is acked before the mutation lands, which is safe
+    /// precisely because these handlers return a bare "OK" the hook discards.
+    private nonisolated func asyncAckResponseIfNeeded(for command: String) -> String? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("{") else { return nil }
+        let head = trimmed.split(separator: " ", maxSplits: 1).first.map(String.init)?.lowercased() ?? ""
+        guard Self.asyncAckV1Commands.contains(head) else { return nil }
+
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated { _ = self.processCommand(command) }
+        }
+        return "OK"
     }
 
     /// v1 telemetry worker entry. Parses head and args off-main, checks the

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -384,13 +384,17 @@ extension Workspace {
             commands.append((panelId: panelSnapshot.id, command: command))
         }
         guard !commands.isEmpty else { return }
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + SessionPersistencePolicy.agentRestartDelay
-        ) { [weak self] in
-            guard let self else { return }
-            for (panelId, command) in commands {
-                guard let terminalPanel = self.panels[panelId] as? TerminalPanel else {
-                    continue
+        // C11-156: stagger resumes (see scheduleAgentRestart) so the legacy
+        // path doesn't herd either.
+        let base = SessionPersistencePolicy.agentRestartDelay
+        let stagger = SessionPersistencePolicy.agentRestartStagger
+        for (index, (panelId, command)) in commands.enumerated() {
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + base + Double(index) * stagger
+            ) { [weak self] in
+                guard let self,
+                      let terminalPanel = self.panels[panelId] as? TerminalPanel else {
+                    return
                 }
                 TextBoxSubmit.send(command, via: terminalPanel.surface)
             }
@@ -509,12 +513,17 @@ extension Workspace {
     ) {
         let plans = pendingRestartPlans(from: snapshot, registry: registry)
         guard !plans.isEmpty else { return }
-        DispatchQueue.main.asyncAfter(
-            deadline: .now() + SessionPersistencePolicy.agentRestartDelay
-        ) { [weak self] in
-            guard let self else { return }
-            for (panelId, action) in plans {
-                self.executeResumeAction(action, on: panelId)
+        // C11-156: stagger the resumes so N agents don't all boot in the same
+        // main-queue turn and fire their SessionStart hooks at once (the
+        // mass-resume thundering herd that beachballs the app). Each agent
+        // resumes one `agentRestartStagger` after the previous.
+        let base = SessionPersistencePolicy.agentRestartDelay
+        let stagger = SessionPersistencePolicy.agentRestartStagger
+        for (index, (panelId, action)) in plans.enumerated() {
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + base + Double(index) * stagger
+            ) { [weak self] in
+                self?.executeResumeAction(action, on: panelId)
             }
         }
     }

--- a/tests_v2/test_v1_handler_main_self_deadlock.py
+++ b/tests_v2/test_v1_handler_main_self_deadlock.py
@@ -193,6 +193,11 @@ def test_v1_main_sync_handlers_return_ok(socket_path: str) -> None:
         ("report_pwd /tmp --tab=" + ws_id, lambda r: r.startswith("OK")),
         ("report_git_branch main --tab=" + ws_id, lambda r: r.startswith("OK")),
         ("clear_git_branch --tab=" + ws_id, lambda r: r.startswith("OK")),
+        # C11-156: the Claude-hook fire-and-forget commands now route through
+        # the async-ack tier (ack OK off-main, apply via main.async). They must
+        # still return OK and leave the listener up under the same dispatcher.
+        ("clear_notifications --tab=" + ws_id, lambda r: r.startswith("OK")),
+        ("set_agent_pid claude_code 99999 --tab=" + ws_id, lambda r: r.startswith("OK")),
     ]
 
     try:


### PR DESCRIPTION
Same fix as #296, cherry-picked onto `main` so main doesn't lag the `release/v0.55.0` branch on this stability fix.

**Identical commit content** to #296 (`set_status`/`clear_notifications`/`set_agent_pid`/`notify_target` async-ack tier + drop the per-hook `surface.list` probe + 0.35s resume stagger). Cherry-picked rather than branch-merged so the `0.55.0` version bump that lives only on `release/v0.55.0` is **not** dragged into main. When `release/v0.55.0` later merges back to main, the identical change is recognized → no conflict.

See #296 for the full root-cause writeup and the hang-watchdog evidence. TL;DR: c11's Claude Code hook integration runs every per-tool-call hook command on the GUI main thread via `DispatchQueue.main.sync`; under a multi-agent fleet (and especially a crash-restore mass-resume) that serialized backlog starves the run loop and beachballs the app (44.5s stall captured in `~/Library/Logs/c11/hang.log`). A sharper, reproduced instance of C11-139 §B.

- `c11` + `c11-cli` build green; `c11-logic` green (validated on the `release/v0.55.0` branch with the same commit).
- Extends `tests_v2/test_v1_handler_main_self_deadlock.py`; full socket + host suites run in CI here.

Closes C11-156 (with #296). Related: C11-139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
