### PR TITLE
Add an optional pinnable effort level for c11-launched agents

### DIFF
--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -95,6 +95,40 @@ enum ClaudeModelFamily: String, CaseIterable, Identifiable {
     }
 }
 
+/// The reasoning-effort levels c11 offers as an optional pinned launch default.
+///
+/// Each raw value is exactly what `claude --effort` accepts. There is no
+/// "inherit" case — an empty stored value means inherit, and c11 injects no
+/// flag so the agent keeps its ambient effort. Higher levels may be restricted
+/// by the operator's plan; c11 passes the value through and lets Claude Code
+/// enforce. See `DefaultAgentResolver.buildCommand` for where the flag is
+/// injected.
+enum ClaudeEffort: String, CaseIterable, Identifiable {
+    case low
+    case medium
+    case high
+    case xhigh
+    case max
+
+    var id: String { rawValue }
+
+    /// Human-readable label for the Settings picker. Localized at the call site.
+    var displayName: String {
+        switch self {
+        case .low:
+            return String(localized: "claudeEffort.low", defaultValue: "Low")
+        case .medium:
+            return String(localized: "claudeEffort.medium", defaultValue: "Medium")
+        case .high:
+            return String(localized: "claudeEffort.high", defaultValue: "High")
+        case .xhigh:
+            return String(localized: "claudeEffort.xhigh", defaultValue: "Extra high")
+        case .max:
+            return String(localized: "claudeEffort.max", defaultValue: "Max")
+        }
+    }
+}
+
 /// Per-agent configuration: command typed into the shell to launch this agent,
 /// optional initial prompt to send after launch, and free-text env overrides.
 struct AgentConfig: Codable, Equatable {
@@ -113,12 +147,18 @@ struct AgentConfig: Codable, Equatable {
     /// operator hardcoded into `command` always wins; see
     /// `DefaultAgentResolver.buildCommand`.
     var model: String
+    /// Pinned reasoning-effort level (e.g. `high`). Injected as
+    /// `--effort <effort>` at launch for agents whose CLI accepts it (currently
+    /// Claude Code). Empty means "don't pin" — inherit the agent's ambient
+    /// effort. An effort the operator hardcoded into `command` always wins.
+    var effort: String
 
-    init(command: String, initialPrompt: String, envOverridesText: String, model: String = "") {
+    init(command: String, initialPrompt: String, envOverridesText: String, model: String = "", effort: String = "") {
         self.command = command
         self.initialPrompt = initialPrompt
         self.envOverridesText = envOverridesText
         self.model = model
+        self.effort = effort
     }
 
     init(from decoder: Decoder) throws {
@@ -126,9 +166,10 @@ struct AgentConfig: Codable, Equatable {
         self.command = (try? c.decode(String.self, forKey: .command)) ?? ""
         self.initialPrompt = (try? c.decode(String.self, forKey: .initialPrompt)) ?? ""
         self.envOverridesText = (try? c.decode(String.self, forKey: .envOverridesText)) ?? ""
-        // Absent in configs written before the model setting existed; those
-        // decode to "" (inherit), preserving their prior launch behavior.
+        // Both absent in configs written before these settings existed; they
+        // decode to "" (inherit), preserving prior launch behavior.
         self.model = (try? c.decode(String.self, forKey: .model)) ?? ""
+        self.effort = (try? c.decode(String.self, forKey: .effort)) ?? ""
     }
 
     /// Factory defaults for a given agent type.
@@ -161,7 +202,7 @@ struct AgentConfig: Codable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case command, initialPrompt, envOverridesText, model
+        case command, initialPrompt, envOverridesText, model, effort
     }
 }
 

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -80,12 +80,15 @@ enum DefaultAgentResolver {
     /// last), so it's applied here rather than after prompt-baking.
     /// Visible for testing.
     static func launcherCommand(agent: AgentType, config: AgentConfig) -> String {
-        let base = config.command.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !base.isEmpty else { return "" }
-        if let flag = modelFlag(agent: agent, config: config, command: base) {
-            return "\(base) \(flag)"
+        var result = config.command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !result.isEmpty else { return "" }
+        if let flag = modelFlag(agent: agent, config: config, command: result) {
+            result += " \(flag)"
         }
-        return base
+        if let flag = effortFlag(agent: agent, config: config, command: result) {
+            result += " \(flag)"
+        }
+        return result
     }
 
     /// Whether c11 injects a `--model` flag for this agent kind. Only agents
@@ -106,6 +109,25 @@ enum DefaultAgentResolver {
         guard !model.isEmpty else { return nil }
         guard !command.lowercased().contains("--model") else { return nil }
         return "--model \(model)"
+    }
+
+    /// Whether c11 injects an `--effort` flag for this agent kind. Same set as
+    /// the model flag today (Claude Code); kept separate so an agent that
+    /// accepts one flag but not the other can diverge later.
+    static func supportsEffortFlag(_ agent: AgentType) -> Bool {
+        agent == .claudeCode
+    }
+
+    /// The `--effort <level>` flag to append for a launch, or `nil` when none
+    /// should be injected: the agent doesn't support it, no level is pinned, or
+    /// the operator already put an effort in the command themselves (their
+    /// explicit choice wins). Visible for testing.
+    static func effortFlag(agent: AgentType, config: AgentConfig, command: String) -> String? {
+        guard supportsEffortFlag(agent) else { return nil }
+        let effort = config.effort.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !effort.isEmpty else { return nil }
+        guard !command.lowercased().contains("--effort") else { return nil }
+        return "--effort \(effort)"
     }
 
     /// Single-quote a value for /bin/sh, escaping embedded single quotes via

--- a/Sources/DefaultAgentSettingsView.swift
+++ b/Sources/DefaultAgentSettingsView.swift
@@ -8,6 +8,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
     @Published var editingAgent: AgentType
     @Published var command: String
     @Published var model: String
+    @Published var effort: String
     @Published var initialPrompt: String
     @Published var envOverridesText: String
 
@@ -24,6 +25,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         self.editingAgent = active
         self.command = entry.command
         self.model = entry.model
+        self.effort = entry.effort
         self.initialPrompt = entry.initialPrompt
         self.envOverridesText = entry.envOverridesText
 
@@ -39,6 +41,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
 
         $command.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
         $model.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
+        $effort.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
         $initialPrompt.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
         $envOverridesText.dropFirst().sink { [weak self] _ in self?.persistFields() }.store(in: &cancellables)
     }
@@ -49,12 +52,19 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         DefaultAgentResolver.supportsModelFlag(editingAgent)
     }
 
+    /// Whether c11 pins an `--effort` flag for the agent currently being edited,
+    /// gating whether the effort picker is shown.
+    var editingAgentSupportsEffort: Bool {
+        DefaultAgentResolver.supportsEffortFlag(editingAgent)
+    }
+
     private func loadFields(for agent: AgentType) {
         suppressSave = true
         defer { suppressSave = false }
         let entry = store.current.config(for: agent)
         command = entry.command
         model = entry.model
+        effort = entry.effort
         initialPrompt = entry.initialPrompt
         envOverridesText = entry.envOverridesText
     }
@@ -66,7 +76,8 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
             command: command,
             initialPrompt: initialPrompt,
             envOverridesText: envOverridesText,
-            model: model
+            model: model,
+            effort: effort
         )
         store.update(captured) { $0 = snapshot }
     }
@@ -77,6 +88,7 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
         let factory = AgentConfig.factory(for: editingAgent)
         command = factory.command
         model = factory.model
+        effort = factory.effort
         initialPrompt = factory.initialPrompt
         envOverridesText = factory.envOverridesText
         suppressSave = false
@@ -127,6 +139,10 @@ struct DefaultAgentSettingsSection: View {
 
             if vm.editingAgentSupportsModel {
                 modelPicker
+            }
+
+            if vm.editingAgentSupportsEffort {
+                effortPicker
             }
 
             VStack(alignment: .leading, spacing: 3) {
@@ -186,6 +202,35 @@ struct DefaultAgentSettingsSection: View {
             }
             Text(String(localized: "settings.defaultAgent.model.help",
                         defaultValue: "pins --model on launch, so agents launched here stay on this family even when your ambient Claude default changes. picks the family, not a version — new releases need no change. a model set in the command above wins."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    /// Effort-level picker, shown only for agents c11 pins an `--effort` flag
+    /// for. The empty tag means "inherit" (no flag injected); each case maps to
+    /// `claude --effort <level>`.
+    private var effortPicker: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 8) {
+                Text(String(localized: "settings.defaultAgent.effort.label", defaultValue: "effort"))
+                    .font(.callout)
+                Picker("", selection: $vm.effort) {
+                    Text(String(localized: "settings.defaultAgent.effort.inherit",
+                                defaultValue: "Inherit (agent default)"))
+                        .tag("")
+                    ForEach(ClaudeEffort.allCases) { level in
+                        Text(level.displayName).tag(level.rawValue)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .fixedSize()
+                .accessibilityIdentifier("DefaultAgentEffortPicker")
+                Spacer()
+            }
+            Text(String(localized: "settings.defaultAgent.effort.help",
+                        defaultValue: "optional. pins --effort on launch so agents launched here run at this reasoning effort. leave on Inherit to keep the agent's ambient effort. higher levels may be limited by your plan."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/c11Tests/DefaultAgentConfigTests.swift
+++ b/c11Tests/DefaultAgentConfigTests.swift
@@ -45,6 +45,37 @@ final class DefaultAgentConfigTests: XCTestCase {
                        ["opus", "sonnet", "haiku", "fable"])
     }
 
+    func testFactoryAgentsHaveNoPinnedEffort() {
+        // Effort is opt-in: nothing ships with a pinned effort, so every agent
+        // inherits its ambient effort until the operator chooses one.
+        for type in AgentType.allCases {
+            XCTAssertEqual(AgentConfig.factory(for: type).effort, "", "\(type) should not pin an effort")
+        }
+    }
+
+    func testClaudeEffortRawValuesAreCliLevels() {
+        // Passed verbatim to `claude --effort`; must stay the CLI's levels.
+        XCTAssertEqual(ClaudeEffort.allCases.map(\.rawValue),
+                       ["low", "medium", "high", "xhigh", "max"])
+    }
+
+    func testCodableRoundTripPreservesEffort() throws {
+        var agents: [AgentType: AgentConfig] = [:]
+        agents[.claudeCode] = AgentConfig(command: "claude", initialPrompt: "", envOverridesText: "", effort: "high")
+        let cfg = DefaultAgentConfig(defaultAgent: .claudeCode, agents: agents)
+        let data = try JSONEncoder().encode(cfg)
+        let decoded = try JSONDecoder().decode(DefaultAgentConfig.self, from: data)
+        XCTAssertEqual(decoded.agents[.claudeCode]?.effort, "high")
+    }
+
+    func testDecodeAgentConfigWithoutEffortDefaultsToInherit() throws {
+        // A per-agent blob written before the effort field existed must decode
+        // to "" (inherit), preserving its prior launch behavior on upgrade.
+        let json = #"{"command":"claude","initialPrompt":"","envOverridesText":"","model":"opus"}"#
+        let decoded = try JSONDecoder().decode(AgentConfig.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.effort, "")
+    }
+
     func testFactoryCodexCommandIncludesYolo() {
         let entry = AgentConfig.factory(for: .codex)
         XCTAssertEqual(entry.command, "codex --yolo")

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -265,6 +265,90 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
     }
 
+    // MARK: - effort pinning
+
+    func testBuildCommandInjectsPinnedEffortBeforePrompt() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "go",
+            envOverridesText: "",
+            effort: "high"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --effort high 'go'"
+        )
+    }
+
+    func testBuildCommandInjectsBothModelAndEffort() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "go",
+            envOverridesText: "",
+            model: "opus",
+            effort: "xhigh"
+        )
+        // model first, then effort, then the positional prompt stays last.
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus --effort xhigh 'go'"
+        )
+    }
+
+    func testBuildCommandEmptyEffortInjectsNothing() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "opus",
+            effort: ""
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus"
+        )
+    }
+
+    func testBuildCommandDoesNotDoubleEffortWhenCommandAlreadyHasOne() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions --effort low",
+            initialPrompt: "",
+            envOverridesText: "",
+            effort: "max"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --effort low"
+        )
+    }
+
+    func testBuildCommandDoesNotInjectEffortForNonClaudeAgent() {
+        let cfg = AgentConfig(
+            command: "codex --yolo",
+            initialPrompt: "",
+            envOverridesText: "",
+            effort: "high"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .codex, config: cfg),
+            "codex --yolo"
+        )
+    }
+
+    func testLauncherCommandCarriesModelAndEffortForBareExport() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "some prompt",
+            envOverridesText: "",
+            model: "opus",
+            effort: "high"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.launcherCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus --effort high"
+        )
+    }
+
     func testShellQuoteEmpty() {
         XCTAssertEqual(DefaultAgentResolver.shellQuote(""), "''")
     }


### PR DESCRIPTION
## What

Follow-on to the model-family pin (#already-on-main). An agent's launch config is now the full triple the operator reasons about: **harness (Claude Code) + model family + reasoning effort**. c11 injects `--effort <level>` at launch alongside `--model`, so agents launched from c11 run at a chosen effort regardless of the ambient default.

## Why

The operator regularly switches ambient model/effort but wants c11-launched agents to hold a chosen configuration. Model pinning shipped first; effort is the second, optional axis of the same idea.

## Changes

- **`AgentConfig.effort`** — new field, backward-compatible decode (absent → `""` = inherit). Nothing ships with a pinned effort; it's opt-in.
- **`ClaudeEffort`** — `low / medium / high / xhigh / max`, the exact levels `claude --effort` accepts (verified against `claude --help`).
- **`DefaultAgentResolver`** — `launcherCommand` appends `--effort` after `--model` and before the positional prompt; an effort already in the command wins; injection gated to Claude Code (`supportsEffortFlag`), a seam for codex.
- **Settings → Agents** — an Effort dropdown (Inherit / Low / Medium / High / Extra high / Max) beside the Model dropdown.

## Test

`c11-logic` green locally: 72 tests, 0 failures across `DefaultAgentResolverTests` + `DefaultAgentConfigTests`, including new effort-injection, combined model+effort ordering, "already-specified wins", non-Claude-agent, Codable round-trip, and legacy-decode cases.

## Notes

- Scope is c11's launch paths only (A-button / new-workspace / socket), matching the model pin — manual `claude` typing is untouched.
- New user-facing strings are English-only pending a localization pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)