### PR TITLE
Fix crash-recovery resume for underscore (and other non-alphanumeric) cwds

### DIFF
--- a/Sources/Conversation/Strategies/ClaudeCode.swift
+++ b/Sources/Conversation/Strategies/ClaudeCode.swift
@@ -87,15 +87,29 @@ struct ClaudeCodeStrategy: ConversationStrategy {
     }
 
     /// Claude Code derives the per-project transcript directory by replacing
-    /// every `/` and `.` in the absolute cwd with `-`. Example:
+    /// **every character that is not an ASCII letter or digit** with `-`
+    /// (JavaScript `cwd.replace(/[^a-zA-Z0-9]/g, "-")`). So `/`, `.`, `_`,
+    /// spaces — all separators — map to `-`, while existing `-` and letter/
+    /// digit case are preserved. Examples:
     /// `/Users/atin/Projects/Stage11/code/c11` →
-    /// `-Users-atin-Projects-Stage11-code-c11`. A path containing `/.claude`
-    /// collapses to `--claude` (slash + dot both map to `-`).
+    /// `-Users-atin-Projects-Stage11-code-c11`; a `/.claude` segment collapses
+    /// to `--claude`; `…/singularist_salon` → `…-singularist-salon`.
+    ///
+    /// Matching this exactly is load-bearing for crash recovery: an
+    /// underscore (or any other non-alphanumeric) left untranslated points
+    /// `transcriptExists` at a directory Claude never created, so a perfectly
+    /// resumable session is misclassified "transcript not found" and silently
+    /// refused on restore.
     static func projectSlug(forCwd cwd: String) -> String {
         var out = ""
-        out.reserveCapacity(cwd.count)
-        for ch in cwd {
-            out.append(ch == "/" || ch == "." ? "-" : ch)
+        out.unicodeScalars.reserveCapacity(cwd.unicodeScalars.count)
+        for scalar in cwd.unicodeScalars {
+            let v = scalar.value
+            let isASCIIAlphanumeric =
+                (v >= 48 && v <= 57)   // 0-9
+                || (v >= 65 && v <= 90)   // A-Z
+                || (v >= 97 && v <= 122)  // a-z
+            out.unicodeScalars.append(isASCIIAlphanumeric ? scalar : "-")
         }
         return out
     }

--- a/c11Tests/ConversationCrashRecoveryTests.swift
+++ b/c11Tests/ConversationCrashRecoveryTests.swift
@@ -45,7 +45,7 @@ final class ConversationCrashRecoveryTests: XCTestCase {
 
     // MARK: - Slug derivation
 
-    func testProjectSlugReplacesSlashesAndDots() {
+    func testProjectSlugReplacesEveryNonAlphanumeric() {
         XCTAssertEqual(
             ClaudeCodeStrategy.projectSlug(forCwd: "/Users/atin/Projects/Stage11/code/c11"),
             "-Users-atin-Projects-Stage11-code-c11"
@@ -54,6 +54,24 @@ final class ConversationCrashRecoveryTests: XCTestCase {
         XCTAssertEqual(
             ClaudeCodeStrategy.projectSlug(forCwd: "/Users/atin/Projects/Stage11/code/c11/.claude/worktrees/c11-41"),
             "-Users-atin-Projects-Stage11-code-c11--claude-worktrees-c11-41"
+        )
+    }
+
+    /// Regression: underscores in the cwd must slug to `-`, exactly as Claude
+    /// Code encodes them. A prior implementation translated only `/` and `.`,
+    /// so every underscore-cwd session (`…/singularist_salon`,
+    /// `…/govee_control`) was pointed at a nonexistent transcript dir on crash
+    /// recovery and silently refused to resume.
+    func testProjectSlugReplacesUnderscoresAndPunctuation() {
+        XCTAssertEqual(
+            ClaudeCodeStrategy.projectSlug(
+                forCwd: "/Users/atin/Projects/Gregorovich/projects/singularist_salon"),
+            "-Users-atin-Projects-Gregorovich-projects-singularist-salon"
+        )
+        // Mixed separators each map to a single dash; digits and case survive.
+        XCTAssertEqual(
+            ClaudeCodeStrategy.projectSlug(forCwd: "/tmp/a_b.c-d E"),
+            "-tmp-a-b-c-d-E"
         )
     }
 
@@ -71,6 +89,23 @@ final class ConversationCrashRecoveryTests: XCTestCase {
         let ref = ConversationRef(kind: "claude-code", id: uuidA, cwd: cwd,
                                   capturedVia: .hook, state: .suspended)
         XCTAssertEqual(ClaudeCodeStrategy().transcriptExists(for: ref, filesystem: fs), false)
+    }
+
+    /// The true crash-recovery regression guard: the transcript lives at the
+    /// DASHED slug dir Claude actually creates. The expected path is written
+    /// out by hand (not via `projectSlug`/`mockFS`) so a slug bug can't cancel
+    /// itself out on both sides of the comparison — the exact way the original
+    /// underscore defect slipped past `testTranscriptExists…WhenPresent`.
+    func testTranscriptExistsFindsUnderscoreCwdTranscriptOnDisk() {
+        let fs = MockFS()  // home = /Users/test
+        let underscoreCwd = "/Users/atin/Projects/Gregorovich/projects/singularist_salon"
+        fs.existingPaths.insert(
+            "/Users/test/.claude/projects/"
+            + "-Users-atin-Projects-Gregorovich-projects-singularist-salon/\(uuidA).jsonl"
+        )
+        let ref = ConversationRef(kind: "claude-code", id: uuidA, cwd: underscoreCwd,
+                                  capturedVia: .hook, state: .suspended)
+        XCTAssertEqual(ClaudeCodeStrategy().transcriptExists(for: ref, filesystem: fs), true)
     }
 
     func testTranscriptExistsNilWhenCwdMissing() {


### PR DESCRIPTION
## What

`ClaudeCodeStrategy.projectSlug` translated only `/` and `.` to `-`. Claude Code actually encodes a project's transcript directory with `cwd.replace(/[^a-zA-Z0-9]/g, "-")` — **every** non-alphanumeric char, underscores included, becomes `-`.

Result: for a cwd like `…/projects/singularist_salon`, c11 looked for the transcript under `…-singularist_salon/` while Claude wrote it to `…-singularist-salon/`.

## Impact (observed live)

On a dirty shutdown, `reclassifyAfterCrash` stats the transcript path via `transcriptExists` to decide if a session is resumable. For any underscore-containing cwd the stat missed → ref marked `state=unknown` (`"crash recovery: transcript not found"`) → `resume()` skipped it.

So after a crash, whole workspaces whose cwd had an underscore came back **empty**, even though their transcripts were intact on disk:

| Workspace | cwd | Resumed before fix |
|---|---|---|
| Salon Chord | `…/singularist_salon` | ❌ |
| Light Control | `…/govee_control` | ❌ |
| (every underscore-free workspace) | — | ✅ |

## Fix

Broaden `projectSlug` to replace any character outside `[A-Za-z0-9]` with `-`, matching Claude Code exactly (existing hyphens and letter/digit case preserved).

## Tests

The prior `transcriptExists` tests built their mock paths through the *same* buggy `projectSlug`, so the defect cancelled out on both sides and slipped through. Added:

- `testTranscriptExistsFindsUnderscoreCwdTranscriptOnDisk` — pins the real dashed on-disk path **by hand** so a slug regression can't self-cancel.
- `testProjectSlugReplacesUnderscoresAndPunctuation` — direct slug assertion.

Both fail against the old slug. Full `ConversationCrashRecoveryTests` class green (17/17) on `c11-logic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)