### PR TITLE
claude-hook session-start: inject c11 orientation into fresh Claude sessions

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -15309,7 +15309,22 @@ struct CMUXCLI {
                     client: client
                 )
             }
-            print("OK")
+            // Inject a one-time orientation nudge into the fresh Claude
+            // session. This SessionStart hook already fires for every claude
+            // launched inside c11 — the Resources/bin/claude wrapper injects a
+            // per-PID `--settings` tempfile that wires it — so emitting
+            // hookSpecificOutput.additionalContext here reaches every in-c11
+            // claude with no per-agent config write. Advisory only: the hook
+            // must never fail startup, and jsonString() degrades to "{}" on any
+            // malformed input, so the worst case is a session with no nudge.
+            let orientation = "You are running inside a c11 surface: c11 is the terminal multiplexer hosting this session. Before other work, load the c11 skill. It owns tab naming, splits, surface targeting, sub-agent orchestration, the embedded browser, and sidebar telemetry. As your first action, name this tab so the operator can see your role: c11 rename-tab --surface \"$C11_SURFACE_ID\" \"<2-4 word role>\". A working agent must not sit under \"Awaiting first task\"."
+            let hookOutput: [String: Any] = [
+                "hookSpecificOutput": [
+                    "hookEventName": "SessionStart",
+                    "additionalContext": orientation
+                ]
+            ]
+            print(jsonString(hookOutput))
 
         case "stop", "idle":
             telemetry.breadcrumb("claude-hook.stop")


### PR DESCRIPTION
## What

`c11 claude-hook session-start` now emits `hookSpecificOutput.additionalContext` (a one-line orientation nudge) instead of a bare `"OK"`. The nudge tells a fresh Claude session it's inside c11, to load the **c11 skill**, and to name its tab first.

## Why

The c11 skill is the agent's steering wheel, but nothing at t=0 reinforced loading it — agents launched without acting on the CLAUDE.md triggers just saw "another terminal." The SessionStart hook is the one place that fires at session start for **every** claude in c11, with **zero per-agent install**: the `Resources/bin/claude` wrapper already injects a per-PID `--settings` tempfile wiring `SessionStart → c11 claude-hook session-start` (PATH is scoped to c11 terminals via `GhosttyTerminalView.swift`). No tenant-config write, consistent with c11's "unopinionated about the terminal" principle.

This is deliberately the claude-in-c11 path only (codex/gemini have separate wrappers with no hooks lifecycle).

## Validation (tagged build `skill-nudge`)

- Hook emits valid `additionalContext` JSON against a live socket.
- Wrapper confirmed to inject the `SessionStart → c11 claude-hook session-start` binding (stub-real-claude argv check), closing the wiring end-to-end.
- Claude Code's consumption of `additionalContext` on SessionStart is its documented, stable contract.

## Note for reviewer

This fires for **every** in-c11 claude session, including the operator's own, not just sub-agents. It's one line at session start. If that reads as noise in a human-driven session, we have a clean knob: gate on `C11_AGENT_TASK`/`C11_AGENT_TYPE` being set (distinguishes spawned sub-agents from a bare operator launch). Left ungated for now since the reinforcement helps operator sessions too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)