### PR TITLE
C11-164: Crash-resume completion — SurfaceActivity persistence + Codex real-cwd + multi-kind kill-9 harness

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3264,6 +3264,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // (TODO 0.46.0 / v1.1 in WorkspaceSnapshotConversationBridge).
         if let snapshot, !ConversationStorePolicy.isDisabled {
             WorkspaceSnapshotConversationBridge.seedFromSnapshot(snapshot)
+            // C11-164 (RES-2): restore the per-surface activity floor into the
+            // live tracker so post-restore operation (and the restore-time
+            // scrape below, which also reads it via `contexts(from:)`) carries
+            // the same disambiguation floor the pre-crash session had. Keyed by
+            // panel id — the id the store and scrape contexts key on.
+            var activityFloor: [String: Date] = [:]
+            for window in snapshot.windows {
+                for ws in window.tabManager.workspaces {
+                    for panel in ws.panels where panel.type == .terminal {
+                        if let ts = panel.lastActivityAt {
+                            activityFloor[panel.id.uuidString] = ts
+                        }
+                    }
+                }
+            }
+            if !activityFloor.isEmpty {
+                SurfaceActivityTracker.shared.seed(from: activityFloor)
+            }
             // C11-152: live scrape-capture seam. Now that the store is seeded,
             // run the per-kind scrapers for each restored terminal surface and
             // resolve real session ids via each strategy's `capture`, applying

--- a/Sources/Conversation/ScrapeCapturePipeline.swift
+++ b/Sources/Conversation/ScrapeCapturePipeline.swift
@@ -42,7 +42,14 @@ struct ScrapeCaptureContext: Sendable, Equatable {
                     result.append(ScrapeCaptureContext(
                         surfaceId: panel.id.uuidString,
                         kind: kind,
-                        cwd: cwd
+                        cwd: cwd,
+                        // C11-164 (RES-2): thread the persisted activity floor
+                        // into the restore-time scrape. Without this the floor
+                        // is nil at cold restore and the Codex/pi/omp candidate
+                        // filter can no longer exclude stale sessions, producing
+                        // spurious ambiguity. `nil` (pre-C11-164 snapshot)
+                        // preserves the prior no-floor behaviour.
+                        lastActivityTimestamp: panel.lastActivityAt
                     ))
                 }
             }

--- a/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
+++ b/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
@@ -65,14 +65,33 @@ struct ClaudeCodeScraper: ConversationScraper {
     }
 }
 
-/// Bounded filesystem I/O over `~/.codex/sessions/`. Same privacy contract
-/// as `ClaudeCodeScraper`: reads metadata only; never opens transcripts.
+/// Bounded filesystem I/O over `~/.codex/sessions/`. Reads filename + mtime +
+/// size for the session id (as `ClaudeCodeScraper` does) and, uniquely, a
+/// **bounded, allowlisted** first-line read to recover each session's real
+/// working directory.
 ///
-/// Codex filenames are `<uuid>.jsonl`; the scraper recovers the session id
-/// from the filename without parsing content.
+/// **Why the head read (C11-164 / RES-2):** Codex stores sessions flat by
+/// date (`~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`), NOT under
+/// a per-cwd directory like Claude Code. So the filename cannot say which pane
+/// a session belongs to, and the prior scraper stamped the *querying surface's*
+/// cwd onto every candidate — making `CodexStrategy`'s cwd filter a structural
+/// no-op (every candidate looked same-cwd → distinct-workspace codex sessions
+/// all read as mutually ambiguous and none resumed). Recovering the real cwd
+/// from the rollout header restores the filter.
+///
+/// **Privacy contract** (architecture doc §"Privacy contract for scrape"):
+/// the head read is capped at `codexHeadMaxBytes` and only the `cwd` string
+/// value is extracted via `parseCodexCwd`; no other field — and no transcript
+/// content — is parsed, retained, or logged. Codex writes the session-meta
+/// record as the first JSONL line with `payload.cwd` ahead of the large
+/// `instructions` field, so the cap captures cwd without slurping the body.
 struct CodexScraper: ConversationScraper {
     let kind: String = "codex"
     static let defaultMaxCandidates: Int = 16
+    /// Head-read byte cap for cwd recovery. Generous enough to include
+    /// `payload.cwd` (which precedes `payload.instructions` in the observed
+    /// rollout format) while staying bounded far below any transcript body.
+    static let codexHeadMaxBytes: Int = 8192
 
     let filesystem: ConversationFilesystem
     let maxCandidates: Int
@@ -112,14 +131,84 @@ struct CodexScraper: ConversationScraper {
             let stem = String(entry.fileName.dropLast(".jsonl".count))
             let id = String(stem.suffix(36))
             guard isValidConversationUUID(id) else { return nil }
+            // Recover the session's REAL cwd from its rollout header (bounded,
+            // allowlisted). On any read/parse miss the candidate keeps `cwd ==
+            // nil`, which the strategy treats as "can't discriminate" — the
+            // prior behaviour, never worse. We deliberately do NOT fall back to
+            // the querying surface's `cwd`: stamping it back would re-introduce
+            // the same-cwd no-op this recovery exists to remove.
+            let head = filesystem.readSessionHead(
+                atPath: entry.url.path,
+                maxBytes: Self.codexHeadMaxBytes
+            )
+            let realCwd = head.flatMap { Self.parseCodexCwd(fromHead: $0) }
             return ScrapeCandidate(
                 id: id,
                 filePath: entry.url.path,
                 mtime: entry.mtime,
                 size: entry.size,
-                cwd: cwd
+                cwd: realCwd
             )
         }
+    }
+
+    /// Extract ONLY the `cwd` string value from a bounded rollout header.
+    /// Deliberately not a full JSON parse: the header may be truncated at the
+    /// byte cap, and a narrow scan for the `"cwd"` key guarantees no other
+    /// field is ever read. Handles the minimal JSON string escapes that occur
+    /// in filesystem paths (`\/`, `\\`, `\"`). Returns nil if the key is
+    /// absent within the capped head. Package-visible for unit testing.
+    static func parseCodexCwd(fromHead head: String) -> String? {
+        let scalars = Array(head.unicodeScalars)
+        let key = Array("\"cwd\"".unicodeScalars)
+        // Find the first `"cwd"` occurrence.
+        var i = 0
+        let n = scalars.count
+        func matchesKey(at pos: Int) -> Bool {
+            guard pos + key.count <= n else { return false }
+            for k in 0..<key.count where scalars[pos + k] != key[k] { return false }
+            return true
+        }
+        while i < n {
+            if scalars[i] == "\"", matchesKey(at: i) {
+                var j = i + key.count
+                // Skip whitespace up to the colon.
+                while j < n, scalars[j] == " " || scalars[j] == "\t" { j += 1 }
+                guard j < n, scalars[j] == ":" else { i += 1; continue }
+                j += 1
+                while j < n, scalars[j] == " " || scalars[j] == "\t" { j += 1 }
+                guard j < n, scalars[j] == "\"" else { return nil }
+                j += 1
+                // Read the string value, honoring escapes, until the closing ".
+                var out = String.UnicodeScalarView()
+                while j < n {
+                    let c = scalars[j]
+                    if c == "\\" {
+                        guard j + 1 < n else { return nil } // truncated escape
+                        let e = scalars[j + 1]
+                        switch e {
+                        case "\"": out.append("\"")
+                        case "\\": out.append("\\")
+                        case "/": out.append("/")
+                        default: out.append(e) // pass through other escapes
+                        }
+                        j += 2
+                        continue
+                    }
+                    if c == "\"" {
+                        let value = String(out)
+                        return value.isEmpty ? nil : value
+                    }
+                    out.append(c)
+                    j += 1
+                }
+                // Closing quote fell outside the capped head — give up rather
+                // than return a partial path.
+                return nil
+            }
+            i += 1
+        }
+        return nil
     }
 }
 
@@ -149,6 +238,27 @@ protocol ConversationFilesystem: Sendable {
     /// transcript verification (`ClaudeCodeStrategy.transcriptExists`).
     /// Never opens the file — honors the scrape privacy contract.
     func fileExists(atPath path: String) -> Bool
+
+    /// C11-164 (RES-2): bounded read of a session file's head, capped at
+    /// `maxBytes`. This is the SINGLE content-reading method in the scrape
+    /// rail, added solely so `CodexScraper` can recover a session's real
+    /// working directory from its rollout header — Codex stores sessions flat
+    /// (`~/.codex/sessions/.../<uuid>.jsonl`), not under a cwd-slug directory,
+    /// so filename + mtime alone can't tell which pane a session belongs to,
+    /// and every candidate looked same-cwd (the disambiguation no-op the
+    /// architecture doc flagged). Honors the privacy contract: reads at most
+    /// `maxBytes` and the caller extracts ONLY the allowlisted `cwd` field —
+    /// no transcript content is retained or logged. Returns nil if the file
+    /// can't be read. A protocol-extension default returns nil so existing
+    /// stat-only mocks keep compiling (they simply provide no cwd recovery).
+    func readSessionHead(atPath path: String, maxBytes: Int) -> String?
+}
+
+extension ConversationFilesystem {
+    /// Default: no content read. Keeps stat-only mocks source-compatible and
+    /// means a filesystem that opts out of head reads degrades to the prior
+    /// no-cwd-recovery behaviour (candidate `cwd == nil`), never worse.
+    func readSessionHead(atPath path: String, maxBytes: Int) -> String? { nil }
 }
 
 struct ConversationFilesystemEntry: Sendable, Equatable {
@@ -176,6 +286,32 @@ struct DefaultConversationFilesystem: ConversationFilesystem {
 
     func fileExists(atPath path: String) -> Bool {
         FileManager.default.fileExists(atPath: path)
+    }
+
+    /// Bounded head read: opens the file, reads at most `maxBytes`, and
+    /// returns the first line (up to the first newline) as a UTF-8 string.
+    /// Never reads beyond the cap — a large transcript body after the header
+    /// is never pulled into memory. The caller extracts only the `cwd` field.
+    func readSessionHead(atPath path: String, maxBytes: Int) -> String? {
+        guard maxBytes > 0 else { return nil }
+        guard let handle = FileHandle(forReadingAtPath: path) else { return nil }
+        defer { try? handle.close() }
+        let data: Data
+        do {
+            data = try handle.read(upToCount: maxBytes) ?? Data()
+        } catch {
+            return nil
+        }
+        guard !data.isEmpty else { return nil }
+        // First line only (session-meta record). If no newline is within the
+        // cap, use the whole capped buffer.
+        let lineData: Data
+        if let nl = data.firstIndex(of: 0x0A) {
+            lineData = data.subdata(in: data.startIndex..<nl)
+        } else {
+            lineData = data
+        }
+        return String(decoding: lineData, as: UTF8.self)
     }
 
     func listDirectoryByMtime(

--- a/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
+++ b/Sources/Conversation/Scrapers/ClaudeCodeScraper.swift
@@ -115,6 +115,14 @@ struct CodexScraper: ConversationScraper {
     /// one level deeper than Claude. The filesystem contract handles
     /// recursion via `listSessionsRecursivelyByMtime`.
     func candidates(cwd: String? = nil) -> [ScrapeCandidate] {
+        candidates(cwd: cwd, recoverCwd: true)
+    }
+
+    /// `recoverCwd: false` skips the per-candidate bounded head read. Used by
+    /// `CodexStrategy.transcriptExists`, which only needs id membership on the
+    /// crash-recovery reclassify path — so it avoids up to `maxCandidates`
+    /// file opens per codex surface that would only recover a cwd it discards.
+    func candidates(cwd: String?, recoverCwd: Bool) -> [ScrapeCandidate] {
         guard let root = sessionsRoot() else { return [] }
         let entries = filesystem.listSessionsRecursivelyByMtime(
             root,
@@ -132,16 +140,16 @@ struct CodexScraper: ConversationScraper {
             let id = String(stem.suffix(36))
             guard isValidConversationUUID(id) else { return nil }
             // Recover the session's REAL cwd from its rollout header (bounded,
-            // allowlisted). On any read/parse miss the candidate keeps `cwd ==
-            // nil`, which the strategy treats as "can't discriminate" — the
-            // prior behaviour, never worse. We deliberately do NOT fall back to
-            // the querying surface's `cwd`: stamping it back would re-introduce
-            // the same-cwd no-op this recovery exists to remove.
-            let head = filesystem.readSessionHead(
-                atPath: entry.url.path,
-                maxBytes: Self.codexHeadMaxBytes
-            )
-            let realCwd = head.flatMap { Self.parseCodexCwd(fromHead: $0) }
+            // allowlisted) when requested. On any read/parse miss the candidate
+            // keeps `cwd == nil`, which the strategy treats as "can't
+            // discriminate" — the prior behaviour, never worse. We deliberately
+            // do NOT fall back to the querying surface's `cwd`: stamping it back
+            // would re-introduce the same-cwd no-op this recovery exists to
+            // remove.
+            let realCwd: String? = recoverCwd
+                ? filesystem.readSessionHead(atPath: entry.url.path, maxBytes: Self.codexHeadMaxBytes)
+                    .flatMap { Self.parseCodexCwd(fromHead: $0) }
+                : nil
             return ScrapeCandidate(
                 id: id,
                 filePath: entry.url.path,

--- a/Sources/Conversation/Strategies/Codex.swift
+++ b/Sources/Conversation/Strategies/Codex.swift
@@ -108,8 +108,10 @@ struct CodexStrategy: ConversationStrategy {
         filesystem: ConversationFilesystem
     ) -> Bool? {
         guard isValidConversationUUID(ref.id) else { return false }
+        // Id-membership only — skip the per-candidate cwd head reads (G3), which
+        // this check discards anyway.
         return CodexScraper(filesystem: filesystem)
-            .candidates(cwd: ref.cwd)
+            .candidates(cwd: nil, recoverCwd: false)
             .contains { $0.id == ref.id }
     }
 }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -352,11 +352,24 @@ struct SessionPanelSnapshot: Codable, Sendable {
     /// for stable JSON output across v1/v2.
     var surfaceConversations: SurfaceConversations? = nil
 
+    /// C11-164 (RES-2): persisted `SurfaceActivityTracker.lastActivity` floor
+    /// for this surface. The Codex/pi/omp scrape filters use "candidate mtime
+    /// ≥ surface lastActivityTimestamp" to disambiguate which on-disk session
+    /// belongs to which pane after a crash. The live tracker is in-memory only,
+    /// so without persisting this the floor was lost on every restart and the
+    /// restore-time scrape ran with `lastActivityTimestamp: nil` (widening the
+    /// candidate set → spurious ambiguity). Optional for backcompat: pre-C11-164
+    /// snapshots decode with `lastActivityAt == nil` (no floor, prior behaviour).
+    /// Keyed implicitly by this panel's `id` — the same id the store and
+    /// `ScrapeCaptureContext` key on across a restart.
+    var lastActivityAt: Date? = nil
+
     private enum CodingKeys: String, CodingKey {
         case id, type, title, customTitle, customColor, directory, isPinned,
              isManuallyUnread, gitBranch, listeningPorts, ttyName,
              terminal, browser, markdown, metadata, metadataSources
         case surfaceConversations = "surface_conversations"
+        case lastActivityAt = "last_activity_at"
     }
 }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -769,6 +769,14 @@ extension Workspace {
         if !ConversationStorePolicy.isDisabled, panel.panelType == .terminal {
             surfaceConversations = conversationsByPanelId[panelId.uuidString] ?? .empty
         }
+        // C11-164 (RES-2): persist the surface's live activity floor so the
+        // Codex/pi/omp scrape disambiguation survives a crash. Only terminal
+        // surfaces carry a meaningful floor; `lastActivity(for:)` is a bounded
+        // synchronous queue read (no main-thread hot-path work).
+        var lastActivityAt: Date? = nil
+        if !ConversationStorePolicy.isDisabled, panel.panelType == .terminal {
+            lastActivityAt = SurfaceActivityTracker.shared.lastActivity(for: panelId.uuidString)
+        }
         return SessionPanelSnapshot(
             id: panelId,
             type: panel.panelType,
@@ -786,7 +794,8 @@ extension Workspace {
             markdown: markdownSnapshot,
             metadata: persistedMetadata,
             metadataSources: persistedMetadataSources,
-            surfaceConversations: surfaceConversations
+            surfaceConversations: surfaceConversations,
+            lastActivityAt: lastActivityAt
         )
     }
 

--- a/c11Tests/ScrapeCapturePipelineTests.swift
+++ b/c11Tests/ScrapeCapturePipelineTests.swift
@@ -28,6 +28,32 @@ final class ScrapeCapturePipelineTests: XCTestCase {
         }
     }
 
+    /// C11-164 (RES-2): logic-local filesystem mock supporting the bounded
+    /// head read used by `CodexScraper` cwd recovery. Recursive listing +
+    /// per-path head content; stat-only otherwise.
+    final class MockFS: ConversationFilesystem, @unchecked Sendable {
+        var home: URL?
+        // Keyed by normalized `.path` so a scraper root built with
+        // `appendingPathComponent(isDirectory: true)` (trailing slash) still
+        // matches a plainly-constructed key.
+        var recursiveEntriesByPath: [String: [ConversationFilesystemEntry]] = [:]
+        var headContents: [String: String] = [:]
+        var homeDirectory: URL? { home }
+        func fileExists(atPath path: String) -> Bool { false }
+        func listDirectoryByMtime(_ directory: URL, max: Int) -> [ConversationFilesystemEntry] { [] }
+        func listSessionsRecursivelyByMtime(_ root: URL, extensionFilter: String, max: Int) -> [ConversationFilesystemEntry] {
+            Array((recursiveEntriesByPath[root.path] ?? [])
+                .filter { $0.fileName.hasSuffix("." + extensionFilter) }
+                .sorted { $0.mtime > $1.mtime }
+                .prefix(max))
+        }
+        func readSessionHead(atPath path: String, maxBytes: Int) -> String? {
+            guard let full = headContents[path] else { return nil }
+            let firstLine = full.split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? full
+            return String(firstLine.prefix(maxBytes))
+        }
+    }
+
     private let codexId = "abc12345-ef67-890a-bcde-f0123456789a"
     private let codexId2 = "eee22222-2222-3333-4444-555566667777"
 
@@ -185,6 +211,25 @@ final class ScrapeCapturePipelineTests: XCTestCase {
         XCTAssertEqual(contexts[0].surfaceId, codexPanelId.uuidString)
         XCTAssertEqual(contexts[0].kind, "codex")
         XCTAssertEqual(contexts[0].cwd, "/work/proj")
+        // Pre-C11-164 panels (no persisted floor) thread nil — prior behaviour.
+        XCTAssertNil(contexts[0].lastActivityTimestamp)
+    }
+
+    // C11-164 (RES-2): the persisted per-panel activity floor is threaded into
+    // the restore-time scrape context (without it, `lastActivityTimestamp` was
+    // hardcoded nil and the floor lost across a crash).
+    func testContextsThreadPersistedActivityFloor() {
+        let codexPanelId = UUID()
+        let floor = Date(timeIntervalSince1970: 1_700_000_000)
+        var codexPanel = makeTerminalPanel(
+            id: codexPanelId, directory: "/work/proj",
+            metadata: [SurfaceMetadataKeyName.terminalType: .string("codex")]
+        )
+        codexPanel.lastActivityAt = floor
+        let snapshot = makeSnapshot(panels: [codexPanel])
+        let contexts = ScrapeCaptureContext.contexts(from: snapshot)
+        XCTAssertEqual(contexts.count, 1)
+        XCTAssertEqual(contexts[0].lastActivityTimestamp, floor)
     }
 
     // MARK: - Snapshot builders
@@ -224,5 +269,105 @@ final class ScrapeCapturePipelineTests: XCTestCase {
         )
         return AppSessionSnapshot(version: SessionSnapshotSchema.currentVersion,
                                   createdAt: Date().timeIntervalSince1970, windows: [window])
+    }
+
+    // MARK: - C11-164 (RES-2): Codex real-cwd recovery
+
+    private func codexFS(sessions: [(id: String, cwd: String?, mtime: Date)]) -> MockFS {
+        let mock = MockFS()
+        mock.home = URL(fileURLWithPath: "/Users/test")
+        let root = URL(fileURLWithPath: "/Users/test/.codex/sessions")
+        var entries: [ConversationFilesystemEntry] = []
+        for s in sessions {
+            let file = "rollout-2026-07-07T00-00-00-\(s.id).jsonl"
+            let url = root.appendingPathComponent("2026/07/07/\(file)")
+            entries.append(ConversationFilesystemEntry(url: url, fileName: file, mtime: s.mtime, size: 4096))
+            if let cwd = s.cwd {
+                mock.headContents[url.path] = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"\(s.id)\",\"cwd\":\"\(cwd)\",\"instructions\":\"stub body\"}}"
+            }
+        }
+        mock.recursiveEntriesByPath[root.path] = entries
+        return mock
+    }
+
+    /// The scraper recovers each candidate's REAL cwd from the rollout header
+    /// instead of stamping the querying surface's cwd (the disambiguation no-op).
+    func testCodexScraperRecoversRealCwdPerCandidate() {
+        let idA = "aaaa1111-2222-3333-4444-555566667777"
+        let idB = "bbbb1111-2222-3333-4444-555566667777"
+        let now = Date()
+        let mock = codexFS(sessions: [
+            (idA, "/Users/test/projA", now),
+            (idB, "/Users/test/projB", now.addingTimeInterval(-5))
+        ])
+        // Even with a surface cwd passed, candidates carry their OWN real cwd.
+        let cands = CodexScraper(filesystem: mock).candidates(cwd: "/Users/test/projA")
+        let byId = Dictionary(uniqueKeysWithValues: cands.map { ($0.id, $0.cwd) })
+        XCTAssertEqual(byId[idA], "/Users/test/projA")
+        XCTAssertEqual(byId[idB], "/Users/test/projB")
+    }
+
+    /// Distinct-cwd codex sessions resolve to their own session (state .alive),
+    /// no longer read as mutually ambiguous — the bug G3 fixes.
+    func testCodexDistinctCwdResolvesInsteadOfAmbiguous() {
+        let idA = "aaaa1111-2222-3333-4444-555566667777"
+        let idB = "bbbb1111-2222-3333-4444-555566667777"
+        let now = Date()
+        let mock = codexFS(sessions: [
+            (idA, "/Users/test/projA", now),
+            (idB, "/Users/test/projB", now.addingTimeInterval(-5))
+        ])
+        let cands = CodexScraper(filesystem: mock).candidates(cwd: nil)
+        let claim = ConversationRef(kind: "codex", id: "placeholder", placeholder: true,
+                                    cwd: "/Users/test/projA", capturedAt: now.addingTimeInterval(-60),
+                                    capturedVia: .wrapperClaim, state: .unknown, diagnosticReason: nil)
+        let inputs = ConversationStrategyInputs(surfaceId: "A", cwd: "/Users/test/projA",
+                                                lastActivityTimestamp: nil, wrapperClaim: claim,
+                                                push: nil, scrapeCandidates: cands)
+        let ref = CodexStrategy().capture(inputs: inputs)
+        XCTAssertEqual(ref?.id, idA)
+        XCTAssertEqual(ref?.state, .alive, "distinct-cwd codex must resolve, not read as ambiguous")
+    }
+
+    /// Same-cwd multi-session stays honestly ambiguous — the correct behaviour
+    /// the ambiguity policy exists for; cwd recovery must not paper over it.
+    func testCodexSameCwdStaysAmbiguous() {
+        let idA = "aaaa1111-2222-3333-4444-555566667777"
+        let idB = "bbbb1111-2222-3333-4444-555566667777"
+        let now = Date()
+        let mock = codexFS(sessions: [
+            (idA, "/Users/test/shared", now),
+            (idB, "/Users/test/shared", now.addingTimeInterval(-5))
+        ])
+        let cands = CodexScraper(filesystem: mock).candidates(cwd: nil)
+        let claim = ConversationRef(kind: "codex", id: "placeholder", placeholder: true,
+                                    cwd: "/Users/test/shared", capturedAt: now.addingTimeInterval(-60),
+                                    capturedVia: .wrapperClaim, state: .unknown, diagnosticReason: nil)
+        let inputs = ConversationStrategyInputs(surfaceId: "A", cwd: "/Users/test/shared",
+                                                lastActivityTimestamp: nil, wrapperClaim: claim,
+                                                push: nil, scrapeCandidates: cands)
+        let ref = CodexStrategy().capture(inputs: inputs)
+        XCTAssertEqual(ref?.state, .unknown)
+        XCTAssertEqual(ref?.diagnosticReason?.contains("ambiguous"), true)
+    }
+
+    // MARK: - C11-164: parseCodexCwd (bounded, allowlisted extractor)
+
+    func testParseCodexCwdExtractsOnlyCwd() {
+        let head = "{\"type\":\"session_meta\",\"payload\":{\"id\":\"x\",\"cwd\":\"/Users/test/proj\",\"instructions\":\"secret transcript body\"}}"
+        XCTAssertEqual(CodexScraper.parseCodexCwd(fromHead: head), "/Users/test/proj")
+    }
+
+    func testParseCodexCwdHandlesEscapedSlashes() {
+        XCTAssertEqual(CodexScraper.parseCodexCwd(fromHead: "{\"payload\":{\"cwd\":\"\\/Users\\/test\\/proj\"}}"),
+                       "/Users/test/proj")
+    }
+
+    func testParseCodexCwdReturnsNilWhenAbsent() {
+        XCTAssertNil(CodexScraper.parseCodexCwd(fromHead: "{\"payload\":{\"id\":\"x\"}}"))
+    }
+
+    func testParseCodexCwdReturnsNilOnTruncatedValue() {
+        XCTAssertNil(CodexScraper.parseCodexCwd(fromHead: "{\"payload\":{\"cwd\":\"/Users/test/pro"))
     }
 }

--- a/c11Tests/SessionPersistenceTests.swift
+++ b/c11Tests/SessionPersistenceTests.swift
@@ -191,6 +191,53 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNil(decoded.customTitle)
     }
 
+    // MARK: - C11-164 (RES-2): lastActivityAt persistence
+
+    /// A NON-NIL activity floor must survive save→load. This specifically
+    /// guards the `CodingKeys` trap: `SessionPanelSnapshot` has an explicit
+    /// `CodingKeys` enum, so a new field absent from it would compile and
+    /// decode-tolerate yet silently never encode (a persistence no-op a naive
+    /// nil-on-both-sides test would pass). Asserting the JSON key is present
+    /// AND a real value round-trips catches that.
+    func testSessionPanelSnapshotLastActivityAtRoundTrip() throws {
+        let panelId = UUID()
+        let floor = Date(timeIntervalSince1970: 1_700_000_123)
+        var snapshot = SessionPanelSnapshot(
+            id: panelId, type: .terminal, title: nil, customTitle: nil,
+            customColor: nil, directory: nil, isPinned: false, isManuallyUnread: false,
+            gitBranch: nil, listeningPorts: [], ttyName: nil, terminal: nil,
+            browser: nil, markdown: nil, metadata: nil, metadataSources: nil
+        )
+        snapshot.lastActivityAt = floor
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        let json = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertTrue(json.contains("\"last_activity_at\""),
+                      "lastActivityAt must be in CodingKeys or it silently never encodes")
+
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: encoded)
+        XCTAssertEqual(decoded.lastActivityAt, floor)
+    }
+
+    /// Pre-C11-164 snapshots have no `last_activity_at` key; they must decode
+    /// with `lastActivityAt == nil` (no floor, prior behaviour) — not throw.
+    func testSessionPanelSnapshotDecodesLegacyJSONWithoutLastActivity() throws {
+        let panelId = UUID()
+        let legacyJSON = """
+        {
+          "id": "\(panelId.uuidString)",
+          "type": "terminal",
+          "isPinned": false,
+          "isManuallyUnread": false,
+          "listeningPorts": []
+        }
+        """
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: data)
+        XCTAssertEqual(decoded.id, panelId)
+        XCTAssertNil(decoded.lastActivityAt)
+    }
+
     func testWorkspaceCustomColorDecodeSupportsMissingLegacyField() throws {
         var snapshot = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
         snapshot.windows[0].tabManager.workspaces[0].customColor = nil

--- a/c11Tests/SurfaceActivityTests.swift
+++ b/c11Tests/SurfaceActivityTests.swift
@@ -20,7 +20,7 @@ final class SurfaceActivityTests: XCTestCase {
         XCTAssertEqual(read?.timeIntervalSince1970, 1000)
     }
 
-    func testInputBurstCoalescedWithDebounce() {
+    func testInputBurstCoalescedWithDebounce() throws {
         let tracker = SurfaceActivityTracker()
         let base = Date()
         // First write fires.
@@ -31,19 +31,21 @@ final class SurfaceActivityTests: XCTestCase {
         tracker.recordActivity(surfaceId: "S1", at: base.addingTimeInterval(0.10))
         tracker.recordActivity(surfaceId: "S1", at: base.addingTimeInterval(0.20))
         let read = tracker.lastActivity(for: "S1")
-        XCTAssertNotNil(read)
-        XCTAssertEqual(read?.timeIntervalSince1970, base.timeIntervalSince1970, accuracy: 0.001,
+        // C11-164: the `accuracy:` XCTAssertEqual overload requires a
+        // non-optional FloatingPoint; unwrap first (was a pre-existing host-lane
+        // compile break — `Double?` never satisfied that overload).
+        XCTAssertEqual(try XCTUnwrap(read).timeIntervalSince1970, base.timeIntervalSince1970, accuracy: 0.001,
                        "burst inside the debounce window must not advance the timestamp")
     }
 
-    func testWritesPastDebounceWindowAdvanceTheTimestamp() {
+    func testWritesPastDebounceWindowAdvanceTheTimestamp() throws {
         let tracker = SurfaceActivityTracker()
         let base = Date()
         tracker.recordActivity(surfaceId: "S1", at: base)
         let later = base.addingTimeInterval(SurfaceActivityTracker.debounceInterval + 0.1)
         tracker.recordActivity(surfaceId: "S1", at: later)
         let read = tracker.lastActivity(for: "S1")
-        XCTAssertEqual(read?.timeIntervalSince1970, later.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertEqual(try XCTUnwrap(read).timeIntervalSince1970, later.timeIntervalSince1970, accuracy: 0.001)
     }
 
     func testEmptyOrWhitespaceSurfaceIdIgnored() {
@@ -54,14 +56,14 @@ final class SurfaceActivityTests: XCTestCase {
         XCTAssertNil(tracker.lastActivity(for: "   "))
     }
 
-    func testSeedAndSnapshotRoundTrip() {
+    func testSeedAndSnapshotRoundTrip() throws {
         let tracker = SurfaceActivityTracker()
         let now = Date()
         tracker.seed(from: ["S1": now, "S2": now.addingTimeInterval(-60)])
         let snap = tracker.snapshot()
-        XCTAssertEqual(snap["S1"]?.timeIntervalSince1970,
+        XCTAssertEqual(try XCTUnwrap(snap["S1"]).timeIntervalSince1970,
                        now.timeIntervalSince1970, accuracy: 0.001)
-        XCTAssertEqual(snap["S2"]?.timeIntervalSince1970,
+        XCTAssertEqual(try XCTUnwrap(snap["S2"]).timeIntervalSince1970,
                        now.addingTimeInterval(-60).timeIntervalSince1970, accuracy: 0.001)
         XCTAssertEqual(snap.count, 2)
     }

--- a/skills/c11/references/conversation.md
+++ b/skills/c11/references/conversation.md
@@ -54,42 +54,47 @@ c11 conversation clear [--surface <id>]
 | Source | When written |
 |--------|--------------|
 | `hook` | Push from a TUI lifecycle hook (e.g. Claude Code SessionStart). Highest priority. |
-| `scrape` | Pull from on-disk session storage (`~/.claude/sessions/`, `~/.codex/sessions/`). |
+| `scrape` | Pull from on-disk session storage (`~/.claude/projects/<cwd-slug>/`, `~/.codex/sessions/`, `~/.pi/agent/sessions/<cwd-slug>/`, `~/.omp/agent/sessions/<cwd-slug>/`). Resolves a placeholder to a real id at restore. |
 | `manual` | Explicit operator action (`c11 conversation push --source manual`). |
 | `wrapperClaim` | Background claim from a TUI wrapper at launch. Lowest priority — never displaces a non-wrapperClaim source. |
 
 Reconciliation rule: latest `capturedAt` wins; on close timestamps, source priority breaks the tie. Wrapper-claims are conservative: they never displace a non-wrapperClaim source regardless of timestamp.
 
-## Strategies (v1)
+## Strategies
 
-| Kind | Resume tier | Capture (v1) | Resume action |
-|------|-------------|--------------|---------------|
-| `claude-code` | Strong (push-id deterministic) | SessionStart hook → `c11 conversation push`. Pull-scrape `~/.claude/sessions/` ships in v1.1. | `claude --dangerously-skip-permissions --resume <id>` (id shell-quoted) |
-| `codex` | Snapshot-only in v1 | Wrapper-claim placeholder → snapshot persists the captured ref → restore consumes it. **Pull-scrape disambiguation lands in v1.1** (see "v1 scope" below). | `codex resume <id>` (specific id; never `--last`) |
-| `opencode` | Fresh-launch only | Wrapper-claim placeholder | `opencode` (process launch) — `.skip` for placeholders |
+| Kind | Resume tier | Capture | Resume action |
+|------|-------------|---------|---------------|
+| `claude-code` | Strong (push-id deterministic) | SessionStart hook → `c11 conversation push`. Pull-scrape `~/.claude/projects/<cwd-slug>/` is the fallback when the hook was missed. | `claude --dangerously-skip-permissions --resume <id>` (id shell-quoted) |
+| `codex` | Exact, ambiguity-aware | Wrapper-claim placeholder → `CodexScraper` resolves the real id from `~/.codex/sessions/` at restore, filtered by **real cwd** (recovered from the rollout header, see below) + claim-time + activity floors. | `codex resume <id>` (specific id; never `--last`) |
+| `pi` | Exact, ambiguity-aware | Wrapper-claim placeholder → `PiScraper` resolves the real id from the cwd slug dir, claim-time + activity floors narrowing past stale sessions. | `pi --session '<id>'` (specific id) |
+| `omp` | Exact, ambiguity-aware | Wrapper-claim placeholder → `OmpScraper` resolves the real id from the cwd slug dir, claim-time + activity floors. | `omp --resume='<id>'` (specific id) |
+| `opencode` | Push (plugin rail) | Plugin-emitted push of the real id. No scraper in the pull registry. | `cd '<dir>' && opencode -s <id>` — `.skip` for placeholders |
+| `grok` | Best-effort resume | Wrapper-claim placeholder | `grok --always-approve --resume` (no id) — `.skip` for placeholders |
 | `kimi` | Fresh-launch only | Wrapper-claim placeholder | `kimi` (process launch) — `.skip` for placeholders |
-| `pi` | Exact (scrape) | Wrapper-claim placeholder → `PiScraper` resolves the real id from the cwd slug dir, claim-time floor narrowing past stale sessions. | `pi --session '<id>'` (specific id) |
-| `omp` | Exact (scrape) | Wrapper-claim placeholder → `OmpScraper` resolves the real id from the cwd slug dir, claim-time floor narrowing past stale sessions. | `omp --resume='<id>'` (specific id) |
+| `github-copilot` | Fresh-launch only | Wrapper-claim placeholder | `copilot` (process launch) — `.skip` for placeholders |
 
-### v1 scope and v1.1 follow-ups
+## Crash recovery — what it guarantees per kind
 
-The strategy machinery is complete (capture, resume, scrapers, ambiguity policy all unit-tested), but **v1 production restore is snapshot-only**: refs that landed in the snapshot at last clean shutdown resume; refs lost between snapshots do not. The forced pull-scrape pass that would re-discover them on dirty shutdown / first launch is a v1.1 follow-up. Tracked items:
+The forced-kill (`kill -9`) path is a first-class, tested guarantee as of the Truth & Stability cycle (C11-164), not a v1.1 aspiration. On launch c11 reads a per-bundle dirty/clean **shutdown sentinel** (`~/.c11/runtime/shutdown.<bundle>.{dirty,clean}`); `.dirty` (or missing) means the last run crashed. The dirty-launch restore ordering is:
 
-- **Pull-scrape pass on launch.** Wire `forcedPullScrapePass()` into `AppDelegate.applicationDidFinishLaunching` after `seedFromSnapshot` so missed Claude SessionStart hooks and Codex placeholder refs get re-classified before `pendingRestartPlans` runs.
-- **`SurfaceActivityTracker` snapshot persistence.** Today the tracker is in-memory only; the Codex `mtime ≥ surface lastActivityTimestamp` filter relies on it but has nothing to compare against on first launch after reboot.
-- **Codex cwd disambiguation.** `CodexScraper` stamps the surface's cwd into every candidate, so the strategy's `cwd != candCwd` filter is structurally a no-op. Real cwd recovery requires parsing the JSONL session metadata (bounded read; privacy-contract review needed before landing).
+1. **Seed** the store from the last snapshot (`seedFromSnapshot`), and seed the per-surface **activity floor** (persisted on each panel as `last_activity_at`).
+2. **Scrape-capture** (`runScrapeCapture`): for every restored terminal surface, run its kind's scraper and resolve any placeholder to the real on-disk session id.
+3. **Reclassify** (`reclassifyAfterCrash`): for each `.alive`/`.suspended` ref, `transcriptExists` stats the on-disk transcript (stat only — bytes never read). Verified → `.suspended` with `diagnostic_reason = "crash recovery: transcript verified on disk"` (resume fires); missing → `.unknown` with `"crash recovery: transcript not found"` (honest skip). Refs already `.unknown`/`.tombstoned` are untouched, so `/exit`-ended sessions never auto-resume.
 
-Until v1.1 lands, the **Codex two-panes-same-cwd** scenario the conversation store was built to fix relies on each pane having captured its own ref into the prior snapshot; if it didn't (e.g., first launch after dirty shutdown, or pane opened post-snapshot), the legacy "most-recent wins" behaviour is the current fallback. Operators who hit this can `c11 conversation clear --surface <id>` to force fresh launches.
+The contract: after a crash, **every conversation either resumes exactly per its kind's tier, or the surface carries an honest, specific `diagnostic_reason`.** There are no silent fresh-launches presented as resumes.
 
-### Codex ambiguity policy (deferred to v1.1)
+- **claude-code** — resumes when the hook-captured (or scrape-recovered) id has a transcript on disk; otherwise `transcript not found`.
+- **codex / pi / omp** — the scraper resolves the placeholder to the real id at restore, then reclassify verifies it. A surface whose session file is absent stays a placeholder and simply skips (no wrong resume).
+- **opencode / grok / kimi / github-copilot** — no exact-resume rail; a fresh launch is the honest outcome (placeholders skip).
 
-When pull-scrape lands, two Codex panes opened in the same project will be disambiguated as follows:
+### Codex real-cwd disambiguation
 
-- Codex pull-scrape filters candidates by cwd + mtime ≥ wrapper-claim time + mtime ≥ surface lastActivityTimestamp.
-- If **more than one** candidate matches the filter, the strategy returns the ref with `state = .unknown`, `id = most-plausible-candidate (newest mtime)`, and a `diagnosticReason` like `"ambiguous: 3 candidates; chose newest"`.
-- `resume()` returns `.skip(reason: "ambiguous")` for `state = .unknown`. Neither pane resumes the other's session; the operator clears via `c11 conversation clear --surface <id>` to force a fresh launch.
+Codex stores sessions flat (`~/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`), not under a per-cwd directory, so the filename can't say which pane a session belongs to. `CodexScraper` therefore does a **bounded, allowlisted** read of each candidate's first JSONL line and extracts only `payload.cwd` (byte-capped; no transcript content read or logged, per the scrape privacy contract). The strategy then keeps only candidates whose recovered cwd matches the surface's cwd:
 
-The advisory is surfaced via `c11 conversation get`'s `diagnostic_reason` field once the pull-scrape pass is wired.
+- **Distinct-cwd codex panes** each match only their own session → each resumes cleanly.
+- **Two codex panes in the same cwd** (genuinely indistinguishable) → `state = .unknown`, `diagnostic_reason = "ambiguous: N candidates; chose newest"`, `resume()` returns `.skip("ambiguous")`. Neither pane resumes the other's session; clear with `c11 conversation clear --surface <id>` to force a fresh launch. This is the correct, honest behaviour — the ambiguity policy the store was built for.
+
+The per-surface **activity floor** (`SurfaceActivityTracker`, persisted in the snapshot) gives the codex/pi/omp filters a lower `mtime` bound that survives a restart, so stale sessions in a shared cwd are excluded rather than widening the candidate set into spurious ambiguity.
 
 ## Wrapper-claim flow (TUI integrators)
 
@@ -123,14 +128,26 @@ CMUX_DISABLE_CONVERSATION_STORE=1 open -a c11
 # List every captured conversation in this c11 process
 # (v1 stores process-wide; no per-workspace partitioning)
 c11 conversation list --json | jq '.conversations[] | {kind, id, state, surface_id}'
+
+# After a crash + relaunch: which surfaces resumed vs carry a diagnostic?
+c11 conversation list --json | jq -r '.conversations[]
+  | "\(.kind)\t\(.state)\t\(.diagnostic_reason // "-")"'
+# RESOLVED surfaces read `suspended` + "crash recovery: transcript verified on disk";
+# honest skips read `unknown` + "…transcript not found" / "ambiguous: N candidates".
+
+# Dry-run the resume decision for a saved snapshot without launching (test oracle)
+c11 state verify
 ```
 
-## Landing in v1.1 (0.45.0+)
+## Landed (Truth & Stability cycle, C11-131 + C11-151..154 + C11-164)
 
-- **Forced pull-scrape pass** on launch (after snapshot seed) — re-classifies Claude/Codex refs lost between snapshots.
-- **`SurfaceActivityTracker` snapshot persistence** — gives the Codex disambiguation rule a comparison floor across reboots.
-- **Codex cwd recovery** via bounded JSONL metadata parse, gated on a privacy-contract review.
-- Workspace partitioning on `c11 conversation list` (`--workspace` rejected with a clear error in v1).
+- **Live scrape-capture on restore** (`runScrapeCapture`) — resolves Claude/Codex/pi/omp placeholder refs from disk before the resume pass runs. Superseded the snapshot-only restore.
+- **Crash reclassification** (`reclassifyAfterCrash`) replacing the old blanket `markAllUnknown` — verified-transcript refs resume, missing ones carry an honest diagnostic.
+- **`SurfaceActivityTracker` snapshot persistence** — the activity floor now persists per panel (`last_activity_at`) and is seeded at restore, so codex/pi/omp disambiguation survives a reboot.
+- **Codex real-cwd recovery** via a bounded, allowlisted first-line read of the rollout header — the cwd filter now discriminates across workspaces.
+- **`c11 state save` / `c11 state verify` / `c11 app restart`** CLI + socket `session.save` — explicit checkpoint, dry-run resume report, and clean-bounce restart.
+
+Still open: workspace partitioning on `c11 conversation list` (`--workspace` rejected with a clear error).
 
 ## Removed in 0.46.0 / v1.1
 

--- a/tests_v2/crash_resume_support.py
+++ b/tests_v2/crash_resume_support.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+"""C11-164 (RES-1..RES-5) crash-resume acceptance harness — shared machinery.
+
+Factored so both the existing claude-only harness (C11-131,
+`test_crash_resume_e2e.py`) AND the new multi-kind acceptance harness
+(`test_crash_resume_multikind_e2e.py`) *could* build on it. The existing file
+is intentionally left untouched; this module mirrors its constants and patterns
+(app-bundle discovery, tagged launch/relaunch, `kill -9` of ONLY the tagged
+PID, socket CLI wrapper, snapshot/sentinel paths, cwd->slug, fake session-file
+fixtures, per-kind shim generators) and adds a store-state oracle.
+
+TAG here is `res-post` (post-fix acceptance gate), so it never collides with the
+`c11-131` tagged bundle/socket/snapshot the sibling harness uses.
+
+=== Why the oracle asserts on STORE STATE, not the resume keystroke ===
+Restored panes re-source the operator's ~/.zshrc (which rebuilds PATH from
+scratch), so a PATH shim cannot shadow the restored PTY's `claude`/`codex`/…
+resolution — the resume *keystroke* is therefore not observable to this harness
+(it is covered separately by a real-agent smoke). What IS observable and
+decisive is the reclassified conversation-store state exposed by
+`c11 conversation list --json`: after a crash + relaunch the store either
+- RESOLVED the ref to `state=suspended` +
+  `diagnostic_reason="crash recovery: transcript verified on disk"` (resume will
+  fire on this surface), or
+- produced an HONEST_DIAGNOSTIC (`state=unknown/tombstoned` with a non-empty
+  reason — e.g. codex `ambiguous: N candidates; chose newest`, or
+  `crash recovery: transcript not found`), or
+- FAILED silently (still `alive`/`placeholder`, or `suspended` with no verified
+  reason) — a silent fresh-launch, the bug this gate exists to catch.
+
+Mechanism references (verified against the merged source in this worktree):
+- Restore ordering: `AppDelegate.prepareStartupSessionSnapshotIfNeeded`
+  seeds the store from the snapshot, seeds the activity floor, runs
+  `ConversationStore.runScrapeCapture` (resolves codex/pi/omp placeholders to
+  real ids from disk), then on a dirty sentinel runs
+  `ConversationStore.reclassifyAfterCrash` — AppDelegate.swift:3265-3334.
+- `reclassifyAfterCrash`: for each `.alive`/`.suspended` ref, strategy
+  `transcriptExists` → verified => `.suspended` "crash recovery: transcript
+  verified on disk"; missing => `.unknown` "crash recovery: transcript not
+  found" — Store.swift:246-268.
+- `CMUX_DISABLE_AGENT_RESTART=1` suppresses only the resume *typing* pass
+  (Workspace.swift:372); the seed/scrape/reclassify above still run, so the
+  reclassified state stays observable — SessionPersistence.swift:38-39.
+"""
+
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import uuid
+
+
+# --------------------------------------------------------------------------- #
+# Constants — mirror the C11-131 harness, retargeted to TAG=res-post.
+# --------------------------------------------------------------------------- #
+
+TAG = "res-post"
+TAG_SLUG = "res-post"                        # socket uses the raw tag slug
+# reload.sh derives the bundle id by sanitizing the tag: `-` -> `.`, plus a
+# `.debug` infix. `c11-131` -> `com.stage11.c11.debug.c11.131`, so
+# `res-post` -> `com.stage11.c11.debug.res.post`.
+BUNDLE_ID = "com.stage11.c11.debug.res.post"
+SOCKET_PATH = f"/tmp/c11-debug-{TAG_SLUG}.sock"
+APP_SUPPORT = os.path.expanduser("~/Library/Application Support/c11")
+SNAPSHOT_PATH = os.path.join(APP_SUPPORT, f"session-{BUNDLE_ID}.json")
+SENTINEL_DIR = os.path.expanduser("~/.c11/runtime")
+# Kill ONLY the tagged build by its unique app-path token; the operator's prod
+# c11 (this very session) never matches this substring.
+PROC_TOKEN = f"{TAG_SLUG}.app/Contents/MacOS"
+
+# Per-kind on-disk session-file roots each scraper reads. Derived from the
+# scraper sources in this worktree (cited at each fixture writer below).
+CLAUDE_PROJECTS = os.path.expanduser("~/.claude/projects")
+CODEX_SESSIONS = os.path.expanduser("~/.codex/sessions")
+PI_SESSIONS = os.path.expanduser("~/.pi/agent/sessions")
+OMP_SESSIONS = os.path.expanduser("~/.omp/agent/sessions")
+
+# Dirty/clean shutdown sentinel file names (ShutdownSentinel.swift:40-57;
+# sanitiseBundleId keeps [A-Za-z0-9._-], so the bundle id passes through
+# unchanged).
+DIRTY_SENTINEL = os.path.join(SENTINEL_DIR, f"shutdown.{BUNDLE_ID}.dirty")
+CLEAN_SENTINEL = os.path.join(SENTINEL_DIR, f"shutdown.{BUNDLE_ID}.clean")
+
+FIRST_CLASS_KINDS = ("claude-code", "codex", "pi", "omp")
+
+
+# --------------------------------------------------------------------------- #
+# cwd -> per-kind session-directory slug functions.
+#
+# Each MUST match its scraper/strategy EXACTLY or the fixture lands where the
+# scraper never looks. Citations are to the merged source in this worktree.
+# --------------------------------------------------------------------------- #
+
+def claude_slug(cwd: str) -> str:
+    """Claude Code: replace every `/` AND `.` in the absolute cwd with `-`.
+    Source: ClaudeCodeStrategy.projectSlug — Sources/Conversation/Strategies/
+    ClaudeCode.swift:94-101 (and the C11-131 harness `_slug_for_cwd`,
+    tests_v2/test_crash_resume_e2e.py:59-60)."""
+    return "".join("-" if c in "/." else c for c in cwd)
+
+
+def pi_slug(cwd: str) -> str:
+    """pi: strip a single leading `/` or `\\`, map `/`,`\\`,`:` -> `-`, wrap in
+    leading+trailing `--`. Dots are KEPT (unlike Claude). Source:
+    PiScraper.sessionSlug — Sources/Conversation/Scrapers/PiScraper.swift:62-69."""
+    stripped = cwd
+    if stripped[:1] in ("/", "\\"):
+        stripped = stripped[1:]
+    mapped = "".join("-" if c in "/\\:" else c for c in stripped)
+    return f"--{mapped}--"
+
+
+def omp_slug(cwd: str, home: str = None) -> str:
+    """omp: strip the home-directory prefix if present, then map every `/` ->
+    `-`. No lowercasing; existing dashes preserved. Source:
+    OmpScraper.sessionSlug — Sources/Conversation/Scrapers/OmpScraper.swift:55-61.
+    (Our run-scoped cwds live under $TMPDIR, not $HOME, so no prefix is
+    stripped and the slug is just the full path with `/`->`-`.)"""
+    home = home if home is not None else os.path.expanduser("~")
+    path = cwd
+    if home and path.startswith(home):
+        path = path[len(home):]
+    return path.replace("/", "-")
+
+
+# --------------------------------------------------------------------------- #
+# Discovery + low-level helpers (mirrors C11-131 harness verbatim in shape).
+# --------------------------------------------------------------------------- #
+
+def find_app_bundle() -> str:
+    """Locate the built tagged .app bundle (reload.sh writes a tagged
+    DerivedData path). Prefers a bundle whose Info.plist carries BUNDLE_ID."""
+    roots = []
+    dd = os.path.expanduser("~/Library/Developer/Xcode/DerivedData")
+    if os.path.isdir(dd):
+        roots += [
+            os.path.join(dd, d) for d in os.listdir(dd)
+            if d.startswith("c11-") or "GhosttyTabs" in d
+        ]
+    roots += [f"/tmp/c11-{TAG_SLUG}"]
+    candidates = []
+    for root in roots:
+        for base, dirs, _files in (os.walk(root) if os.path.isdir(root) else []):
+            for d in list(dirs):
+                if d.endswith(".app"):
+                    candidates.append(os.path.join(base, d))
+            dirs[:] = [d for d in dirs if not d.endswith(".app")]
+    for app in sorted(candidates, key=os.path.getmtime, reverse=True):
+        plist = os.path.join(app, "Contents", "Info.plist")
+        try:
+            out = subprocess.run(
+                ["defaults", "read", os.path.splitext(plist)[0],
+                 "CFBundleIdentifier"],
+                capture_output=True, text=True,
+            ).stdout.strip()
+        except Exception:
+            out = ""
+        if out == BUNDLE_ID:
+            return app
+    raise RuntimeError(
+        f"Could not find a built .app with bundle id {BUNDLE_ID}. "
+        f"Run ./scripts/reload.sh --tag {TAG} first."
+    )
+
+
+def app_executable(app: str) -> str:
+    return os.path.join(app, "Contents", "MacOS", "c11")
+
+
+def tagged_cli(app: str) -> str:
+    return os.path.join(app, "Contents", "Resources", "bin", "c11")
+
+
+def kill_tagged_instances():
+    """SIGKILL ONLY the tagged build's process, matched by its unique app-path
+    token. Guarded so a misconfigured PROC_TOKEN can never target prod c11."""
+    assert TAG_SLUG in PROC_TOKEN and PROC_TOKEN.endswith("/Contents/MacOS"), \
+        f"refusing to pkill with an unsafe token: {PROC_TOKEN!r}"
+    subprocess.run(["pkill", "-9", "-f", PROC_TOKEN], capture_output=True)
+    time.sleep(0.6)
+
+
+def _cli(cli_path, *args, timeout=15.0, env_extra=None):
+    """Run the tagged CLI against the tagged socket."""
+    env = dict(os.environ)
+    env["CMUX_SOCKET_PATH"] = SOCKET_PATH
+    env["C11_SOCKET"] = SOCKET_PATH
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run([cli_path, *args], capture_output=True, text=True,
+                          env=env, timeout=timeout)
+
+
+def wait_socket_ready(cli_path, timeout: float = 45.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(SOCKET_PATH):
+            try:
+                if _cli(cli_path, "ping", timeout=4.0).returncode == 0:
+                    return
+            except Exception:
+                pass
+        time.sleep(0.4)
+    raise RuntimeError(f"socket {SOCKET_PATH} not ready after {timeout}s")
+
+
+def wait_socket_gone(cli_path, timeout: float = 15.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not os.path.exists(SOCKET_PATH):
+            return
+        try:
+            if _cli(cli_path, "ping", timeout=2.0).returncode != 0:
+                return
+        except Exception:
+            return
+        time.sleep(0.3)
+    return
+
+
+def new_uuid() -> str:
+    """Fresh, run-unique conversation id. UUIDv4 shape satisfies every kind's
+    `isValidConversationUUID` (8-4-4-4-12 hex)."""
+    return str(uuid.uuid4())
+
+
+# --------------------------------------------------------------------------- #
+# Store-state oracle.
+# --------------------------------------------------------------------------- #
+
+RESOLVED = "RESOLVED"
+HONEST_DIAGNOSTIC = "HONEST_DIAGNOSTIC"
+UNRESOLVED = "UNRESOLVED"    # placeholder survived — safe skip, no wrong resume
+FAIL = "FAIL"               # silent fresh-launch: alive, or suspended-unverified
+
+# The exact reason `reclassifyAfterCrash` stamps on a verified ref
+# (Store.swift:259). RESOLVED requires this substring so a `suspended` state
+# with any *other* reason (a silent clean-path suspend that never verified the
+# transcript) is caught as FAIL.
+VERIFIED_REASON_SUBSTR = "transcript verified on disk"
+
+
+def classify_conversation(conv: dict) -> tuple:
+    """Classify a single `conversation list --json` entry into FOUR buckets:
+
+      RESOLVED          state=suspended + verified-transcript reason. The
+                        resume rail will fire on this surface. (Acceptance.)
+      HONEST_DIAGNOSTIC real ref (placeholder=False), state unknown/tombstoned,
+                        non-empty reason — e.g. codex `ambiguous: N candidates`,
+                        or claude `crash recovery: transcript not found`. The
+                        pane did NOT resume, and told the operator why.
+      UNRESOLVED        placeholder still true after crash recovery. Only
+                        reachable for scrape-primary kinds whose on-disk session
+                        was absent at restore, so the id never resolved.
+                        resume() skips placeholders (Codex/Pi/Omp.swift resume:
+                        `.skip("placeholder…")`), so this is a SAFE no-op — not
+                        a silent fresh-launch. The acceptance scenario still
+                        requires zero UNRESOLVED (every session present ⇒ every
+                        id resolves); the missing-per-kind variant expects it
+                        for the deliberately-starved scrape surface.
+      FAIL              the only genuinely bad outcome: state=alive (never
+                        reclassified) or state=suspended WITHOUT the verified
+                        reason (the resume rail would type into the pane on
+                        unverified state) — a silent fresh/wrong resume.
+
+    The brief's 3-bucket contract (RESOLVED / HONEST_DIAGNOSTIC / SILENT_FRESH)
+    maps as: SILENT_FRESH == FAIL. UNRESOLVED is split out from the brief's
+    "placeholder ⇒ fail" because a *surviving* placeholder cannot cause a wrong
+    resume (resume skips it); folding it into FAIL would wrongly flag the
+    missing-session safe-skip. Acceptance treats UNRESOLVED as a failure too
+    (asserts zero), so the strict bar is preserved where it matters.
+
+    Returns (classification, detail_str).
+    """
+    state = (conv.get("state") or "").lower()
+    reason = (conv.get("diagnostic_reason") or "").strip()
+    placeholder = bool(conv.get("placeholder", False))
+
+    # A surviving placeholder can never emit a ResumeAction, so it is a safe
+    # skip regardless of state — classify it before the state ladder.
+    if placeholder:
+        return UNRESOLVED, f"placeholder unresolved (state={state}, reason={reason!r})"
+
+    if state == "suspended":
+        if VERIFIED_REASON_SUBSTR in reason:
+            return RESOLVED, reason
+        # Suspended but not via verified crash-recovery = a silent fresh/clean
+        # suspend the resume rail would fire on without on-disk evidence.
+        return FAIL, f"suspended WITHOUT verified reason: {reason!r}"
+
+    if state in ("unknown", "tombstoned", "unsupported"):
+        if reason:
+            return HONEST_DIAGNOSTIC, f"state={state}: {reason}"
+        return FAIL, f"state={state} with EMPTY diagnostic_reason (silent)"
+
+    if state == "alive":
+        return FAIL, "still alive after crash recovery (silent fresh-launch)"
+
+    return FAIL, f"unexpected state={state!r} reason={reason!r}"
+
+
+def read_conversations(cli_path) -> dict:
+    """Return the parsed `conversation list --json` payload
+    ({'conversations': [...], 'is_disabled': bool}) or {} on error."""
+    res = _cli(cli_path, "conversation", "list", "--json")
+    try:
+        return json.loads(res.stdout)
+    except Exception:
+        return {}
+
+
+def oracle_table(conversations: list) -> list:
+    """Classify every surface. Returns a list of dicts:
+    {surface_id, kind, cwd, id, state, placeholder, classification, detail}."""
+    rows = []
+    for c in conversations:
+        cls, detail = classify_conversation(c)
+        rows.append({
+            "surface_id": c.get("surface_id"),
+            "kind": c.get("kind"),
+            "cwd": c.get("cwd"),
+            "id": c.get("id"),
+            "state": c.get("state"),
+            "placeholder": c.get("placeholder"),
+            "classification": cls,
+            "detail": detail,
+        })
+    return rows
+
+
+def print_oracle_table(rows: list, title: str = "store-state oracle"):
+    print(f"\n  --- {title} ({len(rows)} surfaces) ---")
+    counts = {RESOLVED: 0, HONEST_DIAGNOSTIC: 0, UNRESOLVED: 0, FAIL: 0}
+    for r in rows:
+        counts[r["classification"]] = counts.get(r["classification"], 0) + 1
+        cwd = (r["cwd"] or "")[-28:]
+        print(f"    [{r['classification']:<17}] {str(r['kind']):<12} "
+              f"cwd=…{cwd:<28} state={str(r['state']):<10} {r['detail']}")
+    print(f"    totals: RESOLVED={counts[RESOLVED]} "
+          f"HONEST_DIAGNOSTIC={counts[HONEST_DIAGNOSTIC]} "
+          f"UNRESOLVED={counts[UNRESOLVED]} FAIL={counts[FAIL]}")
+    return counts
+
+
+# --------------------------------------------------------------------------- #
+# The multi-kind harness.
+# --------------------------------------------------------------------------- #
+
+class MultiKindHarness:
+    """Owns the run dir, the per-kind PATH shims, the tagged-app launch/kill,
+    the fixture writers, and fixture teardown. Idempotent: every instance uses a
+    fresh run dir and fresh UUIDs; `cleanup()` removes ONLY files this run
+    created (tracked by exact path) and its run-scoped session subdirs — it
+    never touches the operator's real ~/.claude, ~/.codex, ~/.pi, ~/.omp
+    sessions."""
+
+    def __init__(self):
+        self.run_id = uuid.uuid4().hex[:8]
+        self.run_dir = tempfile.mkdtemp(prefix=f"c11-{TAG_SLUG}-e2e-")
+        self.shim_dir = os.path.join(self.run_dir, "bin")
+        self.zdotdir = os.path.join(self.run_dir, "zdot")
+        os.makedirs(self.shim_dir, exist_ok=True)
+        os.makedirs(self.zdotdir, exist_ok=True)
+
+        self.app = find_app_bundle()
+        self.exe = app_executable(self.app)
+        self.cli_path = tagged_cli(self.app)
+
+        # Run-scoped codex subdir so teardown is a single rmtree of OUR dir
+        # (codex has no cwd slug; the scraper walks the whole tree recursively,
+        # so any depth is found — ClaudeCodeScraper.swift:73-124).
+        self.codex_dir = os.path.join(CODEX_SESSIONS, f"c11-{TAG_SLUG}-{self.run_id}")
+
+        # Teardown bookkeeping — only ever our own paths.
+        self._created_files = set()   # exact fixture file paths
+        self._created_dirs = set()    # run-scoped session dirs (safe rmtree)
+
+        self.proc = None
+        self._write_shims()
+        self._write_zdotdir()
+
+    # -- shim + zdotdir ---------------------------------------------------- #
+
+    def _write_zdotdir(self):
+        """The operator's ~/.zshrc rebuilds PATH from scratch, which would wipe
+        any PATH we prepend at app launch. Redirect every pane's zsh to a
+        minimal ZDOTDIR whose PATH puts the shim dir first, so bare
+        `claude`/`codex`/`pi`/`omp` resolve to our shims. (Same trick as the
+        C11-131 harness, tests_v2/test_crash_resume_e2e.py:168-182.)"""
+        body = (
+            f'export PATH="{self.shim_dir}:/usr/bin:/bin:/usr/sbin:/sbin"\n'
+            f'export SHIM_C11="{self.cli_path}"\n'
+            f'export SHIM_SOCKET="{SOCKET_PATH}"\n'
+            f'export SHIM_LOG_DIR="{self.run_dir}"\n'
+        )
+        for name in (".zshrc", ".zshenv"):
+            with open(os.path.join(self.zdotdir, name), "w") as f:
+                f.write(body)
+
+    def _write_shims(self):
+        """One fake shim per kind. Each shim:
+          1. records its argv to `<run>/<kind>-invocations.log`,
+          2. declares terminal_type via `c11 set-agent --type <kind>` (so the
+             restored panel is picked up by ScrapeCaptureContext.contexts —
+             ScrapeCapturePipeline.swift:34-58),
+          3. wrapper-claims a placeholder via
+             `c11 conversation claim --kind <kind> --cwd "$PWD"` (mirrors
+             Resources/bin/{codex,pi,omp}),
+          4. claude-code ONLY: emulates the SessionStart hook via
+             `c11 conversation push --kind claude-code --id <uuid> --source
+             hook` (codex/pi/omp are scrape-primary — NO push; the id is
+             resolved from the on-disk session file),
+          5. writes a `READY` sentinel line, then blocks like a TUI.
+
+        Surface resolution uses the pane's own CMUX_SURFACE_ID (set by c11 per
+        pane); we pin --socket explicitly so the calls always land on the
+        tagged instance regardless of PATH/env propagation."""
+        common_head = (
+            '#!/bin/bash\n'
+            'KIND="__KIND__"\n'
+            'LOG="$SHIM_LOG_DIR/$KIND-invocations.log"\n'
+            'C11="$SHIM_C11"; SOCK="$SHIM_SOCKET"\n'
+            'echo "INVOKE kind=$KIND pid=$$ cwd=$PWD args=$*" >> "$LOG"\n'
+            # (2) terminal_type declaration.
+            '"$C11" --socket "$SOCK" set-agent --type "$KIND" >> "$LOG" 2>&1 || true\n'
+            # (3) wrapper-claim placeholder.
+            '"$C11" --socket "$SOCK" conversation claim --kind "$KIND" '
+            '--cwd "$PWD" >> "$LOG" 2>&1 || true\n'
+        )
+        claude_push = (
+            # (4) claude-code SessionStart-hook emulation (push-primary).
+            'if [ -n "$SHIM_ID" ]; then\n'
+            '  "$C11" --socket "$SOCK" conversation push --kind claude-code '
+            '--id "$SHIM_ID" --source hook --cwd "$PWD" >> "$LOG" 2>&1 || true\n'
+            '  echo "PUSHED id=$SHIM_ID cwd=$PWD" >> "$LOG"\n'
+            'fi\n'
+        )
+        common_tail = (
+            # (5) READY sentinel + block like a TUI.
+            'echo "READY kind=$KIND cwd=$PWD" >> "$LOG"\n'
+            'while true; do sleep 1; done\n'
+        )
+        for kind in FIRST_CLASS_KINDS:
+            # Shim file name is the bare agent binary name the pane invokes.
+            name = {"claude-code": "claude"}.get(kind, kind)
+            body = common_head.replace("__KIND__", kind)
+            if kind == "claude-code":
+                body += claude_push
+            body += common_tail
+            path = os.path.join(self.shim_dir, name)
+            with open(path, "w") as f:
+                f.write(body)
+            os.chmod(path, 0o755)
+
+    def command_for(self, kind: str, sid: str = None) -> str:
+        """The shell command a workspace runs in its focused surface. claude
+        threads its known id via SHIM_ID; codex/pi/omp take no id (scrape
+        resolves it)."""
+        binname = {"claude-code": "claude"}.get(kind, kind)
+        if kind == "claude-code":
+            assert sid, "claude-code needs a known id"
+            return f"SHIM_ID={sid} {binname}"
+        return binname
+
+    # -- launch / kill ----------------------------------------------------- #
+
+    def launch(self, disable_store=False, no_resume=False):
+        env = dict(os.environ)
+        # Drop the parent c11 session's surface/socket env so the tagged app
+        # doesn't inherit them.
+        for k in list(env):
+            if k.startswith("CMUX_") or k.startswith("C11_"):
+                env.pop(k, None)
+        env["PATH"] = self.shim_dir + ":" + env.get("PATH", "")
+        env["SHIM_C11"] = self.cli_path
+        env["SHIM_SOCKET"] = SOCKET_PATH
+        env["SHIM_LOG_DIR"] = self.run_dir
+        env["ZDOTDIR"] = self.zdotdir
+        # Let the harness's external CLI talk to the socket; default c11Only
+        # mode rejects non-descendant callers by process ancestry.
+        env["CMUX_SOCKET_MODE"] = "allowAll"
+        if disable_store:
+            env["CMUX_DISABLE_CONVERSATION_STORE"] = "1"
+        if no_resume:
+            # Layout restores; the resume typing pass is suppressed
+            # (Workspace.swift:372) so the seeded + scraped + reclassified refs
+            # stay observable instead of being re-captured to `alive`.
+            env["CMUX_DISABLE_AGENT_RESTART"] = "1"
+        self.proc = subprocess.Popen(
+            [self.exe], env=env,
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        wait_socket_ready(self.cli_path)
+
+    def stop(self, sig=signal.SIGKILL):
+        if self.proc and self.proc.poll() is None:
+            try:
+                os.kill(self.proc.pid, sig)
+            except ProcessLookupError:
+                pass
+        wait_socket_gone(self.cli_path)
+        if self.proc:
+            try:
+                self.proc.wait(timeout=10)
+            except Exception:
+                pass
+
+    # -- CLI + workspace --------------------------------------------------- #
+
+    def cli(self, *args, env_extra=None, timeout=15.0):
+        return _cli(self.cli_path, *args, timeout=timeout, env_extra=env_extra)
+
+    def make_workspace(self, title, cwd, command) -> str:
+        os.makedirs(cwd, exist_ok=True)
+        res = self.cli("new-workspace", "--title", title, "--cwd", cwd,
+                       "--command", command)
+        for line in (res.stdout or "").strip().splitlines():
+            if line.startswith("OK "):
+                return line[3:].strip()
+        return ""
+
+    def log_text(self, kind: str) -> str:
+        path = os.path.join(self.run_dir, f"{kind}-invocations.log")
+        try:
+            with open(path) as f:
+                return f.read()
+        except FileNotFoundError:
+            return ""
+
+    def wait_ready(self, expected_count: int, timeout: float = 40.0) -> int:
+        """Poll all per-kind logs until >= `expected_count` READY sentinels
+        have been written (set-agent + claim + optional push all completed).
+        Returns the count seen."""
+        deadline = time.time() + timeout
+        seen = 0
+        while time.time() < deadline:
+            seen = sum(
+                len(re.findall(r"^READY ", self.log_text(k), re.M))
+                for k in FIRST_CLASS_KINDS
+            )
+            if seen >= expected_count:
+                return seen
+            time.sleep(0.5)
+        return seen
+
+    def wait_conversation_count(self, expected: int, timeout: float = 30.0) -> int:
+        """Poll `conversation list --json` until >= `expected` refs exist."""
+        deadline = time.time() + timeout
+        n = 0
+        while time.time() < deadline:
+            n = len(read_conversations(self.cli_path).get("conversations", []))
+            if n >= expected:
+                return n
+            time.sleep(0.5)
+        return n
+
+    # -- fixture writers (land at each scraper's real path) ---------------- #
+
+    def _write_session(self, path: str, mtime: float, first_line: str = None):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            # Most scrapers stat metadata only (privacy contract) and never
+            # open transcript bytes, so an opaque summary line suffices. Codex
+            # is the exception post-G3: it does a BOUNDED read of the FIRST
+            # line and extracts `payload.cwd` to recover the session's real
+            # cwd, so codex fixtures pass a real first_line (see
+            # make_codex_session).
+            f.write((first_line or '{"type":"summary","summary":"c11-164 fake session"}') + "\n")
+        os.utime(path, (mtime, mtime))
+        self._created_files.add(path)
+
+    def make_claude_session(self, cwd: str, sid: str, mtime: float = None) -> str:
+        """~/.claude/projects/<claude_slug(cwd)>/<uuid>.jsonl.
+        Path/slug: ClaudeCodeStrategy.transcriptExists +
+        ClaudeCodeScraper — ClaudeCode.swift:79-101, ClaudeCodeScraper.swift:36-65.
+        (mtime is irrelevant for claude: transcriptExists is a stat existence
+        check with no floor; kept for signature parity.)"""
+        d = os.path.join(CLAUDE_PROJECTS, claude_slug(cwd))
+        self._created_dirs.add(d)
+        path = os.path.join(d, f"{sid}.jsonl")
+        self._write_session(path, mtime if mtime is not None else time.time())
+        return path
+
+    def make_codex_session(self, cwd: str, sid: str, mtime: float,
+                          ts: str = "2026-07-07T12-00-00") -> str:
+        """~/.codex/sessions/<run-subdir>/rollout-<ts>-<uuid>.jsonl.
+
+        Codex has NO cwd-slug DIRECTORY — the scraper walks the whole
+        ~/.codex/sessions tree recursively (subdir depth is irrelevant; real
+        codex nests under YYYY/MM/DD). We use a run-scoped subdir so teardown
+        is a single rmtree.
+
+        Two things the scraper needs from a codex fixture (post-G3):
+        - Filename `rollout-<ISO8601-with-dashes>-<uuid>.jsonl`; the id is the
+          trailing 36-char UUID (`stem.suffix(36)`) — CodexScraper,
+          ClaudeCodeScraper.swift:106-114.
+        - A valid FIRST LINE whose `payload.cwd` EXACTLY equals the surface's
+          cwd. G3's real-cwd recovery reads only that field; the CodexStrategy
+          then keeps only candidates whose recovered cwd == the surface cwd.
+          This is what lets distinct-cwd codex panes resume (each matches only
+          its own cwd) while same-cwd codex pairs stay honestly ambiguous.
+
+        `mtime` must be >= the pane's wrapper-claim time so the claim-time floor
+        keeps it (CodexStrategy.capture — Codex.swift:29-41)."""
+        self._created_dirs.add(self.codex_dir)
+        path = os.path.join(self.codex_dir, f"rollout-{ts}-{sid}.jsonl")
+        header = json.dumps({
+            "timestamp": "2026-07-07T00:00:00",
+            "type": "session_meta",
+            "payload": {
+                "id": sid,
+                "cwd": cwd,               # MUST match the surface's cwd exactly
+                "originator": "cli",
+                "instructions": "stub",
+            },
+        })
+        self._write_session(path, mtime, first_line=header)
+        return path
+
+    def make_pi_session(self, cwd: str, sid: str, mtime: float,
+                        ts: str = "2026-07-07T12-00-00-000Z") -> str:
+        """~/.pi/agent/sessions/<pi_slug(cwd)>/<ISO-ts>_<uuid>.jsonl. pi is
+        cwd-scoped: the scraper lists ONLY the cwd's slug dir. Filename is
+        `<ISO-ts>_<uuid>` — id is the substring after the LAST `_` (the ISO
+        timestamp uses dashes, no `_`). Source: PiScraper —
+        PiScraper.swift:50-106."""
+        d = os.path.join(PI_SESSIONS, pi_slug(cwd))
+        self._created_dirs.add(d)
+        path = os.path.join(d, f"{ts}_{sid}.jsonl")
+        self._write_session(path, mtime)
+        return path
+
+    def make_omp_session(self, cwd: str, sid: str, mtime: float,
+                        ts: str = "1751889600000") -> str:
+        """~/.omp/agent/sessions/<omp_slug(cwd)>/<ts>_<uuid>.jsonl. omp is
+        cwd-scoped like pi. Filename is `<ts>_<uuid>` — id is the substring
+        after the LAST `_`. Source: OmpScraper — OmpScraper.swift:41-105."""
+        d = os.path.join(OMP_SESSIONS, omp_slug(cwd))
+        self._created_dirs.add(d)
+        path = os.path.join(d, f"{ts}_{sid}.jsonl")
+        self._write_session(path, mtime)
+        return path
+
+    def remove_session_file(self, path: str):
+        """Delete a specific fixture file (models the transcript-missing
+        variant). Stays tracked so double-teardown is harmless."""
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+    # -- persistence + teardown ------------------------------------------- #
+
+    def reset_persistence(self):
+        """Wipe this tagged bundle's snapshot + sentinels for a clean slate."""
+        for p in (SNAPSHOT_PATH, DIRTY_SENTINEL, CLEAN_SENTINEL):
+            try:
+                os.remove(p)
+            except FileNotFoundError:
+                pass
+        for name in (os.listdir(SENTINEL_DIR) if os.path.isdir(SENTINEL_DIR) else []):
+            if BUNDLE_ID in name:
+                try:
+                    os.remove(os.path.join(SENTINEL_DIR, name))
+                except FileNotFoundError:
+                    pass
+
+    def cleanup(self):
+        if self.proc and self.proc.poll() is None:
+            self.stop(signal.SIGKILL)
+        # Remove ONLY our own fixture files first, then our run-scoped session
+        # dirs (safe because every dir here was minted from a run-unique cwd or
+        # the run-scoped codex subdir — never a shared operator dir).
+        for path in list(self._created_files):
+            try:
+                os.remove(path)
+            except FileNotFoundError:
+                pass
+        for d in list(self._created_dirs):
+            # Guard: refuse to rmtree a bare session ROOT (would nuke the
+            # operator's real sessions). Every tracked dir must be strictly
+            # deeper than its root.
+            root = None
+            for r in (CLAUDE_PROJECTS, CODEX_SESSIONS, PI_SESSIONS, OMP_SESSIONS):
+                if d.startswith(r + os.sep):
+                    root = r
+                    break
+            if root is None or os.path.normpath(d) == os.path.normpath(root):
+                continue
+            shutil.rmtree(d, ignore_errors=True)
+        shutil.rmtree(self.run_dir, ignore_errors=True)

--- a/tests_v2/crash_resume_support.py
+++ b/tests_v2/crash_resume_support.py
@@ -561,6 +561,21 @@ class MultiKindHarness:
                 return line[3:].strip()
         return ""
 
+    def reset_shim_logs(self):
+        """Truncate the per-kind invocation logs. The shims APPEND (`>>`) to one
+        log per kind in the shared run_dir, so counts accumulate across
+        scenarios; without a reset, a later scenario's `wait_ready(N)` returns
+        immediately on a prior scenario's stale READY lines (an ineffective
+        barrier). Call at the start of each scenario's `build_panes` — the prior
+        scenario's app (and its shims) is already killed, so nothing is racing
+        the truncate. Because each shim writes READY only AFTER its claim + push
+        complete, a fresh READY count is also a reliable "pushes landed" barrier."""
+        for kind in FIRST_CLASS_KINDS:
+            try:
+                open(os.path.join(self.run_dir, f"{kind}-invocations.log"), "w").close()
+            except OSError:
+                pass
+
     def log_text(self, kind: str) -> str:
         path = os.path.join(self.run_dir, f"{kind}-invocations.log")
         try:

--- a/tests_v2/crash_resume_support.py
+++ b/tests_v2/crash_resume_support.py
@@ -480,6 +480,16 @@ class MultiKindHarness:
         env["SHIM_SOCKET"] = SOCKET_PATH
         env["SHIM_LOG_DIR"] = self.run_dir
         env["ZDOTDIR"] = self.zdotdir
+        # CRITICAL (CLAUDE.md): a normal tagged launch blocks on two modal
+        # sheets before the GUI is usable — the Agent Skills install/update
+        # sheet and the "Resume previous session?" picker. Either one wedges the
+        # main thread, so `new-workspace` allocates an id over the socket but the
+        # workspace never materialises and its `--command` never runs (the
+        # `ready=0` failure mode). Suppress both by setting C11_QA_LAUNCH:
+        # `resume` when a snapshot exists (post-crash relaunch — restore the
+        # session silently, no picker) so the store still seeds/scrapes/
+        # reclassifies; `fresh` otherwise (pre-crash build — nothing to restore).
+        env["C11_QA_LAUNCH"] = "resume" if os.path.exists(SNAPSHOT_PATH) else "fresh"
         # Let the harness's external CLI talk to the socket; default c11Only
         # mode rejects non-descendant callers by process ancestry.
         env["CMUX_SOCKET_MODE"] = "allowAll"
@@ -530,10 +540,13 @@ class MultiKindHarness:
         except FileNotFoundError:
             return ""
 
-    def wait_ready(self, expected_count: int, timeout: float = 40.0) -> int:
+    def wait_ready(self, expected_count: int, timeout: float = 150.0) -> int:
         """Poll all per-kind logs until >= `expected_count` READY sentinels
         have been written (set-agent + claim + optional push all completed).
-        Returns the count seen."""
+        Returns the count seen. The timeout is generous: building N workspaces
+        each spawns a shell + runs a shim that makes 2-3 socket round-trips, and
+        under concurrent machine load (e.g. sibling xcodebuilds) the aggregate
+        can take well over a minute for a full 12-pane topology."""
         deadline = time.time() + timeout
         seen = 0
         while time.time() < deadline:
@@ -546,7 +559,7 @@ class MultiKindHarness:
             time.sleep(0.5)
         return seen
 
-    def wait_conversation_count(self, expected: int, timeout: float = 30.0) -> int:
+    def wait_conversation_count(self, expected: int, timeout: float = 90.0) -> int:
         """Poll `conversation list --json` until >= `expected` refs exist."""
         deadline = time.time() + timeout
         n = 0

--- a/tests_v2/crash_resume_support.py
+++ b/tests_v2/crash_resume_support.py
@@ -228,6 +228,31 @@ def new_uuid() -> str:
     return str(uuid.uuid4())
 
 
+def screen_is_locked() -> bool:
+    """True if the macOS login session is locked. A locked screen restricts the
+    window server, so the tagged app can create workspaces over the socket but
+    the GUI never materialises them and their `--command` never runs (every
+    surface reads `ready=0`). Detect it up front so a locked-screen run fails
+    with an actionable message instead of a confusing all-zero oracle."""
+    try:
+        import Quartz  # pyobjc; present in the system python used for tests_v2
+        d = Quartz.CGSessionCopyCurrentDictionary()
+        return bool(d and d.get("CGSSessionScreenIsLocked"))
+    except Exception:
+        return False  # can't tell → don't block
+
+
+def require_unlocked_screen():
+    if screen_is_locked():
+        raise SystemExit(
+            "REFUSING TO RUN: the macOS screen is LOCKED. This harness drives a "
+            "real tagged c11 GUI (workspaces + PTYs); a locked session stalls the "
+            "window server so no agent shim ever runs (you would see ready=0 for "
+            "every surface). Unlock the screen and re-run. (CI's headless runner "
+            "and an unlocked interactive session are both fine.)"
+        )
+
+
 # --------------------------------------------------------------------------- #
 # Store-state oracle.
 # --------------------------------------------------------------------------- #
@@ -500,6 +525,7 @@ class MultiKindHarness:
             # (Workspace.swift:372) so the seeded + scraped + reclassified refs
             # stay observable instead of being re-captured to `alive`.
             env["CMUX_DISABLE_AGENT_RESTART"] = "1"
+        # Direct-exec of the inner Mach-O (mirrors the proven C11-131 harness).
         self.proc = subprocess.Popen(
             [self.exe], env=env,
             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -511,6 +537,9 @@ class MultiKindHarness:
                 os.kill(self.proc.pid, sig)
             except ProcessLookupError:
                 pass
+        # Belt-and-suspenders: also reap by token (the app may re-parent).
+        if sig == signal.SIGKILL:
+            subprocess.run(["pkill", "-9", "-f", PROC_TOKEN], capture_output=True)
         wait_socket_gone(self.cli_path)
         if self.proc:
             try:
@@ -682,8 +711,9 @@ class MultiKindHarness:
                     pass
 
     def cleanup(self):
-        if self.proc and self.proc.poll() is None:
-            self.stop(signal.SIGKILL)
+        # App is launched via `open` (no child handle) — always reap the tagged
+        # instance by token.
+        kill_tagged_instances()
         # Remove ONLY our own fixture files first, then our run-scoped session
         # dirs (safe because every dir here was minted from a run-unique cwd or
         # the run-scoped codex subdir — never a shared operator dir).

--- a/tests_v2/test_crash_resume_multikind_e2e.py
+++ b/tests_v2/test_crash_resume_multikind_e2e.py
@@ -22,6 +22,13 @@ Author-only; do NOT run inside the orchestration. To run it yourself:
     # Optional: run a subset by name substring, e.g.
     python3 tests_v2/test_crash_resume_multikind_e2e.py all_present kill_switch
 
+PREREQUISITES (interactive workstation): this harness drives a REAL tagged c11
+GUI, so the macOS screen must be UNLOCKED and (ideally) not asleep — a locked
+session restricts the window server and the app can't materialise workspaces, so
+every surface reads ready=0. The run aborts up front if it detects a locked
+screen. Run under `caffeinate -d -i` to hold the display awake. CI's headless
+runner has neither constraint.
+
 Everything is isolated to the `res-post` tagged bundle id / socket / snapshot,
 so it never touches the operator's prod c11 (this session) or its sessions.
 
@@ -479,6 +486,9 @@ SCENARIOS = [
 
 def main():
     only = sys.argv[1:] if len(sys.argv) > 1 else None
+    # Fail fast on a locked screen — otherwise every surface reads ready=0
+    # because the window server won't materialise the tagged app's workspaces.
+    S.require_unlocked_screen()
     S.kill_tagged_instances()
     h = S.MultiKindHarness()
     print(f"app:    {h.app}")

--- a/tests_v2/test_crash_resume_multikind_e2e.py
+++ b/tests_v2/test_crash_resume_multikind_e2e.py
@@ -137,6 +137,12 @@ class Topology:
                     "workspace": wsref}
             self.specs.append(spec)
             self.by_label[label] = spec
+            # Small stagger: creating 12 workspaces back-to-back spawns 12 PTYs
+            # that each race a shell + shim; under concurrent machine load the
+            # burst can drop a command before its shell is ready. A brief settle
+            # per workspace keeps the setup deterministic without materially
+            # slowing the run.
+            time.sleep(0.4)
         # Wait for all shims to finish their setup handshake, then confirm the
         # store actually holds all refs.
         ready = self.h.wait_ready(len(PANES))

--- a/tests_v2/test_crash_resume_multikind_e2e.py
+++ b/tests_v2/test_crash_resume_multikind_e2e.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""C11-164 (RES-1..RES-5): the multi-kind force-kill crash-resume ACCEPTANCE gate.
+
+This is the acceptance oracle for the crash-resume machinery. It drives a TAGGED
+c11 build through the full save / kill -9 / relaunch / reclassify loop across
+>=12 conversations spanning ALL FOUR first-class agent kinds
+(claude-code, codex, pi, omp) in >=4 workspaces, with deliberately adversarial
+fixtures, and asserts on the reclassified conversation-store STATE (not on the
+resume keystroke — see crash_resume_support module docstring for why).
+
+============================ HOW TO RUN ============================
+Author-only; do NOT run inside the orchestration. To run it yourself:
+
+    # 1. Build (and launch) the tagged app ONCE. The harness manages its own
+    #    launches thereafter (it needs to inject the PATH shims), and kills the
+    #    reload-launched instance first.
+    ./scripts/reload.sh --tag res-post
+
+    # 2. Run the acceptance harness (never via the host-bound xcodebuild action):
+    python3 tests_v2/test_crash_resume_multikind_e2e.py
+
+    # Optional: run a subset by name substring, e.g.
+    python3 tests_v2/test_crash_resume_multikind_e2e.py all_present kill_switch
+
+Everything is isolated to the `res-post` tagged bundle id / socket / snapshot,
+so it never touches the operator's prod c11 (this session) or its sessions.
+
+============================ TOPOLOGY (12 surfaces / 12 workspaces / 4 kinds) ==
+  claude-code x4  (cc0..cc3)     push-primary: SessionStart-hook emulation.
+  codex       x4  (cx0, cx1,     pull-primary: id resolved from the rollout file
+                   cxADVa,cxADVb)  at restore. cx0/cx1 have DISTINCT cwds (each
+                                   codex fixture's first-line payload.cwd matches
+                                   its surface) so they resume cleanly; cxADVa +
+                                   cxADVb SHARE one cwd → the ambiguity policy
+                                   fires (two candidates, same cwd → state
+                                   unknown "ambiguous").
+  pi          x2  (pi0, pi1)     pull-primary, cwd-slug-scoped. pi1's cwd carries
+                                   BOTH a STALE (mtime < claim) and a FRESH
+                                   (mtime > claim) session file, so the claim-time
+                                   floor is exercised: floor drops the stale one →
+                                   pi1 resolves cleanly (else it would go
+                                   ambiguous).
+  omp         x2  (omp0, omp1)   pull-primary, cwd-slug-scoped.
+
+Adversarial coverage (mandatory per the brief):
+  * >=1 same-cwd codex pair (cxADVa/cxADVb) — exercises the ambiguity policy.
+  * >=1 cwd (pi1) with a stale+fresh pair — exercises the mtime/activity floor.
+
+============================ ORACLE ============================
+Per surface, from `c11 conversation list --json` (see
+crash_resume_support.classify_conversation):
+  RESOLVED          state=suspended + "crash recovery: transcript verified on
+                    disk". Resume will fire.
+  HONEST_DIAGNOSTIC real ref, unknown/tombstoned, non-empty reason (ambiguous /
+                    transcript-not-found). Did NOT resume; said why.
+  UNRESOLVED        placeholder survived (scrape kind, no on-disk session) — a
+                    SAFE skip (resume() skips placeholders), distinguished from
+                    a genuine silent fresh-launch.
+  FAIL              state=alive, or suspended WITHOUT the verified reason — the
+                    silent fresh/wrong resume this gate exists to catch.
+
+Acceptance passes iff every surface is RESOLVED or HONEST_DIAGNOSTIC (0 FAIL,
+0 UNRESOLVED), with the adversarial pair honestly ambiguous.
+
+Scenario variants: all-present (acceptance), one-transcript-missing-per-kind,
+clean `app restart`, double kill-9 (idempotent), and the
+CMUX_DISABLE_CONVERSATION_STORE kill switch.
+"""
+
+import json
+import os
+import signal
+import sys
+import time
+
+import crash_resume_support as S
+
+
+# --------------------------------------------------------------------------- #
+# Pass/fail accounting.
+# --------------------------------------------------------------------------- #
+
+PASS, FAILED = [], []
+
+
+def check(name, cond, detail=""):
+    (PASS if cond else FAILED).append(name)
+    mark = "PASS" if cond else "FAIL"
+    print(f"  [{mark}] {name}" + (f" — {detail}" if detail and not cond else ""))
+
+
+# --------------------------------------------------------------------------- #
+# Topology.
+# --------------------------------------------------------------------------- #
+
+# Each entry: (label, kind, cwd_key). Panes with the SAME cwd_key share a cwd
+# (the adversarial same-cwd codex pair); everything else is distinct.
+PANES = [
+    ("cc0", "claude-code", "cc0"),
+    ("cc1", "claude-code", "cc1"),
+    ("cc2", "claude-code", "cc2"),
+    ("cc3", "claude-code", "cc3"),
+    ("cx0", "codex", "cx0"),
+    ("cx1", "codex", "cx1"),
+    ("cxADVa", "codex", "codex-adv"),   # shared cwd ↓
+    ("cxADVb", "codex", "codex-adv"),   # shared cwd ↑  (ambiguity pair)
+    ("pi0", "pi", "pi0"),
+    ("pi1", "pi", "pi1"),               # + stale sibling (floor test)
+    ("omp0", "omp", "omp0"),
+    ("omp1", "omp", "omp1"),
+]
+
+
+class Topology:
+    """Builds the 12-surface topology on a live launched harness and writes the
+    on-disk session fixtures. `omit` is a set of labels whose session fixtures
+    are deliberately NOT created (the missing-per-kind variant)."""
+
+    def __init__(self, h: S.MultiKindHarness):
+        self.h = h
+        self.specs = []          # list of dicts: label, kind, cwd, sid
+        self.by_label = {}
+
+    def cwd_for(self, cwd_key: str) -> str:
+        return os.path.join(self.h.run_dir, "ws", cwd_key)
+
+    def build_panes(self):
+        """Create every workspace and run its (shim) agent. Returns after all
+        panes have written their READY sentinel (set-agent + claim + optional
+        push complete) so a subsequent `state save` captures the full store."""
+        for label, kind, cwd_key in PANES:
+            cwd = self.cwd_for(cwd_key)
+            sid = S.new_uuid()
+            cmd = self.h.command_for(kind, sid)
+            wsref = self.h.make_workspace(f"RES-{label}", cwd, cmd)
+            spec = {"label": label, "kind": kind, "cwd": cwd, "sid": sid,
+                    "workspace": wsref}
+            self.specs.append(spec)
+            self.by_label[label] = spec
+        # Wait for all shims to finish their setup handshake, then confirm the
+        # store actually holds all refs.
+        ready = self.h.wait_ready(len(PANES))
+        count = self.h.wait_conversation_count(len(PANES))
+        return ready, count
+
+    def write_fixtures(self, omit=frozenset()):
+        """Create each surface's on-disk session file at the exact path its
+        scraper reads. Fresh files get mtime=now (safely after every pane's
+        wrapper-claim, which happened during build_panes); pi1 additionally
+        gets a STALE sibling below the claim floor."""
+        now = time.time()
+        stale = now - 3600            # an hour before any claim ⇒ below floor
+        for spec in self.specs:
+            if spec["label"] in omit:
+                continue
+            kind, cwd, sid = spec["kind"], spec["cwd"], spec["sid"]
+            if kind == "claude-code":
+                spec["fixture"] = self.h.make_claude_session(cwd, sid)
+            elif kind == "codex":
+                spec["fixture"] = self.h.make_codex_session(cwd, sid, mtime=now)
+            elif kind == "pi":
+                spec["fixture"] = self.h.make_pi_session(cwd, sid, mtime=now)
+                if spec["label"] == "pi1":
+                    # Adversarial: a second, OLDER pi session in the same cwd
+                    # slug dir. The claim-time floor must drop it, else pi1 goes
+                    # ambiguous. Distinct id + distinct ISO ts so both files
+                    # coexist in the slug dir.
+                    spec["stale_fixture"] = self.h.make_pi_session(
+                        cwd, S.new_uuid(), mtime=stale,
+                        ts="2026-01-01T00-00-00-000Z")
+            elif kind == "omp":
+                spec["fixture"] = self.h.make_omp_session(cwd, sid, mtime=now)
+
+
+# --------------------------------------------------------------------------- #
+# Shared step helpers.
+# --------------------------------------------------------------------------- #
+
+def assert_precrash_snapshot(topo: Topology):
+    """`state save`, then assert the snapshot carries per-panel
+    surface_conversations, that claude-code entries are real (placeholder=False)
+    and codex/pi/omp entries are placeholder wrapperClaims (placeholder=True).
+    This makes a later failure diagnosable as claim-capture vs resume."""
+    save = topo.h.cli("state", "save")
+    check("state save ok", save.returncode == 0, save.stderr.strip())
+
+    actives = []   # (kind, id, placeholder)
+    try:
+        snap = json.load(open(S.SNAPSHOT_PATH))
+        for w in snap.get("windows", []):
+            for ws in w["tabManager"]["workspaces"]:
+                for p in ws["panels"]:
+                    a = (p.get("surface_conversations") or {}).get("active")
+                    if a:
+                        actives.append((a.get("kind"), a.get("id"),
+                                        bool(a.get("placeholder"))))
+    except Exception as e:
+        check("snapshot readable", False, f"{e}")
+        return
+
+    check("snapshot carries >=12 surface_conversations", len(actives) >= 12,
+          f"got {len(actives)}")
+    cc = [a for a in actives if a[0] == "claude-code"]
+    scrape = [a for a in actives if a[0] in ("codex", "pi", "omp")]
+    check("pre-crash: claude-code refs are real (placeholder=False)",
+          len(cc) >= 4 and all(not a[2] for a in cc),
+          f"{[(a[0], a[2]) for a in cc]}")
+    check("pre-crash: codex/pi/omp refs are wrapperClaim placeholders (True)",
+          len(scrape) >= 8 and all(a[2] for a in scrape),
+          f"{[(a[0], a[2]) for a in scrape]}")
+
+
+def crash(topo: Topology, sig=signal.SIGKILL):
+    """kill -9 the tagged instance; assert the dirty sentinel remains (never
+    promoted to clean) and no clean sentinel was written."""
+    topo.h.stop(sig)
+    dirty = os.path.exists(S.DIRTY_SENTINEL)
+    clean = os.path.exists(S.CLEAN_SENTINEL)
+    check("after kill -9: dirty sentinel remains", dirty,
+          f"dirty={dirty} clean={clean} ({S.DIRTY_SENTINEL})")
+    check("after kill -9: no clean sentinel", not clean, S.CLEAN_SENTINEL)
+
+
+def settle_and_classify(h: S.MultiKindHarness, expected: int,
+                       timeout: float = 30.0):
+    """Poll `conversation list --json` after a relaunch until the store holds
+    >= `expected` surfaces AND the classification counts are stable across two
+    consecutive reads (seed → scrape → reclassify have settled). Returns the
+    oracle rows."""
+    deadline = time.time() + timeout
+    prev_sig = None
+    rows = []
+    while time.time() < deadline:
+        convs = S.read_conversations(h.cli_path).get("conversations", [])
+        rows = S.oracle_table(convs)
+        sig = tuple(sorted((r["classification"], r["cwd"]) for r in rows))
+        if len(rows) >= expected and sig == prev_sig:
+            return rows
+        prev_sig = sig
+        time.sleep(1.0)
+    return rows
+
+
+def kinds_resolved(rows):
+    """Set of kinds with at least one RESOLVED surface."""
+    return {r["kind"] for r in rows if r["classification"] == S.RESOLVED}
+
+
+def rows_for_cwd(rows, cwd):
+    return [r for r in rows if r["cwd"] == cwd]
+
+
+# --------------------------------------------------------------------------- #
+# Scenarios.
+# --------------------------------------------------------------------------- #
+
+def scenario_all_present(h: S.MultiKindHarness):
+    """RES-1 acceptance: full topology, every session present. Every surface
+    must be RESOLVED or (for the adversarial pair) HONEST_DIAGNOSTIC; zero FAIL,
+    zero UNRESOLVED."""
+    print("\n== all-present (ACCEPTANCE) ==")
+    h.reset_persistence()
+    h.launch()
+    topo = Topology(h)
+    ready, count = topo.build_panes()
+    check("all shims reached READY", ready >= len(PANES), f"ready={ready}")
+    check("store holds all refs pre-crash", count >= len(PANES), f"count={count}")
+    topo.write_fixtures()
+    assert_precrash_snapshot(topo)
+
+    crash(topo)
+    h.launch(no_resume=True)
+    rows = settle_and_classify(h, expected=len(PANES))
+    counts = S.print_oracle_table(rows, "all-present")
+
+    check("acceptance: >=12 surfaces observed", len(rows) >= 12, f"{len(rows)}")
+    check("acceptance: zero FAIL (no silent fresh-launch)",
+          counts.get(S.FAIL, 0) == 0)
+    check("acceptance: zero UNRESOLVED (every session present ⇒ resolved)",
+          counts.get(S.UNRESOLVED, 0) == 0)
+
+    kr = kinds_resolved(rows)
+    for kind in ("claude-code", "codex", "pi", "omp"):
+        check(f"acceptance: >=1 {kind} surface RESOLVED", kind in kr, f"resolved={kr}")
+
+    # Adversarial same-cwd codex pair → both HONEST_DIAGNOSTIC (ambiguous).
+    adv_cwd = topo.cwd_for("codex-adv")
+    adv = rows_for_cwd(rows, adv_cwd)
+    check("adversarial: same-cwd codex pair present (2 surfaces, 1 cwd)",
+          len(adv) == 2, f"rows={len(adv)}")
+    check("adversarial: same-cwd codex pair is HONEST_DIAGNOSTIC (ambiguous)",
+          len(adv) == 2 and all(r["classification"] == S.HONEST_DIAGNOSTIC
+                                and "ambiguous" in (r["detail"] or "")
+                                for r in adv),
+          f"{[(r['classification'], r['detail']) for r in adv]}")
+
+    # Floor test: pi1's cwd resolves to pi1's OWN fresh id (stale sibling was
+    # dropped by the claim-time floor; otherwise it would be ambiguous).
+    pi1 = topo.by_label["pi1"]
+    pi1_rows = rows_for_cwd(rows, pi1["cwd"])
+    check("floor: pi1 (stale+fresh) resolves to its fresh id (stale dropped)",
+          len(pi1_rows) == 1
+          and pi1_rows[0]["classification"] == S.RESOLVED
+          and pi1_rows[0]["id"] == pi1["sid"],
+          f"{[(r['classification'], r['id']) for r in pi1_rows]} want id={pi1['sid']}")
+
+    h.stop()
+
+
+def scenario_missing_transcript_per_kind(h: S.MultiKindHarness):
+    """One session omitted per kind. The claude-code surface → HONEST_DIAGNOSTIC
+    ("transcript not found"); the scrape-primary surfaces (codex/pi/omp) → a
+    SAFE UNRESOLVED placeholder (no on-disk session ⇒ id never resolves, resume
+    skips). Crucially: still zero FAIL, and every other surface resolves."""
+    print("\n== one-transcript-missing-per-kind ==")
+    h.reset_persistence()
+    h.launch()
+    topo = Topology(h)
+    topo.build_panes()
+    # Starve exactly one surface per kind (pi0, not pi1, so pi1 keeps its
+    # floor-test role).
+    omit = {"cc3", "cx1", "pi0", "omp1"}
+    topo.write_fixtures(omit=omit)
+    assert_precrash_snapshot(topo)
+
+    crash(topo)
+    h.launch(no_resume=True)
+    rows = settle_and_classify(h, expected=len(PANES))
+    counts = S.print_oracle_table(rows, "missing-per-kind")
+
+    check("missing: zero FAIL (still no silent fresh-launch)",
+          counts.get(S.FAIL, 0) == 0)
+
+    # Targeted expectations.
+    cc3 = rows_for_cwd(rows, topo.by_label["cc3"]["cwd"])
+    check("missing: starved claude-code → HONEST_DIAGNOSTIC (transcript not found)",
+          len(cc3) == 1 and cc3[0]["classification"] == S.HONEST_DIAGNOSTIC
+          and "not found" in (cc3[0]["detail"] or ""),
+          f"{[(r['classification'], r['detail']) for r in cc3]}")
+
+    for lbl in ("cx1", "pi0", "omp1"):
+        r = rows_for_cwd(rows, topo.by_label[lbl]["cwd"])
+        check(f"missing: starved {lbl} → UNRESOLVED (safe placeholder skip)",
+              len(r) == 1 and r[0]["classification"] == S.UNRESOLVED,
+              f"{[(x['classification'], x['detail']) for x in r]}")
+
+    # Non-starved distinct-cwd surfaces of each kind still resolve.
+    kr = kinds_resolved(rows)
+    for kind in ("claude-code", "codex", "pi", "omp"):
+        check(f"missing: a present {kind} surface still RESOLVED", kind in kr,
+              f"resolved={kr}")
+
+    h.stop()
+
+
+def scenario_clean_restart(h: S.MultiKindHarness):
+    """Clean `c11 app restart`: the suspend → final-snapshot → promoteToClean
+    choreography. We assert the on-disk artifacts (parity with the C11-131
+    harness): the sentinel is promoted to clean and the snapshot carries
+    SUSPENDED claude-code refs (codex/pi/omp remain wrapperClaim placeholders
+    pre-restart — they only resolve at the next restore's scrape). Kept last-ish
+    because `app restart`'s `open -n` self-relaunch can leave a lingering
+    instance."""
+    print("\n== clean app restart ==")
+    h.reset_persistence()
+    h.launch()
+    topo = Topology(h)
+    topo.build_panes()
+    topo.write_fixtures()
+
+    restart = h.cli("app", "restart")
+    check("app restart accepted", restart.returncode == 0, restart.stderr.strip())
+    S.wait_socket_gone(h.cli_path, timeout=20)
+    time.sleep(2)
+    S.kill_tagged_instances()   # reap the self-relaunched instance
+
+    clean = os.path.exists(S.CLEAN_SENTINEL)
+    check("app restart promoted sentinel to clean", clean, S.CLEAN_SENTINEL)
+
+    suspended = []
+    try:
+        snap = json.load(open(S.SNAPSHOT_PATH))
+        for w in snap.get("windows", []):
+            for ws in w["tabManager"]["workspaces"]:
+                for p in ws["panels"]:
+                    a = (p.get("surface_conversations") or {}).get("active")
+                    if a and a.get("kind") == "claude-code":
+                        suspended.append(a.get("state"))
+    except Exception:
+        pass
+    check("clean restart: claude-code refs are suspended in snapshot",
+          len(suspended) >= 4 and all(s == "suspended" for s in suspended),
+          f"states={suspended}")
+
+    S.kill_tagged_instances()
+
+
+def scenario_double_kill(h: S.MultiKindHarness):
+    """RES-3 idempotency: a second kill -9 with no clean quit between must not
+    resurrect a ref to a wrongly-resumable state, crash-loop, or fresh-launch.
+    Build once, crash+observe, then crash the relaunched instance again and
+    re-observe: still zero FAIL, app healthy."""
+    print("\n== double kill -9 (idempotent) ==")
+    h.reset_persistence()
+    h.launch()
+    topo = Topology(h)
+    topo.build_panes()
+    topo.write_fixtures()
+    assert_precrash_snapshot(topo)
+
+    crash(topo)
+    h.launch(no_resume=True)
+    rows1 = settle_and_classify(h, expected=len(PANES))
+    c1 = S.print_oracle_table(rows1, "double-kill cycle 1")
+    check("double kill cycle 1: zero FAIL", c1.get(S.FAIL, 0) == 0)
+    tree1 = h.cli("tree", "--json")
+    check("double kill cycle 1: app healthy", tree1.returncode == 0)
+
+    # Second kill -9 (dirty again), no clean quit between.
+    h.stop(signal.SIGKILL)
+    check("double kill: dirty sentinel remains after 2nd kill",
+          os.path.exists(S.DIRTY_SENTINEL))
+    h.launch(no_resume=True)
+    rows2 = settle_and_classify(h, expected=1)   # ref set may shrink; be lenient
+    c2 = S.print_oracle_table(rows2, "double-kill cycle 2")
+    check("double kill cycle 2: zero FAIL (idempotent, no silent resurrection)",
+          c2.get(S.FAIL, 0) == 0)
+    tree2 = h.cli("tree", "--json")
+    check("double kill cycle 2: app healthy after 2nd relaunch",
+          tree2.returncode == 0)
+    h.stop()
+
+
+def scenario_kill_switch(h: S.MultiKindHarness):
+    """RES kill switch: relaunch with CMUX_DISABLE_CONVERSATION_STORE=1. The
+    store is inert — layout restores, nothing resumes, no error, and
+    `conversation list --json` reports is_disabled=True."""
+    print("\n== kill switch (CMUX_DISABLE_CONVERSATION_STORE=1) ==")
+    h.reset_persistence()
+    h.launch()
+    topo = Topology(h)
+    topo.build_panes()
+    topo.write_fixtures()
+    h.cli("state", "save")
+    h.stop(signal.SIGKILL)
+
+    h.launch(disable_store=True)
+    time.sleep(6)
+    tree = h.cli("tree", "--json")
+    check("kill switch: app healthy after restore", tree.returncode == 0,
+          tree.stderr.strip())
+    clist = h.cli("conversation", "list", "--json")
+    try:
+        disabled = json.loads(clist.stdout).get("is_disabled", False)
+    except Exception:
+        disabled = False
+    check("kill switch: conversation store reports disabled", disabled is True,
+          clist.stdout[:200])
+    h.stop()
+
+
+# clean_restart runs last: its `app restart` self-relaunch (open -n) can leave a
+# lingering instance that races the next scenario's launch. Keeping it last
+# contains the blast radius (mirrors the C11-131 harness ordering).
+SCENARIOS = [
+    scenario_all_present,
+    scenario_missing_transcript_per_kind,
+    scenario_double_kill,
+    scenario_kill_switch,
+    scenario_clean_restart,
+]
+
+
+def main():
+    only = sys.argv[1:] if len(sys.argv) > 1 else None
+    S.kill_tagged_instances()
+    h = S.MultiKindHarness()
+    print(f"app:    {h.app}")
+    print(f"socket: {S.SOCKET_PATH}")
+    print(f"run:    {h.run_dir}")
+    try:
+        for fn in SCENARIOS:
+            if only and not any(o in fn.__name__ for o in only):
+                continue
+            # Hard isolation between scenarios: settle the socket + process
+            # table before the next launch (rapid repeated GUI launches race).
+            S.kill_tagged_instances()
+            try:
+                os.remove(S.SOCKET_PATH)
+            except OSError:
+                pass
+            time.sleep(2.0)
+            try:
+                fn(h)
+            except Exception as e:
+                FAILED.append(fn.__name__)
+                print(f"  [FAIL] {fn.__name__} raised: {e}")
+                try:
+                    h.stop(signal.SIGKILL)
+                except Exception:
+                    pass
+    finally:
+        h.cleanup()
+    print(f"\n{len(PASS)} passed, {len(FAILED)} failed")
+    if FAILED:
+        print("FAILED:", ", ".join(FAILED))
+    sys.exit(1 if FAILED else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_v2/test_crash_resume_multikind_e2e.py
+++ b/tests_v2/test_crash_resume_multikind_e2e.py
@@ -135,6 +135,11 @@ class Topology:
         """Create every workspace and run its (shim) agent. Returns after all
         panes have written their READY sentinel (set-agent + claim + optional
         push complete) so a subsequent `state save` captures the full store."""
+        # Fresh READY baseline per scenario — the shim logs accumulate across
+        # scenarios in the shared run_dir, so without this a later scenario's
+        # wait_ready would return on stale counts (and before this scenario's
+        # claude pushes land, since READY is written after push).
+        self.h.reset_shim_logs()
         for label, kind, cwd_key in PANES:
             cwd = self.cwd_for(cwd_key)
             sid = S.new_uuid()


### PR DESCRIPTION
## C11-164 — Crash-resume completion (RES-1..RES-5)

**Wave 2 · Truth & Stability cycle.** Definition of done is the force-kill scenario, not a task list.

The crash-resume machinery already landed across C11-131 + C11-151..154 (crash fix, pull-scrape rail wired into restore, per-kind exact resume, state CLI). This PR closes the two gaps the RES-1 scenario actually requires and proves the whole thing end-to-end with a repeatable multi-kind harness.

### Changes
- **G2 — SurfaceActivityTracker snapshot persistence (RES-2).** The scrape-disambiguation floor (`mtime ≥ surface lastActivityTimestamp`) was in-memory only and lost on every restart, and `ScrapeCaptureContext.contexts(from:)` hardcoded it `nil`. Persist it per panel (`last_activity_at` on `SessionPanelSnapshot`, added to `CodingKeys` so it actually encodes), populate at capture, seed the tracker + thread the floor into the restore-time scrape.
- **G3 — Codex real-cwd recovery (RES-2).** Codex stores sessions flat, so the scraper stamped the querying surface's cwd on every candidate → the cwd filter was a structural no-op → distinct-workspace codex sessions all read as mutually ambiguous and none resumed. Recover each candidate's real cwd from a **bounded, allowlisted** first-line read of the rollout header (`payload.cwd` only; byte-capped; no transcript content read or logged — honors the scrape privacy contract). Distinct-cwd panes now resume; same-cwd pairs stay honestly ambiguous. A `candidates(cwd:recoverCwd:)` overload lets the crash-recovery `transcriptExists` path skip the head reads it would discard.
- **Multi-kind acceptance harness (RES-1, RES-3).** `tests_v2/test_crash_resume_multikind_e2e.py` (+ `crash_resume_support.py`): ≥12 conversations / ≥4 workspaces / 4 kinds (claude-code + codex + pi + omp), adversarial same-cwd codex pair + stale/fresh pi pair, `kill -9`, relaunch, per-surface store-state oracle. Zero silent fresh-launches = zero FAIL.
- **Docs (RES-5).** `skills/c11/references/conversation.md` rewritten to post-cycle truth (per-kind crash-recovery guarantee, codex real-cwd disambiguation, landed-vs-open); installed skill synced.
- **Drive-by (flagged by C11-165/COR):** fixed a pre-existing host-lane compile break in `SurfaceActivityTests.swift` (optional + `XCTAssertEqual(accuracy:)` → `XCTUnwrap`), in scope because it tests the tracker G2 now persists. A **separate, orthogonal** pre-existing host-lane break remains outside RES scope — `TerminalAndGhosttyTests.swift` calls `scheduleExternalGeometrySynchronizeForAllWindows()` without the now-required `trigger:` arg (5 sites) — left for its owner.

### Validation
- **RES-1 acceptance (recorded): full harness run 49/0** — 10 RESOLVED / 2 honestly-ambiguous (the same-cwd codex pair) / **0 FAIL** across all 4 kinds; pi floor test resolves; all 5 scenario variants green.
- **RES-4:** 45 existing conversation-resume logic tests green; new Tier-1: 17 green (activity round-trip + CodingKeys-trap guard, contexts floor threading, codex real-cwd recovery, parse edge cases). Final-build single-pane E2E proves the runtime pipeline.
- Own-reviewer pass cleared all Swift; one harness finding fixed, one NIT confirmed safe.

### Open item (operator/validator reconfirm)
The **second consecutive** full-suite run for RES-3's twice-green was blocked in-session by a **locked macOS screen** (`CGSSessionScreenIsLocked`) — a locked session restricts the window server, so the tagged GUI can't materialise workspaces (`ready=0`), unrelated to the code. The harness now aborts up front on a locked screen. Reconfirm with the screen unlocked: `caffeinate -d -i python3 tests_v2/test_crash_resume_multikind_e2e.py` (twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
