### PR TITLE
fix(skills): stop Agent Skills onboarding sheet re-firing every launch (v0.55)

### DIFF
--- a/Sources/AgentSkillsView.swift
+++ b/Sources/AgentSkillsView.swift
@@ -20,7 +20,17 @@ final class AgentSkillsModel: ObservableObject {
             packages.contains { $0.state == .installedOutdated || $0.state == .installedNoManifest || $0.state == .schemaMismatch }
         }
         var needsInstallOrUpdate: Bool {
-            !isSharedDestination && !packages.isEmpty && packages.contains { $0.state == .notInstalled || $0.state == .installedOutdated }
+            // Single source of truth with the auto-show gate: a row is
+            // actionable iff `AgentSkillsOnboarding.shouldRowOffer` (the same
+            // classifier `shouldPresent` uses) would offer one of its packages.
+            // This must stay aligned with the gate — if it counts fewer states
+            // than the gate offers (it previously omitted `.installedNoManifest`
+            // and `.schemaMismatch`), such a row auto-pops the sheet yet renders
+            // the celebratory "Done" branch whose handler persists nothing, so
+            // the sheet re-fires on every launch with no way for the operator to
+            // resolve it. Shared destinations stay non-actionable; their owner
+            // row carries the same on-disk state and remains offerable.
+            !isSharedDestination && packages.contains { AgentSkillsOnboarding.shouldRowOffer($0) }
         }
         var anyInstalled: Bool {
             packages.contains { $0.state != .notInstalled }

--- a/Sources/SkillInstaller.swift
+++ b/Sources/SkillInstaller.swift
@@ -105,7 +105,7 @@ struct SkillInstallerRecord: Codable, Equatable {
     }
 }
 
-enum SkillInstallerState: String, Equatable {
+enum SkillInstallerState: String, Equatable, CaseIterable {
     case notInstalled
     case installedCurrent
     case installedOutdated

--- a/c11Tests/SocketControlPasswordStoreTests.swift
+++ b/c11Tests/SocketControlPasswordStoreTests.swift
@@ -614,6 +614,55 @@ final class AgentSkillsOnboardingDefaultOptInTests: XCTestCase {
         XCTAssertFalse(AgentSkillsOnboarding.shouldOffer(for: rows))
     }
 
+    // C11 Bug B: a detected row whose only non-current package is
+    // `.installedNoManifest` or `.schemaMismatch` is offered by the auto-show
+    // gate (`shouldRowOffer`) but used to be excluded from the sheet's
+    // `needsInstallOrUpdate`, so it rendered the celebratory "Done" branch whose
+    // handler persists nothing → the onboarding sheet re-fired on every launch.
+    // These two states must be actionable so the sheet shows a real "Update"
+    // path instead of a dead-end "Done".
+    func testNoManifestRowIsActionable() {
+        let row = makeRow(target: .claude, detected: true, states: [.installedNoManifest])
+        XCTAssertTrue(row.needsInstallOrUpdate)
+        XCTAssertTrue(AgentSkillsOnboarding.shouldOffer(for: [row]))
+    }
+
+    func testSchemaMismatchRowIsActionable() {
+        let row = makeRow(target: .claude, detected: true, states: [.schemaMismatch])
+        XCTAssertTrue(row.needsInstallOrUpdate)
+        XCTAssertTrue(AgentSkillsOnboarding.shouldOffer(for: [row]))
+    }
+
+    // Structural invariant pinning the sheet's actionable predicate to the gate:
+    // for EVERY state the auto-show gate would offer (`shouldRowOffer == true`), a
+    // detected, non-shared, single-package row in that state must report
+    // `needsInstallOrUpdate == true`. If the two ever diverge again, an offered
+    // row could land in the celebratory branch and re-fire forever.
+    func testActionablePredicateCoversEveryOfferedState() {
+        for state in SkillInstallerState.allCases {
+            let row = makeRow(target: .claude, detected: true, states: [state])
+            let offeredByGate = AgentSkillsOnboarding.shouldRowOffer(makeStatus(target: .claude, state: state))
+            if offeredByGate {
+                XCTAssertTrue(
+                    row.needsInstallOrUpdate,
+                    "state \(state) is offered by the auto-show gate but the sheet treats it as non-actionable — celebratory 'Done' would persist nothing and the sheet would re-fire"
+                )
+            } else {
+                XCTAssertFalse(
+                    row.needsInstallOrUpdate,
+                    "state \(state) is not offered by the gate but the sheet treats it as actionable"
+                )
+            }
+        }
+    }
+
+    // A shared-destination row stays non-actionable even in an offered state, so
+    // the sheet doesn't double-count it; its non-shared owner carries the action.
+    func testSharedNoManifestRowIsNotActionable() {
+        let row = makeRow(target: .codex, detected: true, states: [.installedNoManifest], sharedWith: .claude)
+        XCTAssertFalse(row.needsInstallOrUpdate)
+    }
+
     private func makeRow(
         target: SkillInstallerTarget,
         detected: Bool,

--- a/docs/skills-sheet-refire-rootcause.md
+++ b/docs/skills-sheet-refire-rootcause.md
@@ -1,0 +1,94 @@
+# Bug B — Agent Skills onboarding sheet re-fires on every launch
+
+## Symptom
+On a non-dev **Release** build (v0.55.0 staging, `com.stage11.c11.staging.rel.v0.55.0`),
+the **c11 Agent Skills** onboarding sheet appears on **every** launch. The header is the
+celebratory *"Your agent is current with c11. / Every detected agent has the latest c11
+skill set,"* most rows read **"Already current,"** but exactly one row reads **"Will update
+the installed skill."** The primary button is **"Done."** Clicking **Done** and relaunching
+shows the identical sheet again — it never stops, even though nothing on disk changed.
+
+## Root cause — a predicate mismatch between the auto-show gate and the sheet
+
+Two predicates disagree about whether a skill row in state `.installedNoManifest` or
+`.schemaMismatch` is "something to act on":
+
+1. **The auto-show gate** — `AgentSkillsOnboarding.shouldPresent()` (the
+   `applicationDidBecomeActive` trigger) iterates each detected target's package statuses and
+   calls `shouldRowOffer(status)`, which returns **true** for
+   `.notInstalled`, `.installedOutdated`, `.installedNoManifest`, **and** `.schemaMismatch`.
+   For any such row with no matching hash-pinned dismissal, `shouldPresent` returns `true`
+   and the sheet auto-pops.
+
+2. **The sheet's "actionable" predicate** — the view's `hasActionNeeded` is driven by
+   `TargetRow.needsInstallOrUpdate`, which only counted `.notInstalled` and `.installedOutdated`
+   (and excluded shared destinations). It did **not** count `.installedNoManifest` or
+   `.schemaMismatch`.
+
+So a detected target whose only non-current package is `.installedNoManifest` or
+`.schemaMismatch` lands in a contradictory state:
+
+- The gate **offers** it (`shouldPresent == true`) → the sheet auto-shows.
+- The sheet thinks nothing needs action (`hasActionNeeded == false`) → it renders its
+  **celebratory** branch: header "…is current with c11", primary button **"Done"**, and the
+  row's checkbox is **disabled** (`.disabled(!row.detected || !row.needsInstallOrUpdate)`).
+  The row still shows **"Will update the installed skill"** because the label uses
+  `row.hasOutdated`, which *does* include `.installedNoManifest`/`.schemaMismatch`.
+
+Clicking **Done** runs `activatePrimaryAction()` → celebratory branch → `onDismiss()` **only**.
+It does not install, does not call `recordDismissalsForUncheckedRows` (the hash-pinned
+persistence the "Later" and "Update selected" paths use), and does not even set the in-memory
+`markDismissedThisLaunch()` flag. Nothing is persisted.
+
+Next launch, `shouldPresent` sees the same offerable row with no stored dismissal → returns
+`true` → the sheet re-fires. Forever. The operator has no way out: the checkbox is disabled,
+and the only button is a "Done" that fixes nothing. This is exactly "hit Done, relaunch, same
+sheet, nothing changed."
+
+### Why it surfaced in v0.55 staging but is pre-existing
+The bug is latent until an operator has a skill on disk in `.installedNoManifest`
+(directory present but no `.c11-skill.json` marker, or an undecodable / package-name-mismatched
+marker) or `.schemaMismatch` (marker present but an older `schema` version). That happens
+naturally after upgrading across a marker-schema bump, or when a skill folder was hand-copied.
+The v0.54 "stops over-firing" work added hash-pinned dismissal persistence to the **Later** and
+**Update selected** paths, but the **celebratory Done** path was never wired to persist
+anything — and the row-class mismatch is what funnels these rows into that path. It predates
+v0.55.
+
+## Fix
+Make the sheet's actionable predicate share the gate's offer predicate as a single source of
+truth, so they can never disagree:
+
+```swift
+var needsInstallOrUpdate: Bool {
+    // Single source of truth with the auto-show gate: a row is actionable iff
+    // the gate (AgentSkillsOnboarding.shouldRowOffer / shouldPresent) would offer
+    // any of its packages. Keeps shared destinations non-actionable.
+    !isSharedDestination && packages.contains { AgentSkillsOnboarding.shouldRowOffer($0) }
+}
+```
+
+Effect on the repro: a `.installedNoManifest` / `.schemaMismatch` row now makes
+`hasActionNeeded == true`, so the sheet renders its **non-celebratory** branch — header "Your
+agent already knows c11," an **enabled** checkbox, and an **"Update all" / "Update selected"**
+button. Clicking it calls `model.install(force: true)`, which replaces the directory and writes
+a fresh schema-current manifest → `.installedCurrent`; the install result lists it under
+`refreshed`, which calls `clearDismissal`. Next launch the gate sees `.installedCurrent`
+(`shouldRowOffer == false`) → no re-fire. If the operator instead clicks **Later** or **Don't
+ask again**, those paths already persist a hash-pinned dismissal / global opt-out, so they
+suppress re-fire too.
+
+Because owner/shared rows that point at the same directory share the same on-disk state, any
+offerable shared row always has a non-shared owner row in the same state — so unifying the
+predicate also guarantees the celebratory branch is only ever reached when there is genuinely
+nothing offerable (all `.installedCurrent`), where "Done" doing nothing is correct.
+
+## Regression test
+`AgentSkillsOnboardingDefaultOptInTests` (c11LogicTests target):
+- A detected, non-shared row whose only package is `.installedNoManifest` (and again
+  `.schemaMismatch`) must report `needsInstallOrUpdate == true` and make
+  `AgentSkillsOnboarding.shouldOffer(for: rows) == true`.
+- Structural invariant: for **every** `SkillInstallerState` the gate would offer
+  (`shouldRowOffer == true`), a detected non-shared single-package row in that state must be
+  `needsInstallOrUpdate == true`. This pins the two predicates together so they cannot drift
+  apart again.


### PR DESCRIPTION
v0.55 backport of #298 (cherry-pick onto `release/v0.55.0`).

Found in **v0.55.0 staging smoke**: the **c11 Agent Skills** onboarding sheet re-fires on every launch of a non-dev Release build, with the operator unable to dismiss it permanently (celebratory "Done" path persists nothing).

**Root cause:** the auto-show gate (`shouldRowOffer`) offers `.installedNoManifest`/`.schemaMismatch` rows, but the sheet's `needsInstallOrUpdate` didn't count them, so they rendered the celebratory "Done" branch (disabled checkbox, no persistence) → re-fire. Pre-existing.

**Fix:** unify the sheet's actionable predicate with the gate's classifier (single source of truth) so those rows render the real "Update all" path, which reinstalls → `.installedCurrent` → `clearDismissal` → no re-fire.

Tests: 4 new c11LogicTests (incl. an exhaustive invariant pinning the two predicates together; `SkillInstallerState` made `CaseIterable`). Full write-up in `docs/skills-sheet-refire-rootcause.md`.

See #298 for the full description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)