### PR TITLE
Add the Chord skill family and the distribution skill

### DIFF
--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -277,6 +277,14 @@ struct AgentRegistry: Sendable {
     ])
 }
 
-/// The orientation prompt typed into a freshly launched agent. Mirrors
-/// `AgentType.factoryInitialPrompt` for non-custom agents.
-let c11OrientPrompt = "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it."
+/// The factory initial prompt for c11-launched agents — empty by design.
+/// A freshly launched agent boots straight to ready with no orientation
+/// turn, so there is no dead-time before the operator can give it a task.
+/// c11 supplies the identity the sidebar needs itself: the agent type comes
+/// from `AgentDetector` (process inspection) and the pinned model plus a
+/// placeholder title are stamped at launch in `Workspace.launchAgentSurface`.
+/// The c11 skill loads on demand — when a task actually drives the workspace.
+/// Mirrors `AgentType.factoryInitialPrompt` for non-custom agents; an
+/// operator who wants a launch prompt can still set one per-agent in
+/// Default Agent settings.
+let c11OrientPrompt = ""

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6463,6 +6463,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 // SurfaceSpec.command is delivered verbatim by the layout
                 // executor, so the newline has to live in the value itself.
                 injected.surfaces[idx].command = command + "\n"
+                // No orientation prompt is baked by default (see
+                // `c11OrientPrompt`), so mirror launchAgentSurface: stamp the
+                // identity the sidebar would otherwise wait on the agent to
+                // report — a placeholder title and the pinned model (the type
+                // comes from AgentDetector). Only fill fields the spec left
+                // unset so an explicit blueprint always wins.
+                if injected.surfaces[idx].title == nil {
+                    injected.surfaces[idx].title = String(
+                        localized: "agent.launch.placeholderTitle",
+                        defaultValue: "Awaiting first task"
+                    )
+                }
+                let cfg = projectConfig?.agents[resolved.agent]
+                    ?? userDefault.config(for: resolved.agent)
+                let model = cfg.model.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !model.isEmpty {
+                    var meta = injected.surfaces[idx].metadata ?? [:]
+                    if meta[MetadataKey.model] == nil {
+                        meta[MetadataKey.model] = .string(model)
+                        injected.surfaces[idx].metadata = meta
+                    }
+                }
             }
         }
 

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -54,6 +54,45 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
     var factoryInitialPrompt: String {
         AgentRegistry.shared.manifest(for: self)?.factoryInitialPrompt ?? ""
     }
+
+    /// Factory default for the pinned model family. Only Claude Code carries
+    /// one out of the box — c11 pins `opus` so agents launched here stay on
+    /// Opus even when the operator flips their ambient Claude default to
+    /// another family. Every other agent inherits its own default (empty).
+    /// See `ClaudeModelFamily` for the set of families c11 offers, and
+    /// `DefaultAgentResolver.buildCommand` for where the flag is injected.
+    var factoryModel: String {
+        self == .claudeCode ? ClaudeModelFamily.opus.rawValue : ""
+    }
+}
+
+/// The Claude model-family aliases c11 offers as a pinned launch default.
+///
+/// Each raw value is exactly what `claude --model <alias>` accepts, and Claude
+/// Code resolves a family alias to the *latest* version of that family. Pinning
+/// the family (not a versioned id like `claude-opus-4-8`) means new model
+/// releases need no c11 change — the whole point of the setting.
+enum ClaudeModelFamily: String, CaseIterable, Identifiable {
+    case opus
+    case sonnet
+    case haiku
+    case fable
+
+    var id: String { rawValue }
+
+    /// Human-readable label for the Settings picker. Localized at the call site.
+    var displayName: String {
+        switch self {
+        case .opus:
+            return String(localized: "claudeModelFamily.opus", defaultValue: "Opus")
+        case .sonnet:
+            return String(localized: "claudeModelFamily.sonnet", defaultValue: "Sonnet")
+        case .haiku:
+            return String(localized: "claudeModelFamily.haiku", defaultValue: "Haiku")
+        case .fable:
+            return String(localized: "claudeModelFamily.fable", defaultValue: "Fable")
+        }
+    }
 }
 
 /// Per-agent configuration: command typed into the shell to launch this agent,
@@ -68,11 +107,18 @@ struct AgentConfig: Codable, Equatable {
     /// Multi-line `KEY=value` text, one entry per line. Parsed at use time;
     /// keeps the UI to a single text editor instead of a row-editor list.
     var envOverridesText: String
+    /// Pinned model family (e.g. `opus`). Injected as `--model <model>` at
+    /// launch for agents whose CLI accepts it (currently Claude Code). Empty
+    /// means "don't pin" — inherit the agent's own default. A model the
+    /// operator hardcoded into `command` always wins; see
+    /// `DefaultAgentResolver.buildCommand`.
+    var model: String
 
-    init(command: String, initialPrompt: String, envOverridesText: String) {
+    init(command: String, initialPrompt: String, envOverridesText: String, model: String = "") {
         self.command = command
         self.initialPrompt = initialPrompt
         self.envOverridesText = envOverridesText
+        self.model = model
     }
 
     init(from decoder: Decoder) throws {
@@ -80,6 +126,9 @@ struct AgentConfig: Codable, Equatable {
         self.command = (try? c.decode(String.self, forKey: .command)) ?? ""
         self.initialPrompt = (try? c.decode(String.self, forKey: .initialPrompt)) ?? ""
         self.envOverridesText = (try? c.decode(String.self, forKey: .envOverridesText)) ?? ""
+        // Absent in configs written before the model setting existed; those
+        // decode to "" (inherit), preserving their prior launch behavior.
+        self.model = (try? c.decode(String.self, forKey: .model)) ?? ""
     }
 
     /// Factory defaults for a given agent type.
@@ -87,7 +136,8 @@ struct AgentConfig: Codable, Equatable {
         AgentConfig(
             command: agent.factoryCommand,
             initialPrompt: agent.factoryInitialPrompt,
-            envOverridesText: ""
+            envOverridesText: "",
+            model: agent.factoryModel
         )
     }
 
@@ -111,7 +161,7 @@ struct AgentConfig: Codable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case command, initialPrompt, envOverridesText
+        case command, initialPrompt, envOverridesText, model
     }
 }
 

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -46,7 +46,7 @@ enum DefaultAgentResolver {
             ?? userDefault.config(for: agent)
 
         let command = buildCommand(agent: agent, config: chosenConfig)
-        let bare = chosenConfig.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bare = launcherCommand(agent: agent, config: chosenConfig)
         return (agent, ResolvedAgentLaunch(
             command: command,
             bareCommand: bare,
@@ -61,15 +61,51 @@ enum DefaultAgentResolver {
     /// separate post-launch sendText so each TUI's input contract is honored.
     /// Visible for testing.
     static func buildCommand(agent: AgentType, config: AgentConfig) -> String {
-        let base = config.command.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !base.isEmpty else { return "" }
+        let launcher = launcherCommand(agent: agent, config: config)
+        guard !launcher.isEmpty else { return "" }
         if agent == .claudeCode {
             let prompt = config.initialPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
             if !prompt.isEmpty {
-                return "\(base) \(shellQuote(prompt))"
+                return "\(launcher) \(shellQuote(prompt))"
             }
         }
+        return launcher
+    }
+
+    /// The launcher: the operator's `command` with the pinned model flag
+    /// applied, but no positional prompt baked in. This is what feeds
+    /// `bareCommand` / the `C11_DEFAULT_AGENT_LAUNCH` export, so an orchestrator
+    /// that composes its own prompt still inherits the pinned model. The
+    /// model flag must precede claude-code's positional prompt (which stays
+    /// last), so it's applied here rather than after prompt-baking.
+    /// Visible for testing.
+    static func launcherCommand(agent: AgentType, config: AgentConfig) -> String {
+        let base = config.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !base.isEmpty else { return "" }
+        if let flag = modelFlag(agent: agent, config: config, command: base) {
+            return "\(base) \(flag)"
+        }
         return base
+    }
+
+    /// Whether c11 injects a `--model` flag for this agent kind. Only agents
+    /// whose CLI accepts `--model <family-alias>` qualify; today that's Claude
+    /// Code. Kept as a seam so codex (also `--model`) can opt in later.
+    static func supportsModelFlag(_ agent: AgentType) -> Bool {
+        agent == .claudeCode
+    }
+
+    /// The `--model <family>` flag to append for a launch, or `nil` when none
+    /// should be injected: the agent doesn't support it, no family is pinned,
+    /// or the operator already put a model in the command themselves (their
+    /// explicit choice wins, and we must not pass `--model` twice).
+    /// Visible for testing.
+    static func modelFlag(agent: AgentType, config: AgentConfig, command: String) -> String? {
+        guard supportsModelFlag(agent) else { return nil }
+        let model = config.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !model.isEmpty else { return nil }
+        guard !command.lowercased().contains("--model") else { return nil }
+        return "--model \(model)"
     }
 
     /// Single-quote a value for /bin/sh, escaping embedded single quotes via

--- a/Sources/DefaultAgentSettingsView.swift
+++ b/Sources/DefaultAgentSettingsView.swift
@@ -7,6 +7,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
     @Published var defaultAgent: AgentType
     @Published var editingAgent: AgentType
     @Published var command: String
+    @Published var model: String
     @Published var initialPrompt: String
     @Published var envOverridesText: String
 
@@ -22,6 +23,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         self.defaultAgent = active
         self.editingAgent = active
         self.command = entry.command
+        self.model = entry.model
         self.initialPrompt = entry.initialPrompt
         self.envOverridesText = entry.envOverridesText
 
@@ -36,8 +38,15 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $command.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
+        $model.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
         $initialPrompt.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
         $envOverridesText.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
+    }
+
+    /// Whether c11 pins a `--model` flag for the agent currently being edited,
+    /// gating whether the model picker is shown.
+    var editingAgentSupportsModel: Bool {
+        DefaultAgentResolver.supportsModelFlag(editingAgent)
     }
 
     private func loadFields(for agent: AgentType) {
@@ -45,6 +54,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         defer { suppressSave = false }
         let entry = store.current.config(for: agent)
         command = entry.command
+        model = entry.model
         initialPrompt = entry.initialPrompt
         envOverridesText = entry.envOverridesText
     }
@@ -55,7 +65,8 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         let snapshot = AgentConfig(
             command: command,
             initialPrompt: initialPrompt,
-            envOverridesText: envOverridesText
+            envOverridesText: envOverridesText,
+            model: model
         )
         store.update(captured) { $0 = snapshot }
     }
@@ -65,6 +76,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         suppressSave = true
         let factory = AgentConfig.factory(for: editingAgent)
         command = factory.command
+        model = factory.model
         initialPrompt = factory.initialPrompt
         envOverridesText = factory.envOverridesText
         suppressSave = false
@@ -113,6 +125,10 @@ struct DefaultAgentSettingsSection: View {
                     .foregroundStyle(.secondary)
             }
 
+            if vm.editingAgentSupportsModel {
+                modelPicker
+            }
+
             VStack(alignment: .leading, spacing: 3) {
                 Text(String(localized: "settings.defaultAgent.initialPrompt.label", defaultValue: "initial prompt"))
                     .font(.callout)
@@ -143,6 +159,35 @@ struct DefaultAgentSettingsSection: View {
                 }
                 .controlSize(.small)
             }
+        }
+    }
+
+    /// Model-family picker, shown only for agents c11 pins a `--model` flag
+    /// for. The empty tag means "inherit" (no flag injected); each family maps
+    /// to `claude --model <family>`, resolving to that family's latest version.
+    private var modelPicker: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                Text(String(localized: "settings.defaultAgent.model.label", defaultValue: "model"))
+                    .font(.callout)
+                Picker("", selection: $vm.model) {
+                    Text(String(localized: "settings.defaultAgent.model.inherit",
+                                defaultValue: "Inherit (agent default)"))
+                        .tag("")
+                    ForEach(ClaudeModelFamily.allCases) { family in
+                        Text(family.displayName).tag(family.rawValue)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
+                .accessibilityIdentifier("DefaultAgentModelPicker")
+                Spacer()
+            }
+            Text(String(localized: "settings.defaultAgent.model.help",
+                        defaultValue: "pins --model on launch, so agents launched here stay on this family even when your ambient Claude default changes. picks the family, not a version — new releases need no change. a model set in the command above wins."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11786,12 +11786,55 @@ extension Workspace: BonsplitDelegate {
             inPane: pane,
             startupEnvironment: resolved.launch.envOverrides
         ) else { return }
-        // The launch command goes to bash; for claude-code the initial prompt
-        // is already baked in as a positional arg by the resolver. Other
-        // agents preserve the prompt in their config but don't auto-deliver
-        // (different TUI input contracts; per-agent post-ready delivery is
-        // a follow-up).
+        // By default no orientation prompt is baked (see `c11OrientPrompt`),
+        // so the agent boots straight to ready with no dead-time. c11 stamps
+        // the identity the sidebar needs itself — no agent round-trip: the
+        // type comes from `AgentDetector`, and we stamp the pinned model plus
+        // a placeholder title here. An operator who configured a launch prompt
+        // still gets it delivered below (baked positional for claude-code,
+        // post-ready sendText for other TUIs is a follow-up).
+        stampLaunchIdentity(
+            surfaceId: panel.id,
+            agent: resolved.agent,
+            userDefault: userDefault,
+            projectConfig: projectConfig
+        )
         panel.sendText(resolved.launch.command + "\n")
+    }
+
+    /// Populate a freshly launched agent surface with the identity the sidebar
+    /// would otherwise wait on the agent to report: the pinned model (which
+    /// process detection can't infer) and a placeholder title. Written with
+    /// source `.declare` so a later explicit `set-agent` / `set-title` from the
+    /// agent or operator cleanly wins. The agent *type* is intentionally not
+    /// stamped here — `AgentDetector` owns it authoritatively.
+    private func stampLaunchIdentity(
+        surfaceId: UUID,
+        agent: AgentType,
+        userDefault: DefaultAgentConfig,
+        projectConfig: DefaultAgentConfig?
+    ) {
+        var partial: [String: Any] = [
+            MetadataKey.title: String(
+                localized: "agent.launch.placeholderTitle",
+                defaultValue: "Awaiting first task"
+            )
+        ]
+        // Mirror the resolver's per-agent config pick so the chip shows the
+        // model c11 launched with. Reads config only; no mutation.
+        let cfg = projectConfig?.agents[agent] ?? userDefault.config(for: agent)
+        let model = cfg.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !model.isEmpty {
+            partial[MetadataKey.model] = model
+        }
+        _ = try? SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: id,
+            surfaceId: surfaceId,
+            partial: partial,
+            mode: .merge,
+            source: .declare
+        )
+        syncPanelTitleFromMetadata(panelId: surfaceId)
     }
 
     func splitTabBar(_ controller: BonsplitController, menuItemsForNewTabKind kind: String, inPane pane: PaneID) -> [BonsplitNewTabMenuItem] {

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -21,7 +21,7 @@ final class DefaultAgentConfigTests: XCTestCase {
     func testFactoryClaudeCommandIncludesDangerouslySkipPermissions() {
         let entry = AgentConfig.factory(for: .claudeCode)
         XCTAssertEqual(entry.command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testFactoryClaudePinsOpusModel() {
@@ -48,19 +48,19 @@ final class DefaultAgentConfigTests: XCTestCase {
     func testFactoryCodexCommandIncludesYolo() {
         let entry = AgentConfig.factory(for: .codex)
         XCTAssertEqual(entry.command, "codex --yolo")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testFactoryGrokCommandIncludesAlwaysApprove() {
         let entry = AgentConfig.factory(for: .grok)
         XCTAssertEqual(entry.command, "grok --always-approve")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testFactoryGitHubCopilotCommandIncludesAllowAllAndAutopilot() {
         let entry = AgentConfig.factory(for: .githubCopilot)
         XCTAssertEqual(entry.command, "copilot --allow-all --autopilot")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testAgentTypeGitHubCopilotRawValueIsKebabCase() {
@@ -218,7 +218,7 @@ final class DefaultAgentConfigTests: XCTestCase {
         let (store, _) = makeStore()
         XCTAssertEqual(store.current.defaultAgent, .claudeCode)
         XCTAssertEqual(store.current.config(for: .claudeCode).command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "")
     }
 
     func testStoreReturnsFactoryOnGarbageData() {

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -24,6 +24,27 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
+    func testFactoryClaudePinsOpusModel() {
+        // Claude Code ships pinned to the Opus family so agents launched from
+        // c11 stay on Opus regardless of the operator's ambient Claude default.
+        XCTAssertEqual(AgentConfig.factory(for: .claudeCode).model, "opus")
+        XCTAssertEqual(AgentType.claudeCode.factoryModel, ClaudeModelFamily.opus.rawValue)
+    }
+
+    func testFactoryNonClaudeAgentsHaveNoPinnedModel() {
+        // Only claude-code carries a factory model; everyone else inherits.
+        for type in AgentType.allCases where type != .claudeCode {
+            XCTAssertEqual(AgentConfig.factory(for: type).model, "", "\(type) should not pin a model")
+        }
+    }
+
+    func testClaudeModelFamilyRawValuesAreCliAliases() {
+        // These raw values are passed verbatim to `claude --model`; they must
+        // stay the family aliases the CLI resolves to the latest version.
+        XCTAssertEqual(ClaudeModelFamily.allCases.map(\.rawValue),
+                       ["opus", "sonnet", "haiku", "fable"])
+    }
+
     func testFactoryCodexCommandIncludesYolo() {
         let entry = AgentConfig.factory(for: .codex)
         XCTAssertEqual(entry.command, "codex --yolo")
@@ -73,6 +94,23 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(decoded.agents[.claudeCode]?.initialPrompt, "load skill")
         XCTAssertEqual(decoded.agents[.claudeCode]?.envOverridesText, "K=V")
         XCTAssertEqual(decoded.agents[.codex]?.command, "codex --yolo")
+    }
+
+    func testCodableRoundTripPreservesModel() throws {
+        var agents: [AgentType: AgentConfig] = [:]
+        agents[.claudeCode] = AgentConfig(command: "claude", initialPrompt: "", envOverridesText: "", model: "fable")
+        let cfg = DefaultAgentConfig(defaultAgent: .claudeCode, agents: agents)
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(DefaultAgentConfig.self, from: data)
+        XCTAssertEqual(decoded.agents[.claudeCode]?.model, "fable")
+    }
+
+    func testDecodeAgentConfigWithoutModelDefaultsToInherit() throws {
+        // A per-agent blob written before the model field existed must decode
+        // to "" (inherit), preserving its prior launch behavior on upgrade.
+        let json = #"{"command":"claude","initialPrompt":"","envOverridesText":""}"#
+        let decoded = try JSONDecoder().decode(AgentConfig.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.model, "")
     }
 
     func testLenientDecodeFillsMissingFields() throws {

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -18,7 +18,9 @@ final class DefaultAgentResolverTests: XCTestCase {
             projectConfig: nil
         )
         XCTAssertEqual(agent, .claudeCode)
-        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'")
+        // The factory pins Opus for claude-code, so the launcher carries
+        // `--model opus` ahead of the positional prompt.
+        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'")
     }
 
     func testProjectConfigDefaultAgentBeatsUserDefault() {
@@ -177,6 +179,92 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
     }
 
+    // MARK: - model pinning
+
+    func testBuildCommandInjectsPinnedModelBeforePrompt() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "go",
+            envOverridesText: "",
+            model: "opus"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus 'go'"
+        )
+    }
+
+    func testBuildCommandInjectsPinnedModelWithoutPrompt() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "fable"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model fable"
+        )
+    }
+
+    func testBuildCommandEmptyModelInjectsNothing() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: ""
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions"
+        )
+    }
+
+    func testBuildCommandDoesNotDoubleModelWhenCommandAlreadyHasOne() {
+        // Operator hardcoded a model in the command — their choice wins and we
+        // must not pass --model twice.
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions --model sonnet",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "opus"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model sonnet"
+        )
+    }
+
+    func testBuildCommandDoesNotInjectModelForNonClaudeAgent() {
+        // codex accepts --model too, but c11 only pins it for claude-code today;
+        // a stray model value on another agent must be ignored, not injected.
+        let cfg = AgentConfig(
+            command: "codex --yolo",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "opus"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .codex, config: cfg),
+            "codex --yolo"
+        )
+    }
+
+    func testLauncherCommandCarriesModelForBareExport() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "some prompt",
+            envOverridesText: "",
+            model: "opus"
+        )
+        // bareCommand / C11_DEFAULT_AGENT_LAUNCH carries the model but never the
+        // positional prompt, so orchestrators can append their own.
+        XCTAssertEqual(
+            DefaultAgentResolver.launcherCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus"
+        )
+    }
+
     func testShellQuoteEmpty() {
         XCTAssertEqual(DefaultAgentResolver.shellQuote(""), "''")
     }
@@ -221,12 +309,14 @@ final class DefaultAgentResolverTests: XCTestCase {
             userDefault: user,
             projectConfig: nil
         )
-        XCTAssertEqual(launch.bareCommand, "claude --dangerously-skip-permissions")
+        // The pinned model rides on the launcher (both bareCommand and the
+        // baked command); only the positional prompt distinguishes them.
+        XCTAssertEqual(launch.bareCommand, "claude --dangerously-skip-permissions --model opus")
         XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
         // The baked form still ships on `command` for the A-button path.
         XCTAssertEqual(
             launch.command,
-            "claude --dangerously-skip-permissions 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
+            "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
         )
     }
 

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -18,9 +18,9 @@ final class DefaultAgentResolverTests: XCTestCase {
             projectConfig: nil
         )
         XCTAssertEqual(agent, .claudeCode)
-        // The factory pins Opus for claude-code, so the launcher carries
-        // `--model opus` ahead of the positional prompt.
-        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'")
+        // The factory pins Opus for claude-code and no longer seeds a launch
+        // prompt, so the resolved command is just the launcher with `--model opus`.
+        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions --model opus")
     }
 
     func testProjectConfigDefaultAgentBeatsUserDefault() {
@@ -303,7 +303,16 @@ final class DefaultAgentResolverTests: XCTestCase {
     // caller-appended positional argument (claude takes only the first).
 
     func testBareCommandOmitsClaudeInitialPrompt() {
-        let user = DefaultAgentConfig.factory
+        // The factory no longer seeds a launch prompt, so configure one
+        // explicitly to prove bareCommand strips it while command bakes it.
+        var userAgents = DefaultAgentConfig.factory.agents
+        userAgents[.claudeCode] = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "orient the agent",
+            envOverridesText: "",
+            model: "opus"
+        )
+        let user = DefaultAgentConfig(defaultAgent: .claudeCode, agents: userAgents)
         let (_, launch) = DefaultAgentResolver.resolve(
             explicitAgent: nil,
             userDefault: user,
@@ -312,11 +321,11 @@ final class DefaultAgentResolverTests: XCTestCase {
         // The pinned model rides on the launcher (both bareCommand and the
         // baked command); only the positional prompt distinguishes them.
         XCTAssertEqual(launch.bareCommand, "claude --dangerously-skip-permissions --model opus")
-        XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(launch.initialPrompt, "orient the agent")
         // The baked form still ships on `command` for the A-button path.
         XCTAssertEqual(
             launch.command,
-            "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
+            "claude --dangerously-skip-permissions --model opus 'orient the agent'"
         )
     }
 
@@ -339,8 +348,16 @@ final class DefaultAgentResolverTests: XCTestCase {
 
     func testBareCommandForNonClaudeAgent() {
         // Non-claude agents never bake the prompt into `command`, so `command`
-        // and `bareCommand` should match (modulo trimming).
-        let user = DefaultAgentConfig.factory
+        // and `bareCommand` should match (modulo trimming). The factory no
+        // longer seeds a prompt, so configure one to prove it is still surfaced
+        // on `initialPrompt` for the post-ready delivery path.
+        var userAgents = DefaultAgentConfig.factory.agents
+        userAgents[.codex] = AgentConfig(
+            command: "codex --yolo",
+            initialPrompt: "orient the agent",
+            envOverridesText: ""
+        )
+        let user = DefaultAgentConfig(defaultAgent: .claudeCode, agents: userAgents)
         let (_, launch) = DefaultAgentResolver.resolve(
             explicitAgent: .codex,
             userDefault: user,
@@ -350,7 +367,7 @@ final class DefaultAgentResolverTests: XCTestCase {
         XCTAssertEqual(launch.command, "codex --yolo")
         // The prompt is still surfaced for non-claude agents — the launch
         // delivery path is what differs (post-ready sendText vs positional).
-        XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(launch.initialPrompt, "orient the agent")
     }
 
     func testBareCommandTrimsWhitespace() {

--- a/skills/MANIFEST.json
+++ b/skills/MANIFEST.json
@@ -13,6 +13,7 @@
     "chord-prototype",
     "chord-architect",
     "distribution",
-    "venture-partner"
+    "venture-partner",
+    "sounding"
   ]
 }

--- a/skills/MANIFEST.json
+++ b/skills/MANIFEST.json
@@ -9,6 +9,10 @@
     "tone-initiation",
     "tone-prototype",
     "tone-architect",
+    "chord-initiation",
+    "chord-prototype",
+    "chord-architect",
+    "distribution",
     "venture-partner"
   ]
 }

--- a/skills/MANIFEST.json
+++ b/skills/MANIFEST.json
@@ -14,6 +14,7 @@
     "chord-architect",
     "distribution",
     "venture-partner",
-    "sounding"
+    "sounding",
+    "resonance"
   ]
 }

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -18,23 +18,25 @@ Refs accept UUIDs, short refs, or indexes: `workspace:1`, `pane:2`, `surface:3`,
 
 **Where new work goes:** a new **pane** when the work wants its own spatial slot (a sub-agent, a log tail, a browser for validation); a new **surface** when a pane just wants another tab; a new **workspace** when the operator names a different project or mission. Default to one workspace per project unless the operator's setup says otherwise.
 
-## Orient first — always, on launch
+## Boot fast, orient lazily
+
+On launch you have no task yet — the operator's opening message is usually just "load the skill" or similar context-only text. Don't spend their time deliberating over a mechanical identity ritual; that dead-time before you can even take a task is the single biggest way an agent wastes the operator's first half-minute. **Get reachable in one cheap step, report ready, and let the rest fill in as you work.**
+
+At launch, run exactly this — as one batched shell call, at minimal effort, no per-command deliberation:
 
 ```bash
-c11 identify --json                                                 # your refs (capture them — see footgun below)
-c11 tree                                                            # spatial layout of the current workspace
-c11 set-agent  --surface <surface> --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
-c11 rename-tab --surface <surface> "<2-4 word role>"                # title — what this surface IS (mandatory)
-c11 set-description --surface <surface> "<why it's open right now>" # description (mandatory)
+c11 set-agent  --surface "$C11_SURFACE_ID" --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
+c11 rename-tab --surface "$C11_SURFACE_ID" "Awaiting first task"
 ```
 
-`set-agent` persists your identity to the sidebar chip. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
+Then reply in one line that you're ready for the task. That is the whole launch. `set-agent` puts the right chip in the sidebar; the placeholder title marks the tab as a live-but-unassigned agent. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
 
-**Title and description are mandatory — every agent, every time.** The sidebar is the operator's only view into a room of parallel agents; an unnamed tab is an unidentifiable agent. Key word first, 2–4 words, under 25 chars (the sidebar truncates from the right).
+**Orient the rest lazily** — when you get a real task or first touch the workspace (any split / status / pane op), and not before:
 
-**Bootstrap-only first message?** If the operator's opening message is just "load the c11 skill" (or similar hydrate-context-only text), the real task is one turn behind. Run identity orientation now, set a *placeholder* title (`c11 rename-tab --surface <surface> "Awaiting first task"`), and title properly from the next real user message — as your very first action that turn.
-
-**Declare a stable mailbox address at orientation** if peers will reach you: `c11 set-metadata --surface <surface> --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Mailbox depth — send/receive, stdin delivery, debugging → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
+- `c11 rename-tab` to your real 2–4 word role, and `c11 set-description` to why the surface is open right now (definitions below). The sidebar is the operator's only view into a room of parallel agents, so retitle off the placeholder as your first action once a task lands — a working agent must not sit under "Awaiting first task".
+- `c11 tree` when you actually need the spatial layout; `c11 identify --json` for your refs if you didn't capture them (footgun below).
+- Read the reference for whatever capability you reach for (map below) — not preemptively.
+- **Declare a stable mailbox address** if peers will reach you: `c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Depth → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
 
 > **Footgun — pass `--surface` explicitly on surface- or tab-scoped writes.** The CLI defaults a missing `--surface` to whatever surface the *operator* is currently focused on — usually a peer agent's tab in a multi-surface workspace — so an omitted flag silently writes to the wrong surface. Every surface exports `$C11_SURFACE_ID` (inherited by subprocesses), so `--surface "$C11_SURFACE_ID"` targets you correctly; if it ever reads empty, capture your refs once from `c11 identify --json` and pass the literal `surface:<n>` instead (robust on any build). Apply this to every surface/tab write (`set-metadata`, `set-agent`, `set-title`, `set-description`, `rename-tab`, `clear-metadata`, `trigger-flash`). Verify the first write with `c11 get-titlebar-state --surface <surface>` against the surface marked `◀ here` in `c11 tree --no-layout`.
 

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -20,23 +20,18 @@ Refs accept UUIDs, short refs, or indexes: `workspace:1`, `pane:2`, `surface:3`,
 
 ## Boot fast, orient lazily
 
-On launch you have no task yet — the operator's opening message is usually just "load the skill" or similar context-only text. Don't spend their time deliberating over a mechanical identity ritual; that dead-time before you can even take a task is the single biggest way an agent wastes the operator's first half-minute. **Get reachable in one cheap step, report ready, and let the rest fill in as you work.**
+c11 stamps your launch identity itself: the sidebar chip (agent type from process detection, plus the pinned model) and a placeholder **"Awaiting first task"** title are set the moment you launch, with no action from you. There is nothing you must run just to be identified — don't spend the operator's time on a mechanical identity ritual.
 
-At launch, run exactly this — as one batched shell call, at minimal effort, no per-command deliberation:
+**You'll usually load this skill because a task arrived** that touches the workspace (a split, a status report, a browser check). When that happens, orient in place and keep moving — at minimal effort, no per-command deliberation:
 
-```bash
-c11 set-agent  --surface "$C11_SURFACE_ID" --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
-c11 rename-tab --surface "$C11_SURFACE_ID" "Awaiting first task"
-```
-
-Then reply in one line that you're ready for the task. That is the whole launch. `set-agent` puts the right chip in the sidebar; the placeholder title marks the tab as a live-but-unassigned agent. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
-
-**Orient the rest lazily** — when you get a real task or first touch the workspace (any split / status / pane op), and not before:
-
-- `c11 rename-tab` to your real 2–4 word role, and `c11 set-description` to why the surface is open right now (definitions below). The sidebar is the operator's only view into a room of parallel agents, so retitle off the placeholder as your first action once a task lands — a working agent must not sit under "Awaiting first task".
-- `c11 tree` when you actually need the spatial layout; `c11 identify --json` for your refs if you didn't capture them (footgun below).
-- Read the reference for whatever capability you reach for (map below) — not preemptively.
+- Refine the placeholder into your real role: `c11 rename-tab --surface "$C11_SURFACE_ID" "<2–4 word role>"`. The sidebar is the operator's only view into a room of parallel agents, so a working agent must not sit under "Awaiting first task".
+- Say why it's open right now: `c11 set-description --surface "$C11_SURFACE_ID" "<current context>"`.
+- If your model chip is blank (an unpinned launch c11 couldn't label), set it: `c11 set-agent --surface "$C11_SURFACE_ID" --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"` — substitute your own known type/model if those vars are empty.
+- Reach for `c11 tree` / `c11 identify --json` only when you actually need layout or your refs (footgun below).
+- Read a reference (map below) only for the capability you're using — not preemptively.
 - **Declare a stable mailbox address** if peers will reach you: `c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Depth → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
+
+**Launched with only a hydrate message and no task yet?** An operator can configure a "load the skill" launch prompt, so your first turn may carry no real task. Don't invent a title — leave the placeholder, reply in one line that you're ready, and set your real title/description from the next real message, as your first action that turn.
 
 > **Footgun — pass `--surface` explicitly on surface- or tab-scoped writes.** The CLI defaults a missing `--surface` to whatever surface the *operator* is currently focused on — usually a peer agent's tab in a multi-surface workspace — so an omitted flag silently writes to the wrong surface. Every surface exports `$C11_SURFACE_ID` (inherited by subprocesses), so `--surface "$C11_SURFACE_ID"` targets you correctly; if it ever reads empty, capture your refs once from `c11 identify --json` and pass the literal `surface:<n>` instead (robust on any build). Apply this to every surface/tab write (`set-metadata`, `set-agent`, `set-title`, `set-description`, `rename-tab`, `clear-metadata`, `trigger-flash`). Verify the first write with `c11 get-titlebar-state --surface <surface>` against the surface marked `◀ here` in `c11 tree --no-layout`.
 

--- a/skills/chord-architect/SKILL.md
+++ b/skills/chord-architect/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: chord-architect
+version: 1
+description: Stage 3 of the Chord workflow (chord-initiation → chord-prototype → chord-architect → lattice-orchestrator ×K) — codifies K loved designs into K build contracts under one shared rulebook, authors the pre-registered resolution book, then conducts the ×K build (fresh lattice-orchestrator run per candidate) through to the handoff of K live, instrumented probes. Inherits tone-architect by reference. Invoke when the operator says "chord architect," "codify the portfolio," "spec the candidates," or when a portfolio of loved prototypes needs its build contracts — and stay seated: this skill also owns the conductor's build-and-handoff playbook.
+---
+
+# Chord — Architect & Conduct
+
+Stage 3 of **Chord**, Tone in plural — and the stage that stays in the room longest: first the architecture dialogue that turns K loved designs into K build contracts under one rulebook, then the **conduct phase**, where K lattice-orchestrator runs execute in parallel and the portfolio is held legible until handoff. Separation of duties survives plurality: each build is judged against a spec its builders did not write.
+
+## Inheritance (the load-bearing rule)
+
+On invoke, read `~/.claude/skills/tone-architect/SKILL.md` in full. It is the **base contract**: the evaluation-contract discipline (verifiability tags, human-use checkpoints), spec rigor (guardrails enforced not assumed, judge-gate), build-plan dialogue (merge-friendly boundaries, keyword-safe names, brownfield reconcile, spike tickets), and the non-software variants all bind here unless explicitly overridden. If it is missing, stop and say so. For the conduct phase, `lattice-orchestrator`'s own documentation is the source of truth for each run's mechanics — this skill orchestrates *runs*, never re-documents them.
+
+**Overrides.** This skill replaces its base in exactly three places; everything else is additive.
+
+1. **One contract → K contracts + one rulebook.** One shared problem-spec codifies the shared story core; K candidate specs reference it, never copy it. Evaluation likewise: a shared eval core (identical harness wherever applicable — the honesty instrument) plus per-candidate evals.
+2. **The judge-gate gains two cross-candidate duties.** A **distinctness audit** (K different bets, or one bet in K costumes?) and an **honesty audit** (is the shared core actually judgeable across all K — are they still answering the same problem?).
+3. **The handoff.** Tone hands one contract to one orchestrator run; Chord's architect seat rolls directly into the conduct phase below — K runs, a membrane, a ledger, and an exit.
+
+## Architecture, plural
+
+Champions author their candidate's spec, evaluation, and build plan in dialogue with the operator — decisions batched across candidates wherever they rhyme (one sitting deciding K stacks beats K sittings). Build plans are merge-friendly across candidates by construction, with milestones **aligned across the portfolio where candidate shapes allow**, so human-use checkpoints batch (one session, K walking skeletons); alignment is a scheduling preference in service of batched attention, never a clock imposed on a candidate whose shape needs longer.
+
+**The resolution book** — authored here, before anything ships; pre-registration is the only defense against sunk-cost creep once there are K living products the operator is fond of. Per candidate:
+
+- **Kill / double-down thresholds**, pre-registered and tied to its `ECONOMICS.md`.
+- **The instrumentation contract** — metrics wired from day one; "metrics flowing" is a ship-blocking criterion, not a nice-to-have.
+- **The distribution plan** — mandatory; code without distribution is code nobody can use. Authored with the `distribution` skill: every channel classified by delegability (agent-executable / operator-assisted / operator-only), funnels instrumented, the portfolio's distribution-decorrelation check re-run across all K plans.
+- **The review cadence** the operations layer will run — which also serves pre-ship as the portfolio's **staleness check**: with no shared clock, a candidate that keeps missing its own cadence is the zombie, surfaced to the operator for kill-or-recommit rather than left at "still building" forever.
+
+## Conduct (the ×K build)
+
+Each champion hands its contract to a **fresh lattice-orchestrator session in its own c11 workspace** — a run is workspace-sized, and the orchestrator seat reads the contract cold; the champion's long creation context never sits in it. The champion stays alive in the champions pane as its candidate's advocate: answering the fleet's questions, reviewing drift against the loved prototype. Terminal validation per candidate as lattice-orchestrator specifies, plus that candidate's resolution-book criteria in its validation plan.
+
+The conductor's standing duties while runs execute:
+
+- **The portfolio ledger** — each run's surfaced learnings, recorded as they land.
+- **The membrane** — problem-level facts (a shared-spec bug, a discovered market truth) fast-lane to all runs with operator approval; solution-level ideas cross only by explicit operator choice; every crossing logged in the ledger. Shared-core amendments apply to all candidates simultaneously or none.
+- **Shared infrastructure is an explicit call, never a drift.** Candidates share nothing by default — sharing code (auth, billing, design system) correlates the bets and softens the membrane; when the operator chooses to share anyway, the ledger says so and why.
+- **Batched checkpoints** — where milestones aligned, human-use checkpoints run as one sitting across candidates.
+- **The staleness cadence** — run it; surface zombies; offer the bench.
+- **Repo spawn** — candidate repos are minted at conduct start (private by default, per the Stage 11 hard rule), each referencing the portfolio repo's shared artifacts.
+
+## Handoff & resolution
+
+Chord exits at: **K live, instrumented probes + the resolution book**, delivered to whatever owns the operations cadence. Resolution — reading each candidate against its own pre-registered criteria on the stated cadence; kill, double down, or merge (the organ-transplant pass: losers are purchased parts as well as purchased information) — happens *outside* Chord, and each read is absolute, never head-to-head. The closed loop still fires: after the first real resolution reads, `run-retro` folds validated, generalized lessons back into both the Chord and Tone families.

--- a/skills/chord-initiation/SKILL.md
+++ b/skills/chord-initiation/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: chord-initiation
+version: 1
+description: Stage 1 of the Chord workflow (chord-initiation → chord-prototype → chord-architect → lattice-orchestrator ×K) — Tone in plural: the portfolio initiation of one problem with several complete answers. Commission a portfolio, research to enumerate, generate ~N candidate bets, voice K uncorrelated ones with a champion each, and write the two-tier philosophy & stories. Inherits tone-initiation by reference. Invoke when the operator says "chord," "chord this," "portfolio this," "build several answers," or when a keystone fork resists resolution by research and dialogue.
+---
+
+# Chord — Initiation
+
+**Chord** is Stage 11's portfolio-creation workflow — Tone in plural. Where Tone carries one idea to one loved prototype and one build contract, Chord carries one *problem* to K complete, shipped, instrumented solutions and lets reality pick. The entry bar is the **keystone inversion**: a fork that dialogue, research, and a venture-partner grilling cannot settle stops being a blocker and becomes the axis of variation. If one shape is obviously right with cosmetic variants, the fork isn't wide enough — run Tone. The portfolio buys **effectiveness, not speed**: candidates are not racing, and every design choice below spends one currency — information per unit of operator attention.
+
+## Inheritance (the load-bearing rule)
+
+On invoke, read `~/.claude/skills/tone-initiation/SKILL.md` in full. It is the **base contract**: its pipeline norms, principles, phases, touchpoint discipline, and layout all bind here unless this skill explicitly overrides them. If it is missing, stop and say so — never improvise the base. Then skim the sibling chord skills, exactly as Tone's stages skim theirs. Tone and Chord are coupled on purpose: an improvement to Tone is an improvement to Chord the moment the skills sync.
+
+**Overrides.** This skill replaces its base in exactly three places; everything else is additive. (A Tone edit landing in one of these should check both families.)
+
+1. **Research saturation** — enumerate, not validate: stop when new searches stop yielding new candidate *shapes*.
+2. **Layout** — portfolio root with per-candidate subtrees, in place of the singular project layout.
+3. **Phase 3–4 stories** — two-tier (shared core + per-candidate), in place of one singular stories file.
+
+## The plural norms (additive to Tone's pipeline norms)
+
+1. **One problem, one philosophy, K solutions.** The one thing, the people, and the problem contract are singular. Two candidates needing different philosophies are different projects — split the commission.
+2. **Uncorrelated failures.** Name *the one thing that kills it* per candidate; choose a set whose kill-conditions differ — including **distribution decorrelation**: candidates that all reach users through the operator's personal network are correlated where attention binds hardest.
+3. **One problem, honestly held.** The shared acceptance core is written before any candidate exists. It is a problem-honesty instrument, not a stopwatch — it guarantees all K still answer the same problem, never that their clocks or fleets match.
+4. **The membrane.** The operator is the only channel between candidates. Problem-level facts propagate to all by default; solution-level ideas cross only at operator discretion. Champion topology makes this physical.
+5. **The bench.** The N−K unselected candidates are reserves, not rejects — a candidate that dies at any pre-ship gate can be replaced from the bench at operator discretion.
+6. **Batched attention.** Every human touchpoint sees all K side-by-side, once. K gates in sequence is how the operator drowns.
+7. **Pre-registration.** Kill and double-down criteria per candidate are written before anything ships (authored at chord-architect; honored from here forward).
+8. **Chord creates; operations reads.** The resolution book is a handoff artifact, not a standing loop inside Chord.
+
+Amendments to the *shared* core apply to all candidates simultaneously or none, and are logged. Candidate-level artifacts stay freely living, exactly as in Tone.
+
+## The phases
+
+**C0 — Commission (plural).** Tone's Phase 0, with the fork logic inverted. One problem, agreed and named, with a portfolio home (a portfolio repo for shared artifacts; candidate repos spawn at build — confirm name and location, never default). The Keystone Decisions table splits two ways: resolvable forks get resolved as in Tone; irresolvable ones are captured as **candidate variation axes**. Entry-bar check, honestly applied: if no fork survives as genuinely irresolvable, or the space can't support ~10 distinct shapes, say so and route to Tone — a commission correctly turned away is a success. Venture-partner offered at the portfolio level when the commission is a business.
+
+**C1 — Research (enumeration-oriented).** Tone's Phase 1 dimensions survive wholesale; a fourth is mandatory: **the solution landscape** — how many genuinely distinct shapes others have used against this problem and its analogues. The brief inverts from validate to enumerate, and saturation is redefined (override 1): stop when new searches stop yielding new candidate shapes.
+
+**C2 — Enumerate (new).** Generate ~N candidates (default ≈10), each a one-card bet: name · core assumption · who pays and roughly how · the one thing that kills it · its natural distribution channel. Fan out generation across deliberately different lenses — personas, wedges, business models; cross-model seeds where they add genuine diversity. Distinctness discipline: swap the pitch between two cards and you should still tell them apart. Resist honestly card-by-card — weak candidates die here, where dying is cheap.
+
+**C3 — Voicing (gate).** The portfolio pick, with the operator: select K (default 3–5) under uncorrelated failures — kill-condition diversity and distribution decorrelation weighed together. The selection artifact is `PORTFOLIO.md`: the chosen candidates, their axes of variation, their kill-conditions, why *this set* spans the space, and the bench. Explicit check: is this K different bets, or one bet voiced K ways? Each selection gets its premises signed (venture-partner per candidate, proportional) and a **champion**: a dedicated agent owning the candidate from here through build-contract handoff. Inside c11, champions are surfaces of one champions pane — one pane, K surfaces — with this conductor in its own pane; champions never read each other's surfaces (norm 4, enforced by topology). A bench promotion mints a fresh champion. Each champion writes its candidate's `ECONOMICS.md` where economics are load-bearing.
+
+**C4 — Philosophy & stories (two-tier).** One `PHILOSOPHY.md` at the portfolio root — shared, referenced never copied, by every candidate. Stories split (override 3): the **shared core** (problem-level stories and ACs — the problem-honesty rulebook, identical for all, IDs like `AC-1`) and **per-candidate stories** (candidate-prefixed IDs like `B/AC-4`, authored by each champion). One **batched stories review** (touchpoint): the operator reads all K side-by-side, once.
+
+## Layout (the portfolio's)
+
+```
+<portfolio>/
+├── sequence/
+│   ├── run-state.md          # ONE portfolio run-state; per-candidate status rolls up here
+│   ├── research/             # the enumeration-oriented dossier
+│   └── USER_STORIES.md       # the shared core (AC-n)
+├── PORTFOLIO.md              # voicing artifact: the K, their axes, kill-conditions, the bench
+├── PHILOSOPHY.md             # singular, shared by reference
+├── candidates/<X>/           # per candidate: stories (X/AC-n), ECONOMICS.md, prototypes/ …
+│                             # (own repo spawns at build; this is the pre-build home)
+└── CLAUDE.md                 # pointers to every root artifact, never copies
+```
+
+## Handoff
+
+Champions invoke `chord-prototype` per candidate — proportionality dialed down (divergence was spent at the candidate level), iteration batched portfolio-wide. The conductor keeps `run-state.md` current and its own lane clear for the operator.

--- a/skills/chord-prototype/SKILL.md
+++ b/skills/chord-prototype/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: chord-prototype
+version: 1
+description: Stage 2 of the Chord workflow (chord-initiation → chord-prototype → chord-architect → lattice-orchestrator ×K) — prototype discovery per candidate, run by each candidate's champion and iterated on a portfolio-wide board until the operator loves every surviving candidate's design. Inherits tone-prototype by reference; divergence was already spent at the candidate level, so takes are dialed down and iteration is batched. Invoke when the operator says "chord prototype," "prototype the portfolio," or when a voiced portfolio (PORTFOLIO.md with champions assigned) needs its designs discovered.
+---
+
+# Chord — Prototype
+
+Stage 2 of **Chord**, Tone in plural. Each champion runs prototype discovery for its own candidate; the portfolio meets the operator as **one board, one sitting per round**. The design of every candidate is discovered here at the cheapest level where it can still change — and a candidate whose design cannot be loved is not a design problem, it is *information*: a kill signal the portfolio paid to receive.
+
+## Inheritance (the load-bearing rule)
+
+On invoke, read `~/.claude/skills/tone-prototype/SKILL.md` in full. It is the **base contract**: design as a first-class task, realistic mock data, boundary mocks, PROTOTYPE badges, the non-UI and non-screen variants, and the love bar all bind here unless explicitly overridden. If it is missing, stop and say so — never improvise the base. Skim the sibling chord skills for the arc.
+
+**Overrides.** This skill replaces its base in exactly two places; everything else — including the love bar — is inherited untouched.
+
+1. **Direction fan-out** — Tone defaults to three directions per project; Chord spent its divergence choosing K candidates, so the default is **1–2 takes per candidate**. Go wider only where a candidate's UX *is* its core assumption (PORTFOLIO.md says which).
+2. **Presentation & iteration cadence** — takes are presented and iterated on a **portfolio-wide board**, not per-project sittings: all candidates' takes tiled for single-glance comparison, one round of operator feedback per sitting, champions iterating in parallel between sittings. Attention costs rounds × one sitting, never rounds × K sittings.
+
+## The work, plural
+
+- **Champions execute; the conductor curates the board.** Each champion builds and revises its candidate's takes in its own surface (browser surfaces per take, grouped by candidate on the board). The conductor assembles the board, schedules sittings, and routes the operator's feedback to the right champion.
+- **The membrane holds during iteration.** Feedback on candidate A goes to champion A. A discovery that is *problem-level* — a mock-data truth, a boundary-semantics surprise, a shared-core story gap — fast-lanes to all champions with operator approval; a design idea from one candidate crosses to another only by explicit operator choice, logged in `run-state.md`.
+- **The love bar holds per candidate** (inherited, deliberately not overridden): iteration ends when the operator has used each surviving candidate's converged take and loves it — would keep it if a better option appeared tomorrow. A candidate stuck short of love after generous rounds is surfaced for **kill and optional bench promotion**, not for bar-lowering. Lukewarm probes ship ambiguous failures: bad bet, or just unloved design? The portfolio can't afford the ambiguity.
+- **Living artifacts flow per candidate.** New stories and criteria discovered in a candidate's prototype land in `candidates/<X>/` with fresh `X/AC-n` IDs. An upheld contradiction with the shared `PHILOSOPHY.md` or the shared story core is portfolio-level by definition — it amends the shared artifact for all candidates simultaneously or none.
+
+## Done — and what it produces
+
+Per surviving candidate: the converged take in `candidates/<X>/prototypes/` as that candidate's **binding visual contract**, and `candidates/<X>/DESIGN.md` recording its converged design language — voice, aesthetic, direction, why. Portfolio `run-state.md` updated: takes per candidate, rounds, kills and promotions, stats. Every take carries the PROTOTYPE badge (inherited, non-negotiable).
+
+## Handoff
+
+Invoke `chord-architect`: champions codify their loved designs into K build contracts under one shared rulebook, and the conductor's build-and-handoff playbook takes the portfolio home.

--- a/skills/distribution/SKILL.md
+++ b/skills/distribution/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: distribution
+version: 1
+description: Distribution planning and execution for anything shipped — audience definition, channels classified by who can run them (agent-executable / operator-assisted / operator-only), credibility assets, instrumented funnels, and an execution cadence. Code without distribution is code nobody can use. Invoke on "distribution," "go-to-market," "GTM," "how does this reach users," "market this," or "nobody's using it." Standalone; composed once per project by Tone (from the architect stage onward), per candidate by Chord's champions, and retrofittable onto anything already shipped.
+---
+
+# Distribution
+
+You are designing how a real thing reaches real users — with the same rigor the build got, because distribution left to hope is the most common way a good build dies. The plan is an artifact, not a vibe: `DISTRIBUTION.md` at the project root (or the candidate's resolution-book entry, in a Chord portfolio), with every claim carrying a channel, an owner class, and a metric.
+
+The skill's one structural insight: **the binding budget is operator attention, and channels differ wildly in how much of it they burn.** So the core move is classification — making distribution agent-executable wherever it can be, and honest about where it cannot.
+
+## The spine
+
+**1. Audience.** Borrow venture-partner's currency: specificity. Name the person-shaped profile who needs this most — title, what gets them promoted, what keeps them up at night — and where they *already gather*. Channels are places populated by the audience, not tactics in the abstract; a channel nobody in the audience reads is theater.
+
+**2. Channels, classified by delegability.** Enumerate candidate channels, then tag each:
+
+- **agent-executable** — agents produce and publish end-to-end: content and SEO, landing pages, docs, directories and listings, launch posts, comparison pages, scheduled updates. Accounts and credentials are operator-granted; platform terms are respected; anything that goes public still clears the operator first (publishing is inherently a public act — Stage 11's privacy-by-default rule applies until the operator says ship).
+- **operator-assisted** — agents prepare everything, the operator approves and sends: outreach drafts under the operator's name, community posts, partnership pitches, replies. The agent's job is to make the human's ten minutes count.
+- **operator-only** — personal credibility, warm intros, conference hallways, human-only channels (Signal and personal DMs stay human; agents scaffold facts, never ghostwrite the relationship). Irreducibly human reach — the plan budgets it, batched and scarce.
+
+**The tags are the attention budget made visible.** A plan whose every channel is operator-only is a plan to drown — flag it and redesign toward channels agents can carry, or descope the reach claim honestly. In a Chord portfolio, re-run the **distribution-decorrelation check** across all K plans: candidates all drawing on the operator's one network and reputation are correlated bets no matter how different their kill-conditions look.
+
+**3. Credibility assets.** What must exist before any outreach lands: a real site, a demo that works, proof (numbers, testimonials, a public artifact), a pricing page that answers the first question. Almost all agent-buildable; each is ship-blocking for the channels that need it — outreach pointing at a hollow front costs the audience permanently.
+
+**4. Instrumented funnels.** Every channel gets a measurable entry — UTM, signup source, referral code — wired into the project's instrumentation before the channel goes live, and a pre-registered bar: what this channel must show, by when, to keep receiving effort. A channel with no metric is a belief; pre-registering the bar is what lets you kill it without an argument later.
+
+**5. Cadence.** The execution rhythm: agents run the agent-executable lanes continuously; operator lanes batch into scheduled sittings that respect attention; the funnel numbers get read on a stated cadence and channels get killed or doubled per their pre-registered bars. Where a resolution book exists (Chord), the cadence and thresholds land there; where it doesn't (Tone, retrofits), `DISTRIBUTION.md` carries its own review section.
+
+## Composition
+
+- **In Tone:** invoke from the architect stage onward — the plan's agent-executable items become build-plan tickets like any other work, and credibility assets join the walking-skeleton sequencing.
+- **In Chord:** each champion authors its candidate's plan; the conductor runs the cross-candidate decorrelation check; plans live in the resolution book.
+- **Retrofit:** for anything already shipped and languishing, run the spine as an audit — the gap is usually a missing tag-2/tag-3 honesty (everything was implicitly operator-only, so nothing happened).
+
+## Honesty clauses
+
+Some reach is irreducibly human, and the skill classifies rather than pretends — an agent-executable lane never launders an operator-only relationship. And distribution work is publishing: nothing goes public, gets posted, or sends outbound without the operator having said so for that surface — the confirmation is part of the plan, not friction on it.

--- a/skills/resonance/SKILL.md
+++ b/skills/resonance/SKILL.md
@@ -37,7 +37,7 @@ Assumes c11 (load the c11 skill for mechanics); degrades cleanly to plain files 
 when? Installs, signups, stars, active users, replies, revenue. "We should do
 marketing" is not intent — push until it's a number on a date.
 
-**R1 — Map.** Read the playbook first. Then the ground: who the audience actually is,
+**R1 — Map.** Read whatever playbook exists for this project or its neighbors first. Then the ground: who the audience actually is,
 where they already gather (name real venues, not categories), what the funnel looks
 like today (do we even know weekly installs?), and what the audience currently uses
 instead. Model intelligence and quick research both count — label which is which.
@@ -96,11 +96,12 @@ playbook by being run.
 
 ## The playbook
 
-`resonance/` at the Stage11 root (sibling of `sounding/`), created on first run:
-`experiments/` (one brief per run, immutable once verdicted) and `playbook/` (distilled
-plays — play, audience, channel, creative approach, actual numbers including cost per
-result, conditions where it holds — each citing the experiments that earned it, with
-replication count and as-of date), plus `INDEX.md` (regenerate, don't hand-tend). One
+There is no canonical home — where the record lives depends on the project, and the
+session decides it (the project's repo, a deployment directory, wherever the work
+already lives). What's fixed is the shape, not the address: experiment briefs
+(immutable once verdicted) and distilled plays — play, audience, channel, creative
+approach, actual numbers including cost per result, conditions where it holds — each
+citing the experiments that earned it, with replication count and as-of date. One
 experiment makes a play a candidate; replication promotes it. Early reps run on
 Stage 11's own tools, where a bad landing costs nearly nothing.
 

--- a/skills/resonance/SKILL.md
+++ b/skills/resonance/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: resonance
+version: 1
+description: Stage 11's marketing-capability program — a working session that turns marketing intent into budgeted, pre-registered experiments and accumulates the verdicts into a playbook of plays with real numbers. Demand generation is the unsolved half of the autonomous-business loop; Resonance reps it daily the way agentic coding was repped in 2023–24. Invoke on "resonance," "make this resonate," "marketing," "get users for this," "demand probe," "test demand," or whenever marketing needs to produce a verdict, not a vibe. Standalone; its probe instruments serve Sounding "try" reads; its playbook feeds the distribution skill (per-project channel planning), which feeds every channel result back.
+---
+
+# Resonance
+
+A tone is produced; resonance is the audience amplifying it. The skill in five bullets:
+
+1. **A working session that ends with runnable plays, not a philosophy of marketing.**
+   The operator brings intent — a product that needs users, a launch, a demand question.
+   The session ends with experiment briefs ready to fire, or an explicit "not yet, and
+   here's the number we're missing."
+2. **Every marketing act is an experiment or it doesn't run.** Hypothesis, audience,
+   funnel stage, channel, budget, pre-registered bar, verdict date — written before
+   anything fires. No verdict, no learning; no learning, and it was just spend.
+3. **Check the playbook before designing anything.** Validated plays get run again
+   before novel ones get invented; refuted plays don't get re-bought. The playbook is
+   the capability — this file is just the loop that fills it.
+4. **Bias hard toward agent-native plays.** Automating the human marketing playbook
+   produces slop at scale and burns credibility permanently. The edge is wherever agent
+   economics changes the arithmetic — the forcing question below.
+5. **Nothing goes public without operator sign-off, per surface.** Brand voice
+   (`company/brand/`) binds all public output. No fake social proof, no astroturf, no
+   ToS violations — the whole thesis rests on being the evidence-backed actor.
+
+This skill encodes a capability that doesn't exist yet, at Stage 11 or anywhere; it
+structures acquisition. Early runs will feel underpowered. That's what repping a
+frontier looks like.
+
+Assumes c11 (load the c11 skill for mechanics); degrades cleanly to plain files outside it.
+
+## The session
+
+**R0 — Intent.** What business number is this trying to move, for which product, by
+when? Installs, signups, stars, active users, replies, revenue. "We should do
+marketing" is not intent — push until it's a number on a date.
+
+**R1 — Map.** Read the playbook first. Then the ground: who the audience actually is,
+where they already gather (name real venues, not categories), what the funnel looks
+like today (do we even know weekly installs?), and what the audience currently uses
+instead. Model intelligence and quick research both count — label which is which.
+
+**R2 — Design.** Candidate plays, each stated tactically: play · funnel stage ·
+channel · cost (dollars / agent-hours / operator-minutes) · expected signal ·
+time-to-verdict. Rank by information per dollar per week; take positions. The forcing
+question for every play: **what does agent economics make affordable here that never
+was before?** Fifty positioning variants where humans test two; per-segment landing
+pages; always-on community presence; genuinely deep per-prospect research; measurement
+rigor humans never sustain; machine-legible surfaces for agent-mediated discovery —
+the next buyer is an agent making tooling decisions, and nobody courts them yet. A
+play a human team could run just as well is allowed, but must say why we run it.
+
+**R3 — Pre-register.** Chosen plays become experiment briefs (schema below) before
+anything fires. The bar is a number with a date and a cost cap, decided now — not
+negotiated after the results are in.
+
+**R4 — Run.** Agents carry the agent-executable lanes end-to-end; operator-gated
+surfaces (outreach under his name, community posts, anything public) batch for
+sign-off per the distribution skill's delegability classes.
+
+**R5 — Verdict.** On the verdict date, read the numbers and write it: **validated /
+refuted / inconclusive**. Refuted is full-value — the graveyard prevents re-spend
+forever, and honest negative results are themselves an agent-native edge. Inconclusive
+on the date means kill or redesign with a sharper bar; no zombie experiments.
+
+## The experiment brief
+
+One file, written at R3: **hypothesis** (one sentence, falsifiable) · **product &
+business number** · **audience** · **funnel stage** (aware → considering → trying →
+adopted → advocating) · **channel/surface** · **cost** (dollars, agent-hours,
+operator-minutes) · **bar** · **measurement** (how we'll know, from whatever the
+property already offers — an experiment that can't say how it's measured doesn't run) ·
+**verdict date** · **verdict** · **what we learned**.
+
+## Channels
+
+Name real ones, classified by delegability (per distribution): launch venues (HN,
+Product Hunt, the right subreddits); content and SEO (comparison pages, tutorials,
+docs that answer the buyer's first search); communities (Discords, Slacks, subreddits —
+presence earns, drive-by promotion burns); social (X, build-in-public); directories,
+listings, awesome-lists, package registries; paid micro-spend (small caps, fast
+reads); outreach (drafted by agents, sent under the operator's name); integrations and
+partnerships; agent-mediated discovery (llms.txt, machine-readable docs, being the
+answer agents give when asked "what should I use for X"). The list illustrates; the
+session picks venues the actual audience actually reads.
+
+## The probes
+
+Pre-build demand instruments, available to any Sounding "try" read whose risk is
+demand-shaped: landing page, marketplace listing test, waitlist, paid micro-spend,
+comparison-page probe, concierge run. Each is an experiment like any other — bar
+pre-registered before it fires. Recipes aren't authored here; they're earned into the
+playbook by being run.
+
+## The playbook
+
+`resonance/` at the Stage11 root (sibling of `sounding/`), created on first run:
+`experiments/` (one brief per run, immutable once verdicted) and `playbook/` (distilled
+plays — play, audience, channel, creative approach, actual numbers including cost per
+result, conditions where it holds — each citing the experiments that earned it, with
+replication count and as-of date), plus `INDEX.md` (regenerate, don't hand-tend). One
+experiment makes a play a candidate; replication promotes it. Early reps run on
+Stage 11's own tools, where a bad landing costs nearly nothing.
+
+Runs log to `runs-ledger.md` beside this skill; run-retro folds lessons back (family
+norm: war stories in the ledger, only principles enter the skill).
+
+## Boundaries
+
+`distribution` plans channels for one shipped thing — it consumes this playbook and
+feeds every channel result back as experiment data. Cadence (the standing post-ship
+operations rhythm) is deliberately unauthored until something ships and needs it.
+Resonance is the cross-project capability program: the session, the playbook, the probes.

--- a/skills/resonance/runs-ledger.md
+++ b/skills/resonance/runs-ledger.md
@@ -1,0 +1,6 @@
+# Resonance — runs ledger
+
+War stories and per-run notes live here; only validated, generalized principles enter SKILL.md (via run-retro).
+
+| Date | Intent (operator's words) | Product | Experiments fired | Verdicts | Notes |
+|------|---------------------------|---------|-------------------|----------|-------|

--- a/skills/sounding/SKILL.md
+++ b/skills/sounding/SKILL.md
@@ -14,7 +14,7 @@ A sounding is a depth measurement — taken before the ship commits to the chann
 4. **Produces reads.** Concrete candidate takes on the direction, each packaged as a card: demand evidence, incumbents, distribution hypothesis, build size, kill condition.
 5. **Ends in try / not-try per read.** Made with the operator, side by side, no finer ranking. "Try" reads go to a venture-partner grilling and enter Tone or Chord as commissions.
 
-Pre-build validation (landing pages, listing tests, paid probes) is downstream — Resonance instruments, available to any "try" read whose risk is demand-shaped. Sounding's output is ideas, not experiments.
+Pre-build validation (landing pages, listing tests, paid probes) is downstream — Resonance's probe instruments, available to any "try" read whose risk is demand-shaped. Sounding's output is ideas, not experiments.
 
 Assumes c11 (load the c11 skill for mechanics) and Scanner where app-level evidence pays; on territory Scanner can't reach, the sequence runs on plain research — the discipline is the skill, not the tooling.
 
@@ -56,4 +56,4 @@ One card per read, one file per card:
 
 ## Corpus
 
-Cards and sweeps accumulate in `sounding/` at the Stage11 root (sibling of `scanner/`), created on first run: `cards/`, `sweeps/<territory>/<date>/`, `INDEX.md` (a plain list by status — regenerate, don't hand-tend). Re-sounding a territory diffs against its prior sweep; evidence carries an as-of date, and a stale card re-earns its call or moves to watch. Runs log to `runs-ledger.md` beside this skill; run-retro folds lessons back (family norm: war stories in the ledger, only principles enter the skill).
+The shape is fixed, the address is the operator's: a sounding corpus, created on first run at the workspace root unless the operator points elsewhere, holding `cards/`, `sweeps/<territory>/<date>/`, and `INDEX.md` (a plain list by status — regenerate, don't hand-tend). Re-sounding a territory diffs against its prior sweep; evidence carries an as-of date, and a stale card re-earns its call or moves to watch. Runs log to `runs-ledger.md` beside this skill; run-retro folds lessons back (family norm: war stories in the ledger, only principles enter the skill).

--- a/skills/sounding/SKILL.md
+++ b/skills/sounding/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: sounding
+version: 1
+description: The idea-generation sequence upstream of the Tone/Chord workflows — the operator brings a direction (a market, a hunch, a theme); Sounding arms it with evidence and explores it in dialogue, producing reads — concrete, carded takes on the direction — each ending in a try/not-try call. Where Tone begins with "a raw idea and a client," Sounding is where raw ideas come from. Invoke on "sounding," "take soundings," "sound this," "let's explore ideas," "what should we build next," or whenever the operator brings a direction that isn't yet an idea. Standalone; "try" reads feed venture-partner and the Tone/Chord commissions; composes with Scanner (/scan) for app-level evidence.
+---
+
+# Sounding
+
+A sounding is a depth measurement — taken before the ship commits to the channel. The skill in five bullets:
+
+1. **Starts from a direction the human brings.** A market, a hunch, a theme, an itch. Sounding never runs empty — the direction and the will behind it are the operator's. You may suggest directions you noticed; you never own one.
+2. **Arms the direction with evidence.** Scanner sweeps and demand research over the direction's territory: what exists, who pays, what they pay, where incumbents are weak.
+3. **Plays.** The exploration dialogue — riffs, angles, what-ifs, sharpening in conversation. The heart of the skill, and it is allowed to be playful; that is where the surprising reads come from.
+4. **Produces reads.** Concrete candidate takes on the direction, each packaged as a card: demand evidence, incumbents, distribution hypothesis, build size, kill condition.
+5. **Ends in try / not-try per read.** Made with the operator, side by side, no finer ranking. "Try" reads go to a venture-partner grilling and enter Tone or Chord as commissions.
+
+Pre-build validation (landing pages, listing tests, paid probes) is downstream — Resonance instruments, available to any "try" read whose risk is demand-shaped. Sounding's output is ideas, not experiments.
+
+Assumes c11 (load the c11 skill for mechanics) and Scanner where app-level evidence pays; on territory Scanner can't reach, the sequence runs on plain research — the discipline is the skill, not the tooling.
+
+## The exploration dialogue
+
+This is tone-initiation's interview energy pointed at an open direction instead of a brought idea. You are part researcher, part sparring partner: the operator holds the direction, taste, and context the evidence can't supply; you hold the evidence, the breadth, and the obligation to push back. Neither alone generates good ideas — the dialogue is where they combine, and it is the phase everything else serves.
+
+- **Come armed.** Never open the dialogue empty-handed — bring the sweep: what the territory looks like, where the money visibly moves, what surprised you. The operator's time is spent reacting and steering, not waiting for research.
+- **Two evidence instruments, both encouraged.** Research (sweeps, sources, numbers — cited) and **model intelligence** — your own knowledge of markets, business models, pricing norms, and failure patterns is a legitimate source: use it freely and label it as yours, so the card can tell a cited fact from a model prior. Hiding behind search when you already know the shape of an answer wastes the dialogue; asserting a prior as a citation poisons it.
+- **Ask real questions, liberally.** What pulls the operator toward this direction? What would they never build, and why? Which incumbent's customers do they instinctively understand? Instinct is data — interrogate it like any other source.
+- **Volunteer reads, with a position.** Surface more candidate reads than the operator asked for, take positions on them, and state what formed each position. Enthusiasm is earned by evidence; so is skepticism.
+- **Loop between evidence and conversation.** A dialogue turn that raises a question the evidence can't answer mints a research task; run it and come back. Expect several passes — exploration is iterative by nature, and "not yet knowable, here's how we'd find out" beats a confident guess.
+- **Develop, don't just collect.** When a read shows life, work it *in the dialogue*: sharpen the wedge, name who pays, find the kill condition together. A read leaves the conversation better-formed than it entered, or it doesn't leave as a card.
+
+## The card
+
+One card per read, one file per card:
+
+- **Read** — one paragraph, the wedge in one line.
+- **Origin** — the direction it answers (the operator's own words, from S0) and the evidence or dialogue moment that produced it. No orphan reads.
+- **Demand** — who pays today, what they pay, with links; model priors marked as such. The mandatory column: real displaced spend, or `Unknown — how we'd find out`, never silence.
+- **Incumbents** — who holds the spend, their weakness, Scan refs where they exist.
+- **Distribution hypothesis** — how this acquires users, channels tagged by delegability (per the distribution skill). All-operator-only distribution is named on the card as a strike, before anything is built.
+- **Build sketch** — size tier (S/M/L) only. Buildability is table stakes, never the selling point.
+- **The kill** — the one thing that kills it, plainly.
+- **Call** — try / not-try / watch, and the one-line reason.
+
+## The sequence
+
+**S0 — Receive the direction.** The operator states the direction and why it pulls them — captured in their own words; that paragraph heads every read's Origin. Agree on the territory the direction implies and how deep this run should go.
+
+**S1 — Sweep.** Scanner shallow scans over the territory's incumbents; demand overlay alongside (marketplace stats, review velocity, pricing pages, category spend). Output: the evidence brief that opens the dialogue.
+
+**S2 — Play.** The dialogue, as above. Generation runs throughout — between sittings, fan out candidate reads from the evidence and bring the distinct ones in. Distinctness discipline: swap two pitches and you should still tell them apart.
+
+**S3 — Card.** Reads the dialogue kept get the full schema. Filling the card is itself a test — a card that can't fill its demand column goes back to the dialogue or dies.
+
+**S4 — Call (touchpoint).** The operator reads the cards side by side, once: **try, not-try, or watch** — the calls are the output. "Try" reads go to venture-partner; survivors are commissioned into Tone (or Chord, when the read's keystone fork is genuinely irresolvable). Underwriting formality — budgets, signed kill criteria — lives at that commission gate, and Tone's Phase-1 research inherits the card's evidence rather than re-deriving it.
+
+## Corpus
+
+Cards and sweeps accumulate in `sounding/` at the Stage11 root (sibling of `scanner/`), created on first run: `cards/`, `sweeps/<territory>/<date>/`, `INDEX.md` (a plain list by status — regenerate, don't hand-tend). Re-sounding a territory diffs against its prior sweep; evidence carries an as-of date, and a stale card re-earns its call or moves to watch. Runs log to `runs-ledger.md` beside this skill; run-retro folds lessons back (family norm: war stories in the ledger, only principles enter the skill).

--- a/skills/sounding/runs-ledger.md
+++ b/skills/sounding/runs-ledger.md
@@ -1,0 +1,6 @@
+# Sounding — runs ledger
+
+War stories and per-run notes live here; only validated, generalized principles enter SKILL.md (via run-retro).
+
+| Date | Direction (operator's words) | Territory | Reads carded | Try / not-try / watch | Notes |
+|------|------------------------------|-----------|--------------|-----------------------|-------|


### PR DESCRIPTION
## What

**Chord** — Tone in plural: one problem carried to a portfolio of K complete, shipped, instrumented solutions, with reality picking the winner. Four new installable skills:

- **chord-initiation** (C0–C4) — plural commission with the keystone inversion as entry bar, enumeration-oriented research, ~N one-card candidate bets, the Voicing gate (K selected under uncorrelated failures + distribution decorrelation, one champion agent per candidate), two-tier philosophy & stories.
- **chord-prototype** (C5) — champion-run prototype discovery on a portfolio-wide board; 1–2 takes per candidate (divergence was spent at Voicing), batched iteration rounds; the love bar is inherited from Tone untouched.
- **chord-architect** (C6–C8) — K build contracts under one shared rulebook, distinctness + honesty audits at the judge-gate, the pre-registered **resolution book** (kill/double-down thresholds, instrumentation contract, distribution plan, review cadence), then the conductor's playbook for the ×K lattice-orchestrator build through handoff.
- **distribution** — standalone peer of venture-partner: audience, channels classified by delegability (agent-executable / operator-assisted / operator-only), credibility assets, instrumented funnels, cadence. Composed by Tone once per project and by Chord per candidate; retrofits onto shipped projects.

## Design

Each chord skill is a **delta overlay** on its Tone counterpart, inherited by *runtime reference*: on invoke it reads the `tone-*` skill as its base contract, restates nothing the base owns, and carries an explicit overrides list (3 / 2 / 3 items respectively). Improving Tone improves Chord on the next skill sync — a deliberate architectural decision. A chord skill that cannot find its Tone base stops loudly.

Stacked on `overture-orchestrator-rework` (PR #306) because the family references the `tone-*` names introduced there. Concept memo: `ideation/chord/CONCEPT.md` in the Stage11 monorepo, v0.01.004.

Installed copies mirrored + `scripts/sync-installed-skills.sh` run (13 synced, 0 skipped); `MANIFEST.json` parses clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)