### PR TITLE
fix(cli): read socket-control password from c11/ not c11mux/ (rename casualty)

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -563,7 +563,15 @@ enum CLIIDFormat: String {
 enum SocketPasswordResolver {
     private static let service = "com.cmuxterm.app.socket-control"
     private static let account = "local-socket-password"
-    private static let directoryName = "c11mux"
+    // Must match the app's SocketControlPasswordStore.directoryName ("c11") so
+    // the CLI reads the password file the app actually writes. The legacy name
+    // was "c11mux"; the app moved to "c11" (StateDirectoryMigration.currentName)
+    // and the app's symlink covers migrated machines, but a fresh install never
+    // creates a `c11mux` dir — reading it there returned nil and the password
+    // was silently invisible to the CLI. `legacyDirectoryName` stays as a
+    // read-only fallback for any un-migrated checkout.
+    private static let directoryName = "c11"
+    private static let legacyDirectoryName = "c11mux"
     private static let fileName = "socket-control-password"
 
     static func resolve(explicit: String?, socketPath: String) -> String? {
@@ -589,16 +597,20 @@ enum SocketPasswordResolver {
         guard let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             return nil
         }
-        let passwordURL = appSupport
-            .appendingPathComponent(directoryName, isDirectory: true)
-            .appendingPathComponent(fileName, isDirectory: false)
-        guard let data = try? Data(contentsOf: passwordURL) else {
-            return nil
+        // Canonical "c11" dir first; fall back to the legacy "c11mux" dir for
+        // un-migrated checkouts where the app's migration symlink is absent.
+        for dir in [directoryName, legacyDirectoryName] {
+            let passwordURL = appSupport
+                .appendingPathComponent(dir, isDirectory: true)
+                .appendingPathComponent(fileName, isDirectory: false)
+            guard let data = try? Data(contentsOf: passwordURL),
+                  let value = String(data: data, encoding: .utf8),
+                  let normalizedValue = normalized(value) else {
+                continue
+            }
+            return normalizedValue
         }
-        guard let value = String(data: data, encoding: .utf8) else {
-            return nil
-        }
-        return normalized(value)
+        return nil
     }
 
     static func keychainServices(


### PR DESCRIPTION
## Summary

A `cmux → c11` rename casualty: the state-dir rename `c11mux → c11` updated the **app's** `SocketControlPasswordStore.directoryName` to `"c11"` but missed the **CLI's** `SocketPasswordResolver.directoryName`, which still read `"c11mux"`.

- **Writer (app):** `Sources/SocketControlSettings.swift:67` — writes the password file-only to `~/Library/Application Support/c11/socket-control-password`. The keychain migration (`migrateLegacyKeychainPasswordIfNeeded`) moves any legacy keychain entry into that file and **deletes** the keychain copy.
- **Reader (CLI):** `CLI/c11.swift:566` — `loadFromFile()` read `~/.../c11mux/socket-control-password` with **no `c11` fallback**, then fell through to the now-empty keychain.
- **Proof `c11mux` is the old name:** `Sources/Mailbox/MailboxLayout.swift:191-192` — `StateDirectoryMigration.legacyName = "c11mux"`, `currentName = "c11"`.

The adjacent socket-**path** resolver (`CLISocketPathResolver`, `CLI/c11.swift:695-698`) already hardcodes `"c11"` with the comment *"Must match the app's SocketControlSettings … so the CLI … read the same location the app writes."* The password resolver was the missed casualty.

## Failing scenario (silent break)

1. Fresh install — no legacy `c11mux` dir, so `StateDirectoryMigration` creates **no** `c11mux → c11` compat symlink (and that migration runs only in the app target, not the CLI).
2. Operator sets socket mode = `password` and a password in Settings → app writes `…/c11/socket-control-password`.
3. Operator runs `c11 <cmd>` from a plain terminal (no injected `CMUX_SOCKET_PASSWORD`, no `--socket-password`).
4. CLI resolve: explicit nil → env nil → `loadFromFile()` reads `…/c11mux/…` → missing → nil → keychain → empty → **nil**.
5. CLI sends commands with no password → app in `.password` mode rejects them. The correctly-configured password is silently invisible to the CLI.

Masked on machines that had a legacy `c11mux` dir (symlink resolves the read) or used in-surface CLI (env-injected password) — which is why it survived.

## Fix

`directoryName` → `"c11"` (matches the app + the adjacent path resolver); `loadFromFile()` reads `c11/` first and falls back to legacy `c11mux/` for any un-migrated checkout. One-line behavioural correction plus a defensive legacy fallback.

## Validation

- `xcodebuild -scheme c11-cli build` → **BUILD SUCCEEDED**.
- No unit test: `SocketPasswordResolver.loadFromFile()` is a private path in the `c11` CLI executable target (not reachable from the `c11-logic` test target) and reads real Application Support. The change is a constant correction verified by the green CLI build and the now-matching app/CLI directory names.

## Scope

Found by a dedicated `cmux → c11` rename-casualty audit. **Separate from #300** (the claude-wrapper `$cmux_set_agent_bin` orphan). The audit found no other confirmed silent-break casualties; remaining `cmux` references are cosmetic (write==read) leftovers for a separate hygiene pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)