### PR TITLE
fix(conversation): Bug A session-resume — pi/omp wrapper-claim + claude wrapper-claim typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pi and oh-my-pi resume no longer skip when a working directory holds more than one session.** Pi/omp resolve their session id by scraping the cwd's session store at restore time, but with no launch-time claim the scrape had no way to tell a heavily-used cwd's accumulated sessions apart — so it returned "ambiguous" and the pane came up fresh instead of resuming (the v0.55 staging "Pi did not resume" report). New PATH-scoped `pi` and `omp` wrappers mint a wrapper-claim at launch (mirroring the codex wrapper), giving the restore scrape a time floor that narrows past the stale sessions to this pane's own.
+
 ## [0.54.0] - 2026-06-29
 
 Feature release. Headline: **exact-session conversation resume arrives for Pi, oh-my-pi, and opencode — when c11 restores a workspace, these agents reconnect to the exact session they were in before the restart, not a fresh shell.** Alongside it: Pi and oh-my-pi become first-class agents via a new data-driven registry, splits get size-aware, the tab bar collapses responsively when space runs short, four new chrome themes ship, and surfaces now export the `C11_*` environment namespace the skill documents.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ### Fixed
 
+- **Claude Code wrapper-claim fallback now actually fires.** A `cmux` → `c11` rename left `Resources/bin/claude` testing an undefined variable (`cmux_set_agent_bin` instead of the assigned `C11_SET_AGENT_BIN`), so `conversation claim --kind claude-code` was silently skipped. The documented fallback — meant to leave a resumable claim when the SessionStart hook is dropped (e.g. under a multi-agent socket flood) — never ran. One-line fix restores it.
 - **Pi and oh-my-pi resume no longer skip when a working directory holds more than one session.** Pi/omp resolve their session id by scraping the cwd's session store at restore time, but with no launch-time claim the scrape had no way to tell a heavily-used cwd's accumulated sessions apart — so it returned "ambiguous" and the pane came up fresh instead of resuming (the v0.55 staging "Pi did not resume" report). New PATH-scoped `pi` and `omp` wrappers mint a wrapper-claim at launch (mirroring the codex wrapper), giving the restore scrape a time floor that narrows past the stale sessions to this pane's own.
 
 ## [0.54.0] - 2026-06-29

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -265,6 +265,8 @@
 		C116000100A1B2C3D4E5F010 /* ChromeScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000200A1B2C3D4E5F010 /* ChromeScale.swift */; };
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
 		C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1CDE00001A1B2C3D4E5F719 /* codex */; };
+		C1F1E00002A1B2C3D4E5F719 /* pi in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F1E00001A1B2C3D4E5F719 /* pi */; };
+		C1F2E00002A1B2C3D4E5F719 /* omp in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F2E00001A1B2C3D4E5F719 /* omp */; };
 		C22557799917F42164A6C855 /* TitlebarSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F01B /* TitlebarSnapshotTests.swift */; };
 		C49B42317DA68794CC9C29E4 /* MailboxULIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7105BF1A1B2C3D4E5F60718 /* MailboxULIDTests.swift */; };
 		C622796239CFCFB69D68C5D9 /* CLIHealthRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH015BF1A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift */; };
@@ -422,6 +424,8 @@
 				B900000BA1B2C3D4E5F60719 /* c11 in Copy CLI */,
 				C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */,
 				C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */,
+				C1F1E00002A1B2C3D4E5F719 /* pi in Copy CLI */,
+				C1F2E00002A1B2C3D4E5F719 /* omp in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
 				4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */,
 			);
@@ -648,6 +652,8 @@
 		C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyChromeScaleTests.swift; sourceTree = "<group>"; };
 		C1ADE00001A1B2C3D4E5F719 /* claude */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/claude; sourceTree = SOURCE_ROOT; };
 		C1CDE00001A1B2C3D4E5F719 /* codex */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/codex; sourceTree = SOURCE_ROOT; };
+		C1F1E00001A1B2C3D4E5F719 /* pi */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/pi; sourceTree = SOURCE_ROOT; };
+		C1F2E00001A1B2C3D4E5F719 /* omp */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/omp; sourceTree = SOURCE_ROOT; };
 		C28AE9F41DE55AB88CAE431D /* AgentManifest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
 		C2BBF3CDB766B1FCF30BB765 /* LaunchResumePicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LaunchResumePicker.swift; sourceTree = "<group>"; };
 		C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OpencodeResumeTests.swift; path = OpencodeResumeTests.swift; sourceTree = "<group>"; };
@@ -838,6 +844,8 @@
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
 				C1ADE00001A1B2C3D4E5F719 /* claude */,
 				C1CDE00001A1B2C3D4E5F719 /* codex */,
+				C1F1E00001A1B2C3D4E5F719 /* pi */,
+				C1F2E00001A1B2C3D4E5F719 /* omp */,
 				D8017BF1A1B2C3D4E5F60718 /* Blueprints */,
 				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -194,7 +194,7 @@ c11_conversation_claim_bg() {
     ) &
     disown 2>/dev/null || true
 }
-[[ -n "$cmux_set_agent_bin" ]] && c11_conversation_claim_bg "$cmux_set_agent_bin"
+[[ -n "$C11_SET_AGENT_BIN" ]] && c11_conversation_claim_bg "$C11_SET_AGENT_BIN"
 
 # Build hooks settings JSON.
 # Claude Code merges --settings additively with the user's own settings.json.

--- a/Resources/bin/omp
+++ b/Resources/bin/omp
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# c11 omp wrapper - session-resume capture for oh-my-pi (omp).
+#
+# When running inside a c11 terminal (CMUX_SURFACE_ID set + socket live),
+# this wrapper:
+#   1. declares the surface as terminal_type=omp (sidebar chip / role hint),
+#      and
+#   2. wrapper-claims a placeholder ConversationRef so c11's conversation
+#      store records a post-launch claim time before omp creates its
+#      session file. The OmpStrategy's pull-scrape on next workspace open
+#      then keeps only candidates whose mtime is >= that claim time, which
+#      floors out the older sessions that accumulate in a cwd's slug dir
+#      (`~/.omp/agent/sessions/<slug>/`) so exact resume resolves *this*
+#      pane's session instead of going ambiguous.
+#
+# Outside c11 (or when the socket is unreachable), it passes through to the
+# real omp binary unchanged.
+#
+# === Why this exists (the "pi fails, omp passes" resume bug) =================
+# omp resumes scrape-primary, exactly like pi: c11 resolves the real session
+# id at restore time from the cwd's slug dir, and omp exposes no SessionStart
+# hook to learn the id while it runs. Without a wrapper-claim the restore
+# scrape has no time floor, so a cwd with more than one omp session resolves
+# to state=unknown and resume SKIPS. omp happened to pass the staging smoke
+# because its slug dirs usually hold one session, but it carries the same
+# latent bug pi hit; this wrapper gives omp the codex-style time floor too.
+#
+# See `Resources/bin/claude` for the reference implementation of the
+# session-resume wrapper pattern and the four constraints all wrappers
+# must honour.
+
+set -uo pipefail
+
+# Find the real omp binary, skipping our own directory.
+find_real_omp() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/omp" ]] && printf '%s' "$d/omp" && return 0
+    done
+    return 1
+}
+
+# Return 0 only when CMUX_SOCKET_PATH points to a live c11 socket.
+c11_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir c11_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    c11_bin="$self_dir/c11"
+    [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+    [[ -n "$c11_bin" ]] || return 1
+
+    # Bounded check so omp startup isn't blocked behind the CLI default
+    # timeout when the socket is stale or hung.
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$c11_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+# Pass through if not in a c11 terminal, hooks are disabled, or the socket
+# is unavailable.
+IN_C11=0
+if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
+    IN_C11=1
+fi
+
+if [[ "$IN_C11" == "0" || "${CMUX_OMP_HOOKS_DISABLED:-}" == "1" ]] || ! c11_socket_available; then
+    REAL_OMP="$(find_real_omp)" || { echo "Error: omp not found in PATH" >&2; exit 127; }
+    exec "$REAL_OMP" "$@"
+fi
+
+REAL_OMP="$(find_real_omp)" || { echo "Error: omp not found in PATH" >&2; exit 127; }
+
+# Pass through invocations that are not interactive sessions so they don't
+# flip the surface's terminal_type to "omp" or mint a bogus claim. omp's
+# management/auxiliary subcommands and its non-interactive flags
+# (-p/--print, --export, --list-models, --help, --version) all exit
+# without an interactive session.
+case "${1:-}" in
+    install|remove|uninstall|update|list|config|join|dry-balance|tiny-models|help|--help|-h|--version|-v)
+        exec "$REAL_OMP" "$@"
+        ;;
+esac
+for arg in "$@"; do
+    case "$arg" in
+        -p|--print|--export|--list-models)
+            exec "$REAL_OMP" "$@"
+            ;;
+    esac
+done
+
+# Resolve the c11 binary (bundle-relative first, fall back to PATH so a
+# misconfigured bundle still works in dev builds).
+self_dir="$(cd "$(dirname "$0")" && pwd)"
+c11_bin="$self_dir/c11"
+[[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+
+# (1) Mark the surface as terminal_type=omp (sidebar chip / role hint).
+# (2) Wrapper-claim a placeholder ConversationRef so the conversation store
+#     records a post-launch claim time. Idempotent: a second invocation in
+#     the same surface cannot regress a real id back to a placeholder
+#     (ConversationStore.claim never displaces a non-wrapperClaim source).
+#
+# Both run in the background so omp startup latency is unaffected; `disown`
+# so a stale write can't keep the wrapper process alive after `exec` (moot
+# since exec replaces this process anyway, but defensive).
+if [[ -n "$c11_bin" ]]; then
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" set-agent --type omp \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" \
+            conversation claim --kind omp --cwd "$PWD" \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+fi
+
+exec "$REAL_OMP" "$@"

--- a/Resources/bin/pi
+++ b/Resources/bin/pi
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# c11 pi wrapper - session-resume capture for pi.
+#
+# When running inside a c11 terminal (CMUX_SURFACE_ID set + socket live),
+# this wrapper:
+#   1. declares the surface as terminal_type=pi (sidebar chip / role hint),
+#      and
+#   2. wrapper-claims a placeholder ConversationRef so c11's conversation
+#      store records a post-launch claim time before pi creates its
+#      session file. The PiStrategy's pull-scrape on next workspace open
+#      then keeps only candidates whose mtime is >= that claim time, which
+#      floors out the older sessions that accumulate in a cwd's slug dir
+#      (`~/.pi/agent/sessions/<slug>/`) so exact resume resolves *this*
+#      pane's session instead of going ambiguous.
+#
+# Outside c11 (or when the socket is unreachable), it passes through to the
+# real pi binary unchanged.
+#
+# === Why this exists (the "pi fails, omp passes" resume bug) =================
+# pi (and omp) resume scrape-primary: c11 resolves the real session id at
+# restore time from the cwd's slug dir. pi exposes no SessionStart hook and
+# no session-id injection flag, so c11 cannot learn the id while pi runs.
+# Without a wrapper-claim, the restore scrape has NO time floor: every
+# session in the pane's cwd is an equal candidate, so a cwd with more than
+# one pi session resolves to state=unknown and resume SKIPS (the pane comes
+# up fresh). pi is used heavily, so its slug dirs accumulate sessions and
+# this fires often; omp, used less, usually has one session per cwd and so
+# resumed by luck. Codex already avoided this via exactly this wrapper-claim
+# pattern; this wrapper gives pi the same time floor.
+#
+# See `Resources/bin/claude` for the reference implementation of the
+# session-resume wrapper pattern and the four constraints all wrappers
+# must honour.
+
+set -uo pipefail
+
+# Find the real pi binary, skipping our own directory.
+find_real_pi() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/pi" ]] && printf '%s' "$d/pi" && return 0
+    done
+    return 1
+}
+
+# Return 0 only when CMUX_SOCKET_PATH points to a live c11 socket.
+c11_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir c11_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    c11_bin="$self_dir/c11"
+    [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+    [[ -n "$c11_bin" ]] || return 1
+
+    # Bounded check so pi startup isn't blocked behind the CLI default
+    # timeout when the socket is stale or hung.
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$c11_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+# Pass through if not in a c11 terminal, hooks are disabled, or the socket
+# is unavailable.
+IN_C11=0
+if [[ -n "${CMUX_SURFACE_ID:-}" ]]; then
+    IN_C11=1
+fi
+
+if [[ "$IN_C11" == "0" || "${CMUX_PI_HOOKS_DISABLED:-}" == "1" ]] || ! c11_socket_available; then
+    REAL_PI="$(find_real_pi)" || { echo "Error: pi not found in PATH" >&2; exit 127; }
+    exec "$REAL_PI" "$@"
+fi
+
+REAL_PI="$(find_real_pi)" || { echo "Error: pi not found in PATH" >&2; exit 127; }
+
+# Pass through invocations that are not interactive sessions so they don't
+# flip the surface's terminal_type to "pi" or mint a bogus claim. pi's
+# management subcommands (install/remove/update/list/config) and its
+# non-interactive flags (-p/--print, --export, --list-models, --help,
+# --version) all exit without an interactive session.
+case "${1:-}" in
+    install|remove|uninstall|update|list|config|help|--help|-h|--version|-v)
+        exec "$REAL_PI" "$@"
+        ;;
+esac
+for arg in "$@"; do
+    case "$arg" in
+        -p|--print|--export|--list-models)
+            exec "$REAL_PI" "$@"
+            ;;
+    esac
+done
+
+# Resolve the c11 binary (bundle-relative first, fall back to PATH so a
+# misconfigured bundle still works in dev builds).
+self_dir="$(cd "$(dirname "$0")" && pwd)"
+c11_bin="$self_dir/c11"
+[[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+
+# (1) Mark the surface as terminal_type=pi (sidebar chip / role hint).
+# (2) Wrapper-claim a placeholder ConversationRef so the conversation store
+#     records a post-launch claim time. Idempotent: a second invocation in
+#     the same surface cannot regress a real id back to a placeholder
+#     (ConversationStore.claim never displaces a non-wrapperClaim source).
+#
+# Both run in the background so pi startup latency is unaffected; `disown`
+# so a stale write can't keep the wrapper process alive after `exec` (moot
+# since exec replaces this process anyway, but defensive).
+if [[ -n "$c11_bin" ]]; then
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" set-agent --type pi \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" \
+            conversation claim --kind pi --cwd "$PWD" \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+fi
+
+exec "$REAL_PI" "$@"

--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -230,9 +230,11 @@ struct AgentRegistry: Sendable {
             sfSymbolFallback: "p.circle",
             // `pi -c` continues the most recent session in cwd (best-effort
             // phase-1 fallback, same shape as codex --last). Exact-session
-            // resume is handled by the scrape rail: `PiScraper` +
-            // `PiStrategy` resolve a specific `~/.pi/agent/sessions/` id and
-            // type `pi --session '<id>'`.
+            // resume is handled by the scrape rail: the pi wrapper
+            // (`Resources/bin/pi`) mints a wrapper-claim whose time floor lets
+            // `PiScraper` + `PiStrategy` resolve a specific
+            // `~/.pi/agent/sessions/` id and type `pi --session '<id>'` even
+            // when the cwd holds several sessions.
             resume: .fixed("pi -c\n"),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -247,12 +249,13 @@ struct AgentRegistry: Sendable {
             detectNodeArgsSubstrings: ["@oh-my-pi/"],
             iconAsset: nil,
             sfSymbolFallback: "o.circle",
-            // Exact-session resume via the conversation rail: `OmpScraper`
-            // (JSONL metadata over ~/.omp/agent/sessions/) feeds `OmpStrategy`,
-            // which emits `omp --resume='<id>'`. No fixed-command fallback
-            // exists for the legacy `resume` path (the TUI offers `/resume`
-            // only), so `resume` stays `.none` while the strategy owns exact
-            // resume — same split as the codex row.
+            // Exact-session resume via the conversation rail: the omp wrapper
+            // (`Resources/bin/omp`) mints a wrapper-claim whose time floor lets
+            // `OmpScraper` (JSONL metadata over ~/.omp/agent/sessions/) feed
+            // `OmpStrategy`, which emits `omp --resume='<id>'`. No fixed-command
+            // fallback exists for the legacy `resume` path (the TUI offers
+            // `/resume` only), so `resume` stays `.none` while the strategy owns
+            // exact resume — same split as the codex row.
             resume: .none,
             isCanonicalTerminalType: true,
             hasConversationStrategy: true

--- a/Sources/Conversation/Scrapers/PiScraper.swift
+++ b/Sources/Conversation/Scrapers/PiScraper.swift
@@ -19,14 +19,15 @@ import Foundation
 ///
 /// 2. **cwd-scoped lookup.** pi stores sessions under a **per-cwd slug
 ///    directory** (`~/.pi/agent/sessions/<slug>/`) and resolves sessions by
-///    cwd itself. Unlike codex, pi has no wrapper-claim time floor and no
-///    SessionStart hook, so a whole-tree top-N scrape would return candidates
-///    from every project and `PiStrategy.capture` would see them all as
-///    ambiguous (its cwd filter can't help once every candidate is stamped
-///    with the surface cwd). To make the cwd actually narrow — so exact
-///    resume can fire — when a `cwd` is known the scraper scopes its walk to
-///    that cwd's slug directory (pi's own model). With no `cwd` it falls back
-///    to the whole-tree top-N (best-effort, e.g. a surface with no recorded
+///    cwd itself. The pi wrapper (`Resources/bin/pi`) supplies a
+///    wrapper-claim *time* floor (like codex), but that alone can't narrow by
+///    project: a whole-tree top-N scrape would return candidates from every
+///    project, and several of them could post-date the claim time. So the
+///    cwd slug directory is the project-level narrowing the claim can't do —
+///    when a `cwd` is known the scraper scopes its walk to that cwd's slug
+///    directory (pi's own model); the claim time then narrows *within* that
+///    cwd to this pane's session. With no `cwd` it falls back to the
+///    whole-tree top-N (best-effort, e.g. a surface with no recorded
 ///    directory).
 struct PiScraper: ConversationScraper {
     let kind: String = "pi"

--- a/Sources/Conversation/Strategies/Omp.swift
+++ b/Sources/Conversation/Strategies/Omp.swift
@@ -1,10 +1,14 @@
 import Foundation
 
 /// Pull-primary strategy for oh-my-pi (`omp`). Like codex, omp exposes no
-/// session-id injection flag and no SessionStart hook; the scraper resolves
-/// the real id from `~/.omp/agent/sessions/<cwd-slug>/<ts>_<uuid>.jsonl`
-/// (id = the trailing UUIDv7), filtered by cwd, mtime ≥ wrapper-claim time,
-/// and mtime ≥ surface `lastActivityTimestamp`.
+/// session-id injection flag and no SessionStart hook, so the c11 omp wrapper
+/// (`Resources/bin/omp`) mints a placeholder wrapper-claim at launch; the
+/// scraper resolves the real id from
+/// `~/.omp/agent/sessions/<cwd-slug>/<ts>_<uuid>.jsonl` (id = the trailing
+/// UUIDv7), filtered by cwd, mtime ≥ wrapper-claim time, and mtime ≥ surface
+/// `lastActivityTimestamp`. The claim time floors out the older sessions a
+/// cwd accumulates so resume resolves this pane's session instead of going
+/// `.unknown` (the same latent bug pi hit; see `Resources/bin/omp`).
 ///
 /// Ambiguity policy (mirrors `CodexStrategy`): when more than one candidate
 /// matches the surface filter, return a ref with `state = .unknown`,

--- a/Sources/Conversation/Strategies/Pi.swift
+++ b/Sources/Conversation/Strategies/Pi.swift
@@ -1,12 +1,17 @@
 import Foundation
 
 /// Scrape-primary strategy for pi. pi exposes no SessionStart hook and no
-/// session-id injection flag, so the wrapper never mints a placeholder; the
-/// `PiScraper` resolves the real id from `~/.pi/agent/sessions/**/<ts>_<uuid>.jsonl`
+/// session-id injection flag, so the c11 pi wrapper (`Resources/bin/pi`)
+/// mints a placeholder wrapper-claim at launch instead; the `PiScraper`
+/// resolves the real id from `~/.pi/agent/sessions/**/<ts>_<uuid>.jsonl`
 /// filtered by cwd, mtime ≥ wrapper-claim time, and mtime ≥ surface
-/// `lastActivityTimestamp`. (In production pi has no claim rail, so the
-/// empty-candidates branch returns the absent `wrapperClaim` — i.e. `nil` —
-/// and capture is driven entirely by the scrape rail.)
+/// `lastActivityTimestamp`. The wrapper-claim time floor is what
+/// disambiguates the several sessions a heavily-used cwd accumulates — a
+/// cwd with more than one pi session would otherwise go `.unknown` and skip
+/// resume entirely (the "pi fails, omp passes" bug). Without the wrapper
+/// (socket down, or pi launched outside c11) there is no claim, so the
+/// empty-candidates branch returns the absent `wrapperClaim` — `nil` — and
+/// capture falls back to cwd + mtime scrape alone.
 ///
 /// Ambiguity policy (mirrors `CodexStrategy`): when more than one candidate
 /// matches the surface filter, return ref with `state = .unknown`,

--- a/c11Tests/OmpConversationTests.swift
+++ b/c11Tests/OmpConversationTests.swift
@@ -263,6 +263,37 @@ final class OmpConversationTests: XCTestCase {
         XCTAssertEqual(reason, "ambiguous")
     }
 
+    /// The wrapper-claim time floor disambiguates the common "stale sessions
+    /// accumulated in a cwd" case (the latent bug pi hit). At cold restore
+    /// (`lastActivityTimestamp: nil`) the claim is the only floor: a session
+    /// older than the launch claim is dropped, so the single post-claim active
+    /// session resolves to `.alive` and resume fires — instead of `.unknown`.
+    func testOmpWrapperClaimFloorsStaleSessionToResolveActive() {
+        let strategy = OmpStrategy()
+        let now = Date()
+        let claimTime = now.addingTimeInterval(-60)
+        let inputs = ConversationStrategyInputs(
+            surfaceId: "surface:1",
+            cwd: "/work/proj",
+            lastActivityTimestamp: nil,
+            wrapperClaim: ConversationRef(
+                kind: "omp", id: "placeholder", placeholder: true,
+                cwd: "/work/proj", capturedAt: claimTime,
+                capturedVia: .wrapperClaim, state: .alive),
+            scrapeCandidates: [
+                candidate(id: v7Id, mtime: now, cwd: "/work/proj"),                            // active (post-claim)
+                candidate(id: v7Id2, mtime: now.addingTimeInterval(-3600), cwd: "/work/proj")  // stale (pre-claim)
+            ])
+        let ref = strategy.capture(inputs: inputs)
+        XCTAssertEqual(ref?.state, .alive, "claim floors the stale session → resolves instead of .unknown")
+        XCTAssertEqual(ref?.id, v7Id)
+        XCTAssertFalse(ref?.placeholder ?? true)
+        guard case .typeCommand(let text, _) = strategy.resume(ref: ref!) else {
+            XCTFail("expected typeCommand"); return
+        }
+        XCTAssertEqual(text, "omp --resume='\(v7Id)'")
+    }
+
     func testOmpResumeSkipsPlaceholder() {
         let strategy = OmpStrategy()
         let ref = ConversationRef(

--- a/c11Tests/PiConversationTests.swift
+++ b/c11Tests/PiConversationTests.swift
@@ -268,9 +268,56 @@ final class PiConversationTests: XCTestCase {
         }
     }
 
-    /// pi has no wrapper-claim rail in production, so this state is only
-    /// reachable via future wiring — construct the placeholder directly and
-    /// assert resume skips it.
+    /// The wrapper-claim time floor is what fixes the "pi fails, omp passes"
+    /// resume bug: the same two same-cwd candidates that go `.unknown` without
+    /// a claim (see `testPiAmbiguousCandidatesYieldUnknownAndSkip`) resolve to
+    /// the active session once the pi wrapper's claim floors out the stale,
+    /// pre-launch one — so resume fires `pi --session '<id>'` instead of
+    /// skipping. This is the runtime contract `Resources/bin/pi` relies on.
+    func testPiWrapperClaimFloorsStaleSessionToResolveActive() {
+        let surfaceId = UUID().uuidString
+        let now = Date()
+        // The pi wrapper claimed at launch; pi then created/continued the
+        // active session (mtime after the claim). An older session in the
+        // same cwd predates the claim.
+        let claimTime = now.addingTimeInterval(-60)
+        let scrapers = ConversationScraperRegistry(scrapers: [
+            MockScraper(kind: "pi", preset: [
+                candidate(piUUID, mtime: now),                            // active (post-claim)
+                candidate(piUUID2, mtime: now.addingTimeInterval(-3600))  // stale (pre-claim)
+            ])
+        ])
+        let pipeline = ScrapeCapturePipeline(scrapers: scrapers, strategies: .v1)
+        let contexts = [ScrapeCaptureContext(surfaceId: surfaceId, kind: "pi", cwd: "/work/proj")]
+        let claim = ConversationRef(
+            kind: "pi",
+            id: "wrapper-claim:\(surfaceId)",
+            placeholder: true,
+            cwd: "/work/proj",
+            capturedAt: claimTime,
+            capturedVia: .wrapperClaim,
+            state: .alive
+        )
+        let existing = [surfaceId: SurfaceConversations(active: claim)]
+
+        let captured = pipeline.captureRefs(contexts: contexts, existing: existing)
+        XCTAssertEqual(captured.count, 1)
+        let ref = captured[0].ref
+        XCTAssertEqual(ref.state, .alive,
+                       "claim time floors out the stale session, leaving one → resolves instead of .unknown")
+        XCTAssertEqual(ref.id, piUUID)
+        XCTAssertEqual(ref.capturedVia, .scrape)
+
+        guard case let .typeCommand(text, submit) = PiStrategy().resume(ref: ref) else {
+            return XCTFail("expected .typeCommand, got skip")
+        }
+        XCTAssertEqual(text, "pi --session '\(piUUID)'")
+        XCTAssertTrue(submit)
+    }
+
+    /// While only the wrapper-claim placeholder has been seen (the scrape has
+    /// not yet resolved the real id), resume must skip — never type a
+    /// placeholder id at the prompt.
     func testPiPlaceholderRefSkips() {
         let ref = ConversationRef(
             kind: "pi",

--- a/skills/c11/references/conversation.md
+++ b/skills/c11/references/conversation.md
@@ -68,6 +68,8 @@ Reconciliation rule: latest `capturedAt` wins; on close timestamps, source prior
 | `codex` | Snapshot-only in v1 | Wrapper-claim placeholder → snapshot persists the captured ref → restore consumes it. **Pull-scrape disambiguation lands in v1.1** (see "v1 scope" below). | `codex resume <id>` (specific id; never `--last`) |
 | `opencode` | Fresh-launch only | Wrapper-claim placeholder | `opencode` (process launch) — `.skip` for placeholders |
 | `kimi` | Fresh-launch only | Wrapper-claim placeholder | `kimi` (process launch) — `.skip` for placeholders |
+| `pi` | Exact (scrape) | Wrapper-claim placeholder → `PiScraper` resolves the real id from the cwd slug dir, claim-time floor narrowing past stale sessions. | `pi --session '<id>'` (specific id) |
+| `omp` | Exact (scrape) | Wrapper-claim placeholder → `OmpScraper` resolves the real id from the cwd slug dir, claim-time floor narrowing past stale sessions. | `omp --resume='<id>'` (specific id) |
 
 ### v1 scope and v1.1 follow-ups
 
@@ -92,7 +94,7 @@ The advisory is surfaced via `c11 conversation get`'s `diagnostic_reason` field 
 ## Wrapper-claim flow (TUI integrators)
 
 ```bash
-# Pseudo-shape; real wrappers stay bash. See Resources/bin/{claude,codex}.
+# Pseudo-shape; real wrappers stay bash. See Resources/bin/{claude,codex,pi,omp}.
 1. Detect c11 environment (CMUX_SURFACE_ID + live socket). Pass through if absent.
 2. c11 conversation claim --kind <my-kind> --cwd "$PWD" >/dev/null 2>&1 &
 3. (For TUIs with hooks: inject the necessary flags so hooks fire `c11 conversation push`.)


### PR DESCRIPTION
Bug A (v0.55 staging smoke): after a clean quit + relaunch, **Pi** and **Claude Code** did not resume their prior sessions, while **codex / opencode / omp** did. Pre-existing (resume shipped in v0.54.0), so it lands on `main`. Two independent causes, both in the session-resume wrapper-claim rail.

---

## 1. Pi / oh-my-pi — no wrapper-claim → ambiguous → skip (root cause of the Pi failure)

Pi/omp resume **scrape-primary**: c11 resolves the session id at restore from the cwd's session store. `runScrapeCapture` runs **only** at restore, and at cold restore `lastActivityTimestamp` is nil — so without a launch-time claim the scrape has **no time floor**. A cwd holding more than one pi session (the norm for a heavily-used agent) makes `PiStrategy.capture` return `state=.unknown` (ambiguous) → `resume()` skips → the pane comes up fresh. codex avoided this via its wrapper-claim; pi/omp shipped without a wrapper. omp "passed" the smoke only by luck (one session per cwd) — same latent bug.

**Fix:** new PATH-scoped `Resources/bin/pi` and `Resources/bin/omp` wrappers (mirroring `Resources/bin/codex`) that mint a wrapper-claim at launch (`c11 conversation claim --kind <pi|omp> --cwd "$PWD"`). The claim's time floor narrows past stale sessions to this pane's own. The strategies already consume the claim — the only missing piece was the wrapper that pushes it. Wired into the Copy CLI build phase.

**Validated end-to-end on a tagged build:** seeded a cwd with a stale (pre-claim) + active (post-claim) session, quit cleanly, relaunched. The restore scrape's claim-time floor dropped the stale session and resolved the active one — `state=alive`, `resumable=true`, reason `"matched cwd + mtime after claim"` — and the pane resumed via `pi --session '<id>'`. Without the claim this same setup goes `state=unknown`/skip (the reported bug). New `c11-logic` tests (`testPi/OmpWrapperClaimFloorsStaleSessionToResolveActive`) lock it in — **30 logic tests green.**

## 2. Claude Code — wrapper-claim fired against an undefined variable

The `cmux`→`c11` rename updated `Resources/bin/claude`'s c11-binary resolution to `C11_SET_AGENT_BIN`/`find_c11_bin` (line 174) but left the conversation-claim guard below testing the old, now-undefined `cmux_set_agent_bin` (line 197). So `c11_conversation_claim_bg` **never ran** — the claude wrapper-claim fallback (meant to leave a resumable claim when the SessionStart hook never reports) was silently skipped on every launch.

**Fix:** use the assigned `C11_SET_AGENT_BIN` (matches the `set_agent` call directly above). Validated with a wrapper harness: the fixed wrapper invokes `conversation claim --kind claude-code --cwd "$PWD"`; the buggy version does ping + set-agent but skips the claim.

**Scope (honest):** this repairs the fallback rail (and the claim-time floor a future claude pull-scrape will use). It is **not** by itself sufficient for the operator's *clean-quit* "Claude Code did not resume" — claude resume is hook-push-primary, and the most plausible cause of the clean-quit failure is the **SessionStart hook push being dropped under the multi-agent socket flood**, which is addressed separately by **C11-156 (#296/#297)**. Recommend coordinating the claude clean-quit half with that PR; this commit removes a latent landmine in the fallback path regardless.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)