### PR TITLE
Sidebar: rule-gray hairline outline on every workspace card

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11432,16 +11432,18 @@ private struct TabItemView: View, Equatable {
         explicitRailColor != nil
     }
 
-    // The selected workspace is conveyed by one consistent signal in every
-    // indicator style: a thick white outline. Custom-colored workspaces keep
-    // their color as a rail (.leftRail) or fill (.solidFill) for identity, but
-    // selection itself is always the white outline.
+    // Every workspace row carries a rule-gray hairline so it reads as one
+    // cohesive card against the void. Selection is conveyed by one consistent
+    // signal in every indicator style: the hairline thickens into a white
+    // outline. Custom-colored workspaces keep their color as a rail
+    // (.leftRail) or fill (.solidFill) for identity, but selection itself is
+    // always the white outline.
     private var activeBorderLineWidth: CGFloat {
-        isActive ? 2.5 : 0
+        isActive ? 2.5 : 1
     }
 
     private var activeBorderColor: Color {
-        isActive ? BrandColors.whiteSwiftUI : .clear
+        isActive ? BrandColors.whiteSwiftUI : BrandColors.ruleSwiftUI
     }
 
     // When a workspace has a custom color and is selected in .solidFill mode,


### PR DESCRIPTION
## Summary
Unselected workspace items in the sidebar rendered with no border at all — uncolored workspaces floated as bare text on the void, with nothing marking each item as one cohesive card.

Every row now carries a 1pt `BrandColors.rule` (#333333) hairline, the same gray already used on the Working pill and the Waiting Agent button's rest state. Selection keeps its existing signal: the same stroke thickens into the 2.5pt white outline. Custom-colored workspaces keep their fill/rail, now edged by the hairline when unselected.

## Validation
Tagged build (`waiting-agent-gold` reused tag), QA fresh launch, four workspaces created via socket CLI. Screenshot confirms each unselected card carries the gray hairline and the selected workspace remains clearly distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)