### PR TITLE
C11-168: web/ naming residue — cmuxterm_* event names + safe cmux branding → c11

### DIFF
--- a/web/app/[locale]/(legal)/eula/page.tsx
+++ b/web/app/[locale]/(legal)/eula/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "EULA — cmux",
-  description: "End-User License Agreement for cmux",
+  title: "EULA — c11",
+  description: "End-User License Agreement for c11",
   alternates: { canonical: "./" },
 };
 
@@ -14,7 +14,7 @@ export default function EulaPage() {
 
       <p>
         Please read this End-User License Agreement carefully before
-        downloading or using cmux.
+        downloading or using c11.
       </p>
 
       <h2>Interpretation and Definitions</h2>
@@ -26,7 +26,7 @@ export default function EulaPage() {
           regarding the use of the Application.
         </li>
         <li>
-          <strong>&ldquo;Application&rdquo;</strong> means the cmux desktop
+          <strong>&ldquo;Application&rdquo;</strong> means the c11 desktop
           application for macOS, a native terminal application built on Ghostty.
         </li>
         <li>

--- a/web/app/[locale]/(legal)/privacy-policy/page.tsx
+++ b/web/app/[locale]/(legal)/privacy-policy/page.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import { Link } from "../../../../i18n/navigation";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy — cmux",
-  description: "Privacy policy for cmux",
+  title: "Privacy Policy — c11",
+  description: "Privacy policy for c11",
   alternates: { canonical: "./" },
 };
 
@@ -23,7 +23,7 @@ export default function PrivacyPolicyPage() {
         For purposes of this policy, &ldquo;Site&rdquo; refers to the
         Company&rsquo;s website at{" "}
         <a href="https://c11.stage11.systems">c11.stage11.systems</a>.
-        &ldquo;Application&rdquo; refers to the cmux desktop application for
+        &ldquo;Application&rdquo; refers to the c11 desktop application for
         macOS. &ldquo;Service&rdquo; refers to the Site and Application
         collectively. The terms &ldquo;we,&rdquo; &ldquo;us,&rdquo; and
         &ldquo;our&rdquo; refer to the Company. &ldquo;You&rdquo; refers to

--- a/web/app/[locale]/(legal)/terms-of-service/page.tsx
+++ b/web/app/[locale]/(legal)/terms-of-service/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Service — cmux",
-  description: "Terms of service for cmux",
+  title: "Terms of Service — c11",
+  description: "Terms of service for c11",
   alternates: { canonical: "./" },
 };
 
@@ -15,7 +15,7 @@ export default function TermsOfServicePage() {
       <p>
         The website located at{" "}
         <a href="https://c11.stage11.systems">c11.stage11.systems</a> (the
-        &ldquo;Site&rdquo;) and the cmux desktop application (the
+        &ldquo;Site&rdquo;) and the c11 desktop application (the
         &ldquo;Application&rdquo;) are copyrighted works belonging to Stage 11 Agentics
         (&ldquo;Company&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;, and
         &ldquo;we&rdquo;). These Terms of Use (these &ldquo;Terms&rdquo;) set

--- a/web/app/[locale]/blog/layout.tsx
+++ b/web/app/[locale]/blog/layout.tsx
@@ -16,7 +16,7 @@ export async function generateMetadata({
       default: t("layoutTitle"),
     },
     openGraph: {
-      siteName: "cmux",
+      siteName: "c11",
       type: "article" as const,
     },
     alternates: {

--- a/web/app/[locale]/components/blog-posts.ts
+++ b/web/app/[locale]/components/blog-posts.ts
@@ -5,15 +5,15 @@ export const blogPosts = [
     title: "Cmd+Shift+U",
     date: "2026-03-04",
     summary:
-      "How Cmd+Shift+U navigates between finished agents across workspaces in cmux.",
+      "How Cmd+Shift+U navigates between finished agents across workspaces in c11.",
   },
   {
     slug: "zen-of-cmux",
     key: "zenOfCmux",
-    title: "The Zen of cmux",
+    title: "The Zen of c11",
     date: "2026-02-27",
     summary:
-      "cmux is a primitive, not a solution. It gives you composable pieces and your workflow is up to you.",
+      "c11 is a primitive, not a solution. It gives you composable pieces and your workflow is up to you.",
   },
   {
     slug: "show-hn-launch",
@@ -26,7 +26,7 @@ export const blogPosts = [
   {
     slug: "introducing-c11",
     key: "introducingCmux",
-    title: "Introducing cmux",
+    title: "Introducing c11",
     date: "2026-02-12",
     summary:
       "A native macOS terminal built on Ghostty, designed for running multiple AI coding agents side by side.",

--- a/web/app/[locale]/components/download-button.tsx
+++ b/web/app/[locale]/components/download-button.tsx
@@ -15,7 +15,7 @@ export function DownloadButton({
   return (
     <a
       href="https://github.com/Stage-11-Agentics/c11/releases/latest/download/c11-macos.dmg"
-      onClick={() => posthog.capture("cmuxterm_download_clicked", { location })}
+      onClick={() => posthog.capture("c11_download_clicked", { location })}
       className={`inline-flex items-center whitespace-nowrap rounded-full font-medium bg-foreground hover:opacity-85 transition-opacity ${
         isSmall ? "gap-2 px-4 py-1.5 text-xs" : "gap-2.5 px-5 py-2.5 text-[15px]"
       }`}

--- a/web/app/[locale]/components/github-button.tsx
+++ b/web/app/[locale]/components/github-button.tsx
@@ -10,7 +10,7 @@ export function GitHubButton({ location = "hero" }: { location?: string }) {
       href="https://github.com/Stage-11-Agentics/c11"
       target="_blank"
       rel="noopener noreferrer"
-      onClick={() => posthog.capture("cmuxterm_github_clicked", { location })}
+      onClick={() => posthog.capture("c11_github_clicked", { location })}
       className="inline-flex items-center whitespace-nowrap gap-2 rounded-full border border-border px-5 py-2.5 text-[15px] font-medium text-foreground hover:bg-code-bg transition-colors"
     >
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">

--- a/web/app/[locale]/components/github-stars.tsx
+++ b/web/app/[locale]/components/github-stars.tsx
@@ -49,7 +49,7 @@ export function GitHubStarsBadge({
       target="_blank"
       rel="noopener noreferrer"
       onClick={() =>
-        posthog.capture("cmuxterm_github_clicked", { location })
+        posthog.capture("c11_github_clicked", { location })
       }
       className={className ?? "inline-flex items-center gap-1.5 pr-1 text-sm text-muted hover:text-foreground transition-colors animate-fade-in"}
     >

--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -36,7 +36,7 @@ export function NavLinks() {
         href="https://github.com/Stage-11-Agentics/c11"
         target="_blank"
         rel="noopener noreferrer"
-        onClick={() => posthog.capture("cmuxterm_github_clicked", { location: "navbar" })}
+        onClick={() => posthog.capture("c11_github_clicked", { location: "navbar" })}
         className="hover:text-foreground transition-colors"
       >
         {t("github")}

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -34,13 +34,13 @@ export function SiteHeader({
                 <Link href="/" className="flex items-center gap-2.5">
                   <img
                     src="/logo.png"
-                    alt="cmux"
+                    alt="c11"
                     width={24}
                     height={24}
                     className="rounded-md"
                   />
                   <span className="text-sm font-semibold tracking-tight">
-                    cmux
+                    c11
                   </span>
                 </Link>
                 {section && (

--- a/web/app/[locale]/docs/changelog/changelog-media.ts
+++ b/web/app/[locale]/docs/changelog/changelog-media.ts
@@ -37,7 +37,7 @@ export const changelogMedia: Record<string, VersionMedia> = {
       {
         title: "Find in Browser",
         description:
-          "Browser panels now support Cmd+F with inline find controls, so you can search long docs, dashboards, and issue threads without leaving cmux.",
+          "Browser panels now support Cmd+F with inline find controls, so you can search long docs, dashboards, and issue threads without leaving c11.",
       },
       {
         title: "Vi Copy Mode",
@@ -52,7 +52,7 @@ export const changelogMedia: Record<string, VersionMedia> = {
       {
         title: "Expanded Localization",
         description:
-          "cmux now includes Japanese plus 16 additional languages, and a per-app language override lets you change the UI language without changing macOS system settings.",
+          "c11 now includes Japanese plus 16 additional languages, and a per-app language override lets you change the UI language without changing macOS system settings.",
       },
     ],
   },
@@ -68,7 +68,7 @@ export const changelogMedia: Record<string, VersionMedia> = {
       {
         title: "Command Palette",
         description:
-          "Hit Cmd+Shift+P to open a searchable command palette. Every action in cmux is here: creating workspaces, toggling the sidebar, checking for updates, switching windows. Keyboard shortcuts are shown inline so you can learn them as you go.",
+          "Hit Cmd+Shift+P to open a searchable command palette. Every action in c11 is here: creating workspaces, toggling the sidebar, checking for updates, switching windows. Keyboard shortcuts are shown inline so you can learn them as you go.",
         image: "/changelog/0.61.0-command-palette.png",
       },
       {
@@ -103,7 +103,7 @@ export const changelogMedia: Record<string, VersionMedia> = {
       {
         title: "Browser DevTools",
         description:
-          "The embedded browser now has full WebKit DevTools. Open them with the standard shortcut and they persist across tab switches. Inspect elements, debug JavaScript, and monitor network requests without leaving cmux.",
+          "The embedded browser now has full WebKit DevTools. Open them with the standard shortcut and they persist across tab switches. Inspect elements, debug JavaScript, and monitor network requests without leaving c11.",
         image: "/changelog/0.60.0-devtools.png",
       },
       {

--- a/web/app/[locale]/docs/changelog/page.tsx
+++ b/web/app/[locale]/docs/changelog/page.tsx
@@ -127,7 +127,7 @@ function HeroImage({ src, version }: { src: string; version: string }) {
       <div className="overflow-hidden rounded-lg">
         <Image
           src={src}
-          alt={`cmux ${version}`}
+          alt={`c11 ${version}`}
           width={width}
           height={height}
           sizes="(max-width: 640px) 100vw, 640px"

--- a/web/app/[locale]/docs/layout.tsx
+++ b/web/app/[locale]/docs/layout.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({
       default: t("layoutTitle"),
     },
     openGraph: {
-      siteName: "cmux",
+      siteName: "c11",
       type: "article" as const,
     },
     alternates: {

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -54,7 +54,7 @@ export async function generateMetadata({
       title: t("title"),
       description: t("ogDescription"),
       url,
-      siteName: "cmux",
+      siteName: "c11",
       type: "website",
     },
     twitter: {
@@ -92,7 +92,7 @@ export default async function LocaleLayout({
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
-    name: "cmux",
+    name: "c11",
     operatingSystem: "macOS",
     applicationCategory: "DeveloperApplication",
     url: SITE_URL,

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -31,12 +31,12 @@ function HomeContent() {
         <div className="flex items-center gap-4 mb-10" data-dev="header">
           <img
             src="/logo.png"
-            alt="cmux icon"
+            alt="c11 icon"
             width={48}
             height={48}
             className="rounded-xl"
           />
-          <h1 className="text-2xl font-semibold tracking-tight">cmux</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">c11</h1>
         </div>
 
         {/* Tagline */}
@@ -126,7 +126,7 @@ function HomeContent() {
         >
           <FadeImage
             src={landingImage}
-            alt="cmux terminal app screenshot"
+            alt="c11 terminal app screenshot"
             priority
             className="w-full rounded-xl"
           />


### PR DESCRIPTION
## What

The tokens/event-names half of the cmux→c11 web naming cleanup (WEB-1 in #316 handled manaflow domains/keys). Mechanical only — the **19-locale prose** in `web/messages/**` (1737 occurrences) is deliberately **out of scope**.

## Changes (15 files, net-neutral 32/32 token renames)

**PostHog event names → `c11_*`** — operator decision: rename (not alias), accepting a funnel-history rebuild; historical `cmuxterm_*` events remain queryable under the old name.
- `cmuxterm_download_clicked` → `c11_download_clicked`
- `cmuxterm_github_clicked` → `c11_github_clicked`
(download-button, nav-links, github-stars, github-button)

**Safe English product-name branding → `c11`** — operator decision: safe branding strings only.
- siteName metadata (root/docs/blog layouts)
- homepage `<h1>` + logo/screenshot alt text; site-header logo alt + wordmark
- changelog image alt + changelog prose
- legal-doc product name (privacy policy / EULA / terms of service)
- current-product blog titles/summaries

## Deliberately excluded (kept as-is)

- `web/messages/**` locale JSON (the 19-locale effort)
- URL slugs / redirects / sitemap (`zen-of-cmux`, `introducing-cmux` redirect source) — breaks links/SEO
- i18n message keys (`introducingCmux`, `zenOfCmux`, `automationCmux`, `detectingCmux`) — coupled across all 19 locales
- verbatim testimonial quotes — renaming would falsify them
- `CMUX_NOTIFICATION_*` env-var docs — must match what the app emits
- historical Show-HN claims (“Launching cmux on Show HN”, “cmux hit #2 on Hacker News…”) — true of cmux, false if renamed

## Proof

```
cmuxterm_ occurrences:  4 → 0
non-messages cmux (excl. lineage): 74 → 41  (the 41 are the intentional exclusions above)
bun tsc --noEmit  → exit 0
bun run build     → ✓ Compiled successfully (exit 0)
```

CI's web gate is `bun tsc --noEmit` (the `build` job compiles the macOS app, not web). `next build` was run locally with placeholder env and passes; the pre-existing `wallOfLove` MISSING_MESSAGE warnings are unrelated (untouched locale data) and non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)