### PR TITLE
i18n: localize Model + Effort agent-launch strings

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -39200,6 +39200,664 @@
         }
       }
     },
+    "settings.defaultAgent.model.inherit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inherit (agent default)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "継承（エージェントのデフォルト）"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Успадкувати (типове для агента)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상속(에이전트 기본값)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继承（代理默认）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼承（代理預設）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Наследовать (по умолчанию для агента)"
+          }
+        }
+      }
+    },
+    "settings.defaultAgent.model.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pins --model on launch, so agents launched here stay on this family even when your ambient Claude default changes. picks the family, not a version — new releases need no change. a model set in the command above wins."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "起動時に --model を固定するので、ここで起動したエージェントは、環境の Claude デフォルトが変わってもこのファミリーのままになります。バージョンではなくファミリーを選ぶため、新しいリリースが出ても変更は不要です。上のコマンドで指定したモデルが優先されます。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закріплює --model під час запуску, тож агенти, запущені тут, залишаються в цій родині, навіть коли змінюється загальне типове значення Claude. Обирає родину, а не версію — нові випуски не потребують змін. Модель, задана в команді вище, має пріоритет."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 시 --model을 고정하므로, 여기서 실행한 에이전트는 시스템의 Claude 기본값이 바뀌어도 이 제품군을 유지합니다. 버전이 아니라 제품군을 선택하므로 새 릴리스가 나와도 변경할 필요가 없습니다. 위 명령에 지정된 모델이 우선합니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在启动时固定 --model，因此在此启动的代理即使系统的 Claude 默认值发生变化，也会保持在该系列。选择的是系列而非具体版本——有新版本发布也无需更改。上面命令中设置的模型优先。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在啟動時固定 --model，因此在此啟動的代理即使系統的 Claude 預設值變更，也會維持在該系列。選擇的是系列而非特定版本——有新版本發布也無需變更。上方指令中設定的模型優先。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Закрепляет --model при запуске, поэтому запущенные здесь агенты остаются в этом семействе, даже когда меняется общее значение Claude по умолчанию. Выбирается семейство, а не версия — новые выпуски не требуют изменений. Модель, заданная в команде выше, имеет приоритет."
+          }
+        }
+      }
+    },
+    "settings.defaultAgent.effort.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "effort"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "労力"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зусилля"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노력"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "投入程度"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "投入程度"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Усилие"
+          }
+        }
+      }
+    },
+    "settings.defaultAgent.effort.inherit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inherit (agent default)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "継承（エージェントのデフォルト）"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Успадкувати (типове для агента)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상속(에이전트 기본값)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继承（代理默认）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼承（代理預設）"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Наследовать (по умолчанию для агента)"
+          }
+        }
+      }
+    },
+    "settings.defaultAgent.effort.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "optional. pins --effort on launch so agents launched here run at this reasoning effort. leave on Inherit to keep the agent's ambient effort. higher levels may be limited by your plan."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "省略可。起動時に --effort を固定するので、ここで起動したエージェントはこの推論の労力で動作します。エージェント本来の労力を保つには「継承」のままにします。高いレベルはプランによって制限される場合があります。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необов’язково. Закріплює --effort під час запуску, тож агенти, запущені тут, працюють із цим рівнем зусиль на міркування. Залиште «Успадкувати», щоб зберегти власний рівень агента. Вищі рівні можуть бути обмежені вашим тарифом."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택. 실행 시 --effort를 고정하므로, 여기서 실행한 에이전트는 이 추론 노력 수준으로 동작합니다. 에이전트 본래의 노력 수준을 유지하려면 「상속」으로 두세요. 높은 수준은 요금제에 따라 제한될 수 있습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可选。在启动时固定 --effort，因此在此启动的代理会以该推理投入程度运行。保持为「继承」可沿用代理原本的投入程度。更高的级别可能受你的套餐限制。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選填。在啟動時固定 --effort，因此在此啟動的代理會以該推理投入程度執行。維持「繼承」可沿用代理原本的投入程度。較高的等級可能受你的方案限制。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Необязательно. Закрепляет --effort при запуске, поэтому запущенные здесь агенты работают с этим уровнем усилий на рассуждение. Оставьте «Наследовать», чтобы сохранить собственный уровень агента. Более высокие уровни могут быть ограничены вашим тарифом."
+          }
+        }
+      }
+    },
+    "claudeModelFamily.opus": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opus"
+          }
+        }
+      }
+    },
+    "claudeModelFamily.sonnet": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sonnet"
+          }
+        }
+      }
+    },
+    "claudeModelFamily.haiku": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haiku"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haiku"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haiku"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haiku"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haiku"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haiku"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haiku"
+          }
+        }
+      }
+    },
+    "claudeModelFamily.fable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fable"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fable"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fable"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fable"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fable"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fable"
+          }
+        }
+      }
+    },
+    "claudeEffort.low": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Low"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Низький"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "낮음"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Низкий"
+          }
+        }
+      }
+    },
+    "claudeEffort.medium": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Medium"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Середній"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "보통"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Средний"
+          }
+        }
+      }
+    },
+    "claudeEffort.high": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "High"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Високий"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "높음"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Высокий"
+          }
+        }
+      }
+    },
+    "claudeEffort.xhigh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Extra high"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超高"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Дуже високий"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "매우 높음"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超高"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超高"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очень высокий"
+          }
+        }
+      }
+    },
+    "claudeEffort.max": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Max"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最高"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Максимальний"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최대"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最高"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最高"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Максимальный"
+          }
+        }
+      }
+    },
     "settings.defaultAgent.model.placeholder": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## What

The **Model** (#307) and **Effort** (#311) agent-launch settings shipped their new Settings → Agents dropdown strings **English-only in v0.57.0**. This adds high-quality translations for all six c11 locales: Japanese (ja), Ukrainian (uk), Korean (ko), Simplified Chinese (zh-Hans), Traditional Chinese (zh-Hant), Russian (ru).

Strings-only change to `Resources/Localizable.xcstrings` — pure insertions, no English source values touched, no code changed. JSON validated (`python3 -c "import json; json.load(...)"`).

## String keys translated (14)

**Effort dropdown (from #311):**
- `settings.defaultAgent.effort.label` ("effort")
- `settings.defaultAgent.effort.inherit` ("Inherit (agent default)")
- `settings.defaultAgent.effort.help` (helper text)
- `claudeEffort.low` / `.medium` / `.high` / `.xhigh` ("Extra high") / `.max`

**Model dropdown (from #307):**
- `settings.defaultAgent.model.inherit` ("Inherit (agent default)")
- `settings.defaultAgent.model.help` (helper text)
- `claudeModelFamily.opus` / `.sonnet` / `.haiku` / `.fable`

Note: `settings.defaultAgent.model.label` was already fully localized in a prior pass, so it's untouched.

## Conventions followed

- **Product names stay Latin** in every locale (Opus/Sonnet/Haiku/Fable), matching the existing `agentType.*` pattern (Claude Code, Codex, Kimi are kept as-is across locales).
- CLI flags `--model` / `--effort` kept literal in helper text.
- "agent" / "default" / "optional" / "your plan" rendered consistent with existing `settings.defaultAgent.*` translations already in the catalog.

## For reviewer attention

The **`effort` label** term (reasoning-effort) is a term of art with no settled house translation. Rendered as a plain "effort" noun per locale (ja 労力, uk Зусилля, ko 노력, zh 投入程度, ru Усилие). A native reviewer may prefer a "reasoning intensity"-style phrasing — flagging for a look. Everything else is standard.