### PR TITLE
C11-167: wire TEL↔EVT derived-liveness event emission

### DIFF
--- a/Sources/SurfaceLivenessDeriver.swift
+++ b/Sources/SurfaceLivenessDeriver.swift
@@ -85,7 +85,7 @@ enum SurfaceLivenessDeriver {
             // happened.
             let after = currentActivityRaw(workspaceId: workspaceId, surfaceId: surfaceId)
             if prior != after {
-                emitLivenessTransition(from: prior, to: after, surfaceId: surfaceId)
+                emitLivenessTransition(from: prior, to: after, surfaceId: surfaceId, workspaceId: workspaceId)
             }
             // Mirror the *post-write* store truth (not the intended `derived`)
             // onto the main-actor Workspace projection, so the sidebar can never
@@ -138,7 +138,8 @@ enum SurfaceLivenessDeriver {
         emitLivenessTransition(
             from: SidebarActivityState.working.rawValue,
             to: SidebarActivityState.idle.rawValue,
-            surfaceId: surfaceId
+            surfaceId: surfaceId,
+            workspaceId: workspaceId
         )
         // Mirror onto the Workspace projection if it is currently resident.
         DispatchQueue.main.async {
@@ -195,31 +196,36 @@ enum SurfaceLivenessDeriver {
     /// (including to/from the absent/"unknown" state, represented by `nil`).
     /// This is the derived-liveness transition point EVT-2's taxonomy needs.
     ///
-    /// SEAM (C11-162 ↔ C11-163): EVT (#318) ships the `liveness.derived` event
-    /// type and a stub `EventEmitter.emitDerivedLiveness(...)` with no call site;
-    /// this method IS that call site. It is deliberately NOT wired yet because
-    /// EVT is unmerged — referencing `EventEmitter` here would break `main`
-    /// while #318 is open. Once EVT merges, add the single line inside the
-    /// guard below:
-    ///
-    ///     EventEmitter.emitDerivedLiveness(surfaceId: surfaceId, from: from, to: to)
-    ///
-    /// (match the merged stub's actual signature). Firing only on a real
-    /// post-write transition — see the caller — is intentional so the event
-    /// stream never emits a phantom transition for a precedence-rejected write.
+    /// SEAM (C11-162 ↔ C11-163), wired in C11-167: EVT (#318) ships the
+    /// `liveness.derived` event type + `EventEmitter.emitDerivedLiveness(...)`;
+    /// this method IS its call site. A `liveness.derived` event fires whenever
+    /// the derived truth settles on a concrete state (`working`/`idle`); a
+    /// transition *to* the absent/"unknown" state (`to == nil`) emits nothing,
+    /// since it is not one of the derived liveness states the stub carries.
+    /// Firing only on a real post-write transition — see the caller — is
+    /// intentional so the event stream never emits a phantom transition for a
+    /// precedence-rejected write.
     private static func emitLivenessTransition(
         from: String?,
         to: String?,
-        surfaceId: UUID
+        surfaceId: UUID,
+        workspaceId: UUID
     ) {
-        // TODO(C11-163): once EVT #318 is merged, emit the liveness.derived
-        // event here via EventEmitter.emitDerivedLiveness(...). See doc above.
         #if DEBUG
         dlog(
             "surface.liveness.transition surface=\(surfaceId.uuidString.prefix(5)) " +
             "from=\(from ?? "-") to=\(to ?? "-")"
         )
         #endif
-        // C11-163 EVT-2 hook point — intentionally empty in this ticket.
+        // EVT-2 derived-liveness event. Emit only for a concrete destination
+        // state; `emit` is internally locked + non-blocking (EVT-3), so this is
+        // safe on the off-main queues both callers run on.
+        if let to {
+            EventEmitter.shared.emitDerivedLiveness(
+                workspace: workspaceId,
+                surface: surfaceId,
+                state: to
+            )
+        }
     }
 }

--- a/skills/c11/references/events.md
+++ b/skills/c11/references/events.md
@@ -49,7 +49,7 @@ The nine taxonomy types below are the closed v1 enum. `workspace` / `surface` / 
 | `surface.closed` | workspace + surface | — | Surface torn down. |
 | `workspace.selected` | workspace (the selected one) | `{previous?}` | Sidebar tab switch. `previous` is the prior workspace UUID. |
 | `metadata.changed` | workspace + surface | `{scope, key, value?, prior?, source}` | A canonical/non-canonical metadata write landed. `scope` ∈ `surface`\|`pane`; `source` is the precedence tier (`explicit`\|`declare`\|`osc`\|`derived`\|`heuristic`). **`progress` is excluded in v1** (flood control); this covers `status`/`title`/`description` (+`role`/`task`/`model`). See [metadata.md](metadata.md). |
-| `liveness.derived` | workspace + surface | `{state}` | Derived agent activity, `state` ∈ `working`\|`idle`. Rides a seam with the TEL ticket (C11-162), which *produces* the derived-liveness signal; documented here as v1 taxonomy but **wired by TEL**. |
+| `liveness.derived` | workspace + surface | `{state}` | Derived agent activity, `state` ∈ `working`\|`idle`. Emitted on an actual derived working↔idle transition, computed from shell-activity ground truth; a settle back to the absent/unknown state emits nothing. |
 | `waiting.entered` | workspace (= tabId) + surface? | — | The "agent is waiting" edge — the unread-notification transition, per tab. |
 | `waiting.left` | workspace (= tabId) + surface? | — | Paired exit edge for `waiting.entered`. |
 | `mailbox.accepted` | workspace | `{id, from, to?, topic?}` | A mailbox message was accepted onto the bus. |


### PR DESCRIPTION
## What

Completes the C11-162 (telemetry) ↔ C11-163 (events) seam left open after #320 and #318 merged: the derived working/idle transition point now emits a `liveness.derived` event. Satisfies **SPEC EVT-2** — a derived transition is observable via `c11 events tail`. Until this, `liveness.derived` events silently never emitted.

## The "one-line" claim was inaccurate

The run report described this as a one-line completion. Verified against the merged code, it is not:

- Stub (from #318): `EventEmitter.emitDerivedLiveness(workspace: UUID, surface: UUID, state: String)`
- Emit site (from #320): `SurfaceLivenessDeriver.emitLivenessTransition(from: String?, to: String?, surfaceId: UUID)` — **no `workspaceId` in scope**, carries `from`/`to` not a single `state`. The doc comment's suggested `emitDerivedLiveness(surfaceId:from:to:)` matches no real signature.

Fix threads `workspaceId` through both callers (`onShellActivityChanged`, `reconcile` — both already have it) and maps the post-write destination `to` → the event `state`.

## Behavior

- Emits only on a concrete destination state (`working`/`idle`). A settle back to the absent/unknown state (`to == nil`) emits nothing — matches the stub's working|idle contract and preserves the existing "no phantom event on a precedence-rejected write" guarantee.
- Emission is off-main and non-blocking (EVT-3); safe on both callers' serial queues.

## Docs

`skills/c11/references/events.md` now documents `liveness.derived` as emitted-on-transition rather than "wired by TEL". Installed skill synced via `scripts/sync-installed-skills.sh`.

## Validation

Tagged build `c11-167` (`./scripts/reload.sh --tag c11-167`), BUILD SUCCEEDED. A real `sleep 2` in a shell-integrated surface produced a full round-trip captured live by `c11 events tail --instance c11-167-57726 --follow --filter type=liveness.derived`:

```
{"seq":11,"type":"liveness.derived","payload":{"state":"idle"},"workspace":"17D9EBD5…","surface":"45CF6333…","v":1}
{"seq":12,"type":"liveness.derived","payload":{"state":"working"},…}
{"seq":14,"type":"liveness.derived","payload":{"state":"idle"},…}
```

idle → working (`sleep` started) → idle (`sleep` finished). Full demonstration artifact attached to Lattice C11-167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)