### PR TITLE
Drop the launch-orient prompt; c11 stamps agent identity itself

### DIFF
--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -277,6 +277,14 @@ struct AgentRegistry: Sendable {
     ])
 }
 
-/// The orientation prompt typed into a freshly launched agent. Mirrors
-/// `AgentType.factoryInitialPrompt` for non-custom agents.
-let c11OrientPrompt = "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it."
+/// The factory initial prompt for c11-launched agents — empty by design.
+/// A freshly launched agent boots straight to ready with no orientation
+/// turn, so there is no dead-time before the operator can give it a task.
+/// c11 supplies the identity the sidebar needs itself: the agent type comes
+/// from `AgentDetector` (process inspection) and the pinned model plus a
+/// placeholder title are stamped at launch in `Workspace.launchAgentSurface`.
+/// The c11 skill loads on demand — when a task actually drives the workspace.
+/// Mirrors `AgentType.factoryInitialPrompt` for non-custom agents; an
+/// operator who wants a launch prompt can still set one per-agent in
+/// Default Agent settings.
+let c11OrientPrompt = ""

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6463,6 +6463,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 // SurfaceSpec.command is delivered verbatim by the layout
                 // executor, so the newline has to live in the value itself.
                 injected.surfaces[idx].command = command + "\n"
+                // No orientation prompt is baked by default (see
+                // `c11OrientPrompt`), so mirror launchAgentSurface: stamp the
+                // identity the sidebar would otherwise wait on the agent to
+                // report — a placeholder title and the pinned model (the type
+                // comes from AgentDetector). Only fill fields the spec left
+                // unset so an explicit blueprint always wins.
+                if injected.surfaces[idx].title == nil {
+                    injected.surfaces[idx].title = String(
+                        localized: "agent.launch.placeholderTitle",
+                        defaultValue: "Awaiting first task"
+                    )
+                }
+                let cfg = projectConfig?.agents[resolved.agent]
+                    ?? userDefault.config(for: resolved.agent)
+                let model = cfg.model.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !model.isEmpty {
+                    var meta = injected.surfaces[idx].metadata ?? [:]
+                    if meta[MetadataKey.model] == nil {
+                        meta[MetadataKey.model] = .string(model)
+                        injected.surfaces[idx].metadata = meta
+                    }
+                }
             }
         }
 

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -54,6 +54,45 @@ enum AgentType: String, Codable, CaseIterable, Identifiable {
     var factoryInitialPrompt: String {
         AgentRegistry.shared.manifest(for: self)?.factoryInitialPrompt ?? ""
     }
+
+    /// Factory default for the pinned model family. Only Claude Code carries
+    /// one out of the box — c11 pins `opus` so agents launched here stay on
+    /// Opus even when the operator flips their ambient Claude default to
+    /// another family. Every other agent inherits its own default (empty).
+    /// See `ClaudeModelFamily` for the set of families c11 offers, and
+    /// `DefaultAgentResolver.buildCommand` for where the flag is injected.
+    var factoryModel: String {
+        self == .claudeCode ? ClaudeModelFamily.opus.rawValue : ""
+    }
+}
+
+/// The Claude model-family aliases c11 offers as a pinned launch default.
+///
+/// Each raw value is exactly what `claude --model <alias>` accepts, and Claude
+/// Code resolves a family alias to the *latest* version of that family. Pinning
+/// the family (not a versioned id like `claude-opus-4-8`) means new model
+/// releases need no c11 change — the whole point of the setting.
+enum ClaudeModelFamily: String, CaseIterable, Identifiable {
+    case opus
+    case sonnet
+    case haiku
+    case fable
+
+    var id: String { rawValue }
+
+    /// Human-readable label for the Settings picker. Localized at the call site.
+    var displayName: String {
+        switch self {
+        case .opus:
+            return String(localized: "claudeModelFamily.opus", defaultValue: "Opus")
+        case .sonnet:
+            return String(localized: "claudeModelFamily.sonnet", defaultValue: "Sonnet")
+        case .haiku:
+            return String(localized: "claudeModelFamily.haiku", defaultValue: "Haiku")
+        case .fable:
+            return String(localized: "claudeModelFamily.fable", defaultValue: "Fable")
+        }
+    }
 }
 
 /// Per-agent configuration: command typed into the shell to launch this agent,
@@ -68,11 +107,18 @@ struct AgentConfig: Codable, Equatable {
     /// Multi-line `KEY=value` text, one entry per line. Parsed at use time;
     /// keeps the UI to a single text editor instead of a row-editor list.
     var envOverridesText: String
+    /// Pinned model family (e.g. `opus`). Injected as `--model <model>` at
+    /// launch for agents whose CLI accepts it (currently Claude Code). Empty
+    /// means "don't pin" — inherit the agent's own default. A model the
+    /// operator hardcoded into `command` always wins; see
+    /// `DefaultAgentResolver.buildCommand`.
+    var model: String
 
-    init(command: String, initialPrompt: String, envOverridesText: String) {
+    init(command: String, initialPrompt: String, envOverridesText: String, model: String = "") {
         self.command = command
         self.initialPrompt = initialPrompt
         self.envOverridesText = envOverridesText
+        self.model = model
     }
 
     init(from decoder: Decoder) throws {
@@ -80,6 +126,9 @@ struct AgentConfig: Codable, Equatable {
         self.command = (try? c.decode(String.self, forKey: .command)) ?? ""
         self.initialPrompt = (try? c.decode(String.self, forKey: .initialPrompt)) ?? ""
         self.envOverridesText = (try? c.decode(String.self, forKey: .envOverridesText)) ?? ""
+        // Absent in configs written before the model setting existed; those
+        // decode to "" (inherit), preserving their prior launch behavior.
+        self.model = (try? c.decode(String.self, forKey: .model)) ?? ""
     }
 
     /// Factory defaults for a given agent type.
@@ -87,7 +136,8 @@ struct AgentConfig: Codable, Equatable {
         AgentConfig(
             command: agent.factoryCommand,
             initialPrompt: agent.factoryInitialPrompt,
-            envOverridesText: ""
+            envOverridesText: "",
+            model: agent.factoryModel
         )
     }
 
@@ -111,7 +161,7 @@ struct AgentConfig: Codable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case command, initialPrompt, envOverridesText
+        case command, initialPrompt, envOverridesText, model
     }
 }
 

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -46,7 +46,7 @@ enum DefaultAgentResolver {
             ?? userDefault.config(for: agent)
 
         let command = buildCommand(agent: agent, config: chosenConfig)
-        let bare = chosenConfig.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        let bare = launcherCommand(agent: agent, config: chosenConfig)
         return (agent, ResolvedAgentLaunch(
             command: command,
             bareCommand: bare,
@@ -61,15 +61,51 @@ enum DefaultAgentResolver {
     /// separate post-launch sendText so each TUI's input contract is honored.
     /// Visible for testing.
     static func buildCommand(agent: AgentType, config: AgentConfig) -> String {
-        let base = config.command.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !base.isEmpty else { return "" }
+        let launcher = launcherCommand(agent: agent, config: config)
+        guard !launcher.isEmpty else { return "" }
         if agent == .claudeCode {
             let prompt = config.initialPrompt.trimmingCharacters(in: .whitespacesAndNewlines)
             if !prompt.isEmpty {
-                return "\(base) \(shellQuote(prompt))"
+                return "\(launcher) \(shellQuote(prompt))"
             }
         }
+        return launcher
+    }
+
+    /// The launcher: the operator's `command` with the pinned model flag
+    /// applied, but no positional prompt baked in. This is what feeds
+    /// `bareCommand` / the `C11_DEFAULT_AGENT_LAUNCH` export, so an orchestrator
+    /// that composes its own prompt still inherits the pinned model. The
+    /// model flag must precede claude-code's positional prompt (which stays
+    /// last), so it's applied here rather than after prompt-baking.
+    /// Visible for testing.
+    static func launcherCommand(agent: AgentType, config: AgentConfig) -> String {
+        let base = config.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !base.isEmpty else { return "" }
+        if let flag = modelFlag(agent: agent, config: config, command: base) {
+            return "\(base) \(flag)"
+        }
         return base
+    }
+
+    /// Whether c11 injects a `--model` flag for this agent kind. Only agents
+    /// whose CLI accepts `--model <family-alias>` qualify; today that's Claude
+    /// Code. Kept as a seam so codex (also `--model`) can opt in later.
+    static func supportsModelFlag(_ agent: AgentType) -> Bool {
+        agent == .claudeCode
+    }
+
+    /// The `--model <family>` flag to append for a launch, or `nil` when none
+    /// should be injected: the agent doesn't support it, no family is pinned,
+    /// or the operator already put a model in the command themselves (their
+    /// explicit choice wins, and we must not pass `--model` twice).
+    /// Visible for testing.
+    static func modelFlag(agent: AgentType, config: AgentConfig, command: String) -> String? {
+        guard supportsModelFlag(agent) else { return nil }
+        let model = config.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !model.isEmpty else { return nil }
+        guard !command.lowercased().contains("--model") else { return nil }
+        return "--model \(model)"
     }
 
     /// Single-quote a value for /bin/sh, escaping embedded single quotes via

--- a/Sources/DefaultAgentSettingsView.swift
+++ b/Sources/DefaultAgentSettingsView.swift
@@ -7,6 +7,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
     @Published var defaultAgent: AgentType
     @Published var editingAgent: AgentType
     @Published var command: String
+    @Published var model: String
     @Published var initialPrompt: String
     @Published var envOverridesText: String
 
@@ -22,6 +23,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         self.defaultAgent = active
         self.editingAgent = active
         self.command = entry.command
+        self.model = entry.model
         self.initialPrompt = entry.initialPrompt
         self.envOverridesText = entry.envOverridesText
 
@@ -36,8 +38,15 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         }.store(in: &cancellables)
 
         $command.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
+        $model.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
         $initialPrompt.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
         $envOverridesText.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
+    }
+
+    /// Whether c11 pins a `--model` flag for the agent currently being edited,
+    /// gating whether the model picker is shown.
+    var editingAgentSupportsModel: Bool {
+        DefaultAgentResolver.supportsModelFlag(editingAgent)
     }
 
     private func loadFields(for agent: AgentType) {
@@ -45,6 +54,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         defer { suppressSave = false }
         let entry = store.current.config(for: agent)
         command = entry.command
+        model = entry.model
         initialPrompt = entry.initialPrompt
         envOverridesText = entry.envOverridesText
     }
@@ -55,7 +65,8 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         let snapshot = AgentConfig(
             command: command,
             initialPrompt: initialPrompt,
-            envOverridesText: envOverridesText
+            envOverridesText: envOverridesText,
+            model: model
         )
         store.update(captured) { $0 = snapshot }
     }
@@ -65,6 +76,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         suppressSave = true
         let factory = AgentConfig.factory(for: editingAgent)
         command = factory.command
+        model = factory.model
         initialPrompt = factory.initialPrompt
         envOverridesText = factory.envOverridesText
         suppressSave = false
@@ -113,6 +125,10 @@ struct DefaultAgentSettingsSection: View {
                     .foregroundStyle(.secondary)
             }
 
+            if vm.editingAgentSupportsModel {
+                modelPicker
+            }
+
             VStack(alignment: .leading, spacing: 3) {
                 Text(String(localized: "settings.defaultAgent.initialPrompt.label", defaultValue: "initial prompt"))
                     .font(.callout)
@@ -143,6 +159,35 @@ struct DefaultAgentSettingsSection: View {
                 }
                 .controlSize(.small)
             }
+        }
+    }
+
+    /// Model-family picker, shown only for agents c11 pins a `--model` flag
+    /// for. The empty tag means "inherit" (no flag injected); each family maps
+    /// to `claude --model <family>`, resolving to that family's latest version.
+    private var modelPicker: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                Text(String(localized: "settings.defaultAgent.model.label", defaultValue: "model"))
+                    .font(.callout)
+                Picker("", selection: $vm.model) {
+                    Text(String(localized: "settings.defaultAgent.model.inherit",
+                                defaultValue: "Inherit (agent default)"))
+                        .tag("")
+                    ForEach(ClaudeModelFamily.allCases) { family in
+                        Text(family.displayName).tag(family.rawValue)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
+                .accessibilityIdentifier("DefaultAgentModelPicker")
+                Spacer()
+            }
+            Text(String(localized: "settings.defaultAgent.model.help",
+                        defaultValue: "pins --model on launch, so agents launched here stay on this family even when your ambient Claude default changes. picks the family, not a version — new releases need no change. a model set in the command above wins."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11786,12 +11786,55 @@ extension Workspace: BonsplitDelegate {
             inPane: pane,
             startupEnvironment: resolved.launch.envOverrides
         ) else { return }
-        // The launch command goes to bash; for claude-code the initial prompt
-        // is already baked in as a positional arg by the resolver. Other
-        // agents preserve the prompt in their config but don't auto-deliver
-        // (different TUI input contracts; per-agent post-ready delivery is
-        // a follow-up).
+        // By default no orientation prompt is baked (see `c11OrientPrompt`),
+        // so the agent boots straight to ready with no dead-time. c11 stamps
+        // the identity the sidebar needs itself — no agent round-trip: the
+        // type comes from `AgentDetector`, and we stamp the pinned model plus
+        // a placeholder title here. An operator who configured a launch prompt
+        // still gets it delivered below (baked positional for claude-code,
+        // post-ready sendText for other TUIs is a follow-up).
+        stampLaunchIdentity(
+            surfaceId: panel.id,
+            agent: resolved.agent,
+            userDefault: userDefault,
+            projectConfig: projectConfig
+        )
         panel.sendText(resolved.launch.command + "\n")
+    }
+
+    /// Populate a freshly launched agent surface with the identity the sidebar
+    /// would otherwise wait on the agent to report: the pinned model (which
+    /// process detection can't infer) and a placeholder title. Written with
+    /// source `.declare` so a later explicit `set-agent` / `set-title` from the
+    /// agent or operator cleanly wins. The agent *type* is intentionally not
+    /// stamped here — `AgentDetector` owns it authoritatively.
+    private func stampLaunchIdentity(
+        surfaceId: UUID,
+        agent: AgentType,
+        userDefault: DefaultAgentConfig,
+        projectConfig: DefaultAgentConfig?
+    ) {
+        var partial: [String: Any] = [
+            MetadataKey.title: String(
+                localized: "agent.launch.placeholderTitle",
+                defaultValue: "Awaiting first task"
+            )
+        ]
+        // Mirror the resolver's per-agent config pick so the chip shows the
+        // model c11 launched with. Reads config only; no mutation.
+        let cfg = projectConfig?.agents[agent] ?? userDefault.config(for: agent)
+        let model = cfg.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !model.isEmpty {
+            partial[MetadataKey.model] = model
+        }
+        _ = try? SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: id,
+            surfaceId: surfaceId,
+            partial: partial,
+            mode: .merge,
+            source: .declare
+        )
+        syncPanelTitleFromMetadata(panelId: surfaceId)
     }
 
     func splitTabBar(_ controller: BonsplitController, menuItemsForNewTabKind kind: String, inPane pane: PaneID) -> [BonsplitNewTabMenuItem] {

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -21,7 +21,7 @@ final class DefaultAgentConfigTests: XCTestCase {
     func testFactoryClaudeCommandIncludesDangerouslySkipPermissions() {
         let entry = AgentConfig.factory(for: .claudeCode)
         XCTAssertEqual(entry.command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testFactoryClaudePinsOpusModel() {
@@ -48,19 +48,19 @@ final class DefaultAgentConfigTests: XCTestCase {
     func testFactoryCodexCommandIncludesYolo() {
         let entry = AgentConfig.factory(for: .codex)
         XCTAssertEqual(entry.command, "codex --yolo")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testFactoryGrokCommandIncludesAlwaysApprove() {
         let entry = AgentConfig.factory(for: .grok)
         XCTAssertEqual(entry.command, "grok --always-approve")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testFactoryGitHubCopilotCommandIncludesAllowAllAndAutopilot() {
         let entry = AgentConfig.factory(for: .githubCopilot)
         XCTAssertEqual(entry.command, "copilot --allow-all --autopilot")
-        XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(entry.initialPrompt, "")
     }
 
     func testAgentTypeGitHubCopilotRawValueIsKebabCase() {
@@ -218,7 +218,7 @@ final class DefaultAgentConfigTests: XCTestCase {
         let (store, _) = makeStore()
         XCTAssertEqual(store.current.defaultAgent, .claudeCode)
         XCTAssertEqual(store.current.config(for: .claudeCode).command, "claude --dangerously-skip-permissions")
-        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(store.current.config(for: .claudeCode).initialPrompt, "")
     }
 
     func testStoreReturnsFactoryOnGarbageData() {

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -24,6 +24,27 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(entry.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
     }
 
+    func testFactoryClaudePinsOpusModel() {
+        // Claude Code ships pinned to the Opus family so agents launched from
+        // c11 stay on Opus regardless of the operator's ambient Claude default.
+        XCTAssertEqual(AgentConfig.factory(for: .claudeCode).model, "opus")
+        XCTAssertEqual(AgentType.claudeCode.factoryModel, ClaudeModelFamily.opus.rawValue)
+    }
+
+    func testFactoryNonClaudeAgentsHaveNoPinnedModel() {
+        // Only claude-code carries a factory model; everyone else inherits.
+        for type in AgentType.allCases where type != .claudeCode {
+            XCTAssertEqual(AgentConfig.factory(for: type).model, "", "\(type) should not pin a model")
+        }
+    }
+
+    func testClaudeModelFamilyRawValuesAreCliAliases() {
+        // These raw values are passed verbatim to `claude --model`; they must
+        // stay the family aliases the CLI resolves to the latest version.
+        XCTAssertEqual(ClaudeModelFamily.allCases.map(\.rawValue),
+                       ["opus", "sonnet", "haiku", "fable"])
+    }
+
     func testFactoryCodexCommandIncludesYolo() {
         let entry = AgentConfig.factory(for: .codex)
         XCTAssertEqual(entry.command, "codex --yolo")
@@ -73,6 +94,23 @@ final class DefaultAgentConfigTests: XCTestCase {
         XCTAssertEqual(decoded.agents[.claudeCode]?.initialPrompt, "load skill")
         XCTAssertEqual(decoded.agents[.claudeCode]?.envOverridesText, "K=V")
         XCTAssertEqual(decoded.agents[.codex]?.command, "codex --yolo")
+    }
+
+    func testCodableRoundTripPreservesModel() throws {
+        var agents: [AgentType: AgentConfig] = [:]
+        agents[.claudeCode] = AgentConfig(command: "claude", initialPrompt: "", envOverridesText: "", model: "fable")
+        let cfg = DefaultAgentConfig(defaultAgent: .claudeCode, agents: agents)
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(DefaultAgentConfig.self, from: data)
+        XCTAssertEqual(decoded.agents[.claudeCode]?.model, "fable")
+    }
+
+    func testDecodeAgentConfigWithoutModelDefaultsToInherit() throws {
+        // A per-agent blob written before the model field existed must decode
+        // to "" (inherit), preserving its prior launch behavior on upgrade.
+        let json = #"{"command":"claude","initialPrompt":"","envOverridesText":""}"#
+        let decoded = try JSONDecoder().decode(AgentConfig.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.model, "")
     }
 
     func testLenientDecodeFillsMissingFields() throws {

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -18,7 +18,9 @@ final class DefaultAgentResolverTests: XCTestCase {
             projectConfig: nil
         )
         XCTAssertEqual(agent, .claudeCode)
-        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'")
+        // The factory pins Opus for claude-code, so the launcher carries
+        // `--model opus` ahead of the positional prompt.
+        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'")
     }
 
     func testProjectConfigDefaultAgentBeatsUserDefault() {
@@ -177,6 +179,92 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
     }
 
+    // MARK: - model pinning
+
+    func testBuildCommandInjectsPinnedModelBeforePrompt() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "go",
+            envOverridesText: "",
+            model: "opus"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus 'go'"
+        )
+    }
+
+    func testBuildCommandInjectsPinnedModelWithoutPrompt() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "fable"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model fable"
+        )
+    }
+
+    func testBuildCommandEmptyModelInjectsNothing() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: ""
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions"
+        )
+    }
+
+    func testBuildCommandDoesNotDoubleModelWhenCommandAlreadyHasOne() {
+        // Operator hardcoded a model in the command — their choice wins and we
+        // must not pass --model twice.
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions --model sonnet",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "opus"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model sonnet"
+        )
+    }
+
+    func testBuildCommandDoesNotInjectModelForNonClaudeAgent() {
+        // codex accepts --model too, but c11 only pins it for claude-code today;
+        // a stray model value on another agent must be ignored, not injected.
+        let cfg = AgentConfig(
+            command: "codex --yolo",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "opus"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .codex, config: cfg),
+            "codex --yolo"
+        )
+    }
+
+    func testLauncherCommandCarriesModelForBareExport() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "some prompt",
+            envOverridesText: "",
+            model: "opus"
+        )
+        // bareCommand / C11_DEFAULT_AGENT_LAUNCH carries the model but never the
+        // positional prompt, so orchestrators can append their own.
+        XCTAssertEqual(
+            DefaultAgentResolver.launcherCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus"
+        )
+    }
+
     func testShellQuoteEmpty() {
         XCTAssertEqual(DefaultAgentResolver.shellQuote(""), "''")
     }
@@ -221,12 +309,14 @@ final class DefaultAgentResolverTests: XCTestCase {
             userDefault: user,
             projectConfig: nil
         )
-        XCTAssertEqual(launch.bareCommand, "claude --dangerously-skip-permissions")
+        // The pinned model rides on the launcher (both bareCommand and the
+        // baked command); only the positional prompt distinguishes them.
+        XCTAssertEqual(launch.bareCommand, "claude --dangerously-skip-permissions --model opus")
         XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
         // The baked form still ships on `command` for the A-button path.
         XCTAssertEqual(
             launch.command,
-            "claude --dangerously-skip-permissions 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
+            "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
         )
     }
 

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -18,9 +18,9 @@ final class DefaultAgentResolverTests: XCTestCase {
             projectConfig: nil
         )
         XCTAssertEqual(agent, .claudeCode)
-        // The factory pins Opus for claude-code, so the launcher carries
-        // `--model opus` ahead of the positional prompt.
-        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'")
+        // The factory pins Opus for claude-code and no longer seeds a launch
+        // prompt, so the resolved command is just the launcher with `--model opus`.
+        XCTAssertEqual(launch.command, "claude --dangerously-skip-permissions --model opus")
     }
 
     func testProjectConfigDefaultAgentBeatsUserDefault() {
@@ -303,7 +303,16 @@ final class DefaultAgentResolverTests: XCTestCase {
     // caller-appended positional argument (claude takes only the first).
 
     func testBareCommandOmitsClaudeInitialPrompt() {
-        let user = DefaultAgentConfig.factory
+        // The factory no longer seeds a launch prompt, so configure one
+        // explicitly to prove bareCommand strips it while command bakes it.
+        var userAgents = DefaultAgentConfig.factory.agents
+        userAgents[.claudeCode] = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "orient the agent",
+            envOverridesText: "",
+            model: "opus"
+        )
+        let user = DefaultAgentConfig(defaultAgent: .claudeCode, agents: userAgents)
         let (_, launch) = DefaultAgentResolver.resolve(
             explicitAgent: nil,
             userDefault: user,
@@ -312,11 +321,11 @@ final class DefaultAgentResolverTests: XCTestCase {
         // The pinned model rides on the launcher (both bareCommand and the
         // baked command); only the positional prompt distinguishes them.
         XCTAssertEqual(launch.bareCommand, "claude --dangerously-skip-permissions --model opus")
-        XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(launch.initialPrompt, "orient the agent")
         // The baked form still ships on `command` for the A-button path.
         XCTAssertEqual(
             launch.command,
-            "claude --dangerously-skip-permissions --model opus 'You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.'"
+            "claude --dangerously-skip-permissions --model opus 'orient the agent'"
         )
     }
 
@@ -339,8 +348,16 @@ final class DefaultAgentResolverTests: XCTestCase {
 
     func testBareCommandForNonClaudeAgent() {
         // Non-claude agents never bake the prompt into `command`, so `command`
-        // and `bareCommand` should match (modulo trimming).
-        let user = DefaultAgentConfig.factory
+        // and `bareCommand` should match (modulo trimming). The factory no
+        // longer seeds a prompt, so configure one to prove it is still surfaced
+        // on `initialPrompt` for the post-ready delivery path.
+        var userAgents = DefaultAgentConfig.factory.agents
+        userAgents[.codex] = AgentConfig(
+            command: "codex --yolo",
+            initialPrompt: "orient the agent",
+            envOverridesText: ""
+        )
+        let user = DefaultAgentConfig(defaultAgent: .claudeCode, agents: userAgents)
         let (_, launch) = DefaultAgentResolver.resolve(
             explicitAgent: .codex,
             userDefault: user,
@@ -350,7 +367,7 @@ final class DefaultAgentResolverTests: XCTestCase {
         XCTAssertEqual(launch.command, "codex --yolo")
         // The prompt is still surfaced for non-claude agents — the launch
         // delivery path is what differs (post-ready sendText vs positional).
-        XCTAssertEqual(launch.initialPrompt, "You are inside c11 (a terminal multiplexer). A c11 skill covering panes, splits, and status is available if you need it.")
+        XCTAssertEqual(launch.initialPrompt, "orient the agent")
     }
 
     func testBareCommandTrimsWhitespace() {

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -18,23 +18,25 @@ Refs accept UUIDs, short refs, or indexes: `workspace:1`, `pane:2`, `surface:3`,
 
 **Where new work goes:** a new **pane** when the work wants its own spatial slot (a sub-agent, a log tail, a browser for validation); a new **surface** when a pane just wants another tab; a new **workspace** when the operator names a different project or mission. Default to one workspace per project unless the operator's setup says otherwise.
 
-## Orient first — always, on launch
+## Boot fast, orient lazily
+
+On launch you have no task yet — the operator's opening message is usually just "load the skill" or similar context-only text. Don't spend their time deliberating over a mechanical identity ritual; that dead-time before you can even take a task is the single biggest way an agent wastes the operator's first half-minute. **Get reachable in one cheap step, report ready, and let the rest fill in as you work.**
+
+At launch, run exactly this — as one batched shell call, at minimal effort, no per-command deliberation:
 
 ```bash
-c11 identify --json                                                 # your refs (capture them — see footgun below)
-c11 tree                                                            # spatial layout of the current workspace
-c11 set-agent  --surface <surface> --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
-c11 rename-tab --surface <surface> "<2-4 word role>"                # title — what this surface IS (mandatory)
-c11 set-description --surface <surface> "<why it's open right now>" # description (mandatory)
+c11 set-agent  --surface "$C11_SURFACE_ID" --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
+c11 rename-tab --surface "$C11_SURFACE_ID" "Awaiting first task"
 ```
 
-`set-agent` persists your identity to the sidebar chip. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
+Then reply in one line that you're ready for the task. That is the whole launch. `set-agent` puts the right chip in the sidebar; the placeholder title marks the tab as a live-but-unassigned agent. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
 
-**Title and description are mandatory — every agent, every time.** The sidebar is the operator's only view into a room of parallel agents; an unnamed tab is an unidentifiable agent. Key word first, 2–4 words, under 25 chars (the sidebar truncates from the right).
+**Orient the rest lazily** — when you get a real task or first touch the workspace (any split / status / pane op), and not before:
 
-**Bootstrap-only first message?** If the operator's opening message is just "load the c11 skill" (or similar hydrate-context-only text), the real task is one turn behind. Run identity orientation now, set a *placeholder* title (`c11 rename-tab --surface <surface> "Awaiting first task"`), and title properly from the next real user message — as your very first action that turn.
-
-**Declare a stable mailbox address at orientation** if peers will reach you: `c11 set-metadata --surface <surface> --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Mailbox depth — send/receive, stdin delivery, debugging → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
+- `c11 rename-tab` to your real 2–4 word role, and `c11 set-description` to why the surface is open right now (definitions below). The sidebar is the operator's only view into a room of parallel agents, so retitle off the placeholder as your first action once a task lands — a working agent must not sit under "Awaiting first task".
+- `c11 tree` when you actually need the spatial layout; `c11 identify --json` for your refs if you didn't capture them (footgun below).
+- Read the reference for whatever capability you reach for (map below) — not preemptively.
+- **Declare a stable mailbox address** if peers will reach you: `c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Depth → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
 
 > **Footgun — pass `--surface` explicitly on surface- or tab-scoped writes.** The CLI defaults a missing `--surface` to whatever surface the *operator* is currently focused on — usually a peer agent's tab in a multi-surface workspace — so an omitted flag silently writes to the wrong surface. Every surface exports `$C11_SURFACE_ID` (inherited by subprocesses), so `--surface "$C11_SURFACE_ID"` targets you correctly; if it ever reads empty, capture your refs once from `c11 identify --json` and pass the literal `surface:<n>` instead (robust on any build). Apply this to every surface/tab write (`set-metadata`, `set-agent`, `set-title`, `set-description`, `rename-tab`, `clear-metadata`, `trigger-flash`). Verify the first write with `c11 get-titlebar-state --surface <surface>` against the surface marked `◀ here` in `c11 tree --no-layout`.
 

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -20,23 +20,18 @@ Refs accept UUIDs, short refs, or indexes: `workspace:1`, `pane:2`, `surface:3`,
 
 ## Boot fast, orient lazily
 
-On launch you have no task yet — the operator's opening message is usually just "load the skill" or similar context-only text. Don't spend their time deliberating over a mechanical identity ritual; that dead-time before you can even take a task is the single biggest way an agent wastes the operator's first half-minute. **Get reachable in one cheap step, report ready, and let the rest fill in as you work.**
+c11 stamps your launch identity itself: the sidebar chip (agent type from process detection, plus the pinned model) and a placeholder **"Awaiting first task"** title are set the moment you launch, with no action from you. There is nothing you must run just to be identified — don't spend the operator's time on a mechanical identity ritual.
 
-At launch, run exactly this — as one batched shell call, at minimal effort, no per-command deliberation:
+**You'll usually load this skill because a task arrived** that touches the workspace (a split, a status report, a browser check). When that happens, orient in place and keep moving — at minimal effort, no per-command deliberation:
 
-```bash
-c11 set-agent  --surface "$C11_SURFACE_ID" --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"
-c11 rename-tab --surface "$C11_SURFACE_ID" "Awaiting first task"
-```
-
-Then reply in one line that you're ready for the task. That is the whole launch. `set-agent` puts the right chip in the sidebar; the placeholder title marks the tab as a live-but-unassigned agent. If `$C11_AGENT_TYPE` / `$C11_AGENT_MODEL` are empty you were launched outside the wrapper — substitute your own known type and model, don't guess.
-
-**Orient the rest lazily** — when you get a real task or first touch the workspace (any split / status / pane op), and not before:
-
-- `c11 rename-tab` to your real 2–4 word role, and `c11 set-description` to why the surface is open right now (definitions below). The sidebar is the operator's only view into a room of parallel agents, so retitle off the placeholder as your first action once a task lands — a working agent must not sit under "Awaiting first task".
-- `c11 tree` when you actually need the spatial layout; `c11 identify --json` for your refs if you didn't capture them (footgun below).
-- Read the reference for whatever capability you reach for (map below) — not preemptively.
+- Refine the placeholder into your real role: `c11 rename-tab --surface "$C11_SURFACE_ID" "<2–4 word role>"`. The sidebar is the operator's only view into a room of parallel agents, so a working agent must not sit under "Awaiting first task".
+- Say why it's open right now: `c11 set-description --surface "$C11_SURFACE_ID" "<current context>"`.
+- If your model chip is blank (an unpinned launch c11 couldn't label), set it: `c11 set-agent --surface "$C11_SURFACE_ID" --type "$C11_AGENT_TYPE" --model "$C11_AGENT_MODEL"` — substitute your own known type/model if those vars are empty.
+- Reach for `c11 tree` / `c11 identify --json` only when you actually need layout or your refs (footgun below).
+- Read a reference (map below) only for the capability you're using — not preemptively.
 - **Declare a stable mailbox address** if peers will reach you: `c11 set-metadata --surface "$C11_SURFACE_ID" --key mailbox.address --value "<stable-handle>" --type string`. Titles are mutable and renames silently re-partition the bus; a declared address survives them. (Depth → [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md).)
+
+**Launched with only a hydrate message and no task yet?** An operator can configure a "load the skill" launch prompt, so your first turn may carry no real task. Don't invent a title — leave the placeholder, reply in one line that you're ready, and set your real title/description from the next real message, as your first action that turn.
 
 > **Footgun — pass `--surface` explicitly on surface- or tab-scoped writes.** The CLI defaults a missing `--surface` to whatever surface the *operator* is currently focused on — usually a peer agent's tab in a multi-surface workspace — so an omitted flag silently writes to the wrong surface. Every surface exports `$C11_SURFACE_ID` (inherited by subprocesses), so `--surface "$C11_SURFACE_ID"` targets you correctly; if it ever reads empty, capture your refs once from `c11 identify --json` and pass the literal `surface:<n>` instead (robust on any build). Apply this to every surface/tab write (`set-metadata`, `set-agent`, `set-title`, `set-description`, `rename-tab`, `clear-metadata`, `trigger-flash`). Verify the first write with `c11 get-titlebar-state --surface <surface>` against the surface marked `◀ here` in `c11 tree --no-layout`.
 


### PR DESCRIPTION
## What

Take the fast-boot work to its conclusion: a c11-launched agent now boots straight to an **idle, ready prompt with zero orientation turn** — no dead-time at all before the operator can give it a task.

The launch prompt existed only to make the agent c11-aware. Everything it produced at launch, c11 can supply itself or defer:

- **Agent-type chip** — already comes from `AgentDetector` (process inspection); never needed an agent action.
- **Model chip + "Awaiting first task" placeholder title** — now stamped by c11 at launch, in both launch paths: `Workspace.launchAgentSurface` (A-button / socket) via `SurfaceMetadataStore`, and the `createWorkspace` restore / new-with-agent path via the injected `SurfaceSpec`. Written with source `.declare` so a later explicit `set-agent` / `set-title` cleanly wins.
- **Skill knowledge** — loads on demand, when a task actually drives the workspace.

The factory initial prompt is now empty (`c11OrientPrompt`). The configurable per-agent launch prompt is **preserved** for operators who still want one.

## Why not just the skill (PR #309)?

Even with the lazy-orient skill, an injected prompt forces a first conversational turn, and at the operator's high reasoning effort that turn can't be made free (~10s floor). The only way to reach 0s is to not inject a prompt.

## Skill update

`skills/c11/SKILL.md` orientation section reworked to match: an agent now usually loads the skill *with a task already in hand*, so it sets a real title/description rather than the placeholder; c11's self-stamping of chip + placeholder is documented; the hydrate-only-launch case is kept for operators who configure a prompt. (Installed copy synced via `scripts/sync-installed-skills.sh`.)

## Validation

Tagged build (`c11 DEV noprompt.app`, factory config = empty prompt). `default-agent launch` and the welcome-blueprint launch both produced agents titled **"Awaiting first task" [declare]** with **no prompt typed** — the agents went straight to the operator's first real task and loaded the c11 skill on-demand to drive the workspace correctly (`c11 new-surface`, pane-ref reasoning). `** BUILD SUCCEEDED **`.

Known tradeoff (accepted): for a task that never renames, the placeholder title can lag while the agent works — the visible cost of not orienting up front. Follow-up option: clear the placeholder when `AgentDetector` sees the agent go active.

## Base

Depends on the pinnable default-model field (`AgentConfig.model`), which lives on `chord-family` (PR #307), so this is **based on `chord-family`**, not `main`. Complements the skill-only PR #309.

🤖 Generated with [Claude Code](https://claude.com/claude-code)