### PR TITLE
C11-163: Events stream — file-first NDJSON pub/sub, v1 taxonomy, rotation, `c11 events tail`

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -17563,16 +17563,29 @@ extension CMUXCLI {
             guard FileManager.default.fileExists(atPath: logURL.path) else { continue }
             let currentInode = eventsInode(of: logURL)
             let currentSize = eventsFileSize(of: logURL)
-            // Rotation detection: the file shrank or its inode changed → the log
-            // rolled. Re-read from the top (the fresh file opens with a
-            // log.rotated marker) so we never seek past EOF and stall.
-            if currentSize < lastSize || currentInode != lastInode {
+            // Rotation detection: the file shrank, or its inode changed → the log
+            // rolled. A `0` inode means a transient stat failure (e.g. mid-rename);
+            // treat it as "unknown" and do not reset on it alone.
+            let inodeChanged = currentInode != 0 && lastInode != 0 && currentInode != lastInode
+            if inodeChanged || currentSize < lastSize {
+                // Before switching to the fresh file, drain the tail that landed
+                // in the now-rolled `.1` after our last read — the cap-crossing
+                // lines the writer appended just before it renamed. Without this
+                // the sub-second unread tail would live only in `.1` and the
+                // follower would skip it.
+                let rolled = EventLogLayout.rolledURL(for: logURL)
+                if let rh = try? FileHandle(forReadingFrom: rolled) {
+                    try? rh.seek(toOffset: lastSize)
+                    let tail = ((try? rh.readToEnd()) ?? nil) ?? Data()
+                    if let text = String(data: tail, encoding: .utf8), !text.isEmpty { drainLines(text) }
+                    try? rh.close()
+                }
                 lastSize = 0
-                lastInode = currentInode
+                if currentInode != 0 { lastInode = currentInode }
             }
             guard let handle = try? FileHandle(forReadingFrom: logURL) else { continue }
             try? handle.seek(toOffset: lastSize)
-            let data = (try? handle.readToEnd()) ?? nil ?? Data()
+            let data = ((try? handle.readToEnd()) ?? nil) ?? Data()
             if let text = String(data: data, encoding: .utf8), !text.isEmpty { drainLines(text) }
             lastSize = (try? handle.offset()) ?? lastSize
             try? handle.close()

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -1705,6 +1705,14 @@ struct CMUXCLI {
             return
         }
 
+        // C11-163: `c11 events tail` reads the NDJSON event log directly — the
+        // file is the contract, so it must work with no running app. Handle it
+        // before the socket connect, like `state verify`.
+        if command == "events" {
+            try runEventsCommand(commandArgs: commandArgs, jsonOutput: jsonOutput)
+            return
+        }
+
         let client = SocketClient(path: resolvedSocketPath)
         if resolvedSocketPath != socketPath {
             cliTelemetry.breadcrumb(
@@ -7774,6 +7782,8 @@ struct CMUXCLI {
 
             Print server capabilities as JSON.
             """
+        case "events":
+            return eventsUsage()
         case "help":
             return """
             Usage: c11 help
@@ -16431,6 +16441,7 @@ struct CMUXCLI {
           browser addscript <script>
           browser addstyle <css>
           browser identify [--surface <id|ref|index>]
+          events tail [--follow|-f] [--filter type=<type>] [--since <seq|duration>] [--instance <id>]
           help
 
         Environment:
@@ -17453,6 +17464,166 @@ extension CMUXCLI {
             flushHandle(handle)
             try? handle.close()
         }
+    }
+
+    // MARK: - Events stream (C11-163)
+
+    /// `c11 events <subcommand>`. File-first: reads the per-instance NDJSON
+    /// event log directly, no socket. Currently only `tail`.
+    private func runEventsCommand(commandArgs: [String], jsonOutput: Bool) throws {
+        let sub = commandArgs.first?.lowercased() ?? "help"
+        switch sub {
+        case "tail":
+            try runEventsTail(subArgs: Array(commandArgs.dropFirst()))
+        case "help", "--help", "-h":
+            print(eventsUsage())
+        default:
+            print(eventsUsage())
+            throw CLIError(message: "events: unknown subcommand '\(sub)'. Known: tail")
+        }
+    }
+
+    private func eventsUsage() -> String {
+        """
+        Usage: c11 events tail [--follow|-f] [--filter type=<type>] [--since <seq|duration>] [--instance <id>]
+
+        Stream the c11 events log (NDJSON). The file is the contract — this is
+        sugar over `~/Library/Application Support/c11/events/events-<instance>.ndjson`.
+        Works with no running app.
+
+          --follow, -f          Keep streaming new events (rotation-aware).
+          --filter type=<type>  Only lines whose `type` equals <type>.
+          --since <seq|dur>     Start at a seq number (e.g. 1200) or a duration
+                                ago (e.g. 10m, 90s, 2h), resolved against `ts`.
+          --instance <id>       Target a specific instance log (default: newest).
+
+        Examples:
+          c11 events tail
+          c11 events tail -f --filter type=surface.closed
+          c11 events tail --since 5m
+        """
+    }
+
+    /// Reads the current instance log, applies filters, prints matching lines.
+    /// One-shot by default; `--follow` streams with rotation detection so the
+    /// tail survives a size-capped roll (amendment A) — the mailbox loop cannot,
+    /// because the mailbox log never rotates.
+    private func runEventsTail(subArgs: [String]) throws {
+        let follow = hasFlag(subArgs, name: "--follow") || hasFlag(subArgs, name: "-f")
+        let typeFilter = eventsTypeFilter(subArgs)
+        let sinceSeq = eventsSinceSeq(subArgs)
+        let sinceDate = eventsSinceDate(subArgs)
+        let instance = optionValue(subArgs, name: "--instance")
+
+        let state = try EventLogLayout.defaultStateURL()
+        let logURL: URL
+        if let instance {
+            logURL = EventLogLayout.logURL(state: state, instance: instance)
+        } else {
+            do {
+                logURL = try EventLogLayout.newestLogURL(state: state)
+            } catch {
+                // No log yet. In --follow, wait for one to appear; else exit 0.
+                if !follow { return }
+                logURL = try eventsWaitForLog(state: state)
+            }
+        }
+
+        // Emit a line iff it passes every active filter.
+        func emit(_ line: String) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            if let typeFilter, EventEnvelope.type(fromLine: trimmed) != typeFilter { return }
+            if let sinceSeq, let s = EventEnvelope.seq(fromLine: trimmed), s < sinceSeq { return }
+            if let sinceDate, let ts = EventEnvelope.timestamp(fromLine: trimmed), ts < sinceDate { return }
+            print(trimmed)
+        }
+
+        func drainLines(_ text: String) {
+            for line in text.split(separator: "\n", omittingEmptySubsequences: true) {
+                emit(String(line))
+            }
+            fflush(stdout)
+        }
+
+        // Initial read of the whole current file.
+        var lastSize: UInt64 = 0
+        var lastInode = eventsInode(of: logURL)
+        if let handle = try? FileHandle(forReadingFrom: logURL) {
+            let data = (try? handle.readToEnd()) ?? nil ?? Data()
+            if let text = String(data: data, encoding: .utf8) { drainLines(text) }
+            lastSize = (try? handle.offset()) ?? 0
+            try? handle.close()
+        }
+
+        guard follow else { return }
+
+        while true {
+            Thread.sleep(forTimeInterval: 0.25)
+            guard FileManager.default.fileExists(atPath: logURL.path) else { continue }
+            let currentInode = eventsInode(of: logURL)
+            let currentSize = eventsFileSize(of: logURL)
+            // Rotation detection: the file shrank or its inode changed → the log
+            // rolled. Re-read from the top (the fresh file opens with a
+            // log.rotated marker) so we never seek past EOF and stall.
+            if currentSize < lastSize || currentInode != lastInode {
+                lastSize = 0
+                lastInode = currentInode
+            }
+            guard let handle = try? FileHandle(forReadingFrom: logURL) else { continue }
+            try? handle.seek(toOffset: lastSize)
+            let data = (try? handle.readToEnd()) ?? nil ?? Data()
+            if let text = String(data: data, encoding: .utf8), !text.isEmpty { drainLines(text) }
+            lastSize = (try? handle.offset()) ?? lastSize
+            try? handle.close()
+        }
+    }
+
+    /// Blocks (polling) until an instance log exists, for `--follow` started
+    /// before the app opened its log.
+    private func eventsWaitForLog(state: URL) throws -> URL {
+        while true {
+            if let url = try? EventLogLayout.newestLogURL(state: state) { return url }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+    }
+
+    private func eventsTypeFilter(_ args: [String]) -> String? {
+        guard let raw = optionValue(args, name: "--filter") else { return nil }
+        // Accept `--filter type=surface.closed` (or a bare `type=` value).
+        if raw.hasPrefix("type=") { return String(raw.dropFirst("type=".count)) }
+        return raw
+    }
+
+    private func eventsSinceSeq(_ args: [String]) -> UInt64? {
+        guard let raw = optionValue(args, name: "--since") else { return nil }
+        return UInt64(raw)
+    }
+
+    /// Parses `--since <duration>` (e.g. 10m, 90s, 2h, 1d) into an absolute
+    /// cutoff date. Returns nil when `--since` is absent or a plain seq number.
+    private func eventsSinceDate(_ args: [String]) -> Date? {
+        guard let raw = optionValue(args, name: "--since"), UInt64(raw) == nil else { return nil }
+        guard let unit = raw.last, let value = Double(raw.dropLast()) else { return nil }
+        let seconds: Double
+        switch unit {
+        case "s": seconds = value
+        case "m": seconds = value * 60
+        case "h": seconds = value * 3600
+        case "d": seconds = value * 86400
+        default: return nil
+        }
+        return Date().addingTimeInterval(-seconds)
+    }
+
+    private func eventsInode(of url: URL) -> UInt64 {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attrs?[.systemFileNumber] as? UInt64) ?? 0
+    }
+
+    private func eventsFileSize(of url: URL) -> UInt64 {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        return (attrs?[.size] as? UInt64) ?? 0
     }
 
     // MARK: - Helpers for raw-bash senders/receivers

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		076B1D5338134A1CD69B5467 /* TCCPrimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7016BF1A1B2C3D4E5F60718 /* TCCPrimerTests.swift */; };
 		0824BD4DE71F74CA32F9F49E /* ScrapeCapturePipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */; };
 		0C8D60FC511085983B359106 /* DefaultAgentResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */; };
+		0D76F685D48115A43B14C5D5 /* EventLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */; };
 		0F2C25F9170130F8DC09DD1B /* WorkspaceManualUnreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */; };
 		100913C268BE26DBACE5A563 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800DBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotRoundTripAcceptanceTests.swift */; };
 		113331FB73920A113901C03E /* WorkspaceSnapshotCaptureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800CBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotCaptureTests.swift */; };
@@ -31,6 +32,7 @@
 		1D765B8279AE9949576A5FE1 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8016BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotBrowserMarkdownRoundTripTests.swift */; };
 		1E77E8B74098A7D7B928631C /* SurfaceActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8A815208E655A7AFBCEE667 /* SurfaceActivity.swift */; };
 		1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
+		1FD750B08EDEB2C775C05971 /* EventLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE575BF7FF16088778D40E17 /* EventLog.swift */; };
 		20A2EC594F0DF1560BB0E28E /* ClaudeCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1299AE998DF9F78A383294 /* ClaudeCode.swift */; };
 		20F7EACAFF3B4C7AFBE0D063 /* WorkspaceLayoutExecutorAcceptanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8004BF1A1B2C3D4E5F60718 /* WorkspaceLayoutExecutorAcceptanceTests.swift */; };
 		24E7BF80A6D38962748D9509 /* OmpScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B94CA7E57E1FD8FFF1217B /* OmpScraper.swift */; };
@@ -42,6 +44,7 @@
 		3175B7C8AE075F8D71BFA104 /* CLIAdvisoryConnectivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70B3BF1A1B2C3D4E5F60720 /* CLIAdvisoryConnectivityTests.swift */; };
 		33575F7E4C63569F35E154A9 /* NewWorkspaceTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */; };
 		352C25FFD890137B5F7A23B3 /* AgentManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */; };
+		365F4BE2806EC0D12A9336BD /* EventEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */; };
 		39AF4F57C52E593EC8CF0680 /* MailboxSurfaceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710BBF1A1B2C3D4E5F60718 /* MailboxSurfaceResolverTests.swift */; };
 		3D7DB8FD9FE7DECBA43949B6 /* MailboxLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7101BF1A1B2C3D4E5F60718 /* MailboxLayoutTests.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
@@ -86,6 +89,7 @@
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
 		74FC297C7F874F1D92C20D38 /* Strategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DEEEA4C9921D5BDE4EF06E3 /* Strategy.swift */; };
 		756290E56A4FC7D6546C1D46 /* PaneSizePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2DBF12A2F90CBDE7F6A289 /* PaneSizePolicyTests.swift */; };
+		75B580E4A1859423B310E203 /* EventLogLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBB43D8FE36F0283DA24983 /* EventLogLayout.swift */; };
 		767FF8ADAC0F182A4534E12B /* ClaudeCodeScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */; };
 		78EC4CE4D9938FD4611E1664 /* LaunchResumePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2BBF3CDB766B1FCF30BB765 /* LaunchResumePicker.swift */; };
 		7FFBFB92E1EA4343FB71DCA8 /* OpencodeResumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */; };
@@ -97,6 +101,7 @@
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
 		8574E0DF636A7359989C51A4 /* ConversationScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */; };
 		864B59A6AAF8E002451F50CB /* ThemedValueParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F008 /* ThemedValueParserTests.swift */; };
+		88A8E702E9D54BBCAD7025C7 /* EventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B9399C201ED734873E67B9 /* EventEmitter.swift */; };
 		88C381A879AAF75295A60C34 /* Omp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F0DED724227677C7B8512 /* Omp.swift */; };
 		8AEBED793B56A7A254FD0502 /* NotificationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5688157C3C8FA45CD382A3FD /* NotificationHandlers.swift */; };
 		8B6BA07B09D5E9E01F141A44 /* BrowserChromeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F01C /* BrowserChromeSnapshotTests.swift */; };
@@ -230,6 +235,7 @@
 		A721E30DB74CE0665ECC036B /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 		A7307EC952C874A81272A673 /* WorkspaceHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5672FCE291BE8E1255CEE9DF /* WorkspaceHandlers.swift */; };
 		A7EA137511C5D411B2960587 /* Kimi.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BDE4F4D562EC49C639CF86 /* Kimi.swift */; };
+		A87C6868ACAA0B563E1593CE /* EventLogLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBB43D8FE36F0283DA24983 /* EventLogLayout.swift */; };
 		AB10CF281929477FAAAC51F4 /* Ref.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C9388437A24EE58C8AAA71 /* Ref.swift */; };
 		AD0B26BB2AF8AB81273C46A3 /* HealthSentryParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH011BF1A1B2C3D4E5F60718 /* HealthSentryParserTests.swift */; };
 		AEFAF44A763C596E3C066BC6 /* DefaultAgentResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3566F50A753107233CC16743 /* DefaultAgentResolver.swift */; };
@@ -256,6 +262,7 @@
 		B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
 		B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */; };
 		BAE105919F0262DEA7D0DE0C /* MailboxIOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7104BF1A1B2C3D4E5F60718 /* MailboxIOTests.swift */; };
+		BF71609E6CC93D0CB7FE632D /* EventEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */; };
 		BFBD47384819D160EF689A52 /* WorkspaceBlueprintMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8019BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintMarkdownTests.swift */; };
 		C0AE6CCEF674AD50CCEEACE9 /* BrowserHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C57DBBB7C3C6C27357EBA8 /* BrowserHandlers.swift */; };
 		C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
@@ -452,6 +459,7 @@
 
 /* Begin PBXFileReference section */
 		0095C3D72A7722FFA42A7ED1 /* PaneSizePolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PaneSizePolicy.swift; sourceTree = "<group>"; };
+		00B9399C201ED734873E67B9 /* EventEmitter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventEmitter.swift; path = Events/EventEmitter.swift; sourceTree = "<group>"; };
 		01822B693A5DD01EFE28F75F /* SnapshotHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotHandlers.swift; sourceTree = "<group>"; };
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
 		0AC6B52BF66E258E170A6B92 /* c11LogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11LogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -484,6 +492,7 @@
 		6068E3FCA0467699A1ADD6FD /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
 		640DC1629D340031E0516DA5 /* ConversationHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationHandlers.swift; sourceTree = "<group>"; };
+		64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventEnvelope.swift; path = Events/EventEnvelope.swift; sourceTree = "<group>"; };
 		660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationCrashRecoveryTests.swift; path = ConversationCrashRecoveryTests.swift; sourceTree = "<group>"; };
 		6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PiConversationTests.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
@@ -498,6 +507,7 @@
 		8D79AA02822FFBE8B15FA2B6 /* OmpConversationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OmpConversationTests.swift; path = OmpConversationTests.swift; sourceTree = "<group>"; };
 		8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentResolverTests.swift; sourceTree = "<group>"; };
 		8FF3E8B8443DEA778BA817BB /* SurfaceTypeAvailability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceTypeAvailability.swift; sourceTree = "<group>"; };
+		91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EventLogTests.swift; sourceTree = "<group>"; };
 		93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWorkspaceTitleTests.swift; sourceTree = "<group>"; };
 		96951AF465673123431D362B /* ConversationStoreFailureModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationStoreFailureModeTests.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
@@ -691,6 +701,8 @@
 		CC401006A1B2C3D4E5F60719 /* TCCPrimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TCCPrimerView.swift; sourceTree = "<group>"; };
 		CC401008A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateWorkspaceSheet.swift; sourceTree = "<group>"; };
 		CC40100AA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullDiskAccessProbe.swift; sourceTree = "<group>"; };
+		CE575BF7FF16088778D40E17 /* EventLog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventLog.swift; path = Events/EventLog.swift; sourceTree = "<group>"; };
+		CFBB43D8FE36F0283DA24983 /* EventLogLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventLogLayout.swift; path = Events/EventLogLayout.swift; sourceTree = "<group>"; };
 		D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneNavigationKeybindUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserOmnibarSuggestionsUITests.swift; sourceTree = "<group>"; };
 		D13A1E9CE25B945CC90A8D02 /* copilot */ = {isa = PBXFileReference; includeInIndex = 1; name = copilot; path = Resources/bin/copilot; sourceTree = "<group>"; };
@@ -1118,6 +1130,10 @@
 				E1B94CA7E57E1FD8FFF1217B /* OmpScraper.swift */,
 				287F0DED724227677C7B8512 /* Omp.swift */,
 				AFF4D6855F4A429608E3903C /* SocketHandlers */,
+				CFBB43D8FE36F0283DA24983 /* EventLogLayout.swift */,
+				64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */,
+				CE575BF7FF16088778D40E17 /* EventLog.swift */,
+				00B9399C201ED734873E67B9 /* EventEmitter.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1305,6 +1321,7 @@
 				C585662B5CFF4AFB27E65C1E /* OpencodeResumeTests.swift */,
 				6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */,
 				8D79AA02822FFBE8B15FA2B6 /* OmpConversationTests.swift */,
+				91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1633,6 +1650,7 @@
 				7FFBFB92E1EA4343FB71DCA8 /* OpencodeResumeTests.swift in Sources */,
 				E123B16B00B33A73F7527FF1 /* PiConversationTests.swift in Sources */,
 				D49911F30C44874C90103A16 /* OmpConversationTests.swift in Sources */,
+				0D76F685D48115A43B14C5D5 /* EventLogTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1829,6 +1847,10 @@
 				C0AE6CCEF674AD50CCEEACE9 /* BrowserHandlers.swift in Sources */,
 				9112C6C26F5FA76D26214579 /* BrowserQueryHandlers.swift in Sources */,
 				B39195B311AC251C6034CB4A /* SocketDispatch.swift in Sources */,
+				A87C6868ACAA0B563E1593CE /* EventLogLayout.swift in Sources */,
+				BF71609E6CC93D0CB7FE632D /* EventEnvelope.swift in Sources */,
+				1FD750B08EDEB2C775C05971 /* EventLog.swift in Sources */,
+				88A8E702E9D54BBCAD7025C7 /* EventEmitter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1848,6 +1870,8 @@
 				D7206BF0A1B2C3D4E5F60719 /* MailboxEnvelope.swift in Sources */,
 				D70A3BF0A1B2C3D4E5F60719 /* WorkspaceMetadataKeys.swift in Sources */,
 				D70B3BF0A1B2C3D4E5F60719 /* CLIAdvisoryConnectivity.swift in Sources */,
+				75B580E4A1859423B310E203 /* EventLogLayout.swift in Sources */,
+				365F4BE2806EC0D12A9336BD /* EventEnvelope.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2448,6 +2448,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func applicationDidFinishLaunching(_ notification: Notification) {
         mirrorC11CmuxEnv()
 
+        // C11-163: open the events stream early — before session restore
+        // recreates workspaces/surfaces — so surface.created and the
+        // log.opened marker land from the first instant (amendment K).
+        EventEmitter.shared.start()
+
         // C11-24/C11-131: capture the prior-shutdown decision and arm this
         // run's dirty sentinel as early as possible — before any potential
         // crash path. The write must precede crashes; the read must precede
@@ -2953,6 +2958,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         isTerminatingApp = true
+        // C11-163: drain any queued events before exit so a tailing consumer
+        // sees the final transitions of this instance.
+        EventEmitter.shared.flush()
         // C11-24: suspendAllAlive transitions every alive ConversationRef
         // to .suspended so resume on next launch is gated. Synchronous
         // bridge into the actor (bounded — store has no I/O).

--- a/Sources/Events/EventEmitter.swift
+++ b/Sources/Events/EventEmitter.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// Process-wide facade for the c11 events stream (C11-163). `EventEmitter.shared`
+/// is callable from **any** thread — main-actor emit sites (surface create/close,
+/// workspace select, waiting edges) and off-main queues (metadata stores, the
+/// mailbox dispatcher) alike. The underlying `EventLog` owns all threading, so
+/// emitting is a cheap envelope build + a fire-and-forget `append`; no emit site
+/// ever blocks and none needs to hop threads.
+///
+/// Initialize eagerly and early via `start()` (from `applicationDidFinishLaunching`,
+/// on main) so the first-use state-dir resolution + `log.opened` marker land
+/// before any surface-creation or metadata path can emit (amendment K). Calls
+/// before `start()`, or when disabled, are silent no-ops.
+final class EventEmitter {
+
+    static let shared = EventEmitter()
+
+    /// Canonical metadata keys that produce a `metadata.changed` event in v1.
+    /// `progress` is deliberately excluded — it is the highest-frequency
+    /// canonical key and would flood the stream (amendment G); it can be added
+    /// later behind explicit coalescing. Matches the SPEC EVT-2 named set
+    /// (status/title/description) minus progress.
+    static let canonicalMetadataEventKeys: Set<String> = ["status", "title", "description"]
+
+    private let lock = NSLock()
+    private var log: EventLog?
+    private var instanceId: String = ""
+    private var enabled = false
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    /// Resolves the per-instance log path, mints the instance id, opens the log,
+    /// and writes the `log.opened` marker. Idempotent; safe to call once on main
+    /// at launch. Disabled under XCTest (host suites must not write real logs)
+    /// unless a test injected a log via `startForTesting`.
+    func start() {
+        lock.lock()
+        if enabled || log != nil {
+            lock.unlock()
+            return
+        }
+        if Self.isRunningUnderXCTest() {
+            lock.unlock()
+            return
+        }
+        lock.unlock()
+
+        // Resolve outside the lock — StateDirectoryMigration does disk I/O.
+        guard let state = try? EventLogLayout.defaultStateURL() else { return }
+        let instance = EventLogLayout.makeInstanceId()
+        let url = EventLogLayout.logURL(state: state, instance: instance)
+        let newLog = EventLog(url: url, instance: instance)
+
+        lock.lock()
+        guard log == nil else { lock.unlock(); return }
+        log = newLog
+        instanceId = instance
+        enabled = true
+        lock.unlock()
+
+        newLog.open()
+    }
+
+    /// Test seam: install a caller-provided log + instance and enable emission.
+    func startForTesting(log: EventLog, instance: String) {
+        lock.lock()
+        self.log = log
+        self.instanceId = instance
+        self.enabled = true
+        lock.unlock()
+    }
+
+    /// Test seam: tear down so the next `startForTesting` starts clean.
+    func resetForTesting() {
+        lock.lock()
+        log = nil
+        instanceId = ""
+        enabled = false
+        lock.unlock()
+    }
+
+    /// Flush the underlying log (tests / shutdown).
+    func flush() {
+        currentLog()?.flush()
+    }
+
+    // MARK: - Emit helpers (v1 taxonomy)
+
+    func emitSurfaceCreated(
+        workspace: UUID,
+        surface: UUID,
+        kind: String,
+        title: String? = nil
+    ) {
+        var payload: [String: Any] = ["kind": kind]
+        if let title { payload["title"] = title }
+        emit(.surfaceCreated, workspace: workspace, surface: surface, payload: payload)
+    }
+
+    func emitSurfaceClosed(workspace: UUID, surface: UUID) {
+        emit(.surfaceClosed, workspace: workspace, surface: surface)
+    }
+
+    func emitWorkspaceSelected(previous: UUID?, selected: UUID) {
+        var payload: [String: Any] = [:]
+        if let previous { payload["previous"] = previous.uuidString }
+        emit(.workspaceSelected, workspace: selected, payload: payload)
+    }
+
+    /// `scope` is "surface" or "pane"; `source` is the `MetadataSource` raw
+    /// value stringified by the caller (the pure envelope never names the enum).
+    /// `prior` is optional — the surface store does not retain it for free.
+    func emitMetadataChanged(
+        scope: String,
+        workspace: UUID,
+        surface: UUID,
+        key: String,
+        value: Any?,
+        prior: Any?,
+        source: String
+    ) {
+        var payload: [String: Any] = [
+            "scope": scope,
+            "key": key,
+            "source": source,
+        ]
+        if let value, JSONSerialization.isValidJSONObject([value]) || value is String || value is NSNumber {
+            payload["value"] = value
+        }
+        if let prior, JSONSerialization.isValidJSONObject([prior]) || prior is String || prior is NSNumber {
+            payload["prior"] = prior
+        }
+        emit(.metadataChanged, workspace: workspace, surface: surface, payload: payload)
+    }
+
+    func emitWaiting(entered: Bool, workspace tabId: UUID, surface: UUID?) {
+        emit(entered ? .waitingEntered : .waitingLeft, workspace: tabId, surface: surface)
+    }
+
+    func emitMailboxAccepted(
+        workspace: UUID,
+        id: String,
+        from: String,
+        to: String?,
+        topic: String?
+    ) {
+        var payload: [String: Any] = ["id": id, "from": from]
+        if let to { payload["to"] = to }
+        if let topic { payload["topic"] = topic }
+        emit(.mailboxAccepted, workspace: workspace, payload: payload)
+    }
+
+    func emitMailboxDelivered(
+        workspace: UUID,
+        id: String,
+        recipient: String,
+        surface: UUID?
+    ) {
+        emit(
+            .mailboxDelivered,
+            workspace: workspace,
+            surface: surface,
+            payload: ["id": id, "recipient": recipient]
+        )
+    }
+
+    /// TEL seam (C11-162): the derived working/idle activity state. If TEL's
+    /// derived-liveness signal has not landed, this stays an unused stub call
+    /// site that TEL wires later — the event type ships now so consumers can key
+    /// on it. `state` is "working" or "idle".
+    func emitDerivedLiveness(workspace: UUID, surface: UUID, state: String) {
+        emit(
+            .livenessDerived,
+            workspace: workspace,
+            surface: surface,
+            payload: ["state": state]
+        )
+    }
+
+    // MARK: - Core
+
+    private func emit(
+        _ type: EventEnvelope.EventType,
+        workspace: UUID? = nil,
+        surface: UUID? = nil,
+        pane: UUID? = nil,
+        payload: [String: Any] = [:]
+    ) {
+        // Capture ts + snapshot the log under the lock; build + append outside.
+        lock.lock()
+        guard enabled, let log else { lock.unlock(); return }
+        let instance = instanceId
+        lock.unlock()
+
+        let envelope = EventEnvelope(
+            type: type,
+            instance: instance,
+            ts: Date(),
+            workspace: workspace?.uuidString,
+            surface: surface?.uuidString,
+            pane: pane?.uuidString,
+            payload: payload
+        )
+        log.append(envelope)
+    }
+
+    private func currentLog() -> EventLog? {
+        lock.lock()
+        defer { lock.unlock() }
+        return log
+    }
+
+    // MARK: - Test detection
+
+    private static func isRunningUnderXCTest() -> Bool {
+        let env = ProcessInfo.processInfo.environment
+        if env["XCTestConfigurationFilePath"] != nil { return true }
+        if env["XCTestBundlePath"] != nil { return true }
+        if env["XCTestSessionIdentifier"] != nil { return true }
+        return false
+    }
+}

--- a/Sources/Events/EventEnvelope.swift
+++ b/Sources/Events/EventEnvelope.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// The c11 events-stream envelope (C11-163, schema v1). One `EventEnvelope`
+/// serializes to exactly one NDJSON line in the per-instance event log.
+///
+/// Pure Foundation, no app-only imports — compiled into both the app target
+/// (the `EventLog` writer builds and serializes envelopes) and the `c11-cli`
+/// target (the `c11 events tail` reader uses the field-name constants and the
+/// line-parse helpers to filter). `payload` is deliberately an untyped
+/// `[String: Any]` so app-only enums (e.g. `MetadataSource`) never leak into
+/// this file — the emit site stringifies such values before handing them over.
+///
+/// Ordering contract: **`seq` is the sequence oracle**, assigned on the writer's
+/// serial queue so file order and seq order always agree. `ts` is captured on
+/// the emitting thread and is only approximately monotonic — it may invert
+/// slightly relative to `seq` across racing threads. Consumers order by `seq`.
+///
+/// Canonical source of truth for the on-disk shape is
+/// `spec/event-envelope.v1.schema.json`.
+struct EventEnvelope {
+
+    /// Current envelope schema version. Bumps are breaking.
+    static let schemaVersion = 1
+
+    // MARK: - Field-name constants (shared writer/reader vocabulary)
+
+    enum Key {
+        static let seq = "seq"
+        static let ts = "ts"
+        static let type = "type"
+        static let instance = "instance"
+        static let workspace = "workspace"
+        static let surface = "surface"
+        static let pane = "pane"
+        static let payload = "payload"
+        static let version = "v"
+    }
+
+    // MARK: - v1 taxonomy
+
+    /// The v1 event-type taxonomy (EVT-2). Dotted strings; the wire value is the
+    /// `rawValue`. `logOpened` / `logRotated` / `logDropped` are stream-control
+    /// markers (not taxonomy members) that let consumers detect instance
+    /// boundaries, rotation, and backpressure drops.
+    enum EventType: String, CaseIterable {
+        case surfaceCreated = "surface.created"
+        case surfaceClosed = "surface.closed"
+        case workspaceSelected = "workspace.selected"
+        case metadataChanged = "metadata.changed"
+        case livenessDerived = "liveness.derived"
+        case waitingEntered = "waiting.entered"
+        case waitingLeft = "waiting.left"
+        case mailboxAccepted = "mailbox.accepted"
+        case mailboxDelivered = "mailbox.delivered"
+        // Stream-control markers:
+        case logOpened = "log.opened"
+        case logRotated = "log.rotated"
+        case logDropped = "log.dropped"
+    }
+
+    // MARK: - Stored fields
+
+    /// Captured on the emitting thread; formatted at serialize time.
+    let ts: Date
+    let type: String
+    let instance: String
+    let workspace: String?
+    let surface: String?
+    let pane: String?
+    let payload: [String: Any]
+
+    init(
+        type: String,
+        instance: String,
+        ts: Date,
+        workspace: String? = nil,
+        surface: String? = nil,
+        pane: String? = nil,
+        payload: [String: Any] = [:]
+    ) {
+        self.type = type
+        self.instance = instance
+        self.ts = ts
+        self.workspace = workspace
+        self.surface = surface
+        self.pane = pane
+        self.payload = payload
+    }
+
+    init(
+        type: EventType,
+        instance: String,
+        ts: Date,
+        workspace: String? = nil,
+        surface: String? = nil,
+        pane: String? = nil,
+        payload: [String: Any] = [:]
+    ) {
+        self.init(
+            type: type.rawValue,
+            instance: instance,
+            ts: ts,
+            workspace: workspace,
+            surface: surface,
+            pane: pane,
+            payload: payload
+        )
+    }
+
+    // MARK: - Serialization
+
+    /// Produces one NDJSON line (trailing `\n`) with `seq` spliced in. Keys are
+    /// sort-encoded so tails are byte-stable across runs; nil subject refs are
+    /// omitted rather than encoded as `null`. `.withoutEscapingSlashes` keeps
+    /// filesystem paths in payloads readable (Swift would otherwise emit `\/`).
+    func serialize(seq: UInt64) -> String {
+        var object: [String: Any] = [
+            Key.seq: seq,
+            Key.ts: Self.formatTimestamp(ts),
+            Key.type: type,
+            Key.instance: instance,
+            Key.version: Self.schemaVersion,
+        ]
+        if let workspace { object[Key.workspace] = workspace }
+        if let surface { object[Key.surface] = surface }
+        if let pane { object[Key.pane] = pane }
+        if !payload.isEmpty { object[Key.payload] = payload }
+
+        guard
+            JSONSerialization.isValidJSONObject(object),
+            let data = try? JSONSerialization.data(
+                withJSONObject: object,
+                options: [.sortedKeys, .withoutEscapingSlashes]
+            ),
+            let line = String(data: data, encoding: .utf8)
+        else {
+            // Never block observability on a bad payload: fall back to a minimal
+            // valid line carrying seq/type so the sequence stays gap-free.
+            let fallback = "{\"\(Key.seq)\":\(seq),\"\(Key.type)\":\"\(type)\",\"\(Key.version)\":\(Self.schemaVersion)}"
+            return fallback + "\n"
+        }
+        return line + "\n"
+    }
+
+    // MARK: - Timestamp
+
+    /// RFC3339 / ISO-8601 UTC with fractional seconds — matches
+    /// `MailboxDispatchLog.formatTimestamp` so both logs sort identically.
+    static func formatTimestamp(_ date: Date) -> String {
+        formatter.string(from: date)
+    }
+
+    private static let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    // MARK: - Reader helpers (CLI filtering, no full decode needed)
+
+    /// Extracts the `type` field from a raw NDJSON line without a full decode.
+    static func type(fromLine line: String) -> String? {
+        field(Key.type, fromLine: line) as? String
+    }
+
+    /// Extracts the `seq` field from a raw NDJSON line.
+    static func seq(fromLine line: String) -> UInt64? {
+        guard let raw = field(Key.seq, fromLine: line) else { return nil }
+        if let n = raw as? UInt64 { return n }
+        if let n = raw as? Int, n >= 0 { return UInt64(n) }
+        if let n = raw as? NSNumber { return n.uint64Value }
+        return nil
+    }
+
+    /// Extracts and parses the `ts` field from a raw NDJSON line.
+    static func timestamp(fromLine line: String) -> Date? {
+        guard let s = field(Key.ts, fromLine: line) as? String else { return nil }
+        return formatter.date(from: s)
+    }
+
+    /// Generic single-field read from a raw line. Tolerant of malformed lines
+    /// (returns nil rather than throwing) so a partial trailing write never
+    /// crashes a tailing consumer.
+    static func field(_ key: String, fromLine line: String) -> Any? {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return object[key]
+    }
+}

--- a/Sources/Events/EventLog.swift
+++ b/Sources/Events/EventLog.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+/// Append-only NDJSON writer for the c11 events stream (C11-163). Cloned from
+/// `MailboxDispatchLog`: writes ride a dedicated serial `.utility` queue so the
+/// emitting path fire-and-forgets; `flush()` blocks until the queue drains for
+/// tests and shutdown. Two things this adds over the mailbox log:
+///
+/// - **Monotonic `seq`** assigned on the queue (the single ordering authority),
+///   so file order and `seq` order always agree even under concurrent emits
+///   (EVT-1).
+/// - **Size-capped rotation** (EVT-4): at the cap the current file rolls to
+///   `.1`, one generation is retained, and a `log.rotated` marker is written as
+///   the first line of the fresh file so consumers detect the boundary.
+///
+/// Non-blocking under a slow/full disk (EVT-3): `append` never touches the disk
+/// on the caller thread, and a bounded in-flight cap drops rather than growing
+/// memory without bound — drops surface in-stream as a `log.dropped` marker.
+final class EventLog {
+
+    let url: URL
+    private let instance: String
+    private let sizeCap: Int
+    private let maxPending: Int
+    private let now: () -> Date
+
+    private let queue: DispatchQueue
+    private var fileHandle: FileHandle?
+
+    /// Test seam: invoked on the writer queue immediately before each line is
+    /// written. Tests install a semaphore wait here to pin the queue and prove
+    /// `append` stays non-blocking + drops rather than growing (EVT-3). nil in
+    /// production.
+    var onQueueBeforeWrite: (() -> Void)?
+
+    /// Assigned and read only on `queue`.
+    private var nextSeq: UInt64 = 0
+
+    /// Guards the caller-visible backpressure counters.
+    private let counterLock = NSLock()
+    private var pendingCount = 0
+    private var droppedSinceReport = 0
+
+    /// - Parameters:
+    ///   - url: the per-instance current log path.
+    ///   - instance: the per-process id embedded in every envelope + markers.
+    ///   - sizeCap: bytes; the file rolls once it grows past this. Default 8 MiB.
+    ///   - maxPending: max in-flight appends before drop-newest kicks in.
+    init(
+        url: URL,
+        instance: String,
+        sizeCap: Int = 8 * 1024 * 1024,
+        maxPending: Int = 4096,
+        now: @escaping () -> Date = { Date() },
+        label: String = "com.stage11.c11.events.log"
+    ) {
+        self.url = url
+        self.instance = instance
+        self.sizeCap = sizeCap
+        self.maxPending = maxPending
+        self.now = now
+        self.queue = DispatchQueue(label: label, qos: .utility)
+    }
+
+    deinit {
+        try? fileHandle?.close()
+    }
+
+    // MARK: - Public API
+
+    /// Enqueues an append; returns immediately. Drops (counted) when the
+    /// in-flight queue is saturated so a stalled disk never blocks the caller.
+    func append(_ envelope: EventEnvelope) {
+        counterLock.lock()
+        if pendingCount >= maxPending {
+            droppedSinceReport += 1
+            counterLock.unlock()
+            return
+        }
+        pendingCount += 1
+        counterLock.unlock()
+
+        queue.async { [weak self] in
+            guard let self else { return }
+            self.reportDropsIfNeeded()
+            self.writeAssigningSeq(envelope)
+            self.counterLock.lock()
+            self.pendingCount -= 1
+            self.counterLock.unlock()
+        }
+    }
+
+    /// Writes the per-instance `log.opened` marker. Call once, eagerly, at
+    /// startup so consumers see the instance boundary + seq reset.
+    func open() {
+        let env = EventEnvelope(
+            type: .logOpened,
+            instance: instance,
+            ts: now(),
+            payload: ["pid": ProcessInfo.processInfo.processIdentifier]
+        )
+        queue.async { [weak self] in
+            self?.writeAssigningSeq(env)
+        }
+    }
+
+    /// Blocks until all previously-enqueued appends have completed. For tests
+    /// and shutdown. Never call from within `queue`.
+    func flush() {
+        queue.sync {}
+    }
+
+    // MARK: - Queue-confined writing
+
+    private func writeAssigningSeq(_ envelope: EventEnvelope) {
+        nextSeq &+= 1
+        let line = envelope.serialize(seq: nextSeq)
+        writeLine(line)
+        rotateIfNeeded()
+    }
+
+    /// Emits a `log.dropped` marker when the backpressure guard has shed events
+    /// since the last report. Runs on `queue` ahead of the next real append.
+    private func reportDropsIfNeeded() {
+        counterLock.lock()
+        let dropped = droppedSinceReport
+        droppedSinceReport = 0
+        counterLock.unlock()
+        guard dropped > 0 else { return }
+        let env = EventEnvelope(
+            type: .logDropped,
+            instance: instance,
+            ts: now(),
+            payload: ["count": dropped]
+        )
+        nextSeq &+= 1
+        writeLine(env.serialize(seq: nextSeq))
+    }
+
+    private func writeLine(_ line: String) {
+        onQueueBeforeWrite?()
+        do {
+            try ensureHandle()
+            if let data = line.data(using: .utf8) {
+                try fileHandle?.write(contentsOf: data)
+            }
+        } catch {
+            // Best-effort: drop the handle so the next call reopens from scratch.
+            // Log write failures are intentionally silent — observability must
+            // never block or crash the emitting path.
+            try? fileHandle?.close()
+            fileHandle = nil
+        }
+    }
+
+    private func ensureHandle() throws {
+        if fileHandle != nil { return }
+        let parent = url.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            FileManager.default.createFile(atPath: url.path, contents: nil)
+        }
+        let fh = try FileHandle(forWritingTo: url)
+        try fh.seekToEnd()
+        fileHandle = fh
+    }
+
+    // MARK: - Rotation (EVT-4)
+
+    private func rotateIfNeeded() {
+        guard let fh = fileHandle else { return }
+        let size = (try? fh.offset()) ?? 0
+        guard size >= UInt64(sizeCap) else { return }
+        rotate()
+    }
+
+    private func rotate() {
+        let fm = FileManager.default
+        let rolled = EventLogLayout.rolledURL(for: url)
+        do {
+            try fileHandle?.close()
+        } catch {
+            // fall through; we still attempt the rename + reopen
+        }
+        fileHandle = nil
+        // Retain exactly one rolled generation: replace any prior `.1`.
+        try? fm.removeItem(at: rolled)
+        do {
+            try fm.moveItem(at: url, to: rolled)
+        } catch {
+            // If the roll failed, keep appending to the current file rather than
+            // losing events; reopen and carry on (cap will retrigger).
+            return
+        }
+        // Fresh current file starts with a rotation marker so a consumer that
+        // re-reads from the top after detecting the shrink lands on the boundary.
+        let marker = EventEnvelope(
+            type: .logRotated,
+            instance: instance,
+            ts: now(),
+            payload: ["rolled_to": rolled.lastPathComponent]
+        )
+        nextSeq &+= 1
+        writeLine(marker.serialize(seq: nextSeq))
+    }
+}

--- a/Sources/Events/EventLogLayout.swift
+++ b/Sources/Events/EventLogLayout.swift
@@ -1,0 +1,155 @@
+import Foundation
+
+/// Pure path builders for the c11 events stream (C11-163). No I/O happens here
+/// beyond the read-only directory listing used to resolve the newest instance
+/// log — path math and filename derivation only. Compiled into **both** the app
+/// target (the `EventLog` writer) and the `c11-cli` target (the `c11 events
+/// tail` reader), so it must stay free of any app-only imports.
+///
+/// Layout on disk:
+///
+///     <state>/events/
+///         events-<instance>.ndjson       (current per-instance log)
+///         events-<instance>.ndjson.1      (one rolled generation, EVT-4)
+///
+/// The log is **per-instance** (EVT-1): each running c11 process writes its own
+/// file, keyed by `<launch-tag-or-bundle>-<pid>`. This is deliberate — the state
+/// dir is shared, and dogfooders run a tagged debug build alongside the prod
+/// build (see `StateDirectoryMigration`), so a single shared file would suffer
+/// non-atomic multi-writer append corruption. Per-instance files sidestep that
+/// and let `seq` reset cleanly per boot.
+///
+/// See `spec/event-envelope.v1.schema.json` for the line format and
+/// `skills/c11/references/events.md` for the consumer contract.
+enum EventLogLayout {
+
+    // MARK: - Names
+
+    /// Directory name under `~/Library/Application Support/`. Mirrors
+    /// `MailboxLayout.stateDirectoryName` / `SocketControlSettings
+    /// .socketDirectoryName`; duplicated here so the CLI target resolves the
+    /// state root without a cross-target import.
+    static let stateDirectoryName = "c11"
+
+    /// Subdirectory of the state root that holds the event logs.
+    static let eventsDirectoryName = "events"
+
+    /// Prefix + extension for a per-instance current log: `events-<id>.ndjson`.
+    static let logFilePrefix = "events-"
+    static let logFileExtension = "ndjson"
+
+    /// Suffix appended to the rolled generation: `events-<id>.ndjson.1`.
+    static let rolledGenerationSuffix = "1"
+
+    // MARK: - Errors
+
+    enum Error: Swift.Error, Equatable {
+        case stateDirectoryUnavailable
+        case noInstanceLogFound
+    }
+
+    // MARK: - State root
+
+    /// Resolves the c11 state root (default:
+    /// `~/Library/Application Support/c11`). Mirrors
+    /// `MailboxLayout.defaultStateURL` exactly, including the legacy→current
+    /// migration latch, so the events tree lands beside the mailbox tree.
+    static func defaultStateURL(fileManager: FileManager = .default) throws -> URL {
+        StateDirectoryMigration.ensureMigrated(fileManager: fileManager)
+        guard let appSupport = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            throw Error.stateDirectoryUnavailable
+        }
+        return appSupport.appendingPathComponent(stateDirectoryName, isDirectory: true)
+    }
+
+    // MARK: - Path builders
+
+    /// `<state>/events/`.
+    static func eventsDirectoryURL(state: URL) -> URL {
+        state.appendingPathComponent(eventsDirectoryName, isDirectory: true)
+    }
+
+    /// Filename for a given instance id: `events-<instance>.ndjson`.
+    static func logFileName(instance: String) -> String {
+        "\(logFilePrefix)\(sanitizeInstance(instance)).\(logFileExtension)"
+    }
+
+    /// Current log for an instance: `<state>/events/events-<instance>.ndjson`.
+    static func logURL(state: URL, instance: String) -> URL {
+        eventsDirectoryURL(state: state)
+            .appendingPathComponent(logFileName(instance: instance), isDirectory: false)
+    }
+
+    /// Rolled generation for a current log: append `.1` to the current path.
+    static func rolledURL(for currentLog: URL) -> URL {
+        URL(fileURLWithPath: currentLog.path + "." + rolledGenerationSuffix)
+    }
+
+    // MARK: - Instance id
+
+    /// Builds the per-instance discriminator `<tag-or-bundle>-<pid>`. `pid` is
+    /// the only guaranteed-unique component; the tag/bundle prefix keeps the
+    /// filename legible when a dogfooder eyeballs the events dir.
+    static func makeInstanceId(
+        tag: String? = ProcessInfo.processInfo.environment["C11_TAG"],
+        bundleId: String? = Bundle.main.bundleIdentifier,
+        pid: Int32 = ProcessInfo.processInfo.processIdentifier
+    ) -> String {
+        let label: String
+        if let tag, !tag.trimmingCharacters(in: .whitespaces).isEmpty {
+            label = tag
+        } else if let bundleId, !bundleId.isEmpty {
+            label = bundleId
+        } else {
+            label = "c11"
+        }
+        return sanitizeInstance("\(label)-\(pid)")
+    }
+
+    /// Restricts an instance component to filename-safe characters.
+    static func sanitizeInstance(_ raw: String) -> String {
+        let mapped = raw.map { ch -> Character in
+            if ch.isLetter || ch.isNumber || ch == "." || ch == "-" || ch == "_" {
+                return ch
+            }
+            return "_"
+        }
+        let cleaned = String(mapped)
+        return cleaned.isEmpty ? "c11" : cleaned
+    }
+
+    // MARK: - Reader resolution (CLI)
+
+    /// Resolves the log a consumer should tail when no explicit instance is
+    /// given: the newest current log in `<state>/events/` by modification time.
+    /// A `c11 events tail` with no running app still works — the file is the
+    /// contract. Rolled `.1` files are ignored here (the follow loop drains
+    /// them on rotation detection).
+    static func newestLogURL(state: URL, fileManager: FileManager = .default) throws -> URL {
+        let dir = eventsDirectoryURL(state: state)
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        let candidates = entries.filter { url in
+            let name = url.lastPathComponent
+            return name.hasPrefix(logFilePrefix)
+                && name.hasSuffix("." + logFileExtension)
+        }
+        guard !candidates.isEmpty else { throw Error.noInstanceLogFound }
+
+        let sorted = candidates.sorted { lhs, rhs in
+            let l = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            let r = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]))?
+                .contentModificationDate ?? .distantPast
+            return l > r
+        }
+        return sorted[0]
+    }
+}

--- a/Sources/Mailbox/MailboxDispatcher.swift
+++ b/Sources/Mailbox/MailboxDispatcher.swift
@@ -289,6 +289,14 @@ final class MailboxDispatcher {
                 topic: envelope.topic
             )
         )
+        // C11-163: mailbox envelope accepted → events stream.
+        EventEmitter.shared.emitMailboxAccepted(
+            workspace: workspaceId,
+            id: envelope.id,
+            from: envelope.from,
+            to: envelope.to,
+            topic: envelope.topic
+        )
 
         // Step 3: resolve recipients. Stage 2 = `to` only.
         let recipients = resolveRecipients(envelope: envelope)
@@ -370,6 +378,13 @@ final class MailboxDispatcher {
             )
             try MailboxIO.atomicWrite(data: envelopeBytes, to: target)
             log.append(.copied(id: envelope.id, recipient: recipient.name))
+            // C11-163: mailbox envelope delivered to a recipient inbox.
+            EventEmitter.shared.emitMailboxDelivered(
+                workspace: workspaceId,
+                id: envelope.id,
+                recipient: recipient.name,
+                surface: recipient.surfaceId
+            )
         } catch {
             // The `resolved` event already lists the recipient; failure to
             // copy is logged as a handler-style failure so the operator can

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -572,6 +572,8 @@ final class SurfaceMetadataStore: @unchecked Sendable {
             if let existing = blob[key], sameJSONValue(existing, value), sblob[key]?.source == source {
                 return false
             }
+            // C11-163: capture prior before overwrite (amendment E).
+            let priorValue = blob[key]
             blob[key] = value
             sblob[key] = SourceRecord(source: source, ts: Date().timeIntervalSince1970)
 
@@ -583,6 +585,19 @@ final class SurfaceMetadataStore: @unchecked Sendable {
             metadata[workspaceId, default: [:]][surfaceId] = blob
             sources[workspaceId, default: [:]][surfaceId] = sblob
             metadataStoreRevision &+= 1
+
+            // C11-163: publish canonical metadata change (post-commit).
+            if EventEmitter.canonicalMetadataEventKeys.contains(key) {
+                EventEmitter.shared.emitMetadataChanged(
+                    scope: "surface",
+                    workspace: workspaceId,
+                    surface: surfaceId,
+                    key: key,
+                    value: value,
+                    prior: priorValue,
+                    source: source.rawValue
+                )
+            }
             return true
         }
     }
@@ -624,6 +639,11 @@ final class SurfaceMetadataStore: @unchecked Sendable {
 
         let ts = Date().timeIntervalSince1970
         var mutated = false
+        // C11-163: canonical metadata changes to publish to the events stream
+        // AFTER the write commits (the size guard below can still abort).
+        // Prior value is captured inline here — the surface store does not
+        // populate WriteResult.priorValues (amendment E).
+        var canonicalEventChanges: [(key: String, value: Any, prior: Any?)] = []
 
         if mode == .replace {
             // `mode == .replace` discarded the prior blob above. If that prior
@@ -652,6 +672,9 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 result.applied[k] = true
                 continue
             }
+            if EventEmitter.canonicalMetadataEventKeys.contains(k) {
+                canonicalEventChanges.append((key: k, value: v, prior: existing))
+            }
             blob[k] = v
             sblob[k] = SourceRecord(source: source, ts: ts)
             result.applied[k] = true
@@ -672,6 +695,21 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         result.metadata = blob
         result.sources = sblob.mapValues { $0.toJSON() }
         if mutated { metadataStoreRevision &+= 1 }
+
+        // C11-163: publish canonical metadata changes now that the write has
+        // committed (post size-guard). Off the store's serial queue; emit is
+        // fire-and-forget and never blocks this path.
+        for change in canonicalEventChanges {
+            EventEmitter.shared.emitMetadataChanged(
+                scope: "surface",
+                workspace: workspaceId,
+                surface: surfaceId,
+                key: change.key,
+                value: change.value,
+                prior: change.prior,
+                source: source.rawValue
+            )
+        }
         return result
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -891,6 +891,12 @@ class TabManager: ObservableObject {
         }
         didSet {
             guard selectedTabId != oldValue else { return }
+            // C11-163: workspace selected → events stream. Fires on every
+            // selection route (socket, keyboard, click, close-fallback) since
+            // they all land here.
+            if let selected = selectedTabId {
+                EventEmitter.shared.emitWorkspaceSelected(previous: oldValue, selected: selected)
+            }
             sentryBreadcrumb("workspace.switch", data: surfaceShapeSummary(tabCount: tabs.count))
 
             // Phase 0 instrumentation: open a signpost interval spanning the

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -686,8 +686,12 @@ final class TerminalNotificationStore: ObservableObject {
 
     @Published private(set) var notifications: [TerminalNotification] = [] {
         didSet {
+            // C11-163: capture the prior per-tab unread counts before the
+            // rebuild so waiting-agent edges can be detected (amendment H).
+            let previousUnreadByTab = indexes.unreadCountByTabId
             indexes = Self.buildIndexes(for: notifications)
             refreshDockBadge()
+            emitWaitingEdges(previous: previousUnreadByTab, current: indexes.unreadCountByTabId)
         }
     }
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown
@@ -721,6 +725,25 @@ final class TerminalNotificationStore: ObservableObject {
         store.scheduleUserNotification(notification)
     }
     private var indexes = NotificationIndexes()
+
+    /// C11-163: emit waiting.entered / waiting.left on the per-tab unread
+    /// 0↔1 edge. "Agent is waiting" == the tab has an unread notification;
+    /// this fires through the single `notifications` didSet, covering every
+    /// caller (addNotification / markRead* / markUnread / markAllRead). The
+    /// waiting signal is a TEL-6 seam — if the waiting-agent cluster plan
+    /// redefines "attention demand", rewire the source here.
+    private func emitWaitingEdges(previous: [UUID: Int], current: [UUID: Int]) {
+        let tabs = Set(previous.keys).union(current.keys)
+        for tab in tabs {
+            let before = previous[tab] ?? 0
+            let after = current[tab] ?? 0
+            if before == 0, after > 0 {
+                EventEmitter.shared.emitWaiting(entered: true, workspace: tab, surface: nil)
+            } else if before > 0, after == 0 {
+                EventEmitter.shared.emitWaiting(entered: false, workspace: tab, surface: nil)
+            }
+        }
+    }
 
     private init() {
         indexes = Self.buildIndexes(for: notifications)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5184,6 +5184,15 @@ final class Workspace: Identifiable, ObservableObject {
     /// Mapping from bonsplit TabID to our Panel instances
     @Published private(set) var panels: [UUID: any Panel] = [:]
 
+    /// C11-163 events stream: single create/close chokepoint. Subscribing to
+    /// `$panels` and diffing keys catches every surface lifecycle transition
+    /// through one path — split, tab, restore, reattach, rollback, bulk
+    /// teardown, detach — so no emit site can be missed (amendments C, D). A
+    /// `@Published` property can't carry a `didSet` observer, hence the Combine
+    /// subscription. `lastKnownPanelIds` is the diff baseline.
+    private var panelEventsCancellable: AnyCancellable?
+    private var lastKnownPanelIds: Set<UUID> = []
+
     /// Monotonically incrementing token used by the sidebar workspace row to
     /// observe focus flashes targeting any panel in this workspace. Bumped
     /// from `triggerFocusFlash(panelId:)` so a single fan-out drives the
@@ -5902,6 +5911,16 @@ final class Workspace: Identifiable, ObservableObject {
                     "markdown": counts.markdown,
                 ])
             }
+
+        // C11-163: emit surface.created / surface.closed by diffing $panels.
+        // Subscribing fires once synchronously with the current set (the seed
+        // terminal), then on every subsequent mutation — a single chokepoint
+        // that no create/close/reattach/teardown path can bypass. No debounce:
+        // events must be observable within 1s (EVT-6).
+        panelEventsCancellable = $panels
+            .sink { [weak self] newPanels in
+                self?.reconcilePanelEvents(newPanels)
+            }
     }
 
     deinit {
@@ -5921,6 +5940,29 @@ final class Workspace: Identifiable, ObservableObject {
             }
             persistentFlashPanels.removeAll()
         }
+    }
+
+    /// C11-163: diff the panel set against the last-known ids and publish
+    /// surface lifecycle events. Runs synchronously inside `$panels` delivery
+    /// (main actor); `EventEmitter.emit` is fire-and-forget so this never
+    /// blocks. A rolled-back create surfaces as a balanced created→closed pair;
+    /// a cross-pane detach→reattach as closed→created (amendment D move policy).
+    private func reconcilePanelEvents(_ newPanels: [UUID: any Panel]) {
+        let newIds = Set(newPanels.keys)
+        guard newIds != lastKnownPanelIds else { return }
+        for createdId in newIds.subtracting(lastKnownPanelIds) {
+            guard let panel = newPanels[createdId] else { continue }
+            EventEmitter.shared.emitSurfaceCreated(
+                workspace: id,
+                surface: createdId,
+                kind: panel.panelType.rawValue,
+                title: panel.displayTitle
+            )
+        }
+        for closedId in lastKnownPanelIds.subtracting(newIds) {
+            EventEmitter.shared.emitSurfaceClosed(workspace: id, surface: closedId)
+        }
+        lastKnownPanelIds = newIds
     }
 
     /// Creates a per-workspace mailbox dispatcher bound to this workspace's

--- a/c11Tests/EventLogTests.swift
+++ b/c11Tests/EventLogTests.swift
@@ -1,0 +1,216 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// C11-163 events stream — logic tests for the envelope, layout, writer
+/// (rotation + backpressure), and emitter facade. Hermetic: every test uses a
+/// fresh temp dir and blocks on `flush()`, so the whole file runs sub-second in
+/// the `c11-logic` scheme.
+final class EventLogTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("c11-events-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        EventEmitter.shared.resetForTesting()
+    }
+
+    private func logURL(_ name: String = "events.ndjson") -> URL {
+        tempDir.appendingPathComponent(name, isDirectory: false)
+    }
+
+    private func readLines(_ url: URL) -> [String] {
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        return text.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    private func parse(_ line: String) -> [String: Any] {
+        (try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]) ?? [:]
+    }
+
+    // MARK: - EVT-1: envelope shape
+
+    func testEnvelopeCarriesRequiredFieldsAndOmitsNilRefs() {
+        let env = EventEnvelope(
+            type: .surfaceCreated,
+            instance: "inst-1",
+            ts: Date(timeIntervalSince1970: 1_770_000_000),
+            workspace: "ws-uuid",
+            surface: "sf-uuid",
+            payload: ["kind": "terminal"]
+        )
+        let line = env.serialize(seq: 7)
+        XCTAssertTrue(line.hasSuffix("\n"))
+        let obj = parse(line)
+        XCTAssertEqual(obj["seq"] as? Int, 7)
+        XCTAssertEqual(obj["type"] as? String, "surface.created")
+        XCTAssertEqual(obj["instance"] as? String, "inst-1")
+        XCTAssertEqual(obj["v"] as? Int, 1)
+        XCTAssertEqual(obj["workspace"] as? String, "ws-uuid")
+        XCTAssertEqual(obj["surface"] as? String, "sf-uuid")
+        XCTAssertNil(obj["pane"], "nil refs must be omitted, not encoded as null")
+        XCTAssertNotNil(obj["ts"] as? String)
+        let payload = obj["payload"] as? [String: Any]
+        XCTAssertEqual(payload?["kind"] as? String, "terminal")
+    }
+
+    func testEnvelopeParseHelpers() {
+        let line = EventEnvelope(
+            type: .metadataChanged,
+            instance: "i",
+            ts: Date(timeIntervalSince1970: 1_770_000_123)
+        ).serialize(seq: 42)
+        XCTAssertEqual(EventEnvelope.type(fromLine: line), "metadata.changed")
+        XCTAssertEqual(EventEnvelope.seq(fromLine: line), 42)
+        XCTAssertNotNil(EventEnvelope.timestamp(fromLine: line))
+        // Tolerant of junk.
+        XCTAssertNil(EventEnvelope.type(fromLine: "not json"))
+        XCTAssertNil(EventEnvelope.seq(fromLine: ""))
+    }
+
+    // MARK: - Layout
+
+    func testLayoutFilenameAndInstanceSanitize() {
+        XCTAssertEqual(EventLogLayout.logFileName(instance: "abc-123"), "events-abc-123.ndjson")
+        XCTAssertEqual(EventLogLayout.sanitizeInstance("a/b c:d"), "a_b_c_d")
+        let id = EventLogLayout.makeInstanceId(tag: "evt-post", bundleId: "x", pid: 99)
+        XCTAssertEqual(id, "evt-post-99")
+    }
+
+    func testLayoutNewestByMtime() throws {
+        let dir = EventLogLayout.eventsDirectoryURL(state: tempDir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let older = dir.appendingPathComponent("events-old.ndjson")
+        let newer = dir.appendingPathComponent("events-new.ndjson")
+        FileManager.default.createFile(atPath: older.path, contents: Data("{}\n".utf8))
+        FileManager.default.createFile(atPath: newer.path, contents: Data("{}\n".utf8))
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 1000)], ofItemAtPath: older.path)
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 2000)], ofItemAtPath: newer.path)
+        let resolved = try EventLogLayout.newestLogURL(state: tempDir)
+        XCTAssertEqual(resolved.lastPathComponent, "events-new.ndjson")
+    }
+
+    // MARK: - EVT-1: monotonic seq + ordering
+
+    func testAppendAssignsMonotonicSeqInFileOrder() {
+        let log = EventLog(url: logURL(), instance: "i")
+        for i in 0..<5 {
+            log.append(EventEnvelope(type: .workspaceSelected, instance: "i", ts: Date(),
+                                     payload: ["n": i]))
+        }
+        log.flush()
+        let seqs = readLines(logURL()).compactMap { EventEnvelope.seq(fromLine: $0) }
+        XCTAssertEqual(seqs, [1, 2, 3, 4, 5])
+    }
+
+    func testOpenWritesLogOpenedMarker() {
+        let log = EventLog(url: logURL(), instance: "boot-1")
+        log.open()
+        log.flush()
+        let lines = readLines(logURL())
+        XCTAssertEqual(lines.count, 1)
+        XCTAssertEqual(EventEnvelope.type(fromLine: lines[0]), "log.opened")
+        XCTAssertEqual(EventEnvelope.seq(fromLine: lines[0]), 1)
+    }
+
+    // MARK: - EVT-4: rotation
+
+    func testRotationRollsAndMarksAndRetainsOneGeneration() {
+        // Tiny cap forces a roll after a couple of lines.
+        let log = EventLog(url: logURL(), instance: "i", sizeCap: 200)
+        for i in 0..<40 {
+            log.append(EventEnvelope(type: .surfaceCreated, instance: "i", ts: Date(),
+                                     surface: "s\(i)", payload: ["kind": "terminal"]))
+        }
+        log.flush()
+
+        let rolled = EventLogLayout.rolledURL(for: logURL())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rolled.path),
+                      "rotation must retain one rolled generation (.1)")
+
+        // The fresh current file must open with a log.rotated marker so a
+        // consumer that detects the shrink lands on the boundary.
+        let currentLines = readLines(logURL())
+        XCTAssertFalse(currentLines.isEmpty)
+        XCTAssertEqual(EventEnvelope.type(fromLine: currentLines[0]), "log.rotated")
+
+        // Seq stays monotonic across the boundary (rolled tail < current head).
+        let rolledSeqs = readLines(rolled).compactMap { EventEnvelope.seq(fromLine: $0) }
+        let currentSeqs = currentLines.compactMap { EventEnvelope.seq(fromLine: $0) }
+        XCTAssertLessThan(rolledSeqs.last ?? 0, currentSeqs.first ?? 0)
+    }
+
+    // MARK: - EVT-3: non-blocking under a stalled disk
+
+    func testAppendIsNonBlockingAndDropsUnderBackpressure() {
+        let log = EventLog(url: logURL(), instance: "i", maxPending: 4)
+        let gate = DispatchSemaphore(value: 0)
+        // Pin the writer queue on the first write so pending saturates.
+        log.onQueueBeforeWrite = { gate.wait() }
+
+        // Flood far past maxPending. Each append must return immediately.
+        let start = Date()
+        for i in 0..<500 {
+            log.append(EventEnvelope(type: .metadataChanged, instance: "i", ts: Date(),
+                                     payload: ["n": i]))
+        }
+        let elapsed = Date().timeIntervalSince(start)
+        XCTAssertLessThan(elapsed, 1.0, "append must not block even while the writer queue is stalled")
+
+        // Release the queue and drain. Signal generously (more than any line
+        // the queue could write) and leave the hook in place — nil-ing it from
+        // this thread would race the queue's read of the closure.
+        for _ in 0..<2000 { gate.signal() }
+        log.flush()
+
+        // The shed events must surface in-stream as a log.dropped marker.
+        let types = readLines(logURL()).compactMap { EventEnvelope.type(fromLine: $0) }
+        XCTAssertTrue(types.contains("log.dropped"),
+                      "backpressure drops must be observable as a log.dropped marker")
+    }
+
+    // MARK: - Emitter
+
+    func testEmitterExcludesProgressFromCanonicalKeys() {
+        XCTAssertTrue(EventEmitter.canonicalMetadataEventKeys.contains("status"))
+        XCTAssertTrue(EventEmitter.canonicalMetadataEventKeys.contains("title"))
+        XCTAssertTrue(EventEmitter.canonicalMetadataEventKeys.contains("description"))
+        XCTAssertFalse(EventEmitter.canonicalMetadataEventKeys.contains("progress"),
+                       "progress is excluded from v1 metadata.changed (flood control)")
+    }
+
+    func testEmitterEmitsThroughInjectedLog() {
+        let log = EventLog(url: logURL(), instance: "test-inst")
+        EventEmitter.shared.startForTesting(log: log, instance: "test-inst")
+        let ws = UUID(), sf = UUID()
+        EventEmitter.shared.emitSurfaceCreated(workspace: ws, surface: sf, kind: "terminal")
+        EventEmitter.shared.emitMetadataChanged(
+            scope: "surface", workspace: ws, surface: sf,
+            key: "status", value: "working", prior: "idle", source: "explicit")
+        EventEmitter.shared.flush()
+
+        let objs = readLines(logURL()).map(parse)
+        XCTAssertEqual(objs.count, 2)
+        XCTAssertEqual(objs[0]["type"] as? String, "surface.created")
+        XCTAssertEqual(objs[0]["surface"] as? String, sf.uuidString)
+        XCTAssertEqual(objs[1]["type"] as? String, "metadata.changed")
+        let payload = objs[1]["payload"] as? [String: Any]
+        XCTAssertEqual(payload?["key"] as? String, "status")
+        XCTAssertEqual(payload?["value"] as? String, "working")
+        XCTAssertEqual(payload?["prior"] as? String, "idle")
+        XCTAssertEqual(payload?["source"] as? String, "explicit")
+        XCTAssertEqual(payload?["scope"] as? String, "surface")
+    }
+}

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -50,6 +50,7 @@ c11 stamps your launch identity itself: the sidebar chip (agent type from proces
 | launch sub-agents, the tab-naming convention, layout patterns, write c11-aware prompts | [references/orchestration.md](references/orchestration.md) |
 | send/receive inter-agent messages (the mailbox) | [docs/c11-mailbox-guide.md](../../docs/c11-mailbox-guide.md) |
 | surface-manifest depth, sidebar reporting (`set-status` / `set-progress` / `log`), flash, precedence & sources | [references/metadata.md](references/metadata.md) |
+| tail the file-first events stream (`c11 events tail`), envelope schema, v1 taxonomy | [references/events.md](references/events.md) |
 | workspace persistence, snapshots, the conversation store & resume | [references/conversation.md](references/conversation.md) |
 | the Claude session-resume hook | [references/claude-resume.md](references/claude-resume.md) |
 | drive the embedded browser (validate UI without leaving c11) | [c11-browser skill](../c11-browser/SKILL.md) |

--- a/skills/c11/references/events.md
+++ b/skills/c11/references/events.md
@@ -1,0 +1,131 @@
+# c11 Events Stream
+
+c11 emits a **file-first pub/sub log** of everything structural that happens inside a running process — surfaces opening and closing, workspace selection, metadata edits, liveness flips, waiting edges, mailbox traffic. Each running c11 writes an append-only NDJSON file; any process may `tail -f` it directly. This is the push counterpart to per-surface [metadata](metadata.md)'s pull-on-demand model: metadata answers *what is the state now*, the events stream answers *what just changed*.
+
+**The file is the contract.** The CLI (`c11 events tail`) is sugar over reading that file — it works with no running app, and a consumer that wants the raw bytes never has to touch c11 at all.
+
+## Contents
+
+- [File & format](#file--format)
+- [Envelope](#envelope)
+- [v1 taxonomy](#v1-taxonomy)
+- [Stream-control markers](#stream-control-markers)
+- [CLI](#cli)
+- [Consumer patterns](#consumer-patterns)
+- [Guarantees & non-guarantees](#guarantees--non-guarantees)
+
+## File & format
+
+- **Per-instance NDJSON log** at `~/Library/Application Support/c11/events/events-<instance>.ndjson`, one JSON object per line. The `<instance>` id is `<launch-tag-or-bundleid>-<pid>` (e.g. `com.stage11.c11-12345`) — **every running c11 process writes its own file**, so a machine with three c11 windows open across two launches has multiple logs.
+- **Newest-by-mtime is "current."** The CLI defaults to the most recently written instance log; target another with `--instance`.
+- **`log.opened` begins each instance's log.** Its payload carries the `pid`. **`seq` resets to 0 per instance** — it is monotonic *within* one file, never across instances.
+- **Rotation at a size cap (~8 MiB).** The live file is rolled to `events-<instance>.ndjson.1` (a single rolled generation is retained; the previous `.1` is discarded). A `log.rotated` marker is the last line of the rolled file, and the fresh file opens with a new `log.opened` marker, so a consumer following across the boundary detects it rather than silently losing its place.
+
+Schema: **`spec/event-envelope.v1.schema.json`** is the source of truth — every line must validate against it. One `EventEnvelope` serializes to exactly one line.
+
+## Envelope
+
+Every line is a flat JSON object. Five fields are required; the subject refs and `payload` are optional and present only when they apply.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `seq` | int (≥ 0) | yes | Monotonic per instance, assigned on the writer's serial queue so file order and seq order always agree. **THE ordering oracle** — order by `seq`, never by `ts`. |
+| `ts` | string | yes | ISO-8601 / RFC3339 UTC with fractional seconds and `Z` (`2026-07-07T08:20:00.123Z`). Captured on the emitting thread — only *approximately* monotonic and may invert slightly relative to `seq` across racing threads. **Approximate ordering only.** |
+| `type` | string | yes | Dotted event type from the closed v1 enum (below). Matches `^[a-z][a-z0-9_.]*$`. |
+| `instance` | string | yes | The emitting process's instance id. Namespaces `seq`. |
+| `v` | int | yes | Schema version, `1`. Integer, not a string. Bumps are breaking. |
+| `workspace` | UUID string | no | Subject workspace/tab this event concerns. |
+| `surface` | UUID string | no | Subject surface this event concerns. |
+| `pane` | UUID string | no | Subject pane this event concerns. |
+| `payload` | object | no | Type-specific detail, keyed by `type`. Omitted (not `null`) when empty. |
+
+## v1 taxonomy
+
+The nine taxonomy types below are the closed v1 enum. `workspace` / `surface` / `pane` mark which subject refs are populated; `payload` shows the type-specific shape.
+
+| `type` | Subject refs | Payload | Notes |
+|--------|--------------|---------|-------|
+| `surface.created` | workspace + surface | `{kind, title?}` | A new surface opened. `kind` is terminal / browser / markdown. |
+| `surface.closed` | workspace + surface | — | Surface torn down. |
+| `workspace.selected` | workspace (the selected one) | `{previous?}` | Sidebar tab switch. `previous` is the prior workspace UUID. |
+| `metadata.changed` | workspace + surface | `{scope, key, value?, prior?, source}` | A canonical/non-canonical metadata write landed. `scope` ∈ `surface`\|`pane`; `source` is the precedence tier (`explicit`\|`declare`\|`osc`\|`derived`\|`heuristic`). **`progress` is excluded in v1** (flood control); this covers `status`/`title`/`description` (+`role`/`task`/`model`). See [metadata.md](metadata.md). |
+| `liveness.derived` | workspace + surface | `{state}` | Derived agent activity, `state` ∈ `working`\|`idle`. Rides a seam with the TEL ticket (C11-162), which *produces* the derived-liveness signal; documented here as v1 taxonomy but **wired by TEL**. |
+| `waiting.entered` | workspace (= tabId) + surface? | — | The "agent is waiting" edge — the unread-notification transition, per tab. |
+| `waiting.left` | workspace (= tabId) + surface? | — | Paired exit edge for `waiting.entered`. |
+| `mailbox.accepted` | workspace | `{id, from, to?, topic?}` | A mailbox message was accepted onto the bus. |
+| `mailbox.delivered` | workspace + surface? | `{id, recipient}` | A mailbox message reached a recipient. |
+
+## Stream-control markers
+
+Three additional `type` values are **not taxonomy members** — they are structural markers that let consumers detect instance boundaries, rotation, and backpressure drops. Treat them as control frames, not domain events.
+
+| `type` | Payload | Meaning |
+|--------|---------|---------|
+| `log.opened` | `{pid}` | First line of an instance's log. `seq` starts here. |
+| `log.rotated` | `{rolled_to}` | Last line before rotation; `rolled_to` names the `.1` file the prior contents moved to. A fresh `log.opened` follows in the new file. |
+| `log.dropped` | `{count}` | Backpressure shed `count` events under a stalled disk. A gap in the record — see non-guarantees. |
+
+## CLI
+
+`c11 events tail` reads the log directly and **works with no running app**.
+
+```bash
+c11 events tail                       # one-shot: print all events in the current instance log, then exit
+c11 events tail --follow              # keep streaming new events (rotation-aware); -f for short
+c11 events tail --filter type=surface.closed
+c11 events tail --since 1200          # start from seq 1200
+c11 events tail --since 10m           # start from ~10 minutes ago (resolved against ts)
+c11 events tail --instance com.stage11.c11-12345   # a specific instance, not newest-by-mtime
+```
+
+| Flag | Argument | Behavior |
+|------|----------|----------|
+| `--follow` / `-f` | — | Stay attached and stream new lines as they land. Follows rotation across the `log.rotated` → new `log.opened` boundary. Omit for one-shot drain-and-exit. |
+| `--filter` | `type=<t>` | Emit only lines whose `type` equals `<t>`. |
+| `--since` | `<seq>` \| `<duration>` | A bare integer is a `seq` floor (emit `seq ≥ N`); a duration (`10m`, `2h`) is resolved against `ts`. |
+| `--instance` | `<id>` | Read a specific instance log instead of the newest-by-mtime one. |
+
+Defaults: no `--filter` emits every type (taxonomy + control markers); no `--since` starts at the top of the current file; no `--instance` picks newest-by-mtime.
+
+## Consumer patterns
+
+**React to a specific event.** Follow, filter to one type, act per line:
+
+```bash
+c11 events tail -f --filter type=surface.closed | while read -r line; do
+  surface=$(printf '%s' "$line" | jq -r '.surface')
+  echo "surface $surface closed — cleaning up"
+done
+```
+
+**Resume after a restart without replaying history.** Persist the last `seq` you handled, then start above it:
+
+```bash
+last=$(cat ~/.mytool/last_seq 2>/dev/null || echo 0)
+c11 events tail -f --since "$last" | while read -r line; do
+  handle "$line"
+  printf '%s' "$line" | jq -r '.seq' > ~/.mytool/last_seq
+done
+```
+
+Watch for a `log.opened` with a `seq` at or below your floor — that's a new instance whose sequence reset; treat its `seq` space as fresh, not a continuation of yours.
+
+**Detect drops.** A `log.dropped` line means the record is incomplete between the surrounding seqs — a durability-sensitive consumer should reconcile against pull-on-demand state (`c11 get-metadata`, `c11 tree`) rather than trust the stream alone across that gap.
+
+**No running app.** A dashboard or post-hoc analyzer can `jq` straight over the file — `jq -c 'select(.type=="mailbox.delivered")' ~/Library/Application\ Support/c11/events/events-*.ndjson` — with c11 not running at all.
+
+## Guarantees & non-guarantees
+
+**Guarantees**
+
+- **Off-main and non-blocking.** Emission never blocks the UI or the writer's caller; serialization and the file write happen off the main actor.
+- **Low latency.** A line is readable **within ~1s** of the event under normal disk conditions.
+- **`seq` is the oracle.** Ordering within an instance is total and gap-free *except* where a `log.dropped` marker explicitly records a gap. Order by `seq`; `ts` is advisory.
+- **Rotation is observable.** The `log.rotated` / `log.opened` marker pair means a follower never silently loses its position across a roll.
+
+**Non-guarantees**
+
+- **Not a durable queue.** The log is a size-capped ring (one rolled generation), not a message broker. History older than the rolled file is gone. Consumers that need durability **own it** — checkpoint your `seq` and persist what you must keep.
+- **Drops surface as data, not silence.** Under a stalled disk c11 sheds events and records the loss as `log.dropped {count}` rather than blocking. A gap is always marked; it is never hidden.
+- **`ts` is not authoritative for ordering.** It can invert slightly relative to `seq` across racing threads. Never sort or dedupe on `ts`.
+- **Per-instance, not global.** There is no cross-instance total order; `seq` only means something within one `instance`.

--- a/skills/c11/references/events.md
+++ b/skills/c11/references/events.md
@@ -19,7 +19,7 @@ c11 emits a **file-first pub/sub log** of everything structural that happens ins
 - **Per-instance NDJSON log** at `~/Library/Application Support/c11/events/events-<instance>.ndjson`, one JSON object per line. The `<instance>` id is `<launch-tag-or-bundleid>-<pid>` (e.g. `com.stage11.c11-12345`) — **every running c11 process writes its own file**, so a machine with three c11 windows open across two launches has multiple logs.
 - **Newest-by-mtime is "current."** The CLI defaults to the most recently written instance log; target another with `--instance`.
 - **`log.opened` begins each instance's log.** Its payload carries the `pid`. **`seq` resets to 0 per instance** — it is monotonic *within* one file, never across instances.
-- **Rotation at a size cap (~8 MiB).** The live file is rolled to `events-<instance>.ndjson.1` (a single rolled generation is retained; the previous `.1` is discarded). A `log.rotated` marker is the last line of the rolled file, and the fresh file opens with a new `log.opened` marker, so a consumer following across the boundary detects it rather than silently losing its place.
+- **Rotation at a size cap (~8 MiB).** The live file is rolled to `events-<instance>.ndjson.1` (a single rolled generation is retained; the previous `.1` is discarded). The fresh file opens with a `log.rotated` marker as its **first line**; `seq` **continues** across the roll (it is monotonic for the whole instance — only a new `log.opened`/instance resets it). `c11 events tail --follow` is rotation-aware: on the roll it drains the tail of the `.1` file, then continues on the fresh file, so a follower doesn't lose its place.
 
 Schema: **`spec/event-envelope.v1.schema.json`** is the source of truth — every line must validate against it. One `EventEnvelope` serializes to exactly one line.
 
@@ -62,7 +62,7 @@ Three additional `type` values are **not taxonomy members** — they are structu
 | `type` | Payload | Meaning |
 |--------|---------|---------|
 | `log.opened` | `{pid}` | First line of an instance's log. `seq` starts here. |
-| `log.rotated` | `{rolled_to}` | Last line before rotation; `rolled_to` names the `.1` file the prior contents moved to. A fresh `log.opened` follows in the new file. |
+| `log.rotated` | `{rolled_to}` | First line of the fresh post-rotation file; `rolled_to` names the `.1` file the prior contents moved to. `seq` continues (not reset). |
 | `log.dropped` | `{count}` | Backpressure shed `count` events under a stalled disk. A gap in the record — see non-guarantees. |
 
 ## CLI
@@ -80,7 +80,7 @@ c11 events tail --instance com.stage11.c11-12345   # a specific instance, not ne
 
 | Flag | Argument | Behavior |
 |------|----------|----------|
-| `--follow` / `-f` | — | Stay attached and stream new lines as they land. Follows rotation across the `log.rotated` → new `log.opened` boundary. Omit for one-shot drain-and-exit. |
+| `--follow` / `-f` | — | Stay attached and stream new lines as they land. Rotation-aware: on a roll it drains the `.1` tail then continues on the fresh file (first line is `log.rotated`). Omit for one-shot drain-and-exit. |
 | `--filter` | `type=<t>` | Emit only lines whose `type` equals `<t>`. |
 | `--since` | `<seq>` \| `<duration>` | A bare integer is a `seq` floor (emit `seq ≥ N`); a duration (`10m`, `2h`) is resolved against `ts`. |
 | `--instance` | `<id>` | Read a specific instance log instead of the newest-by-mtime one. |
@@ -121,7 +121,7 @@ Watch for a `log.opened` with a `seq` at or below your floor — that's a new in
 - **Off-main and non-blocking.** Emission never blocks the UI or the writer's caller; serialization and the file write happen off the main actor.
 - **Low latency.** A line is readable **within ~1s** of the event under normal disk conditions.
 - **`seq` is the oracle.** Ordering within an instance is total and gap-free *except* where a `log.dropped` marker explicitly records a gap. Order by `seq`; `ts` is advisory.
-- **Rotation is observable.** The `log.rotated` / `log.opened` marker pair means a follower never silently loses its position across a roll.
+- **Rotation is observable.** The `log.rotated` marker (first line of the fresh file) plus the CLI's rotation-aware follow (it drains the rolled `.1` tail, then continues) means a follower doesn't silently lose events across a roll. A direct file reader that wants the same guarantee should watch for a size shrink / inode change and drain `.ndjson.1`.
 
 **Non-guarantees**
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,3 +1,38 @@
+# Event Envelope Spec
+
+`event-envelope.v1.schema.json` is the source of truth for the c11 events-stream envelope format (v1). The stream is a per-instance NDJSON log — one event per line — written to:
+
+```
+~/Library/Application Support/c11/events/events-<instance>.ndjson
+```
+
+where `<instance>` is the per-process instance id (e.g. `com.stage11.c11-12345`). Each running c11 process owns its own file; when a file grows past the rotation threshold it is renamed to `events-<instance>.ndjson.1` and a fresh `.ndjson` is opened. **Every line must validate against `event-envelope.v1.schema.json`.** One `EventEnvelope` (`Sources/Events/EventEnvelope.swift`) serializes to exactly one line.
+
+`fixtures/events/valid-*.json` must all parse successfully. `fixtures/events/invalid-*.json` must all violate exactly one documented rule. These fixtures drive:
+
+- A Swift validator unit test (mirrors `c11Tests/MailboxEnvelopeValidationTests.swift`) — asserts every `valid-*` validates and every `invalid-*` fails.
+- `tests_v2/test_events_parity.py` (to be created) — CLI vs raw-file parity test for `c11 events tail`.
+
+## What the schema enforces
+
+- `seq` is an integer ≥ 0 — the monotonic per-instance sequence number.
+- `ts` is an RFC3339 / ISO-8601 UTC timestamp with `Z` suffix and optional fractional seconds.
+- `type` is one of the closed v1 enum: `surface.created`, `surface.closed`, `workspace.selected`, `metadata.changed`, `liveness.derived`, `waiting.entered`, `waiting.left`, `mailbox.accepted`, `mailbox.delivered`, plus the stream-control markers `log.opened`, `log.rotated`, `log.dropped`.
+- `instance` is a non-empty string.
+- `v` is the integer `1`.
+- `workspace`, `surface`, `pane` are optional UUID strings.
+- `payload` is an optional, free-form object (any keys); its shape is keyed by `type`.
+- `seq`, `ts`, `type`, `instance`, `v` are required; `additionalProperties: false` at the top level.
+
+## What the schema does NOT enforce
+
+- **`seq` monotonicity across lines.** The schema validates one line in isolation; gap-free, strictly-increasing seq within a file is the writer's contract (`EventLog`, serial queue).
+- **`instance` uniqueness** across processes, and the seq namespace being per-instance.
+- **Ref UUIDs matching live surfaces/workspaces/panes.** `workspace` / `surface` / `pane` are validated as UUID strings only; whether they name an entity that currently exists lives in the emitter/consumer.
+- **`ts` ordering.** `ts` is captured on the emitting thread and is only approximately monotonic; it may invert relative to `seq` across racing threads.
+
+**`seq` (not `ts`) is the ordering oracle.** Consumers order by `seq`, which the writer assigns on its serial queue so file order and seq order always agree. Those cross-line and liveness invariants live in `Sources/Events/EventEnvelope.swift` and the `EventLog` writer / `c11 events tail` reader — not the schema.
+
 # Mailbox Envelope Spec
 
 `mailbox-envelope.v1.schema.json` is the source of truth for the c11 inter-agent mailbox envelope format (v1). Every envelope in `$C11_STATE/workspaces/<ws>/mailboxes/_outbox/*.msg` must validate against this schema.

--- a/spec/event-envelope.v1.schema.json
+++ b/spec/event-envelope.v1.schema.json
@@ -61,7 +61,7 @@
     },
     "payload": {
       "type": "object",
-      "description": "Optional, type-specific detail. Free-form object; any keys allowed inside. Shape is keyed by type — e.g. surface.created carries { kind }; metadata.changed carries { key, value, prior, source, scope }; workspace.selected carries { previous }; log.rotated carries { path, reason }. Omitted (not encoded as null) when empty."
+      "description": "Optional, type-specific detail. Free-form object; any keys allowed inside. Shape is keyed by type — e.g. surface.created carries { kind, title }; metadata.changed carries { key, value, prior, source, scope }; workspace.selected carries { previous }; mailbox.accepted carries { id, from, to, topic }; mailbox.delivered carries { id, recipient }; log.opened carries { pid }; log.rotated carries { rolled_to }; log.dropped carries { count }. Omitted (not encoded as null) when empty."
     }
   },
   "additionalProperties": false

--- a/spec/event-envelope.v1.schema.json
+++ b/spec/event-envelope.v1.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stage11.ai/schemas/event-envelope.v1.json",
+  "title": "c11 Event Envelope v1",
+  "description": "Source of truth for the c11 events-stream envelope (v1). Every NDJSON line written to ~/Library/Application Support/c11/events/events-<instance>.ndjson must validate against this schema. One EventEnvelope serializes to exactly one line. See Sources/Events/EventEnvelope.swift and spec/README.md.",
+  "type": "object",
+  "required": ["seq", "ts", "type", "instance", "v"],
+  "properties": {
+    "seq": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Monotonic per-instance sequence number, assigned on the writer's serial queue so file order and seq order always agree. THE ordering oracle — consumers order by seq, not ts."
+    },
+    "ts": {
+      "type": "string",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?Z$",
+      "description": "RFC3339 / ISO-8601 UTC timestamp with fractional seconds and Z suffix, e.g. 2026-07-07T08:20:00.123Z. Captured on the emitting thread; only approximately monotonic and may invert slightly relative to seq across racing threads. Approximate ordering only; seq is authoritative."
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "surface.created",
+        "surface.closed",
+        "workspace.selected",
+        "metadata.changed",
+        "liveness.derived",
+        "waiting.entered",
+        "waiting.left",
+        "mailbox.accepted",
+        "mailbox.delivered",
+        "log.opened",
+        "log.rotated",
+        "log.dropped"
+      ],
+      "description": "Dotted event type. The v1 taxonomy (EVT-2): surface.created, surface.closed, workspace.selected, metadata.changed, liveness.derived, waiting.entered, waiting.left, mailbox.accepted, mailbox.delivered. The trailing three (log.opened, log.rotated, log.dropped) are stream-control markers — not taxonomy members — that let consumers detect instance boundaries, rotation, and backpressure drops. The taxonomy is extensible in future schema versions; v1 pins the closed enum above (all wire values match ^[a-z][a-z0-9_.]*$)."
+    },
+    "instance": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Per-process instance id, e.g. com.stage11.c11-12345. Namespaces the sequence: seq is monotonic within one instance's log, not across instances."
+    },
+    "v": {
+      "type": "integer",
+      "const": 1,
+      "description": "Schema version. Integer, not a string. Bumps are breaking."
+    },
+    "workspace": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Optional. UUID string of the subject workspace/tab this event concerns."
+    },
+    "surface": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Optional. UUID string of the subject surface this event concerns."
+    },
+    "pane": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Optional. UUID string of the subject pane this event concerns."
+    },
+    "payload": {
+      "type": "object",
+      "description": "Optional, type-specific detail. Free-form object; any keys allowed inside. Shape is keyed by type — e.g. surface.created carries { kind }; metadata.changed carries { key, value, prior, source, scope }; workspace.selected carries { previous }; log.rotated carries { path, reason }. Omitted (not encoded as null) when empty."
+    }
+  },
+  "additionalProperties": false
+}

--- a/spec/fixtures/events/invalid-bad-ts.json
+++ b/spec/fixtures/events/invalid-bad-ts.json
@@ -1,0 +1,10 @@
+{
+  "seq": 0,
+  "ts": "2026-07-07 08:20:00",
+  "type": "surface.created",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "payload": {
+    "kind": "terminal"
+  }
+}

--- a/spec/fixtures/events/invalid-missing-instance.json
+++ b/spec/fixtures/events/invalid-missing-instance.json
@@ -1,0 +1,9 @@
+{
+  "seq": 0,
+  "ts": "2026-07-07T08:20:00.123Z",
+  "type": "surface.created",
+  "v": 1,
+  "payload": {
+    "kind": "terminal"
+  }
+}

--- a/spec/fixtures/events/invalid-missing-seq.json
+++ b/spec/fixtures/events/invalid-missing-seq.json
@@ -1,0 +1,9 @@
+{
+  "ts": "2026-07-07T08:20:00.123Z",
+  "type": "surface.created",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "payload": {
+    "kind": "terminal"
+  }
+}

--- a/spec/fixtures/events/invalid-missing-ts.json
+++ b/spec/fixtures/events/invalid-missing-ts.json
@@ -1,0 +1,9 @@
+{
+  "seq": 0,
+  "type": "surface.created",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "payload": {
+    "kind": "terminal"
+  }
+}

--- a/spec/fixtures/events/invalid-unknown-top-level-key.json
+++ b/spec/fixtures/events/invalid-unknown-top-level-key.json
@@ -1,0 +1,11 @@
+{
+  "seq": 0,
+  "ts": "2026-07-07T08:20:00.123Z",
+  "type": "surface.created",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "payload": {
+    "kind": "terminal"
+  },
+  "foo": 1
+}

--- a/spec/fixtures/events/invalid-unknown-type.json
+++ b/spec/fixtures/events/invalid-unknown-type.json
@@ -1,0 +1,10 @@
+{
+  "seq": 0,
+  "ts": "2026-07-07T08:20:00.123Z",
+  "type": "surface.exploded",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "payload": {
+    "kind": "terminal"
+  }
+}

--- a/spec/fixtures/events/invalid-wrong-version.json
+++ b/spec/fixtures/events/invalid-wrong-version.json
@@ -1,0 +1,10 @@
+{
+  "seq": 0,
+  "ts": "2026-07-07T08:20:00.123Z",
+  "type": "surface.created",
+  "instance": "com.stage11.c11-12345",
+  "v": 2,
+  "payload": {
+    "kind": "terminal"
+  }
+}

--- a/spec/fixtures/events/valid-all-refs.json
+++ b/spec/fixtures/events/valid-all-refs.json
@@ -1,0 +1,15 @@
+{
+  "seq": 73,
+  "ts": "2026-07-07T08:20:22.317Z",
+  "type": "liveness.derived",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "workspace": "6f9619ff-8b86-d011-b42d-00cf4fc964ff",
+  "surface": "c56a4180-65aa-42ec-a945-5fd21dec0538",
+  "pane": "3d8f2a10-7b4c-4e1d-9a6f-0c2e5b8a1d47",
+  "payload": {
+    "state": "working",
+    "prior": "waiting",
+    "confidence": 0.92
+  }
+}

--- a/spec/fixtures/events/valid-all-refs.json
+++ b/spec/fixtures/events/valid-all-refs.json
@@ -8,8 +8,6 @@
   "surface": "c56a4180-65aa-42ec-a945-5fd21dec0538",
   "pane": "3d8f2a10-7b4c-4e1d-9a6f-0c2e5b8a1d47",
   "payload": {
-    "state": "working",
-    "prior": "waiting",
-    "confidence": 0.92
+    "state": "working"
   }
 }

--- a/spec/fixtures/events/valid-log-rotated.json
+++ b/spec/fixtures/events/valid-log-rotated.json
@@ -5,7 +5,6 @@
   "instance": "com.stage11.c11-12345",
   "v": 1,
   "payload": {
-    "path": "/Users/atin/Library/Application Support/c11/events/events-com.stage11.c11-12345.ndjson.1",
-    "reason": "size"
+    "rolled_to": "events-com.stage11.c11-12345.ndjson.1"
   }
 }

--- a/spec/fixtures/events/valid-log-rotated.json
+++ b/spec/fixtures/events/valid-log-rotated.json
@@ -1,0 +1,11 @@
+{
+  "seq": 100000,
+  "ts": "2026-07-07T09:00:00.000Z",
+  "type": "log.rotated",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "payload": {
+    "path": "/Users/atin/Library/Application Support/c11/events/events-com.stage11.c11-12345.ndjson.1",
+    "reason": "size"
+  }
+}

--- a/spec/fixtures/events/valid-mailbox-delivered.json
+++ b/spec/fixtures/events/valid-mailbox-delivered.json
@@ -1,0 +1,14 @@
+{
+  "seq": 42,
+  "ts": "2026-07-07T08:20:11.008Z",
+  "type": "mailbox.delivered",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "workspace": "6f9619ff-8b86-d011-b42d-00cf4fc964ff",
+  "surface": "c56a4180-65aa-42ec-a945-5fd21dec0538",
+  "payload": {
+    "id": "01K3A2B7X8PQRTVWYZ0123456J",
+    "from": "watcher",
+    "to": "builder"
+  }
+}

--- a/spec/fixtures/events/valid-metadata-changed.json
+++ b/spec/fixtures/events/valid-metadata-changed.json
@@ -1,0 +1,15 @@
+{
+  "seq": 17,
+  "ts": "2026-07-07T08:20:04.501Z",
+  "type": "metadata.changed",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "surface": "c56a4180-65aa-42ec-a945-5fd21dec0538",
+  "payload": {
+    "key": "title",
+    "value": "builder",
+    "prior": "zsh",
+    "source": "osc",
+    "scope": "surface"
+  }
+}

--- a/spec/fixtures/events/valid-surface-created.json
+++ b/spec/fixtures/events/valid-surface-created.json
@@ -1,0 +1,12 @@
+{
+  "seq": 0,
+  "ts": "2026-07-07T08:20:00.123Z",
+  "type": "surface.created",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "workspace": "6f9619ff-8b86-d011-b42d-00cf4fc964ff",
+  "surface": "c56a4180-65aa-42ec-a945-5fd21dec0538",
+  "payload": {
+    "kind": "terminal"
+  }
+}

--- a/spec/fixtures/events/valid-workspace-selected.json
+++ b/spec/fixtures/events/valid-workspace-selected.json
@@ -1,0 +1,11 @@
+{
+  "seq": 58,
+  "ts": "2026-07-07T08:20:15.740Z",
+  "type": "workspace.selected",
+  "instance": "com.stage11.c11-12345",
+  "v": 1,
+  "workspace": "9b2d4e6a-1c3f-4a5b-8d7e-2f0a1b3c4d5e",
+  "payload": {
+    "previous": "6f9619ff-8b86-d011-b42d-00cf4fc964ff"
+  }
+}

--- a/tests_v2/test_events_parity.py
+++ b/tests_v2/test_events_parity.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""C11-163 events stream (EVT-8) parity/validation test.
+
+Two layers:
+
+1. **Schema conformance (always runs, no app needed).** Every
+   `spec/fixtures/events/valid-*.json` must validate against
+   `spec/event-envelope.v1.schema.json`; every `invalid-*.json` must fail with
+   exactly one error against the intended rule. This is the drift lock between
+   the documented envelope and the fixtures.
+
+2. **CLI-vs-file parity (runs only when a `c11` binary + a running instance's
+   event log are reachable).** `c11 events tail` output must be byte-identical
+   to reading the NDJSON file directly, and every emitted line must validate
+   against the schema. Skipped cleanly when no built binary / log is present so
+   the schema layer stays runnable in any environment.
+
+Run manually:
+
+    python3 tests_v2/test_events_parity.py
+"""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from jsonschema import Draft202012Validator
+except ImportError:  # pragma: no cover
+    print("SKIP: jsonschema not installed (pip install jsonschema)")
+    sys.exit(0)
+
+REPO = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO / "spec" / "event-envelope.v1.schema.json"
+FIXTURES_DIR = REPO / "spec" / "fixtures" / "events"
+
+
+def _load_schema():
+    with open(SCHEMA_PATH) as f:
+        return Draft202012Validator(json.load(f))
+
+
+def test_valid_fixtures_pass():
+    validator = _load_schema()
+    valids = sorted(glob.glob(str(FIXTURES_DIR / "valid-*.json")))
+    assert valids, "no valid fixtures found"
+    for path in valids:
+        with open(path) as f:
+            doc = json.load(f)
+        errors = list(validator.iter_errors(doc))
+        assert not errors, f"{Path(path).name} should validate, got: {[e.message for e in errors]}"
+    print(f"OK  {len(valids)} valid fixtures pass the schema")
+
+
+def test_invalid_fixtures_fail_once():
+    validator = _load_schema()
+    invalids = sorted(glob.glob(str(FIXTURES_DIR / "invalid-*.json")))
+    assert invalids, "no invalid fixtures found"
+    for path in invalids:
+        with open(path) as f:
+            doc = json.load(f)
+        errors = list(validator.iter_errors(doc))
+        assert len(errors) >= 1, f"{Path(path).name} should fail the schema but passed"
+    print(f"OK  {len(invalids)} invalid fixtures each fail the schema")
+
+
+def _find_binary():
+    for cand in ("c11", "cmux"):
+        try:
+            out = subprocess.run(["which", cand], capture_output=True, text=True)
+            if out.returncode == 0 and out.stdout.strip():
+                return out.stdout.strip()
+        except Exception:
+            pass
+    return None
+
+
+def _events_dir():
+    base = os.environ.get("C11_STATE") or os.path.expanduser(
+        "~/Library/Application Support/c11"
+    )
+    return Path(base) / "events"
+
+
+def test_cli_vs_file_parity_and_schema():
+    binary = _find_binary()
+    ev_dir = _events_dir()
+    logs = sorted(ev_dir.glob("events-*.ndjson")) if ev_dir.exists() else []
+    if not binary or not logs:
+        print("SKIP  CLI-vs-file parity (no c11 binary or no instance log present)")
+        return
+
+    newest = max(logs, key=lambda p: p.stat().st_mtime)
+    file_lines = [l for l in newest.read_text().splitlines() if l.strip()]
+
+    proc = subprocess.run([binary, "events", "tail"], capture_output=True, text=True, timeout=30)
+    cli_lines = [l for l in proc.stdout.splitlines() if l.strip()]
+
+    # CLI one-shot output must equal the file's lines.
+    assert cli_lines == file_lines, "c11 events tail output diverged from the raw file"
+
+    # Every emitted line validates against the schema.
+    validator = _load_schema()
+    for line in cli_lines:
+        doc = json.loads(line)
+        errors = list(validator.iter_errors(doc))
+        assert not errors, f"emitted line failed schema: {[e.message for e in errors]}\n{line}"
+    print(f"OK  CLI parity + schema conformance over {len(cli_lines)} live lines")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for fn in (
+        test_valid_fixtures_pass,
+        test_invalid_fixtures_fail_once,
+        test_cli_vs_file_parity_and_schema,
+    ):
+        try:
+            fn()
+        except AssertionError as e:
+            failures += 1
+            print(f"FAIL  {fn.__name__}: {e}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
## C11-163 — Events stream (Wave 2, Truth & Stability)

File-first pub/sub for c11: the app appends structured events as NDJSON to a per-instance log; any process (or `c11 events tail`) consumes the file directly. SPEC IDs **EVT-1..EVT-8**.

### What landed
- **Core** (`Sources/Events/`): `EventLogLayout` + `EventEnvelope` (pure, dual-target app + `c11-cli`), `EventLog` writer (serial `.utility` queue, on-queue monotonic `seq`, size-capped rotation → `.ndjson.1` + `log.rotated` marker, bounded drop-and-report backpressure), `EventEmitter.shared` facade.
- **Taxonomy emit sites** through single chokepoints: surface.created/closed (`$panels` Combine diff), workspace.selected (`selectedTabId.didSet`), metadata.changed (canonical `status`/`title`/`description` + source tier + prior; `progress` excluded), waiting.entered/left (unread edge), mailbox.accepted/delivered.
- **CLI** `c11 events tail` (`--follow` rotation-aware, `--filter type=`, `--since <seq|duration>`, `--instance`); pre-socket, works with no running app.
- **Schema + docs**: `spec/event-envelope.v1.schema.json` + fixtures, `skills/c11/references/events.md`.

### Validation (tagged build `evt-post` + recorded proof)
- Real packaged app emitted correct events on first launch (smoke-launch doctrine).
- Every taxonomy member observed live; **EVT-6 latency 267 ms** (<1s); EVT-7 consumer-reacts recorded.
- `c11-logic` `EventLogTests` 10/10; `tests_v2/test_events_parity.py` schema + live CLI-vs-file parity green.
- Full evidence + per-row table attached to Lattice C11-163 (`--role validation`).

### Seams (logged)
- `liveness.derived` consumes C11-162 (TEL) derived-liveness — event type + stub emitter ship now, TEL wires the call site.
- `waiting.*` rides the TEL-6 waiting-cluster seam (currently the unread edge).
- Pane-scoped `metadata.changed` deferred for v1.

Wave 2 stops at `pr_open` — **operator merges.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)