### PR TITLE
Release v0.56.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.56.1] - 2026-07-01
+
+Patch release. Headline: **auto-update failures are no longer a dead end.** When Sparkle can't launch its installer (error 4005 — most often a damaged `Sparkle.framework` on the installed copy, not a real location problem), the update popover used to show a misleading "c11 needs to live in Applications" message with only a Retry that re-hit the same wall. It now explains the failure plainly and offers a **Download Latest** button that opens the releases page so you can reinstall in one click. If auto-update ever errors with 4005, download the latest DMG and drag it over c11 in Applications once — auto-update resumes afterward.
+
+### Fixed
+
+- **Sparkle update error 4005 no longer dead-ends.** A 4005 ("couldn't launch the installer") now reads "Update Couldn't Be Installed" and offers a prominent **Download Latest** button to the releases page instead of a futile Retry and a misleading "move to Applications" message. Genuine "app isn't in Applications" cases (Sparkle 1003 disk-image / 1005 translocated) keep their move-and-relaunch guidance. ([#304](https://github.com/Stage-11-Agentics/c11/pull/304))
+
 ## [0.56.0] - 2026-06-30
 
 Re-signing release — **no functional changes from 0.55.0.** 0.54.0 and 0.55.0 were signed under a different Apple Developer ID team, so existing installs couldn't auto-update across the team boundary (Sparkle declines a cross-team swap). This build is re-signed under the original Developer ID team, restoring seamless auto-update. Updating from 0.53.x lands all of the 0.54.0 and 0.55.0 changes (exact-session resume for Pi/oh-my-pi/opencode, the agent registry, size-aware splits, the collapsing tab bar, chrome themes, `c11 tree --report`, the Agent Skills sheet fix, and the resume/socket hardening) in one step — see those sections below.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -1881,10 +1881,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1962,7 +1962,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -1972,7 +1972,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -2003,7 +2003,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -2013,7 +2013,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -2081,10 +2081,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2099,14 +2099,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2121,14 +2121,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2144,10 +2144,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2163,10 +2163,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 113;
+				CURRENT_PROJECT_VERSION = 114;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.56.0;
+				MARKETING_VERSION = 0.56.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Patch release bumping to **0.56.1** (build 114).

## Changes

### Fixed
- **Sparkle update error 4005 no longer dead-ends.** A 4005 ("couldn't launch the installer") now reads "Update Couldn't Be Installed" and offers a prominent **Download Latest** button to the releases page instead of a futile Retry and a misleading "move to Applications" message. Genuine "app isn't in Applications" cases (1003 disk-image / 1005 translocated) keep their move-and-relaunch guidance. (#304)

The underlying incident (a local `Sparkle.framework` symlink strip that produced 4005) is documented in `notes/sparkle-4005-investigation-2026-06-30.md`, landed via #304.

## Notes
- In-app graceful handling helps 0.56.1+ forward; an already-broken install still needs a one-time manual reinstall (the changelog says so).
- Build number 113 → 114 (required for Sparkle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)