### PR TITLE
Release v0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.59.0] - 2026-07-14
+
+Headline: **`c11 send` actually submits.** Sending a message to an agent in a background workspace — the normal fleet case, where only one workspace is on screen — used to type the text and silently drop the Return, so the message sat unsent in the composer while `send` reported OK. A briefed-looking agent that never received anything was the single biggest source of friction in multi-agent runs. That path is fixed four ways, and `send` now tells you what actually happened (`submitted` / `queued` / `delivered`) instead of only "bytes accepted."
+
+### Added
+
+- **Fresh Claude Code sessions get oriented to c11 automatically.** A session-start claude-hook injects a short c11 orientation into new Claude sessions, so an agent launched inside a c11 surface knows it can drive panes, report status, and target other surfaces without being told. ([#328](https://github.com/Stage-11-Agentics/c11/pull/328)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+
+### Changed
+
+- **Waiting Agent button restyled.** The sidebar's next-notification control gets a gold lit state and a cleaner gap above the workspace-nav arrows. ([#329](https://github.com/Stage-11-Agentics/c11/pull/329)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+- **Every workspace card now carries a rule-gray hairline outline** in the sidebar, so cards read as discrete surfaces at a glance. ([#331](https://github.com/Stage-11-Agentics/c11/pull/331)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+
+### Fixed
+
+- **`c11 send` reliably submits — including into a background workspace.** Four defects fixed together: (1) the submit Return was dropped for any pane not in an on-screen window (the fleet case — a background agent got typed at but never submitted), now injected straight into Ghostty so it lands regardless of window; (2) multi-line briefs fragmented into one turn per line or tripped the TUI's paste heuristic and submitted nothing — prose now goes out as a real bracketed paste with a single trailing Return, so a brief arrives whole; (3) `send-key space` wrote nothing (keycode-only printable keys encoded to zero bytes) and now emits its character; (4) an empty or stale `--surface` ref silently misrouted to the caller's own input box and is now a hard error, while an explicit surface ref resolves across workspaces. `send` also reports `submitted` / `queued` / `delivered` rather than a bare OK. ([#340](https://github.com/Stage-11-Agentics/c11/pull/340)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+- **Crash-recovery resume works for working directories with underscores** (or any non-alphanumeric character). A path like `~/Projects/my_app` no longer blocks a surface's conversation from resuming after a crash or force-quit. ([#330](https://github.com/Stage-11-Agentics/c11/pull/330)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+
+### Thanks to 1 contributor!
+
+[@BenevolentFutures](https://github.com/BenevolentFutures)
+
 ## [0.58.0] - 2026-07-08
 
 The Truth & Stability release. Headline: **the sidebar stops lying.** Every status an agent reports now carries its age and visibly decays when it goes stale, and c11 itself derives a live working/idle state for every terminal from what it can observe externally — so a pane whose agent never self-reports (or stopped reporting twenty minutes ago) still shows the truth. Alongside it: a subscribable **events stream** (`c11 events tail`) so agents and tools can react to workspace changes instead of polling, **crash-proof session resume** (force-quit or crash, relaunch, your agent conversations come back), and the elimination of a class of main-thread hangs and silent write-misroutes on the socket.

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -2031,10 +2031,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2112,7 +2112,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -2122,7 +2122,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -2153,7 +2153,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -2163,7 +2163,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -2231,10 +2231,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2249,14 +2249,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2271,14 +2271,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2294,10 +2294,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2313,10 +2313,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 116;
+				CURRENT_PROJECT_VERSION = 117;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.58.0;
+				MARKETING_VERSION = 0.59.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## v0.59.0 — "send actually submits"

Cuts the release for the 5 user-facing changes merged since v0.58.0. Headline is the **`c11 send` fix (#340)**: sending to an agent in a background workspace typed the text but silently dropped the submit Return, so messages sat unsent while `send` reported OK — the biggest friction source in multi-agent runs.

### Changelog
**Added**
- Session-start claude-hook injects c11 orientation into fresh Claude sessions (#328)

**Changed**
- Sidebar: gold Waiting Agent button + gap above nav arrows (#329)
- Sidebar: rule-gray hairline outline on every workspace card (#331)

**Fixed**
- `c11 send` reliably submits — background-workspace submit, multi-line paste stays whole, `send-key space`, empty/stale-ref rejection; response now reports `submitted`/`queued`/`delivered` (#340)
- Crash-recovery resume for cwds with underscores / non-alphanumeric chars (#330)

### Version
- `MARKETING_VERSION` 0.58.0 → 0.59.0, `CURRENT_PROJECT_VERSION` 116 → 117

### Test plan
- All five changes are already merged and reviewed on `main`; this PR is version bump + changelog only.
- The send fix (#340) ships with 5 `tests_v2` socket tests (incl. the exact background-workspace repro using a Return-only sentinel) + a C0-range logic test, plus an independent code review this cycle.
- Security threat-model recheck: release-range diff touches none of the security-sensitive surfaces (Info.plist / entitlements / sdef / SocketControl* / URL handler / WebView config) — no posture change.
- **Note:** the usual pre-merge staging smoke (`reloads.sh`) was intentionally skipped this cycle — the operator has a live multi-agent fleet running, and `reloads.sh` resumes the shared session snapshot (isolated socket but not session state), which bounces the live app. Filed as a follow-up. CI runs the full test suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)