### PR TITLE
c11 skill: boot fast, orient lazily on agent launch

### DIFF
--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -18,23 +18,25 @@ Refs accept UUIDs, short refs, or indexes: `workspace:1`, `pane:2`, `surface:3`,
 
 **Where new work goes:** a new **pane** when the work wants its own spatial slot (a sub-agent, a log tail, a browser for validation); a new **surface** when a pane just wants another tab; a new **workspace** when the operator names a different project or mission. Default to one workspace per project unless the operator's setup says otherwise.
 
-## Orient first — always, on launch
+## Boot fast, orient lazily
+
+On launch you have no task yet — the operator's opening message is usually just "load the skill" or similar context-only text. Don't spend their time deliberating over a mechanical identity ritual; that dead-time before you can even take a task is the single biggest way an agent wastes the operator's first half-minute. **Get reachable in one cheap step, report ready, and let the rest fill in as you work.**
+
+At launch, run exactly this — as one batched shell call, at minimal effort, no per-command deliberation:
 
 ```bash
-c11 identify --json                                                 # your refs (capture them — see footgun below)
-c11 tree                                                            # spatial layout of the current workspace
-c11 set-agent  --surface <surface> --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
-c11 rename-tab --surface <surface> "<2-4 word role>"                # title — what this surface IS (mandatory)
-c11 set-description --surface <surface> "<why it's open right now>" # description (mandatory)
+c11 set-agent  --surface "$C11_SURFACE_ID" --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
+c11 rename-tab --surface "$C11_SURFACE_ID" "Awaiting first task"
 ```
 
-`set-agent` persists your identity to the sidebar chip. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
+Then reply in one line that you're ready for the task. That is the whole launch. `set-agent` puts the right chip in the sidebar; the placeholder title marks the tab as a live-but-unassigned agent. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
 
-**Title and description are mandatory — every agent, every time.** The sidebar is the operator's only view into a room of parallel agents; an unnamed tab is an unidentifiable agent. Key word first, 2–4 words, under 25 chars (the sidebar truncates from the right).
+**Orient the rest lazily** — when you get a real task or first touch the workspace (any split / status / pane op), and not before:
 
-**Bootstrap-only first message?** If the operator's opening message is just "load the c11 skill" (or similar hydrate-context-only text), the real task is one turn behind. Run identity orientation now, set a *placeholder* title (`c11 rename-tab --surface <surface> "Awaiting first task"`), and title properly from the next real user message — as your very first action that turn.
-
-**Declare a stable mailbox address at orientation** if peers will reach you: `c11 set-metadata --surface <surface> --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Mailbox depth — send/receive, stdin delivery, debugging → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
+- `c11 rename-tab` to your real 2–4 word role, and `c11 set-description` to why the surface is open right now (definitions below). The sidebar is the operator's only view into a room of parallel agents, so retitle off the placeholder as your first action once a task lands — a working agent must not sit under "Awaiting first task".
+- `c11 tree` when you actually need the spatial layout; `c11 identify --json` for your refs if you didn't capture them (footgun below).
+- Read the reference for whatever capability you reach for (map below) — not preemptively.
+- **Declare a stable mailbox address** if peers will reach you: `c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Depth → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
 
 > **Footgun — pass `--surface` explicitly on surface- or tab-scoped writes.** The CLI defaults a missing `--surface` to whatever surface the *operator* is currently focused on — usually a peer agent's tab in a multi-surface workspace — so an omitted flag silently writes to the wrong surface. Every surface exports `$C11_SURFACE_ID` (inherited by subprocesses), so `--surface "$C11_SURFACE_ID"` targets you correctly; if it ever reads empty, capture your refs once from `c11 identify --json` and pass the literal `surface:<n>` instead (robust on any build). Apply this to every surface/tab write (`set-metadata`, `set-agent`, `set-title`, `set-description`, `rename-tab`, `clear-metadata`, `trigger-flash`). Verify the first write with `c11 get-titlebar-state --surface <surface>` against the surface marked `◀ here` in `c11 tree --no-layout`.
 


### PR DESCRIPTION
## Problem

A freshly launched c11 agent burned ~45s of dead-time before it could take a task. The launch prompt (`"...load the skill."`) sent the agent into the c11 skill's **"Orient first — always, on launch"** mandate — an identify → tree → set-agent → rename-tab → set-description burst, run as separate deliberated tool calls at the operator's high reasoning effort. Pure dead-time: the operator can't even give the task until it finishes, and ends up escaping out of it. (Confirmed repro: a "load the skill" launch that "Worked for 41s" before reporting ready.)

## Fix

Rework the skill's orientation section from **"Orient first — always"** to **"Boot fast, orient lazily"**:

- **On launch:** one batched shell call — `set-agent` (sidebar chip) + `rename-tab "Awaiting first task"` — at minimal effort, then a one-line "ready." That's the whole launch.
- **Everything else is deferred** — real title, description, `tree`, reference reads — until the agent gets a real task or first touches the workspace (any split / status / pane op).

This keeps agents c11-aware when they actually drive the workspace, without paying for it before there's a task.

## Measurement

Ran `c11 default-agent launch` (the "A-button" path) against the synced skill. The agent booted to **titled + idle-ready in ~10s** (incl. claude cold-start) vs the confirmed **41s** before — no heavy identify/tree/role-title burst. Titlebar confirmed: `title=Awaiting first task`, a light bootstrap description, idle.

## Scope

Skill-only (`skills/c11/SKILL.md`). No code, no resolver edits. Maintainer must run `scripts/sync-installed-skills.sh c11` to refresh their live copy (already done on the authoring machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)