### PR TITLE
C11-166: fix c11-unit host-lane compile (missing trigger: arg)

### DIFF
--- a/c11Tests/TerminalAndGhosttyTests.swift
+++ b/c11Tests/TerminalAndGhosttyTests.swift
@@ -2235,7 +2235,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
             "Before the external geometry sync, hit-testing should still point at the stale portal location"
         )
 
-        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows(trigger: "test")
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
         XCTAssertNil(
@@ -2293,7 +2293,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
             "Initial hit-testing should resolve the portal-hosted terminal at its original window position"
         )
 
-        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window, trigger: "test")
         DispatchQueue.main.async {
             shiftedContainer.frame.origin.x += 72
             contentView.layoutSubtreeIfNeeded()
@@ -2386,7 +2386,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
             shiftedContainer.frame.origin.x += 72
             contentView.layoutSubtreeIfNeeded()
             window.displayIfNeeded()
-            TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+            TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows(trigger: "test")
         }
 
         drainMainQueue()
@@ -2465,7 +2465,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         shiftedContainer.frame.size.width -= 72
         contentView.layoutSubtreeIfNeeded()
         window.displayIfNeeded()
-        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window, trigger: "test")
 
         drainMainQueue()
 
@@ -2610,7 +2610,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
             "Before syncing, unrelated windows should still report the stale portal location"
         )
 
-        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: firstWindow)
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: firstWindow, trigger: "test")
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
         XCTAssertNil(


### PR DESCRIPTION
## What

Fixes the pre-existing c11-unit host-lane compile break found during the Truth & Stability run (C11-164 triage). `TerminalWindowPortal`'s external-geometry-synchronize entry points now require a `trigger: String` diagnostic argument; five call sites in `c11Tests/TerminalAndGhosttyTests.swift` still used the old arity, so `xcodebuild -scheme c11-unit` failed to compile.

## Fix

Supply `trigger: "test"` at all five sites (the argument is diagnostic-only; production sites pass a descriptive event string):

- `scheduleExternalGeometrySynchronize(for:)` — lines 2296, 2468, 2613
- `scheduleExternalGeometrySynchronizeForAllWindows()` — lines 2238, 2389

(The ticket estimated the sites; two are the `ForAllWindows` overload and three are the per-window overload.)

## Verify

```
xcodebuild -project GhosttyTabs.xcodeproj -scheme c11-unit -configuration Debug \
  -destination "platform=macOS" build-for-testing
** TEST BUILD SUCCEEDED **
```

Host suite not run unattended, per repo testing policy. Test-only change; no product source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)