### PR TITLE
CLI: close-surface honors a named surface ref instead of silently closing the caller

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -5277,16 +5277,15 @@ struct CMUXCLI {
 
         let action = actionRaw.lowercased().replacingOccurrences(of: "-", with: "_")
 
-        // A leftover positional handle is a mis-typed target, not a title. Left
-        // alone it is swallowed into `title` and the tab resolver falls back to
-        // $CMUX_TAB_ID/$CMUX_SURFACE_ID, so `tab-action --action close-others
-        // surface:9` would close every tab *except* the caller's, while the
-        // operator is looking at the ref they typed. Refuse instead: the
-        // positional slot here already belongs to the action and the rename
-        // title, so there is no unambiguous way to honor it.
-        if action != "rename",
-           let stray = positional.first(where: { CLISurfaceRefArguments.looksLikeHandle($0) }) {
-            throw CLIError(message: "tab-action: unexpected argument '\(stray)'. Did you mean '--tab \(stray)'?")
+        // Only rename owns trailing positional arguments (its title). For every
+        // other action, refuse every leftover token: accepting a handle, bare
+        // index, malformed handle, or arbitrary text would discard the apparent
+        // target and let the action fall back to the caller-focused tab.
+        if let rejection = CLISurfaceRefArguments.tabActionPositionalRejection(
+            action: action,
+            positional: positional
+        ) {
+            throw CLIError(message: rejection)
         }
 
         let workspaceArg = workspaceOpt ?? (windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -5359,10 +5359,22 @@ struct CMUXCLI {
         idFormat: CLIIDFormat,
         windowOverride: String?
     ) throws {
-        let (workspaceOpt, rem0) = parseOption(commandArgs, name: "--workspace")
-        let (tabOpt, rem1) = parseOption(rem0, name: "--tab")
-        let (surfaceOpt, rem2) = parseOption(rem1, name: "--surface")
-        let (titleOpt, rem3) = parseOption(rem2, name: "--title")
+        // `rename-tab` is a compatibility wrapper over `tab-action rename`.
+        // Parse its target flags through the same conflict-aware seam before
+        // forwarding so distinct repeated/cross-alias targets cannot collapse
+        // to the generic option parser's last value.
+        let targetPlan: CLISurfaceRefArguments.TabActionTargetPlan
+        switch CLISurfaceRefArguments.parseTabActionTargets(
+            commandArgs,
+            commandName: "rename-tab"
+        ) {
+        case .plan(let plan):
+            targetPlan = plan
+        case .reject(let message):
+            throw CLIError(message: message)
+        }
+
+        let (titleOpt, rem3) = parseOption(targetPlan.remaining, name: "--title")
 
         if rem3.contains("--action") {
             throw CLIError(message: "rename-tab does not accept --action (it always performs rename)")
@@ -5383,13 +5395,14 @@ struct CMUXCLI {
         }
 
         var forwarded: [String] = ["--action", "rename", "--title", title]
-        if let workspaceOpt {
-            forwarded += ["--workspace", workspaceOpt]
+        if let workspace = targetPlan.workspace {
+            forwarded += ["--workspace", workspace]
         }
-        if let tabOpt {
-            forwarded += ["--tab", tabOpt]
-        } else if let surfaceOpt {
-            forwarded += ["--surface", surfaceOpt]
+        if let target = targetPlan.target {
+            // `runTabAction` deliberately accepts both tab and surface refs
+            // through either alias, so one canonical forwarding flag keeps the
+            // wrapper from reintroducing alias precedence.
+            forwarded += ["--tab", target]
         }
 
         try runTabAction(

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2322,9 +2322,21 @@ struct CMUXCLI {
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
         case "close-surface":
-            let csWsFlag = optionValue(commandArgs, name: "--workspace")
+            // Closing the caller's own surface is the right default for a bare
+            // `c11 close-surface`, and only for a bare one. Any argument that
+            // names a target is honored or refused, never discarded: a discarded
+            // ref used to fall through to $CMUX_SURFACE_ID and make
+            // `c11 close-surface surface:101` silently mean "close myself".
+            let csPlan: CLISurfaceRefArguments.CloseSurfacePlan
+            switch CLISurfaceRefArguments.parseCloseSurface(commandArgs) {
+            case .reject(let message):
+                throw CLIError(message: message)
+            case .plan(let parsed):
+                csPlan = parsed
+            }
+            let csWsFlag = csPlan.workspace
             let workspaceArg = csWsFlag ?? (windowId == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-            let surfaceRaw = optionValue(commandArgs, name: "--surface") ?? optionValue(commandArgs, name: "--panel") ?? (csWsFlag == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
+            let surfaceRaw = csPlan.surface ?? (csWsFlag == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
             var params: [String: Any] = [:]
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
@@ -5264,6 +5276,19 @@ struct CMUXCLI {
         }
 
         let action = actionRaw.lowercased().replacingOccurrences(of: "-", with: "_")
+
+        // A leftover positional handle is a mis-typed target, not a title. Left
+        // alone it is swallowed into `title` and the tab resolver falls back to
+        // $CMUX_TAB_ID/$CMUX_SURFACE_ID, so `tab-action --action close-others
+        // surface:9` would close every tab *except* the caller's, while the
+        // operator is looking at the ref they typed. Refuse instead: the
+        // positional slot here already belongs to the action and the rename
+        // title, so there is no unambiguous way to honor it.
+        if action != "rename",
+           let stray = positional.first(where: { CLISurfaceRefArguments.looksLikeHandle($0) }) {
+            throw CLIError(message: "tab-action: unexpected argument '\(stray)'. Did you mean '--tab \(stray)'?")
+        }
+
         let workspaceArg = workspaceOpt ?? (windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
         let tabArg = tabOpt
             ?? surfaceOpt
@@ -8701,9 +8726,12 @@ struct CMUXCLI {
             """
         case "close-surface":
             return """
-            Usage: c11 close-surface [flags]
+            Usage: c11 close-surface [<surface>] [flags]
 
-            Close a surface. Defaults to the focused surface if none specified.
+            Close a surface. With no arguments, closes the caller's own surface
+            ($CMUX_SURFACE_ID). Naming a target, positionally or by flag, never
+            falls back to the caller's surface; an argument that cannot be
+            honored is an error, not a silent default.
 
             Flags:
               --surface <id|ref>     Surface to close (default: $CMUX_SURFACE_ID)
@@ -8712,7 +8740,9 @@ struct CMUXCLI {
 
             Example:
               c11 close-surface
+              c11 close-surface surface:3
               c11 close-surface --surface surface:3
+              c11 close-surface --surface=surface:3
             """
         case "drag-surface-to-split":
             return """

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -5253,14 +5253,20 @@ struct CMUXCLI {
         idFormat: CLIIDFormat,
         windowOverride: String?
     ) throws {
-        let (workspaceOpt, rem0) = parseOption(commandArgs, name: "--workspace")
-        let (tabOpt, rem1) = parseOption(rem0, name: "--tab")
-        let (surfaceOpt, rem2) = parseOption(rem1, name: "--surface")
-        let (actionOpt, rem3) = parseOption(rem2, name: "--action")
-        let (titleOpt, rem4) = parseOption(rem3, name: "--title")
-        let (urlOpt, rem5) = parseOption(rem4, name: "--url")
+        let targetPlan: CLISurfaceRefArguments.TabActionTargetPlan
+        switch CLISurfaceRefArguments.parseTabActionTargets(commandArgs) {
+        case .plan(let plan):
+            targetPlan = plan
+        case .reject(let message):
+            throw CLIError(message: message)
+        }
 
-        var positional = rem5
+        let workspaceOpt = targetPlan.workspace
+        let (actionOpt, rem0) = parseOption(targetPlan.remaining, name: "--action")
+        let (titleOpt, rem1) = parseOption(rem0, name: "--title")
+        let (urlOpt, rem2) = parseOption(rem1, name: "--url")
+
+        var positional = rem2
         let actionRaw: String
         if let actionOpt {
             actionRaw = actionOpt
@@ -5289,8 +5295,7 @@ struct CMUXCLI {
         }
 
         let workspaceArg = workspaceOpt ?? (windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-        let tabArg = tabOpt
-            ?? surfaceOpt
+        let tabArg = targetPlan.target
             ?? (workspaceOpt == nil && windowOverride == nil
                 ? (ProcessInfo.processInfo.environment["CMUX_TAB_ID"] ?? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"])
                 : nil)

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		2DAD13E51CF90A021D8893D5 /* SocketSurfaceRefRejectionWiringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36732611CC1BEFB8D99BB606 /* SocketSurfaceRefRejectionWiringTests.swift */; };
 		2E31BAE909C0A3DD44589F3E /* HealthIPSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */; };
 		3175B7C8AE075F8D71BFA104 /* CLIAdvisoryConnectivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70B3BF1A1B2C3D4E5F60720 /* CLIAdvisoryConnectivityTests.swift */; };
+		D71C0FE2A1B2C3D4E5F60718 /* CLISurfaceRefArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71C0FE3A1B2C3D4E5F60718 /* CLISurfaceRefArgumentsTests.swift */; };
 		33575F7E4C63569F35E154A9 /* NewWorkspaceTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */; };
 		352C25FFD890137B5F7A23B3 /* AgentManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */; };
 		ACB000000000000000000101 /* AgentCompanionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACB000000000000000000001 /* AgentCompanionContext.swift */; };
@@ -347,6 +348,8 @@
 		D70A3BF0A1B2C3D4E5F60719 /* WorkspaceMetadataKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */; };
 		D70B3BF0A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70B3BF1A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift */; };
 		D70B3BF0A1B2C3D4E5F60719 /* CLIAdvisoryConnectivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70B3BF1A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift */; };
+		D71C0FE0A1B2C3D4E5F60718 /* CLISurfaceRefArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71C0FE1A1B2C3D4E5F60718 /* CLISurfaceRefArguments.swift */; };
+		D71C0FE0A1B2C3D4E5F60719 /* CLISurfaceRefArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = D71C0FE1A1B2C3D4E5F60718 /* CLISurfaceRefArguments.swift */; };
 		D7100BF0A1B2C3D4E5F60718 /* MailboxLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7100BF1A1B2C3D4E5F60718 /* MailboxLayout.swift */; };
 		D7102BF0A1B2C3D4E5F60718 /* MailboxIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7102BF1A1B2C3D4E5F60718 /* MailboxIO.swift */; };
 		D7103BF0A1B2C3D4E5F60718 /* MailboxULID.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7103BF1A1B2C3D4E5F60718 /* MailboxULID.swift */; };
@@ -787,7 +790,9 @@
 		D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataKeys.swift; sourceTree = "<group>"; };
 		D70A4BF1A1B2C3D4E5F60718 /* WorkspaceMetadataValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceMetadataValidatorTests.swift; sourceTree = "<group>"; };
 		D70B3BF1A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAdvisoryConnectivity.swift; sourceTree = "<group>"; };
+		D71C0FE1A1B2C3D4E5F60718 /* CLISurfaceRefArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISurfaceRefArguments.swift; sourceTree = "<group>"; };
 		D70B3BF1A1B2C3D4E5F60720 /* CLIAdvisoryConnectivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAdvisoryConnectivityTests.swift; sourceTree = "<group>"; };
+		D71C0FE3A1B2C3D4E5F60718 /* CLISurfaceRefArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISurfaceRefArgumentsTests.swift; sourceTree = "<group>"; };
 		D7100BF1A1B2C3D4E5F60718 /* MailboxLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxLayout.swift; sourceTree = "<group>"; };
 		D7101BF1A1B2C3D4E5F60718 /* MailboxLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailboxLayoutTests.swift; sourceTree = "<group>"; };
 		D7102BF1A1B2C3D4E5F60718 /* MailboxIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mailbox/MailboxIO.swift; sourceTree = "<group>"; };
@@ -1046,6 +1051,7 @@
 				A5001543 /* SurfaceMetadataStore.swift */,
 				D70A3BF1A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift */,
 				D70B3BF1A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift */,
+				D71C0FE1A1B2C3D4E5F60718 /* CLISurfaceRefArguments.swift */,
 				D7005BF1A1B2C3D4E5F60718 /* PersistedMetadata.swift */,
 				D7010BF1A1B2C3D4E5F60718 /* PaneMetadataStore.swift */,
 				D7C24002A1B2C3D4E5F60718 /* SurfaceManifestView.swift */,
@@ -1368,6 +1374,7 @@
 				D8019BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintMarkdownTests.swift */,
 				D801BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotSetCodableTests.swift */,
 				D70B3BF1A1B2C3D4E5F60720 /* CLIAdvisoryConnectivityTests.swift */,
+				D71C0FE3A1B2C3D4E5F60718 /* CLISurfaceRefArgumentsTests.swift */,
 				A5C36031 /* StatusBarButtonDisplayTests.swift */,
 				D7101BF1A1B2C3D4E5F60718 /* MailboxLayoutTests.swift */,
 				D7104BF1A1B2C3D4E5F60718 /* MailboxIOTests.swift */,
@@ -1664,6 +1671,7 @@
 				53A8353DD72E0C6954D5F42A /* ChromeScaleSettingsTests.swift in Sources */,
 				9C51A1CE6AEEBF2E0B4C3E61 /* ChromeScaleTokensTests.swift in Sources */,
 				3175B7C8AE075F8D71BFA104 /* CLIAdvisoryConnectivityTests.swift in Sources */,
+				D71C0FE2A1B2C3D4E5F60718 /* CLISurfaceRefArgumentsTests.swift in Sources */,
 				C622796239CFCFB69D68C5D9 /* CLIHealthRuntimeTests.swift in Sources */,
 				C75D53A733AD58B6F40CFE9C /* CLIResolutionSnapshotTests.swift in Sources */,
 				949D60897130D3A2A359CC20 /* CommandPaletteSearchEngineTests.swift in Sources */,
@@ -1802,6 +1810,7 @@
 				A5001542 /* SurfaceMetadataStore.swift in Sources */,
 				D70A3BF0A1B2C3D4E5F60718 /* WorkspaceMetadataKeys.swift in Sources */,
 				D70B3BF0A1B2C3D4E5F60718 /* CLIAdvisoryConnectivity.swift in Sources */,
+				D71C0FE0A1B2C3D4E5F60718 /* CLISurfaceRefArguments.swift in Sources */,
 				D7005BF0A1B2C3D4E5F60718 /* PersistedMetadata.swift in Sources */,
 				D7010BF0A1B2C3D4E5F60718 /* PaneMetadataStore.swift in Sources */,
 				D7C24001A1B2C3D4E5F60718 /* SurfaceManifestView.swift in Sources */,
@@ -1998,6 +2007,7 @@
 				D7206BF0A1B2C3D4E5F60719 /* MailboxEnvelope.swift in Sources */,
 				D70A3BF0A1B2C3D4E5F60719 /* WorkspaceMetadataKeys.swift in Sources */,
 				D70B3BF0A1B2C3D4E5F60719 /* CLIAdvisoryConnectivity.swift in Sources */,
+				D71C0FE0A1B2C3D4E5F60719 /* CLISurfaceRefArguments.swift in Sources */,
 				75B580E4A1859423B310E203 /* EventLogLayout.swift in Sources */,
 				365F4BE2806EC0D12A9336BD /* EventEnvelope.swift in Sources */,
 				D1510386129C337B5868E50D /* AgentLaunchStats.swift in Sources */,

--- a/Sources/CLISurfaceRefArguments.swift
+++ b/Sources/CLISurfaceRefArguments.swift
@@ -151,12 +151,16 @@ public enum CLISurfaceRefArguments {
     }
 
     /// Consume `--workspace`, `--tab`, and `--surface` from a `tab-action`
-    /// command line without the generic option parser's last-value-wins
-    /// behavior. Distinct repeated values — whether on one flag or split
-    /// across the `--tab`/`--surface` aliases — are ambiguous destructive
-    /// targets and reject before any socket resolution or dispatch. Repeating
-    /// the same trimmed value is harmless and remains accepted.
-    public static func parseTabActionTargets(_ args: [String]) -> TabActionTargetParseResult {
+    /// command line or one of its compatibility wrappers without the generic
+    /// option parser's last-value-wins behavior. Distinct repeated values —
+    /// whether on one flag or split across the `--tab`/`--surface` aliases —
+    /// are ambiguous destructive targets and reject before any socket
+    /// resolution or dispatch. Repeating the same trimmed value is harmless
+    /// and remains accepted.
+    public static func parseTabActionTargets(
+        _ args: [String],
+        commandName: String = "tab-action"
+    ) -> TabActionTargetParseResult {
         let targetFlags: Set<String> = ["--workspace", "--tab", "--surface"]
         var namedWorkspaces: [String] = []
         var namedTargets: [String] = []
@@ -179,15 +183,15 @@ public enum CLISurfaceRefArguments {
             }
 
             guard index + 1 < args.count else {
-                return .reject("tab-action: flag '\(raw)' requires a value")
+                return .reject("\(commandName): flag '\(raw)' requires a value")
             }
             let value = args[index + 1]
             guard !value.hasPrefix("--") else {
-                return .reject("tab-action: flag '\(raw)' requires a value, got another flag '\(value)'")
+                return .reject("\(commandName): flag '\(raw)' requires a value, got another flag '\(value)'")
             }
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else {
-                return .reject("tab-action: flag '\(raw)' requires a non-empty value")
+                return .reject("\(commandName): flag '\(raw)' requires a non-empty value")
             }
 
             if raw == "--workspace" {
@@ -201,13 +205,13 @@ public enum CLISurfaceRefArguments {
         let distinctWorkspaces = distinctTrimmedValues(namedWorkspaces)
         if distinctWorkspaces.count > 1 {
             let listed = distinctWorkspaces.sorted().joined(separator: ", ")
-            return .reject("tab-action: more than one workspace named (\(listed)). Name exactly one workspace.")
+            return .reject("\(commandName): more than one workspace named (\(listed)). Name exactly one workspace.")
         }
 
         let distinctTargets = distinctTrimmedValues(namedTargets)
         if distinctTargets.count > 1 {
             let listed = distinctTargets.sorted().joined(separator: ", ")
-            return .reject("tab-action: more than one tab or surface named (\(listed)). Name exactly one target.")
+            return .reject("\(commandName): more than one tab or surface named (\(listed)). Name exactly one target.")
         }
 
         return .plan(TabActionTargetPlan(

--- a/Sources/CLISurfaceRefArguments.swift
+++ b/Sources/CLISurfaceRefArguments.swift
@@ -45,6 +45,26 @@ public enum CLISurfaceRefArguments {
         case reject(String)
     }
 
+    /// Target flags consumed from a `tab-action` command line. `remaining`
+    /// preserves action/title/url flags and positional rename text for the
+    /// command runner to parse normally.
+    public struct TabActionTargetPlan: Equatable {
+        public let workspace: String?
+        public let target: String?
+        public let remaining: [String]
+
+        public init(workspace: String?, target: String?, remaining: [String]) {
+            self.workspace = workspace
+            self.target = target
+            self.remaining = remaining
+        }
+    }
+
+    public enum TabActionTargetParseResult: Equatable {
+        case plan(TabActionTargetPlan)
+        case reject(String)
+    }
+
     private static let knownValueFlags: Set<String> = ["--surface", "--panel", "--workspace"]
 
     private static let knownFlagsHelp =
@@ -56,7 +76,7 @@ public enum CLISurfaceRefArguments {
     /// positional surface handle (`c11 close-surface surface:101`), and refuses
     /// anything else rather than silently discarding it.
     public static func parseCloseSurface(_ args: [String]) -> ParseResult {
-        var workspace: String?
+        var namedWorkspaces: [String] = []
         var namedSurfaces: [String] = []
         var index = 0
 
@@ -105,11 +125,17 @@ public enum CLISurfaceRefArguments {
             }
 
             if name == "--workspace" {
-                workspace = value
+                namedWorkspaces.append(value)
             } else {
                 namedSurfaces.append(value)
             }
             index += 1
+        }
+
+        let distinctWorkspaces = distinctTrimmedValues(namedWorkspaces)
+        if distinctWorkspaces.count > 1 {
+            let listed = distinctWorkspaces.sorted().joined(separator: ", ")
+            return .reject("close-surface: more than one workspace named (\(listed)). Name exactly one workspace.")
         }
 
         let distinct = Set(namedSurfaces.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })
@@ -118,7 +144,77 @@ public enum CLISurfaceRefArguments {
             return .reject("close-surface: more than one surface named (\(listed)). Name exactly one target.")
         }
 
-        return .plan(CloseSurfacePlan(workspace: workspace, surface: namedSurfaces.first))
+        return .plan(CloseSurfacePlan(
+            workspace: distinctWorkspaces.first,
+            surface: distinct.first
+        ))
+    }
+
+    /// Consume `--workspace`, `--tab`, and `--surface` from a `tab-action`
+    /// command line without the generic option parser's last-value-wins
+    /// behavior. Distinct repeated values — whether on one flag or split
+    /// across the `--tab`/`--surface` aliases — are ambiguous destructive
+    /// targets and reject before any socket resolution or dispatch. Repeating
+    /// the same trimmed value is harmless and remains accepted.
+    public static func parseTabActionTargets(_ args: [String]) -> TabActionTargetParseResult {
+        let targetFlags: Set<String> = ["--workspace", "--tab", "--surface"]
+        var namedWorkspaces: [String] = []
+        var namedTargets: [String] = []
+        var remaining: [String] = []
+        var index = 0
+        var pastTerminator = false
+
+        while index < args.count {
+            let raw = args[index]
+            if raw == "--" {
+                pastTerminator = true
+                remaining.append(raw)
+                index += 1
+                continue
+            }
+            guard !pastTerminator, targetFlags.contains(raw) else {
+                remaining.append(raw)
+                index += 1
+                continue
+            }
+
+            guard index + 1 < args.count else {
+                return .reject("tab-action: flag '\(raw)' requires a value")
+            }
+            let value = args[index + 1]
+            guard !value.hasPrefix("--") else {
+                return .reject("tab-action: flag '\(raw)' requires a value, got another flag '\(value)'")
+            }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                return .reject("tab-action: flag '\(raw)' requires a non-empty value")
+            }
+
+            if raw == "--workspace" {
+                namedWorkspaces.append(trimmed)
+            } else {
+                namedTargets.append(trimmed)
+            }
+            index += 2
+        }
+
+        let distinctWorkspaces = distinctTrimmedValues(namedWorkspaces)
+        if distinctWorkspaces.count > 1 {
+            let listed = distinctWorkspaces.sorted().joined(separator: ", ")
+            return .reject("tab-action: more than one workspace named (\(listed)). Name exactly one workspace.")
+        }
+
+        let distinctTargets = distinctTrimmedValues(namedTargets)
+        if distinctTargets.count > 1 {
+            let listed = distinctTargets.sorted().joined(separator: ", ")
+            return .reject("tab-action: more than one tab or surface named (\(listed)). Name exactly one target.")
+        }
+
+        return .plan(TabActionTargetPlan(
+            workspace: distinctWorkspaces.first,
+            target: distinctTargets.first,
+            remaining: remaining
+        ))
     }
 
     /// Refuse any positional token left after `tab-action` has consumed its
@@ -141,6 +237,10 @@ public enum CLISurfaceRefArguments {
     private enum PositionalClass {
         case surface(String)
         case refuse(String)
+    }
+
+    private static func distinctTrimmedValues(_ values: [String]) -> Set<String> {
+        Set(values.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })
     }
 
     private static func classifyPositional(_ raw: String) -> PositionalClass {

--- a/Sources/CLISurfaceRefArguments.swift
+++ b/Sources/CLISurfaceRefArguments.swift
@@ -99,10 +99,15 @@ public enum CLISurfaceRefArguments {
                 index += 1
             }
 
+            guard let value,
+                  !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .reject("close-surface: flag '\(name)' requires a non-empty value")
+            }
+
             if name == "--workspace" {
                 workspace = value
             } else {
-                namedSurfaces.append(value ?? "")
+                namedSurfaces.append(value)
             }
             index += 1
         }
@@ -116,14 +121,21 @@ public enum CLISurfaceRefArguments {
         return .plan(CloseSurfacePlan(workspace: workspace, surface: namedSurfaces.first))
     }
 
-    /// True when a token is plainly one of c11's `<kind>:<ordinal>` handles or a
-    /// UUID, i.e. the caller meant it as a target, not as free text. Bare
-    /// integers are deliberately excluded: `3` is as likely to be a title as an
-    /// index.
-    public static func looksLikeHandle(_ raw: String) -> Bool {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if UUID(uuidString: trimmed) != nil { return true }
-        return handleKindAndOrdinal(trimmed) != nil
+    /// Refuse any positional token left after `tab-action` has consumed its
+    /// action, except for `rename`, whose trailing positionals intentionally
+    /// form the title.
+    ///
+    /// Other actions do not own a positional slot. Accepting even an
+    /// innocent-looking value such as a bare index or a malformed handle would
+    /// discard the caller's apparent target and let tab resolution fall back to
+    /// caller focus. Keep this generic so every present and future non-rename
+    /// action gets the same destructive-target safety rule.
+    public static func tabActionPositionalRejection(action: String, positional: [String]) -> String? {
+        let normalizedAction = action.lowercased().replacingOccurrences(of: "-", with: "_")
+        guard normalizedAction != "rename", let stray = positional.first else {
+            return nil
+        }
+        return "tab-action: action '\(normalizedAction)' does not take positional arguments; unexpected '\(stray)'. Pass the target with '--tab <id|ref|index>'."
     }
 
     private enum PositionalClass {

--- a/Sources/CLISurfaceRefArguments.swift
+++ b/Sources/CLISurfaceRefArguments.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+/// Surface-targeting argument parser for destructive, surface-scoped CLI
+/// commands.
+///
+/// Lives in `Sources/` (shared by the c11 app target and c11-cli target) so the
+/// logic-test target can exercise it directly without linking the CLI
+/// executable or dragging `CLIError` (CLI-local) into the app module. Callers
+/// map `.reject` onto their own error type.
+///
+/// The rule this encodes: **the caller's own surface is a safe default only on
+/// a genuinely bare command line.** The moment an argument names a target, the
+/// environment must not be consulted. Resolving a named ref to some *other*
+/// surface can never be what the caller meant, and when the command is
+/// `close-surface` the difference is a destroyed session.
+///
+/// This is the client-side sibling of `SocketSurfaceRefValidator`, which
+/// hardened *empty* refs into loud errors server-side. An *ignored* ref is as
+/// dangerous as an empty one, and it cannot be caught server-side: by the time
+/// the socket sees the request, the mis-targeted ref is already gone.
+public enum CLISurfaceRefArguments {
+
+    /// A resolved `close-surface` command line.
+    public struct CloseSurfacePlan: Equatable {
+        /// Value of `--workspace`, if the command line carried one.
+        public let workspace: String?
+        /// The surface the command line named, via `--surface`, `--panel`, or a
+        /// positional handle. `nil` only when nothing named a surface.
+        public let surface: String?
+
+        public init(workspace: String?, surface: String?) {
+            self.workspace = workspace
+            self.surface = surface
+        }
+
+        /// True when the command line named a surface. Callers must not fall
+        /// back to `$CMUX_SURFACE_ID` when this is true.
+        public var namesSurface: Bool { surface != nil }
+    }
+
+    public enum ParseResult: Equatable {
+        case plan(CloseSurfacePlan)
+        /// The command line named something that cannot be honored. The message
+        /// is operator-facing and names the fix.
+        case reject(String)
+    }
+
+    private static let knownValueFlags: Set<String> = ["--surface", "--panel", "--workspace"]
+
+    private static let knownFlagsHelp =
+        "--surface <id|ref|index>, --panel <id|ref|index>, --workspace <id|ref|index>"
+
+    /// Parse `close-surface` arguments into an explicit plan, or refuse.
+    ///
+    /// Accepts `--flag value` and `--flag=value`, honors a well-formed
+    /// positional surface handle (`c11 close-surface surface:101`), and refuses
+    /// anything else rather than silently discarding it.
+    public static func parseCloseSurface(_ args: [String]) -> ParseResult {
+        var workspace: String?
+        var namedSurfaces: [String] = []
+        var index = 0
+
+        while index < args.count {
+            let raw = args[index]
+
+            guard raw.hasPrefix("--") else {
+                switch classifyPositional(raw) {
+                case .surface(let ref):
+                    namedSurfaces.append(ref)
+                case .refuse(let message):
+                    return .reject(message)
+                }
+                index += 1
+                continue
+            }
+
+            let name: String
+            var value: String?
+            if let equals = raw.firstIndex(of: "=") {
+                name = String(raw[..<equals])
+                value = String(raw[raw.index(after: equals)...])
+            } else {
+                name = raw
+            }
+
+            guard knownValueFlags.contains(name) else {
+                return .reject("close-surface: unknown flag '\(name)'. Known flags: \(knownFlagsHelp)")
+            }
+
+            if value == nil {
+                guard index + 1 < args.count else {
+                    return .reject("close-surface: flag '\(name)' requires a value")
+                }
+                let next = args[index + 1]
+                if next.hasPrefix("--") {
+                    return .reject("close-surface: flag '\(name)' requires a value, got another flag '\(next)'")
+                }
+                value = next
+                index += 1
+            }
+
+            if name == "--workspace" {
+                workspace = value
+            } else {
+                namedSurfaces.append(value ?? "")
+            }
+            index += 1
+        }
+
+        let distinct = Set(namedSurfaces.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+        if distinct.count > 1 {
+            let listed = distinct.sorted().joined(separator: ", ")
+            return .reject("close-surface: more than one surface named (\(listed)). Name exactly one target.")
+        }
+
+        return .plan(CloseSurfacePlan(workspace: workspace, surface: namedSurfaces.first))
+    }
+
+    /// True when a token is plainly one of c11's `<kind>:<ordinal>` handles or a
+    /// UUID, i.e. the caller meant it as a target, not as free text. Bare
+    /// integers are deliberately excluded: `3` is as likely to be a title as an
+    /// index.
+    public static func looksLikeHandle(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if UUID(uuidString: trimmed) != nil { return true }
+        return handleKindAndOrdinal(trimmed) != nil
+    }
+
+    private enum PositionalClass {
+        case surface(String)
+        case refuse(String)
+    }
+
+    private static func classifyPositional(_ raw: String) -> PositionalClass {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if UUID(uuidString: trimmed) != nil {
+            return .surface(trimmed)
+        }
+
+        if let (kind, ordinal) = handleKindAndOrdinal(trimmed) {
+            switch kind {
+            case "surface":
+                return .surface(trimmed)
+            case "tab":
+                return .refuse("close-surface: '\(trimmed)' is a tab handle, not a surface. Did you mean 'surface:\(ordinal)'?")
+            case "pane":
+                return .refuse("close-surface: '\(trimmed)' is a pane handle, not a surface. Did you mean 'c11 kill \(trimmed)'?")
+            case "workspace":
+                return .refuse("close-surface: '\(trimmed)' is a workspace handle. Did you mean 'c11 close-workspace --workspace \(trimmed)'?")
+            case "window":
+                return .refuse("close-surface: '\(trimmed)' is a window handle. Did you mean 'c11 close-window --window \(ordinal)'?")
+            default:
+                break
+            }
+        }
+
+        if Int(trimmed) != nil {
+            return .refuse("close-surface: bare index '\(trimmed)' is ambiguous. Pass '--surface \(trimmed)' to target surface index \(trimmed).")
+        }
+
+        return .refuse("close-surface: unexpected argument '\(trimmed)'. Did you mean '--surface \(trimmed)'?")
+    }
+
+    /// Split a `<kind>:<ordinal>` handle. Returns nil for anything else.
+    private static func handleKindAndOrdinal(_ value: String) -> (kind: String, ordinal: String)? {
+        let pieces = value.split(separator: ":", omittingEmptySubsequences: false)
+        guard pieces.count == 2 else { return nil }
+        let ordinal = String(pieces[1])
+        guard Int(ordinal) != nil else { return nil }
+        let kind = String(pieces[0]).lowercased()
+        guard ["window", "workspace", "pane", "surface", "tab"].contains(kind) else { return nil }
+        return (kind, ordinal)
+    }
+}

--- a/Sources/Metadata/SocketSurfaceRefValidator.swift
+++ b/Sources/Metadata/SocketSurfaceRefValidator.swift
@@ -30,7 +30,7 @@ internal enum SocketSurfaceRefValidator {
 
     /// Classification of one raw param value.
     enum RefState: Equatable {
-        /// Key missing entirely, or present as JSON `null` (`NSNull`).
+        /// Key missing entirely.
         case absent
         /// Key present as a string that is empty/whitespace-only, or as a
         /// non-string value (a malformed ref — refs are always strings).
@@ -40,10 +40,13 @@ internal enum SocketSurfaceRefValidator {
     }
 
     /// Classify `raw` where `raw` is the result of `params[key]` (an
-    /// `Any?`). A missing key arrives as `nil`; an explicit JSON null as
-    /// `NSNull`; both are `.absent`.
+    /// `Any?`). Only a missing key (`nil`) is `.absent`. An explicit JSON
+    /// `null` arrives as `NSNull` and is `.empty`: the caller supplied a
+    /// target key that cannot resolve, so optional-target commands must not
+    /// mistake it for permission to use their focused-surface fallback.
     static func classify(_ raw: Any?) -> RefState {
-        guard let raw, !(raw is NSNull) else { return .absent }
+        guard let raw else { return .absent }
+        guard !(raw is NSNull) else { return .empty }
         guard let s = raw as? String else { return .empty }
         let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? .empty : .present(trimmed)

--- a/Sources/SocketHandlers/MiscHandlers.swift
+++ b/Sources/SocketHandlers/MiscHandlers.swift
@@ -61,6 +61,10 @@ extension TerminalController {
         ])
 
         v2MainSync {
+            if let rejection = v2RejectInvalidOptionalWorkspacePin(params, tabManager: tabManager) {
+                result = rejection
+                return
+            }
             guard let workspace = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return

--- a/Sources/SocketHandlers/MiscHandlers.swift
+++ b/Sources/SocketHandlers/MiscHandlers.swift
@@ -35,11 +35,9 @@ extension TerminalController {
             return .err(code: "invalid_params", message: "Missing action", data: nil)
         }
 
-        // C11-165 COR-1: rename (rename-tab) is a surface/tab-scoped write; an
-        // empty or absent ref must not rename the operator-focused tab. Here
-        // `tab_id` and `surface_id` both pin the target (line 57 resolves both
-        // to a surface id). Other tab.action verbs (close_*, pin, duplicate, …)
-        // are outside COR-1's enumerated 10 and keep their focused-tab default.
+        // C11-165 COR-1: rename (rename-tab) is a surface/tab-scoped write and
+        // therefore requires an explicit pin. Other tab actions intentionally
+        // retain their focused-tab default when both pin keys are absent.
         if action == "rename",
            let reject = v2RejectInvalidSurfaceRef(
                params,
@@ -68,7 +66,19 @@ extension TerminalController {
                 return
             }
 
-            let surfaceId = v2UUID(params, "surface_id") ?? v2UUID(params, "tab_id") ?? workspace.focusedPanelId
+            // Explicit pins must never collapse into the focused-tab default:
+            // stale, empty, case-mismatched, or conflicting refs all reject
+            // before the action switch can mutate workspace state.
+            let surfaceId: UUID?
+            switch v2ResolveOptionalSurfacePin(params, pinningKeys: ["surface_id", "tab_id"]) {
+            case .absent:
+                surfaceId = workspace.focusedPanelId
+            case .resolved(let resolved):
+                surfaceId = resolved
+            case .rejected(let rejection):
+                result = rejection
+                return
+            }
             guard let surfaceId else {
                 result = .err(code: "not_found", message: "No focused tab", data: nil)
                 return

--- a/Sources/SocketHandlers/SurfaceHandlers.swift
+++ b/Sources/SocketHandlers/SurfaceHandlers.swift
@@ -457,6 +457,10 @@ extension TerminalController {
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to close surface", data: nil)
         v2MainSync {
+            if let rejection = v2RejectInvalidOptionalWorkspacePin(params, tabManager: tabManager) {
+                result = rejection
+                return
+            }
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                 result = .err(code: "not_found", message: "Workspace not found", data: nil)
                 return

--- a/Sources/SocketHandlers/SurfaceHandlers.swift
+++ b/Sources/SocketHandlers/SurfaceHandlers.swift
@@ -462,7 +462,16 @@ extension TerminalController {
                 return
             }
 
-            let surfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            let surfaceId: UUID?
+            switch v2ResolveOptionalSurfacePin(params, pinningKeys: ["surface_id"]) {
+            case .absent:
+                surfaceId = ws.focusedPanelId
+            case .resolved(let resolved):
+                surfaceId = resolved
+            case .rejected(let rejection):
+                result = rejection
+                return
+            }
             guard let surfaceId else {
                 result = .err(code: "not_found", message: "No focused surface", data: nil)
                 return

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2352,6 +2352,14 @@ class TerminalController {
         case err(code: String, message: String, data: Any?)
     }
 
+    /// Resolution result for commands that intentionally default to the
+    /// focused surface only when the caller supplied no explicit pin.
+    enum V2OptionalSurfacePinResolution {
+        case absent
+        case resolved(UUID)
+        case rejected(V2CallResult)
+    }
+
     nonisolated func v2Result(id: Any?, _ res: V2CallResult) -> String {
         switch res {
         case .ok(let payload):
@@ -2671,6 +2679,56 @@ class TerminalController {
             message: "surface ref did not resolve to a known handle (one of \(pinningKeys.joined(separator: ", "))); refusing to fall back to the focused surface",
             data: nil
         )
+    }
+
+    /// Resolve an optional surface/tab pin without collapsing a bad explicit
+    /// ref into "not supplied". Callers may use their focused-surface default
+    /// only for `.absent`; every explicit pin must be non-empty, resolve, and
+    /// agree with any other explicit pin.
+    func v2ResolveOptionalSurfacePin(
+        _ params: [String: Any],
+        pinningKeys: [String]
+    ) -> V2OptionalSurfacePinResolution {
+        var resolvedPins: [(key: String, ref: String, id: UUID)] = []
+
+        for key in pinningKeys {
+            switch SocketSurfaceRefValidator.classify(params[key]) {
+            case .absent:
+                continue
+            case .empty:
+                return .rejected(.err(
+                    code: SocketSurfaceRefValidator.emptyRefCode,
+                    message: "surface ref '\(key)' was provided but empty — pass a concrete id (no focused-surface fallback)",
+                    data: nil
+                ))
+            case .present(let ref):
+                guard let id = v2UUID(params, key) else {
+                    return .rejected(.err(
+                        code: "not_found",
+                        message: "surface ref '\(ref)' did not resolve to a known handle; refusing to fall back to the focused surface",
+                        data: ["target_key": key, "target_ref": ref]
+                    ))
+                }
+                resolvedPins.append((key: key, ref: ref, id: id))
+            }
+        }
+
+        guard let first = resolvedPins.first else {
+            return .absent
+        }
+        if let conflict = resolvedPins.dropFirst().first(where: { $0.id != first.id }) {
+            return .rejected(.err(
+                code: "invalid_params",
+                message: "conflicting explicit surface targets; refusing to choose one or fall back to the focused surface",
+                data: [
+                    "first_target_key": first.key,
+                    "first_target_ref": first.ref,
+                    "conflicting_target_key": conflict.key,
+                    "conflicting_target_ref": conflict.ref
+                ]
+            ))
+        }
+        return .resolved(first.id)
     }
 
     func v2StrictInt(_ params: [String: Any], _ key: String) -> Int? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2731,6 +2731,40 @@ class TerminalController {
         return .resolved(first.id)
     }
 
+    /// Validate an optional workspace pin before a destructive handler calls
+    /// `v2ResolveWorkspace`. That resolver intentionally falls back to the
+    /// selected workspace when `v2UUID` returns nil, so an explicit null,
+    /// empty, malformed, or stale workspace ref must be rejected first.
+    ///
+    /// A genuinely missing key remains valid: surface.close and tab.action
+    /// intentionally support caller-focused defaults when no workspace was
+    /// named.
+    func v2RejectInvalidOptionalWorkspacePin(
+        _ params: [String: Any],
+        tabManager: TabManager
+    ) -> V2CallResult? {
+        switch SocketSurfaceRefValidator.classify(params["workspace_id"]) {
+        case .absent:
+            return nil
+        case .empty:
+            return .err(
+                code: SocketSurfaceRefValidator.emptyRefCode,
+                message: "workspace ref 'workspace_id' was provided but empty — pass a concrete id (no focused-workspace fallback)",
+                data: nil
+            )
+        case .present(let ref):
+            guard let id = v2UUID(params, "workspace_id"),
+                  tabManager.tabs.contains(where: { $0.id == id }) else {
+                return .err(
+                    code: "not_found",
+                    message: "workspace ref '\(ref)' did not resolve to a known handle; refusing to fall back to the focused workspace",
+                    data: ["target_key": "workspace_id", "target_ref": ref]
+                )
+            }
+            return nil
+        }
+    }
+
     func v2StrictInt(_ params: [String: Any], _ key: String) -> Int? {
         v2StrictIntAny(params[key])
     }

--- a/c11Tests/CLISurfaceRefArgumentsTests.swift
+++ b/c11Tests/CLISurfaceRefArgumentsTests.swift
@@ -257,6 +257,61 @@ final class CLISurfaceRefArgumentsTests: XCTestCase {
         XCTAssertTrue(tabTargetRejection(["--workspace", " "])?.contains("non-empty") == true)
     }
 
+    func testRenameTabCompatibilityWrapperRejectsConflictingTargets() {
+        let cases = [
+            ["--tab", "surface:1", "--tab", "surface:2", "new title"],
+            ["--tab", "surface:1", "--surface", "surface:2", "new title"],
+        ]
+
+        for args in cases {
+            let result = CLISurfaceRefArguments.parseTabActionTargets(
+                args,
+                commandName: "rename-tab"
+            )
+            guard case .reject(let message) = result else {
+                return XCTFail("rename-tab must reject conflicting targets: \(args)")
+            }
+            XCTAssertTrue(message.hasPrefix("rename-tab:"))
+            XCTAssertTrue(message.contains("more than one tab or surface"))
+        }
+    }
+
+    func testRenameTabCompatibilityWrapperRejectsConflictingWorkspaces() {
+        let result = CLISurfaceRefArguments.parseTabActionTargets(
+            [
+                "--workspace", "workspace:1",
+                "--workspace", "workspace:2",
+                "--tab", "surface:3",
+                "new title",
+            ],
+            commandName: "rename-tab"
+        )
+        guard case .reject(let message) = result else {
+            return XCTFail("rename-tab must reject conflicting workspaces")
+        }
+        XCTAssertTrue(message.hasPrefix("rename-tab:"))
+        XCTAssertTrue(message.contains("more than one workspace"))
+    }
+
+    func testRenameTabCompatibilityWrapperAcceptsExactDuplicates() {
+        let result = CLISurfaceRefArguments.parseTabActionTargets(
+            [
+                "--workspace", "workspace:1",
+                "--workspace", "workspace:1",
+                "--tab", "surface:3",
+                "--surface", "surface:3",
+                "new title",
+            ],
+            commandName: "rename-tab"
+        )
+        guard case .plan(let parsed) = result else {
+            return XCTFail("rename-tab must accept exact duplicate target values")
+        }
+        XCTAssertEqual(parsed.workspace, "workspace:1")
+        XCTAssertEqual(parsed.target, "surface:3")
+        XCTAssertEqual(parsed.remaining, ["new title"])
+    }
+
     // MARK: - tab-action positional safety
 
     func testEveryNonRenameTabActionRejectsEveryLeftoverPositionalShape() {

--- a/c11Tests/CLISurfaceRefArgumentsTests.swift
+++ b/c11Tests/CLISurfaceRefArgumentsTests.swift
@@ -114,6 +114,13 @@ final class CLISurfaceRefArgumentsTests: XCTestCase {
         XCTAssertTrue(rejection(["--surface", "--workspace", "workspace:1"])?.contains("requires a value") == true)
     }
 
+    func testEmptyFlagValuesAreRefusedClientSide() {
+        XCTAssertTrue(rejection(["--surface="])?.contains("requires a non-empty value") == true)
+        XCTAssertTrue(rejection(["--surface", " \t "])?.contains("requires a non-empty value") == true)
+        XCTAssertTrue(rejection(["--panel="])?.contains("requires a non-empty value") == true)
+        XCTAssertTrue(rejection(["--workspace="])?.contains("requires a non-empty value") == true)
+    }
+
     func testConflictingTargetsAreRefused() {
         // Naming two different surfaces can only ever be a mistake; guessing
         // which one to destroy is not an option.
@@ -126,20 +133,73 @@ final class CLISurfaceRefArgumentsTests: XCTestCase {
         XCTAssertEqual(plan(["--surface", "surface:1", "surface:1"])?.surface, "surface:1")
     }
 
-    // MARK: - looksLikeHandle (guards tab-action's destructive close-* actions)
+    // MARK: - tab-action positional safety
 
-    func testLooksLikeHandleAcceptsHandlesAndUUIDs() {
-        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("surface:101"))
-        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("tab:3"))
-        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("pane:46"))
-        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("9E4C3E52-6E4E-4B0E-9E2E-0A1B2C3D4E5F"))
+    func testEveryNonRenameTabActionRejectsEveryLeftoverPositionalShape() {
+        let actions = [
+            "clear-name",
+            "close-left", "close-right", "close-others",
+            "new-terminal-right", "new-browser-right",
+            "reload", "duplicate", "pin", "unpin", "mark-unread",
+            "future-action",
+        ]
+        let unexpected = [
+            "surface:9",
+            "9",
+            "surface:",
+            "ordinary text",
+        ]
+
+        for action in actions {
+            for positional in unexpected {
+                let rejection = CLISurfaceRefArguments.tabActionPositionalRejection(
+                    action: action,
+                    positional: [positional]
+                )
+                XCTAssertNotNil(
+                    rejection,
+                    "\(action) must reject leftover positional '\(positional)' instead of falling back to caller focus"
+                )
+                XCTAssertTrue(rejection?.contains("unexpected '\(positional)'") == true)
+                XCTAssertTrue(rejection?.contains("--tab <id|ref|index>") == true)
+            }
+        }
     }
 
-    func testLooksLikeHandleRejectsFreeText() {
-        // tab-action's positional slot carries the rename title; ordinary words
-        // and bare numbers must stay usable as titles.
-        XCTAssertFalse(CLISurfaceRefArguments.looksLikeHandle("Session forensics"))
-        XCTAssertFalse(CLISurfaceRefArguments.looksLikeHandle("3"))
-        XCTAssertFalse(CLISurfaceRefArguments.looksLikeHandle("notes:today"))
+    func testNonRenameTabActionRejectsTheFirstOfMultipleLeftovers() {
+        let rejection = CLISurfaceRefArguments.tabActionPositionalRejection(
+            action: "close-others",
+            positional: ["surface:", "ignored-second-token"]
+        )
+        XCTAssertTrue(rejection?.contains("unexpected 'surface:'") == true)
+    }
+
+    func testTabActionWithoutLeftoverPositionalIsAccepted() {
+        XCTAssertNil(
+            CLISurfaceRefArguments.tabActionPositionalRejection(
+                action: "close-others",
+                positional: []
+            )
+        )
+    }
+
+    func testRenamePreservesAllTrailingTitleSemantics() {
+        let titles = [
+            ["Session", "forensics"],
+            ["3"],
+            ["surface:9"],
+            ["surface:"],
+            ["notes:today"],
+        ]
+
+        for title in titles {
+            XCTAssertNil(
+                CLISurfaceRefArguments.tabActionPositionalRejection(
+                    action: "ReNaMe",
+                    positional: title
+                ),
+                "rename must preserve trailing title tokens \(title)"
+            )
+        }
     }
 }

--- a/c11Tests/CLISurfaceRefArgumentsTests.swift
+++ b/c11Tests/CLISurfaceRefArgumentsTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// `c11 close-surface surface:101` once closed the *caller's* surface: the
+/// positional was parsed by nothing, matched by nothing, and silently
+/// discarded, so the resolver fell through to $CMUX_SURFACE_ID. It killed a
+/// live operator session and the two sub-agents under it.
+///
+/// The invariant these tests pin: **an argument that names a target is honored
+/// or refused, never discarded.** The caller's own surface stays the default
+/// for a bare command line and nothing else.
+final class CLISurfaceRefArgumentsTests: XCTestCase {
+
+    private func plan(_ args: [String], file: StaticString = #filePath, line: UInt = #line)
+        -> CLISurfaceRefArguments.CloseSurfacePlan? {
+        switch CLISurfaceRefArguments.parseCloseSurface(args) {
+        case .plan(let plan):
+            return plan
+        case .reject(let message):
+            XCTFail("expected a plan, got reject: \(message)", file: file, line: line)
+            return nil
+        }
+    }
+
+    private func rejection(_ args: [String], file: StaticString = #filePath, line: UInt = #line) -> String? {
+        switch CLISurfaceRefArguments.parseCloseSurface(args) {
+        case .plan(let plan):
+            XCTFail("expected a rejection, got plan surface=\(String(describing: plan.surface))", file: file, line: line)
+            return nil
+        case .reject(let message):
+            return message
+        }
+    }
+
+    // MARK: - The incident
+
+    func testPositionalSurfaceHandleIsHonoredNotDiscarded() {
+        guard let plan = plan(["surface:101"]) else { return }
+        XCTAssertEqual(plan.surface, "surface:101")
+        XCTAssertTrue(
+            plan.namesSurface,
+            "naming surface:101 must disable the $CMUX_SURFACE_ID fallback — this is the bug that killed a live session"
+        )
+    }
+
+    func testPositionalHandleWithWorkspaceFlagInEitherOrder() {
+        XCTAssertEqual(plan(["--workspace", "workspace:2", "surface:101"])?.surface, "surface:101")
+        XCTAssertEqual(plan(["surface:101", "--workspace", "workspace:2"])?.surface, "surface:101")
+        XCTAssertEqual(plan(["surface:101", "--workspace", "workspace:2"])?.workspace, "workspace:2")
+    }
+
+    func testUUIDPositionalIsHonored() {
+        let uuid = "9E4C3E52-6E4E-4B0E-9E2E-0A1B2C3D4E5F"
+        XCTAssertEqual(plan([uuid])?.surface, uuid)
+    }
+
+    // MARK: - The `=` form, which failed the same way
+
+    func testInlineEqualsValueIsHonored() {
+        // `optionValue` matches `--surface` exactly, so `--surface=surface:101`
+        // was discarded and fell through to the caller's own surface — with the
+        // operator having explicitly typed the flag.
+        guard let plan = plan(["--surface=surface:101"]) else { return }
+        XCTAssertEqual(plan.surface, "surface:101")
+        XCTAssertTrue(plan.namesSurface)
+    }
+
+    func testInlineEqualsWorkspaceIsHonored() {
+        XCTAssertEqual(plan(["--workspace=workspace:4"])?.workspace, "workspace:4")
+    }
+
+    // MARK: - The default that should stay
+
+    func testBareCommandLineStillDefaultsToCaller() {
+        guard let plan = plan([]) else { return }
+        XCTAssertNil(plan.surface)
+        XCTAssertNil(plan.workspace)
+        XCTAssertFalse(plan.namesSurface, "a bare `c11 close-surface` must still close the caller's own surface")
+    }
+
+    func testExplicitFlagsStillWork() {
+        XCTAssertEqual(plan(["--surface", "surface:3"])?.surface, "surface:3")
+        XCTAssertEqual(plan(["--panel", "surface:3"])?.surface, "surface:3")
+    }
+
+    // MARK: - Refusals
+
+    func testWrongKindHandlesAreRefusedWithGuidance() {
+        XCTAssertTrue(rejection(["pane:46"])?.contains("c11 kill pane:46") == true)
+        XCTAssertTrue(rejection(["workspace:2"])?.contains("close-workspace") == true)
+        XCTAssertTrue(rejection(["tab:5"])?.contains("surface:5") == true)
+        XCTAssertTrue(rejection(["window:1"])?.contains("close-window") == true)
+    }
+
+    func testBareIndexIsRefusedAsAmbiguous() {
+        XCTAssertTrue(rejection(["3"])?.contains("--surface 3") == true)
+    }
+
+    func testUnknownPositionalIsRefused() {
+        XCTAssertTrue(rejection(["banana"])?.contains("unexpected argument 'banana'") == true)
+    }
+
+    func testUnknownFlagIsRefused() {
+        XCTAssertTrue(rejection(["--json"])?.contains("unknown flag '--json'") == true)
+    }
+
+    func testFlagMissingValueIsRefused() {
+        XCTAssertTrue(rejection(["--surface"])?.contains("requires a value") == true)
+        XCTAssertTrue(rejection(["--surface", "--workspace", "workspace:1"])?.contains("requires a value") == true)
+    }
+
+    func testConflictingTargetsAreRefused() {
+        // Naming two different surfaces can only ever be a mistake; guessing
+        // which one to destroy is not an option.
+        XCTAssertTrue(rejection(["--surface", "surface:1", "surface:2"])?.contains("more than one surface") == true)
+        XCTAssertTrue(rejection(["surface:1", "surface:2"])?.contains("more than one surface") == true)
+        XCTAssertTrue(rejection(["--surface", "surface:1", "--panel", "surface:2"])?.contains("more than one surface") == true)
+    }
+
+    func testRepeatingTheSameTargetIsNotAConflict() {
+        XCTAssertEqual(plan(["--surface", "surface:1", "surface:1"])?.surface, "surface:1")
+    }
+
+    // MARK: - looksLikeHandle (guards tab-action's destructive close-* actions)
+
+    func testLooksLikeHandleAcceptsHandlesAndUUIDs() {
+        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("surface:101"))
+        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("tab:3"))
+        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("pane:46"))
+        XCTAssertTrue(CLISurfaceRefArguments.looksLikeHandle("9E4C3E52-6E4E-4B0E-9E2E-0A1B2C3D4E5F"))
+    }
+
+    func testLooksLikeHandleRejectsFreeText() {
+        // tab-action's positional slot carries the rename title; ordinary words
+        // and bare numbers must stay usable as titles.
+        XCTAssertFalse(CLISurfaceRefArguments.looksLikeHandle("Session forensics"))
+        XCTAssertFalse(CLISurfaceRefArguments.looksLikeHandle("3"))
+        XCTAssertFalse(CLISurfaceRefArguments.looksLikeHandle("notes:today"))
+    }
+}

--- a/c11Tests/CLISurfaceRefArgumentsTests.swift
+++ b/c11Tests/CLISurfaceRefArgumentsTests.swift
@@ -37,6 +37,38 @@ final class CLISurfaceRefArgumentsTests: XCTestCase {
         }
     }
 
+    private func tabTargetPlan(
+        _ args: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> CLISurfaceRefArguments.TabActionTargetPlan? {
+        switch CLISurfaceRefArguments.parseTabActionTargets(args) {
+        case .plan(let plan):
+            return plan
+        case .reject(let message):
+            XCTFail("expected a tab-action target plan, got reject: \(message)", file: file, line: line)
+            return nil
+        }
+    }
+
+    private func tabTargetRejection(
+        _ args: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> String? {
+        switch CLISurfaceRefArguments.parseTabActionTargets(args) {
+        case .plan(let plan):
+            XCTFail(
+                "expected a tab-action target rejection, got workspace=\(String(describing: plan.workspace)) target=\(String(describing: plan.target))",
+                file: file,
+                line: line
+            )
+            return nil
+        case .reject(let message):
+            return message
+        }
+    }
+
     // MARK: - The incident
 
     func testPositionalSurfaceHandleIsHonoredNotDiscarded() {
@@ -131,6 +163,98 @@ final class CLISurfaceRefArgumentsTests: XCTestCase {
 
     func testRepeatingTheSameTargetIsNotAConflict() {
         XCTAssertEqual(plan(["--surface", "surface:1", "surface:1"])?.surface, "surface:1")
+        XCTAssertEqual(
+            plan(["--surface", "surface:1", "--surface", "surface:1"])?.surface,
+            "surface:1"
+        )
+        XCTAssertEqual(
+            plan(["--surface", "surface:1", "--panel", "surface:1"])?.surface,
+            "surface:1"
+        )
+    }
+
+    func testCloseSurfaceRejectsDistinctRepeatedWorkspaceValues() {
+        XCTAssertTrue(
+            rejection([
+                "--workspace", "workspace:1",
+                "--workspace", "workspace:2",
+                "--surface", "surface:3"
+            ])?.contains("more than one workspace") == true
+        )
+    }
+
+    func testCloseSurfaceAcceptsExactRepeatedWorkspaceValue() {
+        let parsed = plan([
+            "--workspace", "workspace:1",
+            "--workspace", "workspace:1",
+            "--surface", "surface:3"
+        ])
+        XCTAssertEqual(parsed?.workspace, "workspace:1")
+        XCTAssertEqual(parsed?.surface, "surface:3")
+    }
+
+    // MARK: - tab-action target flag safety
+
+    func testTabActionRejectsDistinctCrossAliasAndRepeatedTargetValues() {
+        let cases = [
+            ["--tab", "tab:2", "--surface", "surface:3", "--action", "close-others"],
+            ["--tab", "tab:2", "--tab", "tab:3", "--action", "close-others"],
+            ["--surface", "surface:2", "--surface", "surface:3", "--action", "close-others"]
+        ]
+
+        for args in cases {
+            XCTAssertTrue(
+                tabTargetRejection(args)?.contains("more than one tab or surface") == true,
+                "distinct destructive targets must reject before socket dispatch: \(args)"
+            )
+        }
+    }
+
+    func testTabActionRejectsDistinctRepeatedWorkspaceValues() {
+        let rejection = tabTargetRejection([
+            "--workspace", "workspace:1",
+            "--workspace", "workspace:2",
+            "--tab", "tab:3",
+            "--action", "close-others"
+        ])
+        XCTAssertTrue(rejection?.contains("more than one workspace") == true)
+    }
+
+    func testTabActionAcceptsExactDuplicateTargetAndWorkspaceValues() {
+        let parsed = tabTargetPlan([
+            "--workspace", "workspace:1",
+            "--workspace", "workspace:1",
+            "--tab", "surface:3",
+            "--surface", "surface:3",
+            "--action", "close-others"
+        ])
+
+        XCTAssertEqual(parsed?.workspace, "workspace:1")
+        XCTAssertEqual(parsed?.target, "surface:3")
+        XCTAssertEqual(parsed?.remaining, ["--action", "close-others"])
+    }
+
+    func testTabActionAcceptsExactRepeatedValueOnEachTargetFlag() {
+        let cases = [
+            (["--tab", "tab:3", "--tab", "tab:3"], "tab:3"),
+            (["--surface", "surface:3", "--surface", "surface:3"], "surface:3")
+        ]
+
+        for (args, expected) in cases {
+            XCTAssertEqual(
+                tabTargetPlan(args + ["--action", "close-others"])?.target,
+                expected,
+                "an exact normalized duplicate is not an ambiguous target: \(args)"
+            )
+        }
+    }
+
+    func testTabActionTargetFlagsRequireNonEmptyValues() {
+        XCTAssertTrue(tabTargetRejection(["--tab"])?.contains("requires a value") == true)
+        XCTAssertTrue(
+            tabTargetRejection(["--surface", "--action", "close-others"])?.contains("requires a value") == true
+        )
+        XCTAssertTrue(tabTargetRejection(["--workspace", " "])?.contains("non-empty") == true)
     }
 
     // MARK: - tab-action positional safety

--- a/c11Tests/SocketSurfaceRefRejectionWiringTests.swift
+++ b/c11Tests/SocketSurfaceRefRejectionWiringTests.swift
@@ -138,6 +138,55 @@ final class SocketSurfaceRefRejectionWiringTests: XCTestCase {
         XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
     }
 
+    func testSurfaceCloseRejectsExplicitNullWithoutClosingFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+        let code = responseCode(for: """
+        {"method":"surface.close","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","surface_id":null}}
+        """)
+
+        XCTAssertEqual(code, "empty_ref")
+        XCTAssertEqual(
+            Set(fixture.workspace.panels.keys),
+            panelIdsBefore,
+            "an explicit null is a named invalid target, not permission to close focus"
+        )
+        XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+    }
+
+    func testSurfaceCloseRejectsInvalidExplicitWorkspaceWithoutClosingFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+        let cases = [
+            (workspaceJSON: "null", expectedCode: "empty_ref", label: "null"),
+            (workspaceJSON: "\"workspace:999999999\"", expectedCode: "not_found", label: "stale")
+        ]
+
+        for testCase in cases {
+            let code = responseCode(for: """
+            {"method":"surface.close","params":{"workspace_id":\(testCase.workspaceJSON)}}
+            """)
+
+            XCTAssertEqual(code, testCase.expectedCode, "unexpected result for \(testCase.label) workspace")
+            XCTAssertEqual(
+                Set(fixture.workspace.panels.keys),
+                panelIdsBefore,
+                "an invalid explicit workspace must not become permission to close the focused surface"
+            )
+            XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+        }
+    }
+
     func testSurfaceCloseRejectsCaseMismatchedLiveRefWithoutClosingFocusedSurface() throws {
         let controller = TerminalController.shared
         let previousManager = controller.tabManager
@@ -250,24 +299,54 @@ final class SocketSurfaceRefRejectionWiringTests: XCTestCase {
 
         let liveRef = controller.surfaceRefOnly(forSurfaceUUID: fixture.otherSurfaceId)
         let cases = [
-            (targetKey: "surface_id", targetRef: "surface:999999999", expectedCode: "not_found"),
-            (targetKey: "tab_id", targetRef: "tab:999999999", expectedCode: "not_found"),
-            (targetKey: "surface_id", targetRef: liveRef.uppercased(), expectedCode: "not_found"),
-            (targetKey: "surface_id", targetRef: " ", expectedCode: "empty_ref"),
-            (targetKey: "tab_id", targetRef: " ", expectedCode: "empty_ref")
+            (targetKey: "surface_id", targetJSON: "\"surface:999999999\"", label: "surface:999999999", expectedCode: "not_found"),
+            (targetKey: "tab_id", targetJSON: "\"tab:999999999\"", label: "tab:999999999", expectedCode: "not_found"),
+            (targetKey: "surface_id", targetJSON: "\"\(liveRef.uppercased())\"", label: liveRef.uppercased(), expectedCode: "not_found"),
+            (targetKey: "surface_id", targetJSON: "\" \"", label: "whitespace", expectedCode: "empty_ref"),
+            (targetKey: "tab_id", targetJSON: "\" \"", label: "whitespace", expectedCode: "empty_ref"),
+            (targetKey: "surface_id", targetJSON: "null", label: "null", expectedCode: "empty_ref"),
+            (targetKey: "tab_id", targetJSON: "null", label: "null", expectedCode: "empty_ref")
         ]
         let panelIdsBefore = Set(fixture.workspace.panels.keys)
 
         for testCase in cases {
             let code = responseCode(for: """
-            {"method":"tab.action","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","action":"close_others","\(testCase.targetKey)":"\(testCase.targetRef)"}}
+            {"method":"tab.action","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","action":"close_others","\(testCase.targetKey)":\(testCase.targetJSON)}}
             """)
 
-            XCTAssertEqual(code, testCase.expectedCode, "unexpected result for \(testCase.targetKey)=\(testCase.targetRef)")
+            XCTAssertEqual(code, testCase.expectedCode, "unexpected result for \(testCase.targetKey)=\(testCase.label)")
             XCTAssertEqual(
                 Set(fixture.workspace.panels.keys),
                 panelIdsBefore,
                 "a rejected \(testCase.targetKey) must not let close_others mutate the workspace"
+            )
+            XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+        }
+    }
+
+    func testTabActionRejectsInvalidExplicitWorkspaceBeforeDestructiveAction() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+        let cases = [
+            (workspaceJSON: "null", expectedCode: "empty_ref", label: "null"),
+            (workspaceJSON: "\"workspace:999999999\"", expectedCode: "not_found", label: "stale")
+        ]
+
+        for testCase in cases {
+            let code = responseCode(for: """
+            {"method":"tab.action","params":{"workspace_id":\(testCase.workspaceJSON),"action":"close_others"}}
+            """)
+
+            XCTAssertEqual(code, testCase.expectedCode, "unexpected result for \(testCase.label) workspace")
+            XCTAssertEqual(
+                Set(fixture.workspace.panels.keys),
+                panelIdsBefore,
+                "an invalid explicit workspace must not let close_others use the focused workspace"
             )
             XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
         }

--- a/c11Tests/SocketSurfaceRefRejectionWiringTests.swift
+++ b/c11Tests/SocketSurfaceRefRejectionWiringTests.swift
@@ -7,9 +7,9 @@ import XCTest
 /// seam, so a future handler that forgets the guard is caught in CI (the
 /// `c11-unit` scheme runs host tests). It drives `processV2Command`
 /// end-to-end (dispatch → per-domain handler → validator) — the same entry
-/// the socket accept loop calls. An empty/absent `surface_id` is rejected by
-/// the validator *before* any surface resolution, so no live surface is
-/// required.
+/// the socket accept loop calls. The close/tab-action cases install a real
+/// two-surface workspace and assert the resulting mutation (or lack of one),
+/// covering the destructive fallback that a response-code-only test misses.
 ///
 /// Host target (not `c11LogicTests`): `processV2Command` is a
 /// `@MainActor` method on the app's `TerminalController`; per CLAUDE.md /
@@ -19,15 +19,39 @@ import XCTest
 @MainActor
 final class SocketSurfaceRefRejectionWiringTests: XCTestCase {
 
-    private func responseCode(for json: String) -> String {
+    private func responseObject(for json: String) -> [String: Any]? {
         let response = TerminalController.shared.processV2Command(json)
         guard let data = response.data(using: .utf8),
-              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let error = obj["error"] as? [String: Any],
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            XCTFail("Expected a JSON response, got: \(response)")
+            return nil
+        }
+        return obj
+    }
+
+    private func responseCode(for json: String) -> String {
+        guard let obj = responseObject(for: json) else {
+            return "<invalid-response>"
+        }
+        guard let error = obj["error"] as? [String: Any],
               let code = error["code"] as? String else {
-            return "<no-error:\(response)>"
+            return "<no-error:\(String(describing: obj))>"
         }
         return code
+    }
+
+    private func makeTwoSurfaceFixture()
+        throws -> (manager: TabManager, workspace: Workspace, focusedSurfaceId: UUID, otherSurfaceId: UUID) {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let focusedSurfaceId = try XCTUnwrap(workspace.focusedPanelId)
+        let paneId = try XCTUnwrap(workspace.bonsplitController.focusedPaneId)
+        let otherSurfaceId = try XCTUnwrap(
+            workspace.newTerminalSurface(inPane: paneId, focus: false)?.id
+        )
+        XCTAssertEqual(workspace.panels.count, 2)
+        XCTAssertEqual(workspace.focusedPanelId, focusedSurfaceId)
+        return (manager, workspace, focusedSurfaceId, otherSurfaceId)
     }
 
     func testSurfaceSetMetadataRejectsEmptySurfaceRef() {
@@ -70,5 +94,216 @@ final class SocketSurfaceRefRejectionWiringTests: XCTestCase {
         """)
         XCTAssertEqual(code, "empty_ref",
                        "rename with an empty surface_id must be rejected")
+    }
+
+    func testSurfaceCloseRejectsStaleNamedRefWithoutClosingFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+        let code = responseCode(for: """
+        {"method":"surface.close","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","surface_id":"surface:999999999"}}
+        """)
+
+        XCTAssertEqual(code, "not_found")
+        XCTAssertEqual(
+            Set(fixture.workspace.panels.keys),
+            panelIdsBefore,
+            "an unresolved named surface must not close any surface"
+        )
+        XCTAssertEqual(
+            fixture.workspace.focusedPanelId,
+            fixture.focusedSurfaceId,
+            "an unresolved named surface must not change caller focus"
+        )
+    }
+
+    func testSurfaceCloseRejectsEmptyNamedRefWithoutClosingFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+        let code = responseCode(for: """
+        {"method":"surface.close","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","surface_id":"  "}}
+        """)
+
+        XCTAssertEqual(code, "empty_ref")
+        XCTAssertEqual(Set(fixture.workspace.panels.keys), panelIdsBefore)
+        XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+    }
+
+    func testSurfaceCloseRejectsCaseMismatchedLiveRefWithoutClosingFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let liveRef = controller.surfaceRefOnly(forSurfaceUUID: fixture.otherSurfaceId)
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+        let code = responseCode(for: """
+        {"method":"surface.close","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","surface_id":"\(liveRef.uppercased())"}}
+        """)
+
+        XCTAssertEqual(code, "not_found")
+        XCTAssertEqual(Set(fixture.workspace.panels.keys), panelIdsBefore)
+        XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+    }
+
+    func testSurfaceCloseWithLiveNamedRefClosesNamedSurfaceNotFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let liveRef = controller.surfaceRefOnly(forSurfaceUUID: fixture.otherSurfaceId)
+        let response = responseObject(for: """
+        {"method":"surface.close","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","surface_id":"\(liveRef)"}}
+        """)
+
+        XCTAssertNil(response?["error"])
+        XCTAssertNil(fixture.workspace.panels[fixture.otherSurfaceId])
+        XCTAssertNotNil(
+            fixture.workspace.panels[fixture.focusedSurfaceId],
+            "an explicit live ref must close its named surface, not the focused surface"
+        )
+        XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+    }
+
+    func testSurfaceCloseWithoutNamedRefStillClosesFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let response = responseObject(for: """
+        {"method":"surface.close","params":{"workspace_id":"\(fixture.workspace.id.uuidString)"}}
+        """)
+
+        XCTAssertNil(response?["error"], "an absent surface ref must retain the focused-surface fallback")
+        XCTAssertEqual(fixture.workspace.panels.count, 1)
+        XCTAssertNil(
+            fixture.workspace.panels[fixture.focusedSurfaceId],
+            "the focused surface should close when no surface ref was named"
+        )
+    }
+
+    func testTabActionWithoutExplicitPinStillUsesFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let response = responseObject(for: """
+        {"method":"tab.action","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","action":"pin"}}
+        """)
+
+        XCTAssertNil(response?["error"])
+        XCTAssertTrue(fixture.workspace.isPanelPinned(fixture.focusedSurfaceId))
+        XCTAssertFalse(fixture.workspace.isPanelPinned(fixture.otherSurfaceId))
+        XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+    }
+
+    func testTabActionLiveSurfaceAndTabPinsMutateNamedSurfaceNotFocusedSurface() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let surfaceRef = controller.surfaceRefOnly(forSurfaceUUID: fixture.otherSurfaceId)
+        let targets = [
+            ("surface_id", surfaceRef),
+            ("tab_id", surfaceRef.replacingOccurrences(of: "surface:", with: "tab:"))
+        ]
+
+        for (targetKey, targetRef) in targets {
+            let response = responseObject(for: """
+            {"method":"tab.action","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","action":"pin","\(targetKey)":"\(targetRef)"}}
+            """)
+
+            XCTAssertNil(response?["error"], "live \(targetKey) should resolve")
+            XCTAssertTrue(fixture.workspace.isPanelPinned(fixture.otherSurfaceId))
+            XCTAssertFalse(
+                fixture.workspace.isPanelPinned(fixture.focusedSurfaceId),
+                "live \(targetKey) must not fall back to the focused surface"
+            )
+            fixture.workspace.setPanelPinned(panelId: fixture.otherSurfaceId, pinned: false)
+        }
+    }
+
+    func testTabActionRejectsInvalidExplicitPinsBeforeDestructiveAction() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let liveRef = controller.surfaceRefOnly(forSurfaceUUID: fixture.otherSurfaceId)
+        let cases = [
+            (targetKey: "surface_id", targetRef: "surface:999999999", expectedCode: "not_found"),
+            (targetKey: "tab_id", targetRef: "tab:999999999", expectedCode: "not_found"),
+            (targetKey: "surface_id", targetRef: liveRef.uppercased(), expectedCode: "not_found"),
+            (targetKey: "surface_id", targetRef: " ", expectedCode: "empty_ref"),
+            (targetKey: "tab_id", targetRef: " ", expectedCode: "empty_ref")
+        ]
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+
+        for testCase in cases {
+            let code = responseCode(for: """
+            {"method":"tab.action","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","action":"close_others","\(testCase.targetKey)":"\(testCase.targetRef)"}}
+            """)
+
+            XCTAssertEqual(code, testCase.expectedCode, "unexpected result for \(testCase.targetKey)=\(testCase.targetRef)")
+            XCTAssertEqual(
+                Set(fixture.workspace.panels.keys),
+                panelIdsBefore,
+                "a rejected \(testCase.targetKey) must not let close_others mutate the workspace"
+            )
+            XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+        }
+    }
+
+    func testEveryTabActionFamilyRejectsStaleExplicitPinBeforeMutation() throws {
+        let controller = TerminalController.shared
+        let previousManager = controller.tabManager
+        let fixture = try makeTwoSurfaceFixture()
+        controller.setActiveTabManager(fixture.manager)
+        defer { controller.setActiveTabManager(previousManager) }
+
+        let actions = [
+            "rename", "clear_name",
+            "pin", "unpin",
+            "mark_read", "mark_unread",
+            "reload", "duplicate",
+            "new_terminal_right", "new_browser_right",
+            "close_left", "close_right", "close_others"
+        ]
+        let panelIdsBefore = Set(fixture.workspace.panels.keys)
+
+        for action in actions {
+            let code = responseCode(for: """
+            {"method":"tab.action","params":{"workspace_id":"\(fixture.workspace.id.uuidString)","action":"\(action)","title":"renamed","surface_id":"surface:999999999"}}
+            """)
+
+            XCTAssertEqual(code, "not_found", "\(action) must reject a stale explicit pin")
+            XCTAssertEqual(
+                Set(fixture.workspace.panels.keys),
+                panelIdsBefore,
+                "\(action) must not mutate surfaces after explicit-pin rejection"
+            )
+            XCTAssertFalse(fixture.workspace.isPanelPinned(fixture.focusedSurfaceId))
+            XCTAssertFalse(fixture.workspace.isPanelPinned(fixture.otherSurfaceId))
+            XCTAssertEqual(fixture.workspace.focusedPanelId, fixture.focusedSurfaceId)
+        }
     }
 }

--- a/c11Tests/SocketSurfaceRefValidatorTests.swift
+++ b/c11Tests/SocketSurfaceRefValidatorTests.swift
@@ -16,8 +16,8 @@ final class SocketSurfaceRefValidatorTests: XCTestCase {
     func testClassifyDistinguishesAbsentEmptyPresent() {
         // Missing key → absent.
         XCTAssertEqual(SocketSurfaceRefValidator.classify(([String: Any]())["surface_id"]), .absent)
-        // Explicit JSON null → absent.
-        XCTAssertEqual(SocketSurfaceRefValidator.classify(NSNull()), .absent)
+        // Explicit JSON null is an explicit-but-invalid target → empty.
+        XCTAssertEqual(SocketSurfaceRefValidator.classify(NSNull()), .empty)
         // Empty / whitespace-only string → empty.
         XCTAssertEqual(SocketSurfaceRefValidator.classify(""), .empty)
         XCTAssertEqual(SocketSurfaceRefValidator.classify("   "), .empty)
@@ -71,13 +71,13 @@ final class SocketSurfaceRefValidatorTests: XCTestCase {
         XCTAssertEqual(r?.code, SocketSurfaceRefValidator.missingRefCode)
     }
 
-    func testExplicitNullPinnedRefIsMissingRef() {
+    func testExplicitNullPinnedRefIsEmptyRef() {
         let r = SocketSurfaceRefValidator.rejection(
             params: ["surface_id": NSNull()],
             targetKeys: ["surface_id"],
             requiredAnyOf: ["surface_id"]
         )
-        XCTAssertEqual(r?.code, SocketSurfaceRefValidator.missingRefCode)
+        XCTAssertEqual(r?.code, SocketSurfaceRefValidator.emptyRefCode)
     }
 
     func testCoarserRefDoesNotSatisfyPinnedRequirement() {

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -157,9 +157,18 @@ c11 rename-workspace <title>
 c11 rename-tab [--workspace <id|ref>] [--surface <id|ref>] <title>
 
 # Close
-c11 close-surface [--surface <id|ref>]      # Close a surface (defaults to caller's)
+c11 close-surface [--workspace <id|ref>] [--surface <id|ref> | --panel <id|ref> | <surface:ref|UUID>]
+                                             # Close a named surface; a truly bare command defaults to caller's
 c11 close-workspace --workspace <id|ref>    # Close entire workspace
 ```
+
+`close-surface` honors a positional `surface:N` handle or UUID exactly like
+`--surface`; a bare numeric index is ambiguous and must be passed explicitly as
+`--surface <index>`. Named targets are never discarded or replaced with caller
+focus. For destructive `close-surface` and `tab-action` targeting, distinct
+repeated values across `--workspace`, `--surface`, `--panel`, or `--tab`
+aliases are rejected before socket dispatch; repeating the same value is
+accepted.
 
 ### `new-split` vs `new-pane` vs `new-surface`
 

--- a/tests/test_cli_destructive_target_zero_dispatch.py
+++ b/tests/test_cli_destructive_target_zero_dispatch.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Compiled-CLI regression: ambiguous rename targets never dispatch tab.action.
+
+The pure Swift parser tests protect the shared target seam. This test protects
+the executable `rename-tab` compatibility wrapper that once stripped repeated
+targets with the generic last-value-wins parser before forwarding to
+`tab-action`. The no-global-`--window` cases below must fail locally and write
+zero socket bytes. A command with global pre-command `--window` may first send
+its separate `window.focus` RPC; that does not weaken the invariant that an
+ambiguous rename never dispatches `tab.action`.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+
+def resolve_c11_cli() -> str:
+    for key in ("C11_CLI_BIN", "CMUX_CLI_BIN", "CMUX_CLI"):
+        candidate = os.environ.get(key)
+        if candidate and os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    raise RuntimeError(
+        "Set C11_CLI_BIN (or CMUX_CLI_BIN) to the freshly built c11 CLI binary."
+    )
+
+
+class RecordingSocket:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.ready = threading.Event()
+        self.finished = threading.Event()
+        self.received = bytearray()
+        self.error: Exception | None = None
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+        if not self.ready.wait(timeout=2):
+            raise RuntimeError("recording socket did not become ready")
+
+    def wait(self) -> None:
+        if not self.finished.wait(timeout=2):
+            raise RuntimeError("recording socket did not finish")
+        if self.error is not None:
+            raise self.error
+
+    def _run(self) -> None:
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            server.bind(str(self.path))
+            server.listen(1)
+            server.settimeout(1)
+            self.ready.set()
+            try:
+                connection, _ = server.accept()
+            except TimeoutError:
+                return
+            with connection:
+                connection.settimeout(1)
+                while True:
+                    try:
+                        chunk = connection.recv(4096)
+                    except TimeoutError:
+                        break
+                    if not chunk:
+                        break
+                    self.received.extend(chunk)
+        except Exception as exc:  # surfaced on the test thread
+            self.error = exc
+        finally:
+            server.close()
+            self.finished.set()
+
+
+def run_case(cli: str, socket_path: Path, args: list[str]) -> tuple[bool, str]:
+    recorder = RecordingSocket(socket_path)
+    recorder.start()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "CMUX_CLAUDE_HOOK_SENTRY_DISABLED": "1",
+            # If a regression does dispatch, keep the failure fast while the
+            # fake server deliberately withholds a response.
+            "C11_DEFAULT_SOCKET_DEADLINE_MS": "300",
+            "CMUX_WORKSPACE_ID": "workspace:99",
+            "CMUX_SURFACE_ID": "surface:99",
+        }
+    )
+    process = subprocess.run(
+        [cli, "--socket", str(socket_path), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+        env=env,
+    )
+    recorder.wait()
+
+    merged = f"{process.stdout}\n{process.stderr}".strip()
+    if process.returncode == 0:
+        return False, f"expected a non-zero local rejection, got 0: {merged!r}"
+    if "more than one" not in merged:
+        return False, f"expected an ambiguity error, got: {merged!r}"
+    if recorder.received:
+        return False, f"expected zero socket bytes, got {bytes(recorder.received)!r}"
+    return True, ""
+
+
+def main() -> int:
+    cli = resolve_c11_cli()
+    cases = [
+        [
+            "rename-tab",
+            "--tab", "surface:1",
+            "--tab", "surface:2",
+            "new title",
+        ],
+        [
+            "rename-tab",
+            "--tab", "surface:1",
+            "--surface", "surface:2",
+            "new title",
+        ],
+        [
+            "rename-tab",
+            "--workspace", "workspace:1",
+            "--workspace", "workspace:2",
+            "--tab", "surface:3",
+            "new title",
+        ],
+    ]
+
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="c11-zero-dispatch-") as temp_dir:
+        for index, args in enumerate(cases):
+            socket_path = Path(temp_dir) / f"case-{index}.sock"
+            ok, detail = run_case(cli, socket_path, args)
+            label = " ".join(args)
+            print(f"{'PASS' if ok else 'FAIL'}: {label}")
+            if not ok:
+                failures.append(f"{label}: {detail}")
+
+    if failures:
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+
+    print(f"PASS: all {len(cases)} ambiguous rename-tab commands wrote zero socket bytes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Incident

`c11 close-surface surface:101` used to discard the positional ref and fall
through to `$CMUX_SURFACE_ID`, closing the caller instead of surface 101. The
same class also affected `--surface=surface:101`, and `tab-action` could discard
an apparent positional target before a destructive action.

The invariant for this PR is:

> A named destructive target is honored or rejected. It is never discarded and
> replaced by caller focus.

## What changed

### CLI parsing

- `close-surface` now uses `CLISurfaceRefArguments`:
  - honors positional `surface:N` handles and UUIDs
  - accepts `--flag value` and `--flag=value`
  - rejects wrong-kind handles, unknown flags, missing/empty values, conflicting
    aliases, and distinct repeated workspace/surface values
  - preserves the caller default only for a genuinely bare command
- `tab-action` consumes `--workspace`, `--tab`, and `--surface` through the same
  conflict-aware seam:
  - distinct repeated or cross-alias targets reject
  - exact duplicates remain accepted
  - non-rename actions reject leftover positional tokens instead of silently
    treating them as ignored targets
- `rename-tab`, the compatibility wrapper over `tab-action rename`, now uses
  that same target parser before forwarding. It no longer collapses repeated or
  cross-alias refs through the generic last-value-wins parser.

Examples now rejected locally:

```text
c11 rename-tab --tab surface:1 --tab surface:2 x
c11 rename-tab --tab surface:1 --surface surface:2 x
c11 rename-tab --workspace workspace:1 --workspace workspace:2 --tab surface:3 x
```

### Socket/server fallback boundary

The server now separately hardens `surface.close` and `tab.action`:

- missing target keys remain absent, so the intentional focused-target default
  is preserved where the method contract allows it
- explicit JSON `null`, empty/whitespace, malformed, stale, case-mismatched, or
  conflicting workspace/surface/tab pins reject before mutation
- `tab.action rename` still requires an explicit tab/surface pin
- other `tab.action` verbs and `surface.close` use focus only when their target
  keys are truly absent

This is intentionally scoped to `surface.close` / `tab.action`. It does not
generalize null-vs-absent semantics across every socket method, and it does not
change the existing `send` / `send-key` targeting contract.

Client and server checks cover different failures: the server can reject an
explicit invalid pin that reaches it, while the client parser must prevent a
typed ref from being discarded before any destructive request is formed.

### Skill contract

`skills/c11/references/api.md` now documents positional `close-surface`
handles, bare-index ambiguity, focused fallback only for a truly bare close,
and conflict rejection for destructive native targets.

`docs/socket-api-reference.md` remains unchanged because it is a capability
inventory rather than the CLI/error-semantics reference.

## Destructive call-site audit

All CLI call sites for these socket methods were inspected:

| Entry point | Socket method | Result |
|---|---|---|
| native `close-surface` | `surface.close` | strict parser plus server pin validation |
| native `tab-action` | `tab.action` | shared conflict-aware parser plus server pin validation |
| compatibility `rename-tab` | forwards to `tab.action` | shared parser applied before forwarding |
| internal tmux `kill-pane` / `killp` | `surface.close` | supplied `-t` is explicitly resolved; stale/malformed targets error rather than falling back |

The tmux shim retains tmux-style last-`-t` behavior for repeated `-t` options;
that is an explicit bounded target choice, not the ignored-ref-to-focus fallback
fixed here.

One global CLI caveat: pre-command `--window` may send its separate
`window.focus` RPC before subcommand parsing. Therefore the guarantee is zero
destructive `surface.close` / `tab.action` dispatch for rejected ambiguity, not
universal zero-RPC for commands that include global `--window`. The three
no-`--window` examples above were additionally proven to write zero socket
bytes.

## Exact-head verification

Head: `6af6e90e3fab5c3466cbdf4880cb0b024775171b`

- focused logic: `CLISurfaceRefArgumentsTests` +
  `SocketSurfaceRefValidatorTests` — **40 tests, 0 failures**
- host mutation matrix: `SocketSurfaceRefRejectionWiringTests` —
  **17 tests, 0 failures**
- compiled arm64 CLI fake-socket regression:
  `tests/test_cli_destructive_target_zero_dispatch.py` —
  **3 cases, 0 failures**, zero socket bytes for the three required
  no-`--window` commands
- `xcodebuild -project GhosttyTabs.xcodeproj -list` — succeeded
- `git diff --check` — clean
- Python test syntax compilation — succeeded

No app reload, live-session mutation, comment, or merge was performed.
