### PR TITLE
Sidebar: gold Waiting Agent button + gap above workspace-nav arrows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10618,7 +10618,7 @@ private struct SidebarWaitingAgentCluster: View {
     }
 
     var body: some View {
-        VStack(spacing: 1) {
+        VStack(spacing: 6) {
             WaitingAgentRow(display: display, onJump: jump)
             WorkspaceNavRow(
                 isFirstDisabled: isFirstWorkspace,
@@ -10698,14 +10698,13 @@ private struct WaitingAgentRow: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
-            // TEL-6: sustained "agent is waiting" lit state is an off-white
-            // paper-fill inversion (content flips to void) with a thin gold
-            // hairline at the fill edge — deliberately no motion; the
-            // inversion does the attention work. Rest state stays
-            // paper-white-on-void with a rule outline.
+            // Sustained "agent is waiting" lit state is a solid c11-gold
+            // fill with void (black) content — the standard c11 gold button.
+            // Deliberately no motion; the gold does the attention work. Rest
+            // state stays paper-white-on-void with a rule outline.
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(isLit ? BrandColors.paperFillSwiftUI : BrandColors.surfaceSwiftUI)
+                    .fill(isLit ? BrandColors.goldSwiftUI : BrandColors.surfaceSwiftUI)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)


### PR DESCRIPTION
## What

Three small sidebar tweaks to the Waiting Agent + Workspace Nav cluster:

1. **Gold Waiting Agent button.** The lit "agent is waiting" state used an off-white paper-fill (TEL-6) that read as whitish. Reverted to a solid **c11-gold** fill with void (black) content — the standard c11 gold button.
2. **Gap above the arrows.** Bumped the cluster `VStack` spacing `1 → 6` so there's a visible gap between the Waiting Agent button and the ▲/▼ workspace-nav arrows.
3. **Assignable arrow shortcuts — already present, verified.** The ▲/▼ arrows trigger `.prevSidebarTab` / `.nextSidebarTab`, which are AppStorage-backed and rebindable in **Settings → Keyboard Shortcuts → Navigation** (defaults ⌃⌘[ / ⌃⌘]). No code change needed.

## Validation (tagged build `waiting-gold`)

Screenshot with the lit state triggered via `c11 notify`:
- Waiting Agent button renders solid c11 gold with black content ✓
- Clear gap between the button and the ▲/▼ arrow row ✓

Only `Sources/ContentView.swift` changed. No new user-facing strings, so no localization pass needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)