### PR TITLE
Tabs: spawn-button click focuses its new surface even in an unfocused pane

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11881,6 +11881,15 @@ extension Workspace: BonsplitDelegate {
     }
 
     func splitTabBar(_ controller: BonsplitController, didRequestNewTab kind: String, inPane pane: PaneID) {
+        // An explicit tab-bar spawn click ("A"/terminal/browser/markdown/"+") is an
+        // unambiguous "open a new surface here and let me use it" gesture, so the new
+        // surface must take focus immediately. Focus the clicked pane first — mirroring
+        // how tapping a tab focuses its pane — so the surface creators (which default
+        // `focus` to `focusedPaneId == pane`) reliably focus + select what they create.
+        // Without this, clicking a spawn button in a pane that was NOT the focused pane
+        // created the surface but left focus on the other pane, so the view never
+        // switched to the new tab.
+        bonsplitController.focusPane(pane)
         switch kind {
         case "terminal":
             _ = newTerminalSurface(inPane: pane)

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -1577,6 +1577,67 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
     }
 
+    func testSpawnButtonInUnfocusedPaneFocusesNewSurface() {
+        // Regression: a tab-bar spawn click ("A"/terminal/browser/markdown/"+") routes
+        // through the didRequestNewTab delegate with an explicit pane. When that pane is
+        // NOT the currently focused pane, the new surface must still take focus — the
+        // view should switch to it — rather than being created silently in the
+        // background. Previously the surface creators only auto-focused when the clicked
+        // pane already had focus, so a spawn in the other pane left focus behind and the
+        // new tab never became active.
+        let workspace = Workspace()
+        guard let firstPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected initial focused panel")
+            return
+        }
+
+        // Split to create a second pane; the new split becomes the focused pane.
+        guard let splitPanel = workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal),
+              let splitPaneId = workspace.paneId(forPanelId: splitPanel.id) else {
+            XCTFail("Expected split panel and its pane")
+            return
+        }
+        workspace.focusPanel(splitPanel.id)
+        drainMainQueue()
+
+        // Re-derive the original pane after the split (ids are stable, but be robust).
+        guard let targetPaneId = workspace.paneId(forPanelId: firstPanelId) else {
+            XCTFail("Expected the original panel to still resolve to a pane")
+            return
+        }
+        XCTAssertNotEqual(targetPaneId, splitPaneId)
+        XCTAssertEqual(
+            workspace.bonsplitController.focusedPaneId,
+            splitPaneId,
+            "Precondition: the split pane holds focus before the spawn"
+        )
+
+        // Simulate clicking a spawn button in the OTHER (unfocused) pane.
+        let beforePanels = Set(workspace.panels.keys)
+        workspace.splitTabBar(
+            workspace.bonsplitController,
+            didRequestNewTab: "terminal",
+            inPane: targetPaneId
+        )
+        drainMainQueue()
+        drainMainQueue()
+
+        let created = Set(workspace.panels.keys).subtracting(beforePanels)
+        XCTAssertEqual(created.count, 1, "Expected exactly one new surface")
+        guard let newPanelId = created.first else { return }
+
+        XCTAssertEqual(
+            workspace.focusedPanelId,
+            newPanelId,
+            "Expected the spawn-button surface to be focused even though its pane was unfocused"
+        )
+        XCTAssertEqual(
+            workspace.bonsplitController.focusedPaneId,
+            targetPaneId,
+            "Expected focus to move to the pane the spawn button was clicked in"
+        )
+    }
+
     func testClosingFocusedSplitRestoresBranchForRemainingFocusedPanel() {
         let workspace = Workspace()
         guard let firstPanelId = workspace.focusedPanelId else {


### PR DESCRIPTION
## Problem

Pressing a tab-bar **spawn button** (the **A** agent button, terminal, browser, markdown, or the plain **+** "New Tab") in a pane that **isn't currently focused** creates the new tab but leaves keyboard focus — and the visible view — on the *other* pane. The new tab never becomes active; you have to click it. Reported symptom: *"it creates a new tab but doesn't put focus on it / the view doesn't switch to it."*

## Root cause

All five spawn kinds route through the one delegate `Workspace.splitTabBar(_:didRequestNewTab:inPane:)`, which calls the surface creators (`newTerminalSurface` / `newBrowserSurface` / `newMarkdownSurface` / `launchAgentSurface` / `createNewTabOfFocusedKind`) with `focus: nil`. Each creator resolves:

```swift
let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
```

So the new surface is focused **only if the clicked pane was already the focused pane**. The bonsplit tab-bar buttons (`TabBarView.swift`) call `requestNewTab(kind:inPane:)` without focusing the pane first (unlike tapping a tab, which does `selectTab` + `focusPane`). Net effect: spawn in a non-focused pane → surface created, focus left behind. The **A** button appears to "work" only because it's habitually clicked in the already-focused pane — identical code path.

## Fix

One line at the top of the delegate — focus the clicked pane first, exactly as tapping a tab already does:

```swift
bonsplitController.focusPane(pane)
```

An explicit spawn-button click is an unambiguous "open a new surface here and let me use it" gesture, so all five kinds now reliably focus + select what they create, regardless of which pane held focus. No change to programmatic/split creation (which still passes explicit `focus:` and keeps the "don't steal focus" default).

## Test

`testSpawnButtonInUnfocusedPaneFocusesNewSurface` — splits into two panes, focuses one, spawns via the delegate in the *other*, asserts the new surface (and its pane) take focus.

- ✅ Passes with the fix
- ❌ Fails without it (both assertions — focus stays on the old pane), verified by reverting the one line

## Notes

- Validated at the model level (unit test); the real AppKit button click wasn't driven from CI/CLI. Worth a quick live smoke: two panes, focus one, click **+**/**A** in the other, confirm focus moves.
- Heads-up unrelated to this PR: `testSidebarPullRequestsTrackFocusedPanelOnly` currently fails on pristine `main` as well (confirmed by stashing this change) — pre-existing, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
