### PR TITLE
launch-agent: first-class CLI for launching typed agents (agent.launch)

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2182,6 +2182,69 @@ struct CMUXCLI {
             printSizeWarning(payload)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
+        case "launch-agent":
+            // Typed-agent launch: one command that owns per-agent invocation
+            // quirks, identity-at-birth, and machine-readable refs. Thin
+            // client over `agent.launch` (docs/launch-agent-reference.md).
+            guard let agentKind = optionValue(commandArgs, name: "--type") else {
+                throw CLIError(message: "launch-agent requires --type <kind> (built-in: claude-code, codex, grok, kimi, opencode, github-copilot, pi, omp; or a kebab-case custom kind with ~/.config/c11/agents/<kind>.json)")
+            }
+            let launchNewWorkspace = commandArgs.contains("--new-workspace")
+            let launchPaneRaw = optionValue(commandArgs, name: "--pane")
+            let launchWorkspaceRaw = optionValue(commandArgs, name: "--workspace")
+            if launchNewWorkspace && (launchPaneRaw != nil || launchWorkspaceRaw != nil) {
+                throw CLIError(message: "launch-agent: --new-workspace is mutually exclusive with --pane/--workspace")
+            }
+            let launchPromptInline = optionValue(commandArgs, name: "--prompt")
+            let launchPromptFile = optionValue(commandArgs, name: "--prompt-file")
+            if launchPromptInline != nil && launchPromptFile != nil {
+                throw CLIError(message: "launch-agent: --prompt and --prompt-file are mutually exclusive")
+            }
+            var launchPrompt = launchPromptInline
+            if let launchPromptFile {
+                let path = resolvePath(launchPromptFile)
+                guard let contents = try? String(contentsOfFile: path, encoding: .utf8),
+                      !contents.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    throw CLIError(message: "launch-agent: failed to read --prompt-file: \(path)")
+                }
+                launchPrompt = contents
+            }
+            // Repeatable --env KEY=VALUE.
+            var launchEnv: [String: Any] = [:]
+            var launchEnvIdx = 0
+            while launchEnvIdx < commandArgs.count {
+                if commandArgs[launchEnvIdx] == "--env", launchEnvIdx + 1 < commandArgs.count {
+                    let entry = commandArgs[launchEnvIdx + 1]
+                    guard let eq = entry.firstIndex(of: "="), eq != entry.startIndex else {
+                        throw CLIError(message: "launch-agent: --env expects KEY=VALUE (got: \(entry))")
+                    }
+                    launchEnv[String(entry[..<eq])] = String(entry[entry.index(after: eq)...])
+                    launchEnvIdx += 2
+                } else {
+                    launchEnvIdx += 1
+                }
+            }
+            var params: [String: Any] = ["type": agentKind]
+            if let v = optionValue(commandArgs, name: "--model") { params["model"] = v }
+            if let v = optionValue(commandArgs, name: "--effort") { params["effort"] = v }
+            if let v = optionValue(commandArgs, name: "--task") { params["task"] = v }
+            if let v = optionValue(commandArgs, name: "--title") { params["title"] = v }
+            if let launchPrompt { params["prompt"] = launchPrompt }
+            if let v = optionValue(commandArgs, name: "--cwd") { params["cwd"] = resolvePath(v) }
+            if !launchEnv.isEmpty { params["env"] = launchEnv }
+            if launchNewWorkspace {
+                params["new_workspace"] = true
+            } else {
+                let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
+                let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
+                if let wsId { params["workspace_id"] = wsId }
+                let paneId = try normalizePaneHandle(launchPaneRaw, client: client, workspaceHandle: wsId)
+                if let paneId { params["pane_id"] = paneId }
+            }
+            if commandArgs.contains("--no-focus") { params["focus"] = false }
+            let launchPayload = try client.sendV2(method: "agent.launch", params: params)
+            printV2Payload(launchPayload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(launchPayload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
+
         case "new-surface":
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)
             let type = optionValue(commandArgs, name: "--type")
@@ -8506,6 +8569,39 @@ struct CMUXCLI {
               c11 new-pane --title "Parent :: Code Review"
               c11 new-pane --cwd /Users/me/project
               c11 new-pane --allow-undersized
+            """
+        case "launch-agent":
+            return """
+            Usage: c11 launch-agent --type <kind> [flags]
+
+            Launch a typed coding agent into a new surface (or a fresh workspace):
+            correct per-agent invocation, model/effort flags, identity stamped at
+            birth (env + sidebar metadata + tab title), machine-readable refs back.
+            Canonical reference: docs/launch-agent-reference.md.
+
+            Flags:
+              --type <kind>            Required. Built-in: claude-code, codex, grok,
+                                       kimi, opencode, github-copilot, pi, omp — or a
+                                       kebab-case custom kind backed by
+                                       ~/.config/c11/agents/<kind>.json
+              --model <id>             Model to pin (rendered per the kind's template)
+              --effort <tier>          Effort/thinking tier (errors if the kind has none)
+              --task <id>              Task identifier for sidebar telemetry
+              --pane <id|ref>          Target pane (default: focused pane)
+              --workspace <id|ref>     Target workspace (default: $C11_WORKSPACE_ID)
+              --new-workspace          Launch into a fresh workspace instead
+              --cwd <path>             Working directory for the agent
+              --prompt <text>          Initial prompt (one-shot argv where supported)
+              --prompt-file <path>     Read the initial prompt from a file
+              --title <text>           Tab title (default: launch placeholder)
+              --env KEY=VALUE          Extra spawn env (repeatable)
+              --no-focus               Do not focus the new surface
+              --json                   Print the machine-readable result object
+
+            Examples:
+              c11 launch-agent --type claude-code --model opus --effort high
+              c11 launch-agent --type codex --model gpt-5.2 --new-workspace --json
+              c11 launch-agent --type opencode --prompt-file /tmp/brief.md --pane pane:2
             """
         case "new-surface":
             return """
@@ -16492,6 +16588,7 @@ struct CMUXCLI {
           claude-hook <session-start|stop|notification> [--workspace <id|ref>] [--surface <id|ref>]
           set-agent --type <terminal_type> [--model <id>] [--task <id>] [--role <id>] [--surface <id|ref>] [--workspace <id|ref>]
           default-agent {get | set <type> | launch [--in-surface <id|ref> | --pane <id>] [--agent <type>] [--cwd <path>] [--prompt <text> | --prompt-file <path>]}
+          launch-agent --type <kind> [--model <id>] [--effort <tier>] [--task <id>] [--pane <id|ref> | --workspace <id|ref> | --new-workspace] [--cwd <path>] [--prompt <text> | --prompt-file <path>] [--title <text>] [--env K=V ...] [--json]
           set-metadata (--json '{...}' | --key <K> --value <V> [--type string|number|bool|json]) [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>] [--mode merge|replace] [--source <src>]
           get-metadata [--key <K> ...] [--sources] [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]
           clear-metadata [--key <K> ...] [--source <src>] [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2243,7 +2243,10 @@ struct CMUXCLI {
             }
             if commandArgs.contains("--no-focus") { params["focus"] = false }
             let launchPayload = try client.sendV2(method: "agent.launch", params: params)
-            printV2Payload(launchPayload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(launchPayload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
+            // Accept --json in trailing position too (the documented form);
+            // the global parser only consumes it before the subcommand.
+            let launchJSONOut = jsonOutput || commandArgs.contains("--json")
+            printV2Payload(launchPayload, jsonOutput: launchJSONOut, idFormat: idFormat, fallbackText: v2OKSummary(launchPayload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
         case "new-surface":
             let workspaceArg = workspaceFromArgsOrEnv(commandArgs, windowOverride: windowId)

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -8598,8 +8598,10 @@ struct CMUXCLI {
               --prompt-file <path>     Read the initial prompt from a file
               --title <text>           Tab title (default: launch placeholder)
               --env KEY=VALUE          Extra spawn env (repeatable)
-              --no-focus               Do not focus the new surface
               --json                   Print the machine-readable result object
+
+            Launches never steal focus or selection (socket focus policy) —
+            the new surface is created in the background.
 
             Examples:
               c11 launch-agent --type claude-code --model opus --effort high

--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -54,6 +54,10 @@ struct AgentManifest: Sendable, Equatable, Identifiable {
     /// How a snapshot/crash restart resumes this agent.
     let resume: ResumeSpec
 
+    /// Launch-time composition facts (model/effort flag syntax, prompt
+    /// delivery) consumed by `launch-agent` and `DefaultAgentResolver`.
+    let launch: AgentLaunchTemplate
+
     /// Whether `kind` is a recognized `terminal_type`
     /// (`SurfaceMetadataKeys.canonicalTerminalTypes`). `custom` is not.
     let isCanonicalTerminalType: Bool
@@ -87,6 +91,68 @@ struct AgentManifest: Sendable, Equatable, Identifiable {
             return "\(resumeCmd)\n"
         }
     }
+}
+
+/// How a launch-time value (a model id, an effort tier) renders onto an
+/// agent's command line. Data, not code: `launch-agent`, the resolver, and any
+/// future launch surface consult this instead of growing per-agent switches.
+enum AgentLaunchArgStyle: Sendable, Equatable {
+    /// `.flag("--model")` → `--model <value>`.
+    case flag(String)
+    /// `.configKV("model_reasoning_effort")` → `-c model_reasoning_effort=<value>`
+    /// (codex's config-override syntax).
+    case configKV(String)
+
+    /// Substring whose presence in the operator's configured command means the
+    /// value is already hardcoded there — c11 must not inject it twice.
+    var detectToken: String {
+        switch self {
+        case .flag(let name): return name
+        case .configKV(let key): return key
+        }
+    }
+
+    /// Render the argument for `value`, shell-quoting only when the value
+    /// needs it so the common case stays byte-identical to the historical
+    /// `--model opus` form.
+    func render(_ value: String) -> String {
+        let quoted = DefaultAgentResolver.shellQuoteIfNeeded(value)
+        switch self {
+        case .flag(let name): return "\(name) \(quoted)"
+        case .configKV(let key): return "-c \(key)=\(quoted)"
+        }
+    }
+}
+
+/// How an initial prompt reaches the agent at launch.
+enum AgentPromptDelivery: Sendable, Equatable {
+    /// Appended to the launch argv as a single-quoted positional argument —
+    /// one shot, no ready-state race (claude, codex, grok, pi, omp, and
+    /// opencode's `run` form).
+    case positional
+    /// Appended as `<flag> '<prompt>'` for TUIs whose initial prompt only
+    /// rides a named flag.
+    case flag(String)
+    /// Typed into the TUI after a fixed post-launch delay. Best-effort and
+    /// racy by nature; used only for agents with no argv delivery.
+    case postBoot
+}
+
+/// The per-kind launch facts `launch-agent` composes from: how model and
+/// effort flags render, which effort values are legal, and how a prompt is
+/// delivered. Seeded per built-in manifest; custom kinds decode the same
+/// shape from `~/.config/c11/agents/<kind>.json` (`UserAgentLaunchTemplate`).
+struct AgentLaunchTemplate: Sendable, Equatable {
+    /// Model-flag syntax, or `nil` when the CLI has no model flag c11 knows —
+    /// a `--model` request for such a kind errors instead of guessing.
+    let modelArg: AgentLaunchArgStyle?
+    /// Effort-flag syntax (claude `--effort`, codex reasoning-effort config
+    /// key, pi/omp `--thinking`), or `nil` when the CLI has no effort axis.
+    let effortArg: AgentLaunchArgStyle?
+    /// Non-empty → `--effort` values are validated early with a friendly
+    /// error; empty → passed through and the agent CLI enforces.
+    let effortValues: [String]
+    let promptDelivery: AgentPromptDelivery
 }
 
 /// How a captured session is resumed on restart. Mirrors today's
@@ -142,6 +208,12 @@ struct AgentRegistry: Sendable {
                 command: "claude --dangerously-skip-permissions --resume",
                 projectDirKey: SurfaceMetadataKeyName.claudeSessionProjectDir
             ),
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+                effortArg: .flag("--effort"),
+                effortValues: ["low", "medium", "high", "xhigh", "max"],
+                promptDelivery: .positional
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -156,6 +228,14 @@ struct AgentRegistry: Sendable {
             iconAsset: "AgentIcons/codex",
             sfSymbolFallback: "chevron.left.forwardslash.chevron.right",
             resume: .fixed("codex resume --last\n"),
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+            // Codex has no --effort flag; reasoning effort rides the
+            // config-override syntax. Values pass through (codex enforces).
+                effortArg: .configKV("model_reasoning_effort"),
+                effortValues: [],
+                promptDelivery: .positional
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -170,6 +250,12 @@ struct AgentRegistry: Sendable {
             iconAsset: "AgentIcons/grok",
             sfSymbolFallback: "bolt.fill",
             resume: .fixed("grok --always-approve --resume\n"),
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+                effortArg: nil,
+                effortValues: [],
+                promptDelivery: .positional
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -184,6 +270,13 @@ struct AgentRegistry: Sendable {
             iconAsset: "AgentIcons/kimi",
             sfSymbolFallback: "moon.stars",
             resume: .fixed("kimi\n"),
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+            // kimi's --thinking is boolean, not tiered — no effort axis.
+                effortArg: nil,
+                effortValues: [],
+                promptDelivery: .postBoot
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -198,6 +291,15 @@ struct AgentRegistry: Sendable {
             iconAsset: "AgentIcons/opencode",
             sfSymbolFallback: "curlybraces",
             resume: .fixed("opencode run --dangerously-skip-permissions\n"),
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+                effortArg: nil,
+                effortValues: [],
+            // Positional because the factory command is the `opencode run`
+            // form, whose message is positional. An operator who rebases
+            // the command onto the bare TUI owns the delivery consequences.
+                promptDelivery: .positional
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -213,6 +315,12 @@ struct AgentRegistry: Sendable {
             sfSymbolFallback: "paperplane.fill",
             // No phase1 row today → fresh launch via the normal path.
             resume: .none,
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+                effortArg: nil,
+                effortValues: [],
+                promptDelivery: .postBoot
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -236,6 +344,12 @@ struct AgentRegistry: Sendable {
             // `~/.pi/agent/sessions/` id and type `pi --session '<id>'` even
             // when the cwd holds several sessions.
             resume: .fixed("pi -c\n"),
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+                effortArg: .flag("--thinking"),
+                effortValues: ["off", "minimal", "low", "medium", "high", "xhigh"],
+                promptDelivery: .positional
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -257,6 +371,12 @@ struct AgentRegistry: Sendable {
             // `/resume` only), so `resume` stays `.none` while the strategy owns
             // exact resume — same split as the codex row.
             resume: .none,
+            launch: AgentLaunchTemplate(
+                modelArg: .flag("--model"),
+                effortArg: .flag("--thinking"),
+                effortValues: ["off", "minimal", "low", "medium", "high", "xhigh"],
+                promptDelivery: .positional
+            ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
         ),
@@ -271,6 +391,12 @@ struct AgentRegistry: Sendable {
             iconAsset: nil,
             sfSymbolFallback: nil,
             resume: .none,
+            launch: AgentLaunchTemplate(
+                modelArg: nil,
+                effortArg: nil,
+                effortValues: [],
+                promptDelivery: .postBoot
+            ),
             isCanonicalTerminalType: false,
             hasConversationStrategy: false
         )
@@ -288,3 +414,70 @@ struct AgentRegistry: Sendable {
 /// operator who wants a launch prompt can still set one per-agent in
 /// Default Agent settings.
 let c11OrientPrompt = ""
+
+/// Launch template for a kebab-case custom agent kind, decoded from
+/// `~/.config/c11/agents/<kind>.json`. This file is the launch-template
+/// subset of the planned runtime agent manifest (docs/agent-registry-design.md
+/// §7); when full runtime manifests land they subsume it. Only `command` is
+/// required:
+///
+/// ```json
+/// { "command": "aider --yes-always",
+///   "modelFlag": "--model",
+///   "effortFlag": null,
+///   "effortValues": [],
+///   "promptDelivery": "post-boot",
+///   "env": { "AIDER_ANALYTICS": "false" } }
+/// ```
+///
+/// `promptDelivery` accepts `"positional"`, `"post-boot"`, or a flag name
+/// (any string starting with `-`), e.g. `"--prompt"`.
+struct UserAgentLaunchTemplate: Codable, Equatable {
+    var command: String
+    var modelFlag: String?
+    var effortFlag: String?
+    var effortValues: [String]?
+    var promptDelivery: String?
+    var env: [String: String]?
+
+    /// The composed launch-template view over the decoded fields.
+    var template: AgentLaunchTemplate {
+        AgentLaunchTemplate(
+            modelArg: modelFlag.flatMap { $0.isEmpty ? nil : .flag($0) },
+            effortArg: effortFlag.flatMap { $0.isEmpty ? nil : .flag($0) },
+            effortValues: effortValues ?? [],
+            promptDelivery: {
+                switch promptDelivery {
+                case .some("positional"): return .positional
+                case .some(let s) where s.hasPrefix("-"): return .flag(s)
+                default: return .postBoot
+                }
+            }()
+        )
+    }
+
+    /// Kind grammar shared with the sidebar's `terminal_type` metadata key:
+    /// lowercase kebab, ≤ 32 chars.
+    static func isValidKind(_ kind: String) -> Bool {
+        guard !kind.isEmpty, kind.count <= 32 else { return false }
+        return kind.range(of: "^[a-z][a-z0-9-]*$", options: .regularExpression) != nil
+    }
+
+    static func templateURL(kind: String) -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".config/c11/agents", isDirectory: true)
+            .appendingPathComponent("\(kind).json")
+    }
+
+    /// Load the template for a custom kind, or `nil` when no file exists or
+    /// it fails to decode. Callers treat `nil` as "unknown agent type".
+    static func load(kind: String) -> UserAgentLaunchTemplate? {
+        guard isValidKind(kind) else { return nil }
+        let url = templateURL(kind: kind)
+        guard let data = try? Data(contentsOf: url),
+              let decoded = try? JSONDecoder().decode(UserAgentLaunchTemplate.self, from: data),
+              !decoded.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return decoded
+    }
+}

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -91,43 +91,42 @@ enum DefaultAgentResolver {
         return result
     }
 
-    /// Whether c11 injects a `--model` flag for this agent kind. Only agents
-    /// whose CLI accepts `--model <family-alias>` qualify; today that's Claude
-    /// Code. Kept as a seam so codex (also `--model`) can opt in later.
+    /// Whether c11 injects a model flag for this agent kind — driven by the
+    /// kind's launch template (`AgentManifest.launch.modelArg`), so an agent
+    /// opts in by declaring its flag syntax as data, not by editing call sites.
     static func supportsModelFlag(_ agent: AgentType) -> Bool {
-        agent == .claudeCode
+        AgentRegistry.shared.manifest(for: agent)?.launch.modelArg != nil
     }
 
-    /// The `--model <family>` flag to append for a launch, or `nil` when none
-    /// should be injected: the agent doesn't support it, no family is pinned,
-    /// or the operator already put a model in the command themselves (their
-    /// explicit choice wins, and we must not pass `--model` twice).
-    /// Visible for testing.
+    /// The model flag to append for a launch (rendered per the kind's launch
+    /// template), or `nil` when none should be injected: the agent's template
+    /// declares no model syntax, no model is pinned, or the operator already
+    /// put a model in the command themselves (their explicit choice wins, and
+    /// we must not pass the flag twice). Visible for testing.
     static func modelFlag(agent: AgentType, config: AgentConfig, command: String) -> String? {
-        guard supportsModelFlag(agent) else { return nil }
+        guard let arg = AgentRegistry.shared.manifest(for: agent)?.launch.modelArg else { return nil }
         let model = config.model.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !model.isEmpty else { return nil }
-        guard !command.lowercased().contains("--model") else { return nil }
-        return "--model \(model)"
+        guard !command.lowercased().contains(arg.detectToken) else { return nil }
+        return arg.render(model)
     }
 
-    /// Whether c11 injects an `--effort` flag for this agent kind. Same set as
-    /// the model flag today (Claude Code); kept separate so an agent that
-    /// accepts one flag but not the other can diverge later.
+    /// Whether c11 injects an effort flag for this agent kind — like
+    /// `supportsModelFlag`, driven by the kind's launch template.
     static func supportsEffortFlag(_ agent: AgentType) -> Bool {
-        agent == .claudeCode
+        AgentRegistry.shared.manifest(for: agent)?.launch.effortArg != nil
     }
 
-    /// The `--effort <level>` flag to append for a launch, or `nil` when none
-    /// should be injected: the agent doesn't support it, no level is pinned, or
-    /// the operator already put an effort in the command themselves (their
-    /// explicit choice wins). Visible for testing.
+    /// The effort flag to append for a launch (rendered per the kind's launch
+    /// template — `--effort` for claude, `-c model_reasoning_effort=` for
+    /// codex, `--thinking` for pi/omp), or `nil` when none should be injected.
+    /// Visible for testing.
     static func effortFlag(agent: AgentType, config: AgentConfig, command: String) -> String? {
-        guard supportsEffortFlag(agent) else { return nil }
+        guard let arg = AgentRegistry.shared.manifest(for: agent)?.launch.effortArg else { return nil }
         let effort = config.effort.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !effort.isEmpty else { return nil }
-        guard !command.lowercased().contains("--effort") else { return nil }
-        return "--effort \(effort)"
+        guard !command.lowercased().contains(arg.detectToken) else { return nil }
+        return arg.render(effort)
     }
 
     /// Single-quote a value for /bin/sh, escaping embedded single quotes via
@@ -136,5 +135,227 @@ enum DefaultAgentResolver {
         if value.isEmpty { return "''" }
         let escaped = value.replacingOccurrences(of: "'", with: "'\\''")
         return "'\(escaped)'"
+    }
+
+    /// Quote only when the value needs it, so the common flag values stay
+    /// byte-identical to their historical bare form (`--model opus`) while
+    /// anything with shell-significant characters is safely single-quoted.
+    static func shellQuoteIfNeeded(_ value: String) -> String {
+        if value.isEmpty { return "''" }
+        let safe = value.unicodeScalars.allSatisfy { scalar in
+            switch scalar {
+            case "a"..."z", "A"..."Z", "0"..."9", ".", "_", "-", "/", ":", ",", "@", "+", "=", "%":
+                return true
+            default:
+                return false
+            }
+        }
+        return safe ? value : shellQuote(value)
+    }
+}
+
+// MARK: - launch-agent planning
+
+/// The caller's request for `agent.launch` / `c11 launch-agent`, normalized.
+struct AgentLaunchRequest: Equatable {
+    var kind: String
+    var model: String?
+    var effort: String?
+    var task: String?
+    var prompt: String?
+    var title: String?
+    var extraEnv: [String: String] = [:]
+}
+
+/// Structured planning failures — each maps 1:1 onto a wire error code so the
+/// CLI/socket surface stays machine-readable (docs/launch-agent-reference.md).
+enum AgentLaunchPlanError: Error, Equatable {
+    case unknownAgentType(String)
+    case emptyCommand(String)
+    case modelFlagUnsupported(String)
+    case effortFlagUnsupported(String)
+    case invalidEffort(value: String, allowed: [String])
+
+    var code: String {
+        switch self {
+        case .unknownAgentType: return "unknown_agent_type"
+        case .emptyCommand: return "empty_command"
+        case .modelFlagUnsupported: return "model_flag_unsupported"
+        case .effortFlagUnsupported: return "effort_flag_unsupported"
+        case .invalidEffort: return "invalid_effort"
+        }
+    }
+
+    var message: String {
+        switch self {
+        case .unknownAgentType(let kind):
+            let builtIn = AgentType.allCases.map(\.rawValue).joined(separator: ", ")
+            return "unknown agent type '\(kind)' — built-in types: \(builtIn); custom kinds need \(UserAgentLaunchTemplate.templateURL(kind: kind).path)"
+        case .emptyCommand(let kind):
+            return "agent '\(kind)' resolved to an empty launch command (configure it in Settings → Agents & Automation)"
+        case .modelFlagUnsupported(let kind):
+            return "agent '\(kind)' declares no model-flag syntax; --model is not supported for it"
+        case .effortFlagUnsupported(let kind):
+            return "agent '\(kind)' declares no effort-flag syntax; --effort is not supported for it"
+        case .invalidEffort(let value, let allowed):
+            return "invalid effort '\(value)' — allowed: \(allowed.joined(separator: ", "))"
+        }
+    }
+}
+
+/// A fully composed launch: the line to type, the env to spawn with, the
+/// identity to stamp, and any prompt that must follow post-boot.
+struct AgentLaunchPlan: Equatable {
+    let kind: String
+    /// `nil` for custom kebab kinds that only exist as a user template.
+    let agentType: AgentType?
+    /// The full line typed into the new PTY (launcher + flags [+ prompt]).
+    let launchLine: String
+    /// Non-nil when the kind's template delivers prompts post-boot.
+    let delayedPrompt: String?
+    /// Spawn environment: operator env overrides, then the launch identity
+    /// (`C11_AGENT_TYPE/MODEL/TASK` + `CMUX_*` aliases), then caller extras.
+    let env: [String: String]
+    /// The resolved model pin ("" = inherit the agent's ambient default).
+    let model: String
+    let effort: String
+    let warnings: [String]
+}
+
+/// Pure composer for `agent.launch`. No I/O — callers pass the merged configs
+/// and (for custom kinds) the pre-loaded user template, so the whole planning
+/// path is exercisable from `c11LogicTests`.
+enum AgentLaunchPlanner {
+
+    static func plan(
+        request: AgentLaunchRequest,
+        userDefault: DefaultAgentConfig,
+        projectConfig: DefaultAgentConfig?,
+        userTemplate: UserAgentLaunchTemplate?
+    ) -> Result<AgentLaunchPlan, AgentLaunchPlanError> {
+        let kind = request.kind.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let agentType = AgentType(rawValue: kind)
+        let template: AgentLaunchTemplate
+        let baseCommand: String
+        let baseEnv: [String: String]
+        let pinnedModel: String
+        let pinnedEffort: String
+
+        if let agentType {
+            guard let manifest = AgentRegistry.shared.manifest(for: agentType) else {
+                return .failure(.unknownAgentType(kind))
+            }
+            // Same per-agent config pick as the A button: project entry beats
+            // user Settings, factory fills the gaps.
+            let config = projectConfig?.agents[agentType] ?? userDefault.config(for: agentType)
+            template = manifest.launch
+            baseCommand = config.command.trimmingCharacters(in: .whitespacesAndNewlines)
+            baseEnv = config.envMap
+            pinnedModel = config.model.trimmingCharacters(in: .whitespacesAndNewlines)
+            pinnedEffort = config.effort.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else if let userTemplate {
+            template = userTemplate.template
+            baseCommand = userTemplate.command.trimmingCharacters(in: .whitespacesAndNewlines)
+            baseEnv = userTemplate.env ?? [:]
+            pinnedModel = ""
+            pinnedEffort = ""
+        } else {
+            return .failure(.unknownAgentType(kind))
+        }
+
+        guard !baseCommand.isEmpty else {
+            return .failure(.emptyCommand(kind))
+        }
+
+        var warnings: [String] = []
+        var line = baseCommand
+
+        // Model: an operator-hardcoded flag in the command always wins; then
+        // the caller's --model; then the Settings/project pin; then nothing.
+        let requestedModel = request.model?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let requestedModel, !requestedModel.isEmpty, template.modelArg == nil {
+            return .failure(.modelFlagUnsupported(kind))
+        }
+        var resolvedModel = ""
+        if let arg = template.modelArg {
+            let hardcoded = baseCommand.lowercased().contains(arg.detectToken)
+            let value = (requestedModel?.isEmpty == false) ? requestedModel! : pinnedModel
+            if hardcoded {
+                if requestedModel?.isEmpty == false {
+                    warnings.append("configured command already pins a model; --model \(requestedModel!) ignored")
+                }
+            } else if !value.isEmpty {
+                line += " \(arg.render(value))"
+                resolvedModel = value
+            }
+        }
+
+        // Effort: same precedence ladder as model.
+        let requestedEffort = request.effort?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let requestedEffort, !requestedEffort.isEmpty, template.effortArg == nil {
+            return .failure(.effortFlagUnsupported(kind))
+        }
+        var resolvedEffort = ""
+        if let arg = template.effortArg {
+            let hardcoded = baseCommand.lowercased().contains(arg.detectToken)
+            let value = (requestedEffort?.isEmpty == false) ? requestedEffort! : pinnedEffort
+            if hardcoded {
+                if requestedEffort?.isEmpty == false {
+                    warnings.append("configured command already pins an effort; --effort \(requestedEffort!) ignored")
+                }
+            } else if !value.isEmpty {
+                if !template.effortValues.isEmpty, !template.effortValues.contains(value) {
+                    return .failure(.invalidEffort(value: value, allowed: template.effortValues))
+                }
+                line += " \(arg.render(value))"
+                resolvedEffort = value
+            }
+        }
+
+        // Prompt: one-shot argv where the template supports it; post-boot send
+        // otherwise.
+        var delayedPrompt: String?
+        let prompt = request.prompt?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let prompt, !prompt.isEmpty {
+            switch template.promptDelivery {
+            case .positional:
+                line += " \(DefaultAgentResolver.shellQuote(prompt))"
+            case .flag(let flagName):
+                line += " \(flagName) \(DefaultAgentResolver.shellQuote(prompt))"
+            case .postBoot:
+                delayedPrompt = prompt
+            }
+        }
+
+        // Spawn env: operator/template env first, then the launch identity,
+        // then caller extras (caller wins on collision). Both C11_* and the
+        // legacy CMUX_* names are set — the PATH-shim wrappers read CMUX_*.
+        var env = baseEnv
+        var identity: [String: String] = [
+            "C11_AGENT_TYPE": kind,
+            "CMUX_AGENT_TYPE": kind
+        ]
+        if !resolvedModel.isEmpty {
+            identity["C11_AGENT_MODEL"] = resolvedModel
+            identity["CMUX_AGENT_MODEL"] = resolvedModel
+        }
+        if let task = request.task?.trimmingCharacters(in: .whitespacesAndNewlines), !task.isEmpty {
+            identity["C11_AGENT_TASK"] = task
+            identity["CMUX_AGENT_TASK"] = task
+        }
+        env.merge(identity) { _, new in new }
+        env.merge(request.extraEnv) { _, new in new }
+
+        return .success(AgentLaunchPlan(
+            kind: kind,
+            agentType: agentType,
+            launchLine: line,
+            delayedPrompt: delayedPrompt,
+            env: env,
+            model: resolvedModel,
+            effort: resolvedEffort,
+            warnings: warnings
+        ))
     }
 }

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -157,13 +157,14 @@ enum DefaultAgentResolver {
 // MARK: - launch-agent planning
 
 /// The caller's request for `agent.launch` / `c11 launch-agent`, normalized.
+/// The tab title is not part of this request — it never influences command
+/// composition, so the handler threads it straight to the metadata stamp.
 struct AgentLaunchRequest: Equatable {
     var kind: String
     var model: String?
     var effort: String?
     var task: String?
     var prompt: String?
-    var title: String?
     var extraEnv: [String: String] = [:]
 }
 

--- a/Sources/SocketHandlers/SocketDispatch.swift
+++ b/Sources/SocketHandlers/SocketDispatch.swift
@@ -986,13 +986,16 @@ extension TerminalController {
             let panel: TerminalPanel
             let paneUUID: UUID?
             if newWorkspace {
-                // Env + command ride workspace creation itself, so identity is
-                // present at PTY birth and the command flushes on shell-ready —
-                // no follow-up sends, no race. autoWelcome is suppressed: this
-                // workspace hosts an agent, not the onboarding grid.
+                // Identity env rides workspace creation so it is present at
+                // PTY birth; the launch line is *typed* into the interactive
+                // shell below (queue-until-ready, same as the A button) rather
+                // than baked as the ghostty spawn command — a spawn command
+                // execs over the shell (agent exit kills the surface) and
+                // skips shell rc, which changes PATH-wrapper resolution.
+                // autoWelcome is suppressed: this workspace hosts an agent,
+                // not the onboarding grid.
                 let created = tabManager.addWorkspace(
                     workingDirectory: cwdOverride,
-                    initialTerminalCommand: plan.launchLine + "\n",
                     initialTerminalEnvironment: plan.env,
                     select: focus,
                     eagerLoadTerminal: !focus,
@@ -1005,6 +1008,7 @@ extension TerminalController {
                 ws = created
                 panel = initialPanel
                 paneUUID = created.bonsplitController.focusedPaneId?.id
+                panel.sendText(plan.launchLine + "\n")
             } else {
                 guard let target = self.v2ResolveWorkspace(params: params, tabManager: tabManager) else {
                     result = .err(code: "not_found", message: "Workspace not found", data: nil)
@@ -1036,7 +1040,14 @@ extension TerminalController {
                 ws = target
                 panel = created
                 paneUUID = paneId.id
-                // Same queue-until-ready delivery as the A button.
+                // A surface created in an unselected workspace stays lazily
+                // unattached (`tty: null`) and would never flush a queued
+                // command — kick the background start like
+                // `launchInExistingSurface` does (C11-121), then use the same
+                // queue-until-ready delivery as the A button.
+                if panel.surface.surface == nil {
+                    panel.surface.requestBackgroundSurfaceStartIfNeeded()
+                }
                 panel.sendText(plan.launchLine + "\n")
             }
 

--- a/Sources/SocketHandlers/SocketDispatch.swift
+++ b/Sources/SocketHandlers/SocketDispatch.swift
@@ -955,7 +955,6 @@ extension TerminalController {
             effort: v2RawString(params, "effort"),
             task: v2RawString(params, "task"),
             prompt: v2RawString(params, "prompt"),
-            title: v2RawString(params, "title"),
             extraEnv: v2StringMap(params, "env") ?? [:]
         )
         let plan: AgentLaunchPlan
@@ -976,7 +975,7 @@ extension TerminalController {
             warnings.append(binaryWarning)
         }
 
-        let title = request.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = v2RawString(params, "title")?.trimmingCharacters(in: .whitespacesAndNewlines)
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to launch agent", data: nil)
         guard v2MainSyncWithDeadline({
             let callerWantsFocus = self.v2Bool(params, "focus") ?? true

--- a/Sources/SocketHandlers/SocketDispatch.swift
+++ b/Sources/SocketHandlers/SocketDispatch.swift
@@ -884,6 +884,7 @@ extension TerminalController {
     /// seam DX-1 asks for; the router (parse/auth-gate/policy/main-sync) is
     /// unchanged. Runs on the main actor exactly like the switch it replaces.
     func v2DispatchExtracted(_ method: String, id: Any?, params: [String: Any]) -> String? {
+        if method.hasPrefix("agent.") { return v2DispatchAgent(method, id: id, params: params) }
         if method.hasPrefix("window.") { return v2DispatchWindow(method, id: id, params: params) }
         if method.hasPrefix("workspace.") { return v2DispatchWorkspace(method, id: id, params: params) }
         if method.hasPrefix("pane.") { return v2DispatchPane(method, id: id, params: params) }
@@ -900,4 +901,224 @@ extension TerminalController {
         return nil
     }
 
+}
+
+// MARK: - agent.* domain (launch-agent)
+
+extension TerminalController {
+    /// v2 dispatch slice for the `agent.*` domain — the typed-agent launch
+    /// primitive behind `c11 launch-agent` (docs/launch-agent-reference.md).
+    func v2DispatchAgent(_ method: String, id: Any?, params: [String: Any]) -> String {
+        switch method {
+        case "agent.launch":
+            return v2Result(id: id, self.v2AgentLaunch(params: params))
+        default:
+            return v2Error(id: id, code: "method_not_found", message: "Unknown method")
+        }
+    }
+
+    /// `agent.launch` — resolve a typed agent's launch plan, create the target
+    /// surface (pane / workspace / fresh workspace), inject the identity env,
+    /// stamp metadata, and type the composed command, atomically server-side.
+    /// Parsing/planning runs off-main; only surface creation + stamping is
+    /// main-synced (socket threading policy).
+    func v2AgentLaunch(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let kindRaw = v2RawString(params, "type")?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !kindRaw.isEmpty else {
+            return .err(code: "invalid_params", message: "Missing required param: type", data: nil)
+        }
+
+        let newWorkspace = v2Bool(params, "new_workspace") ?? false
+        let paneParam = v2UUID(params, "pane_id")
+        if newWorkspace && (paneParam != nil || params["workspace_id"] != nil) {
+            return .err(code: "invalid_params", message: "new_workspace is mutually exclusive with pane_id/workspace_id", data: nil)
+        }
+
+        var cwdOverride: String?
+        if let err = v2ResolveCwdParam(params, resolved: &cwdOverride) {
+            return err
+        }
+
+        // Config + (for custom kinds) template I/O happens here, off-main.
+        let lookupCwd = cwdOverride ?? FileManager.default.currentDirectoryPath
+        let userDefault = DefaultAgentConfigStore.shared.current
+        let projectConfig = DefaultAgentProjectConfig.find(from: lookupCwd)
+        let userTemplate: UserAgentLaunchTemplate? =
+            AgentType(rawValue: kindRaw) == nil ? UserAgentLaunchTemplate.load(kind: kindRaw) : nil
+
+        let request = AgentLaunchRequest(
+            kind: kindRaw,
+            model: v2RawString(params, "model"),
+            effort: v2RawString(params, "effort"),
+            task: v2RawString(params, "task"),
+            prompt: v2RawString(params, "prompt"),
+            title: v2RawString(params, "title"),
+            extraEnv: v2StringMap(params, "env") ?? [:]
+        )
+        let plan: AgentLaunchPlan
+        switch AgentLaunchPlanner.plan(
+            request: request,
+            userDefault: userDefault,
+            projectConfig: projectConfig,
+            userTemplate: userTemplate
+        ) {
+        case .failure(let error):
+            return .err(code: error.code, message: error.message, data: nil)
+        case .success(let composed):
+            plan = composed
+        }
+
+        var warnings = plan.warnings
+        if let binaryWarning = Self.agentLaunchBinaryWarning(launchLine: plan.launchLine) {
+            warnings.append(binaryWarning)
+        }
+
+        let title = request.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to launch agent", data: nil)
+        guard v2MainSyncWithDeadline({
+            let callerWantsFocus = self.v2Bool(params, "focus") ?? true
+            let focus = self.v2FocusAllowed(requested: callerWantsFocus)
+
+            let ws: Workspace
+            let panel: TerminalPanel
+            let paneUUID: UUID?
+            if newWorkspace {
+                // Env + command ride workspace creation itself, so identity is
+                // present at PTY birth and the command flushes on shell-ready —
+                // no follow-up sends, no race. autoWelcome is suppressed: this
+                // workspace hosts an agent, not the onboarding grid.
+                let created = tabManager.addWorkspace(
+                    workingDirectory: cwdOverride,
+                    initialTerminalCommand: plan.launchLine + "\n",
+                    initialTerminalEnvironment: plan.env,
+                    select: focus,
+                    eagerLoadTerminal: !focus,
+                    autoWelcomeIfNeeded: false
+                )
+                guard let initialPanel = created.focusedTerminalPanel else {
+                    result = .err(code: "internal_error", message: "New workspace has no terminal surface", data: nil)
+                    return
+                }
+                ws = created
+                panel = initialPanel
+                paneUUID = created.bonsplitController.focusedPaneId?.id
+            } else {
+                guard let target = self.v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                    result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                    return
+                }
+                if focus {
+                    self.v2MaybeFocusWindow(for: tabManager)
+                    self.v2MaybeSelectWorkspace(tabManager, workspace: target)
+                }
+                let paneId: PaneID? = {
+                    if let paneParam {
+                        return target.bonsplitController.allPaneIds.first(where: { $0.id == paneParam })
+                    }
+                    return target.bonsplitController.focusedPaneId
+                }()
+                guard let paneId else {
+                    result = .err(code: "not_found", message: "Pane not found", data: nil)
+                    return
+                }
+                guard let created = target.newTerminalSurface(
+                    inPane: paneId,
+                    focus: focus,
+                    workingDirectory: cwdOverride,
+                    startupEnvironment: plan.env
+                ) else {
+                    result = .err(code: "internal_error", message: "Failed to create surface", data: nil)
+                    return
+                }
+                ws = target
+                panel = created
+                paneUUID = paneId.id
+                // Same queue-until-ready delivery as the A button.
+                panel.sendText(plan.launchLine + "\n")
+            }
+
+            ws.stampAgentLaunchIdentity(
+                surfaceId: panel.id,
+                kind: plan.kind,
+                model: plan.model,
+                task: request.task,
+                title: title
+            )
+
+            if let delayedPrompt = plan.delayedPrompt {
+                // Post-boot delivery for TUIs with no argv prompt. Same fixed
+                // delay rail as `default-agent launch` (readiness detection is
+                // a follow-up there too).
+                let panelId = panel.id
+                let wsId = ws.id
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(2500)) { [weak tabManager] in
+                    guard let tabManager,
+                          let liveWs = tabManager.tabs.first(where: { $0.id == wsId }),
+                          let livePanel = liveWs.terminalPanel(for: panelId) else { return }
+                    livePanel.surface.sendSubmitFormText(delayedPrompt)
+                }
+            }
+
+            // Make the just-minted refs resolvable by the caller's next command.
+            self.v2RefreshKnownRefs()
+
+            let windowId = self.v2ResolveWindowId(tabManager: tabManager)
+            var agent: [String: Any] = ["type": plan.kind]
+            agent["model"] = plan.model.isEmpty ? NSNull() : plan.model
+            agent["effort"] = plan.effort.isEmpty ? NSNull() : plan.effort
+            agent["task"] = self.v2OrNull(request.task)
+            result = .ok([
+                "agent": agent,
+                "command": plan.launchLine,
+                "window_id": self.v2OrNull(windowId?.uuidString),
+                "window_ref": self.v2Ref(kind: .window, uuid: windowId),
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": self.v2Ref(kind: .workspace, uuid: ws.id),
+                "pane_id": self.v2OrNull(paneUUID?.uuidString),
+                "pane_ref": paneUUID.map { self.v2Ref(kind: .pane, uuid: $0) } ?? NSNull(),
+                "surface_id": panel.id.uuidString,
+                "surface_ref": self.v2Ref(kind: .surface, uuid: panel.id),
+                "warnings": warnings
+            ])
+        }) != nil else {
+            return .err(code: "main_thread_timeout", message: "main thread did not respond within deadline", data: nil)
+        }
+        return result
+    }
+
+    /// Best-effort binary availability check for the launch line's argv[0].
+    /// A warning, never a hard error: the app process PATH (especially when
+    /// c11 was launched from Finder) is poorer than the login-shell PATH a
+    /// surface actually gets, so an absent binary here may still resolve in
+    /// the pane. Searches the bundled wrapper dir, the app PATH, and the
+    /// common user-install dirs.
+    nonisolated static func agentLaunchBinaryWarning(launchLine: String) -> String? {
+        guard let binary = launchLine.split(separator: " ").first.map(String.init),
+              !binary.isEmpty else { return nil }
+        let fm = FileManager.default
+        if binary.contains("/") {
+            return fm.isExecutableFile(atPath: (binary as NSString).expandingTildeInPath)
+                ? nil
+                : "launch binary not found: \(binary)"
+        }
+        var dirs: [String] = []
+        if let bundled = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
+            dirs.append(bundled)
+        }
+        if let path = ProcessInfo.processInfo.environment["PATH"] {
+            dirs.append(contentsOf: path.split(separator: ":").map(String.init))
+        }
+        let home = fm.homeDirectoryForCurrentUser.path
+        dirs.append(contentsOf: [
+            "/opt/homebrew/bin", "/usr/local/bin",
+            "\(home)/.local/bin", "\(home)/bin", "\(home)/.grok/bin"
+        ])
+        for dir in dirs where fm.isExecutableFile(atPath: "\(dir)/\(binary)") {
+            return nil
+        }
+        return "binary '\(binary)' not found on the app PATH or common install dirs; the pane's login shell may still resolve it"
+    }
 }

--- a/Sources/SocketHandlers/SystemHandlers.swift
+++ b/Sources/SocketHandlers/SystemHandlers.swift
@@ -110,6 +110,7 @@ extension TerminalController {
             "surface.set_metadata",
             "surface.get_metadata",
             "surface.clear_metadata",
+            "agent.launch",
             "mailbox.resolve",
             "pane.list",
             "pane.focus",

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12017,6 +12017,52 @@ extension Workspace: BonsplitDelegate {
         syncPanelTitleFromMetadata(panelId: surfaceId)
     }
 
+    /// Identity-at-birth stamp for `agent.launch` (`c11 launch-agent`). Unlike
+    /// `stampLaunchIdentity` (A button), the caller *explicitly requested* this
+    /// agent kind, so `terminal_type` is stamped as a declaration too — the
+    /// same tier `c11 set-agent` writes, so a later explicit declaration still
+    /// cleanly wins, and `AgentDetector`'s heuristic tier never fights it.
+    /// Models that don't fit the canonical kebab grammar (e.g. `gpt-5.2`,
+    /// `provider/model`) land on the non-canonical `model_label` display hint
+    /// instead so the chip still shows them.
+    func stampAgentLaunchIdentity(
+        surfaceId: UUID,
+        kind: String,
+        model: String,
+        task: String?,
+        title: String?
+    ) {
+        var partial: [String: Any] = [
+            MetadataKey.terminalType: kind,
+            MetadataKey.title: title?.isEmpty == false
+                ? title!
+                : String(
+                    localized: "agent.launch.placeholderTitle",
+                    defaultValue: "Awaiting first task"
+                )
+        ]
+        let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedModel.isEmpty {
+            if trimmedModel.range(of: "^[a-z][a-z0-9-]*$", options: .regularExpression) != nil,
+               trimmedModel.count <= 64 {
+                partial[MetadataKey.model] = trimmedModel
+            } else {
+                partial[MetadataKey.modelLabel] = String(trimmedModel.prefix(16))
+            }
+        }
+        if let task = task?.trimmingCharacters(in: .whitespacesAndNewlines), !task.isEmpty {
+            partial[MetadataKey.task] = String(task.prefix(128))
+        }
+        _ = try? SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: id,
+            surfaceId: surfaceId,
+            partial: partial,
+            mode: .merge,
+            source: .declare
+        )
+        syncPanelTitleFromMetadata(panelId: surfaceId)
+    }
+
     func splitTabBar(_ controller: BonsplitController, menuItemsForNewTabKind kind: String, inPane pane: PaneID) -> [BonsplitNewTabMenuItem] {
         guard kind == "agent" else { return [] }
         let current = DefaultAgentConfigStore.shared.current.defaultAgent

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -235,18 +235,33 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
     }
 
-    func testBuildCommandDoesNotInjectModelForNonClaudeAgent() {
-        // codex accepts --model too, but c11 only pins it for claude-code today;
-        // a stray model value on another agent must be ignored, not injected.
+    func testBuildCommandInjectsModelForCodexViaTemplate() {
+        // Flag injection is template-driven: codex's manifest declares
+        // `--model`, so a pinned model now renders for it too.
         let cfg = AgentConfig(
             command: "codex --yolo",
+            initialPrompt: "",
+            envOverridesText: "",
+            model: "gpt-5.2"
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .codex, config: cfg),
+            "codex --yolo --model gpt-5.2"
+        )
+    }
+
+    func testBuildCommandDoesNotInjectModelForTemplatelessAgent() {
+        // `custom` declares no model-flag syntax — a stray model value must be
+        // ignored, not guessed into a flag.
+        let cfg = AgentConfig(
+            command: "myagent --go",
             initialPrompt: "",
             envOverridesText: "",
             model: "opus"
         )
         XCTAssertEqual(
-            DefaultAgentResolver.buildCommand(agent: .codex, config: cfg),
-            "codex --yolo"
+            DefaultAgentResolver.buildCommand(agent: .custom, config: cfg),
+            "myagent --go"
         )
     }
 
@@ -322,7 +337,9 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
     }
 
-    func testBuildCommandDoesNotInjectEffortForNonClaudeAgent() {
+    func testBuildCommandInjectsEffortForCodexViaConfigKV() {
+        // codex's effort syntax is the config-override form, rendered from its
+        // template — not `--effort`.
         let cfg = AgentConfig(
             command: "codex --yolo",
             initialPrompt: "",
@@ -331,7 +348,21 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
         XCTAssertEqual(
             DefaultAgentResolver.buildCommand(agent: .codex, config: cfg),
-            "codex --yolo"
+            "codex --yolo -c model_reasoning_effort=high"
+        )
+    }
+
+    func testBuildCommandDoesNotInjectEffortForTemplatelessAgent() {
+        let cfg = AgentConfig(
+            command: "grok --always-approve",
+            initialPrompt: "",
+            envOverridesText: "",
+            effort: "high"
+        )
+        // grok's template declares a model flag but no effort axis.
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .grok, config: cfg),
+            "grok --always-approve"
         )
     }
 
@@ -481,5 +512,224 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
         XCTAssertEqual(launch.bareCommand, "")
         XCTAssertEqual(launch.command, "")
+    }
+}
+
+// MARK: - launch-agent planning (docs/launch-agent-reference.md)
+
+final class AgentLaunchPlannerTests: XCTestCase {
+
+    private func userDefault(
+        _ agent: AgentType = .claudeCode,
+        command: String? = nil,
+        model: String = "",
+        effort: String = "",
+        env: String = ""
+    ) -> DefaultAgentConfig {
+        var cfg = DefaultAgentConfig.factory
+        cfg.agents[agent] = AgentConfig(
+            command: command ?? agent.factoryCommand,
+            initialPrompt: "",
+            envOverridesText: env,
+            model: model,
+            effort: effort
+        )
+        return cfg
+    }
+
+    private func plan(
+        _ request: AgentLaunchRequest,
+        userDefault: DefaultAgentConfig = .factory,
+        projectConfig: DefaultAgentConfig? = nil,
+        userTemplate: UserAgentLaunchTemplate? = nil
+    ) -> Result<AgentLaunchPlan, AgentLaunchPlanError> {
+        AgentLaunchPlanner.plan(
+            request: request,
+            userDefault: userDefault,
+            projectConfig: projectConfig,
+            userTemplate: userTemplate
+        )
+    }
+
+    // MARK: composition per kind
+
+    func testClaudeModelEffortAndPositionalPrompt() throws {
+        let result = plan(AgentLaunchRequest(
+            kind: "claude-code", model: "opus", effort: "high", prompt: "do the thing"
+        ))
+        let p = try result.get()
+        XCTAssertEqual(
+            p.launchLine,
+            "claude --dangerously-skip-permissions --model opus --effort high 'do the thing'"
+        )
+        XCTAssertNil(p.delayedPrompt)
+        XCTAssertEqual(p.agentType, .claudeCode)
+    }
+
+    func testCodexEffortRendersConfigKV() throws {
+        let p = try plan(AgentLaunchRequest(
+            kind: "codex", model: "gpt-5.2", effort: "high"
+        )).get()
+        XCTAssertEqual(p.launchLine, "codex --yolo --model gpt-5.2 -c model_reasoning_effort=high")
+    }
+
+    func testPiEffortRendersThinkingFlag() throws {
+        let p = try plan(AgentLaunchRequest(kind: "pi", effort: "xhigh")).get()
+        XCTAssertEqual(p.launchLine, "pi --thinking xhigh")
+    }
+
+    func testOpencodeModelWithSlashStaysUnquoted() throws {
+        let p = try plan(AgentLaunchRequest(
+            kind: "opencode", model: "anthropic/claude-sonnet-4-5"
+        )).get()
+        XCTAssertEqual(
+            p.launchLine,
+            "opencode run --dangerously-skip-permissions --model anthropic/claude-sonnet-4-5"
+        )
+    }
+
+    func testKimiPromptGoesPostBoot() throws {
+        let p = try plan(AgentLaunchRequest(kind: "kimi", prompt: "hello")).get()
+        XCTAssertEqual(p.launchLine, "kimi")
+        XCTAssertEqual(p.delayedPrompt, "hello")
+    }
+
+    // MARK: precedence
+
+    func testRequestModelBeatsSettingsPin() throws {
+        let cfg = userDefault(.claudeCode, model: "opus")
+        let p = try plan(
+            AgentLaunchRequest(kind: "claude-code", model: "sonnet"),
+            userDefault: cfg
+        ).get()
+        XCTAssertTrue(p.launchLine.contains("--model sonnet"))
+        XCTAssertFalse(p.launchLine.contains("opus"))
+        XCTAssertEqual(p.model, "sonnet")
+    }
+
+    func testSettingsPinAppliesWhenRequestOmitsModel() throws {
+        let cfg = userDefault(.claudeCode, model: "opus")
+        let p = try plan(AgentLaunchRequest(kind: "claude-code"), userDefault: cfg).get()
+        XCTAssertTrue(p.launchLine.contains("--model opus"))
+        XCTAssertEqual(p.model, "opus")
+    }
+
+    func testHardcodedModelInCommandWinsWithWarning() throws {
+        let cfg = userDefault(.claudeCode, command: "claude --dangerously-skip-permissions --model haiku")
+        let p = try plan(
+            AgentLaunchRequest(kind: "claude-code", model: "opus"),
+            userDefault: cfg
+        ).get()
+        XCTAssertFalse(p.launchLine.contains("--model opus"))
+        XCTAssertEqual(p.warnings.count, 1)
+        XCTAssertEqual(p.model, "")
+    }
+
+    // MARK: errors
+
+    func testUnknownKindFails() {
+        guard case .failure(let err) = plan(AgentLaunchRequest(kind: "not-a-real-agent")) else {
+            return XCTFail("expected failure")
+        }
+        XCTAssertEqual(err.code, "unknown_agent_type")
+    }
+
+    func testEffortUnsupportedFails() {
+        guard case .failure(let err) = plan(AgentLaunchRequest(kind: "grok", effort: "high")) else {
+            return XCTFail("expected failure")
+        }
+        XCTAssertEqual(err.code, "effort_flag_unsupported")
+    }
+
+    func testInvalidEffortValueFails() {
+        guard case .failure(let err) = plan(AgentLaunchRequest(kind: "claude-code", effort: "warp")) else {
+            return XCTFail("expected failure")
+        }
+        XCTAssertEqual(err.code, "invalid_effort")
+    }
+
+    // MARK: identity env
+
+    func testEnvCarriesIdentityInBothPrefixes() throws {
+        let p = try plan(AgentLaunchRequest(
+            kind: "codex", model: "gpt-5.2", task: "sekhem-42"
+        )).get()
+        XCTAssertEqual(p.env["C11_AGENT_TYPE"], "codex")
+        XCTAssertEqual(p.env["CMUX_AGENT_TYPE"], "codex")
+        XCTAssertEqual(p.env["C11_AGENT_MODEL"], "gpt-5.2")
+        XCTAssertEqual(p.env["CMUX_AGENT_MODEL"], "gpt-5.2")
+        XCTAssertEqual(p.env["C11_AGENT_TASK"], "sekhem-42")
+        XCTAssertEqual(p.env["CMUX_AGENT_TASK"], "sekhem-42")
+    }
+
+    func testCallerExtraEnvWinsOverOperatorEnv() throws {
+        let cfg = userDefault(.claudeCode, env: "FOO=operator\nBAR=kept")
+        let p = try plan(
+            AgentLaunchRequest(kind: "claude-code", extraEnv: ["FOO": "caller"]),
+            userDefault: cfg
+        ).get()
+        XCTAssertEqual(p.env["FOO"], "caller")
+        XCTAssertEqual(p.env["BAR"], "kept")
+    }
+
+    // MARK: custom kinds
+
+    func testCustomKindUsesUserTemplate() throws {
+        let template = UserAgentLaunchTemplate(
+            command: "aider --yes-always",
+            modelFlag: "--model",
+            effortFlag: nil,
+            effortValues: nil,
+            promptDelivery: "post-boot",
+            env: ["AIDER_ANALYTICS": "false"]
+        )
+        let p = try plan(
+            AgentLaunchRequest(kind: "aider", model: "gpt-5.2", prompt: "fix it"),
+            userTemplate: template
+        ).get()
+        XCTAssertEqual(p.launchLine, "aider --yes-always --model gpt-5.2")
+        XCTAssertEqual(p.delayedPrompt, "fix it")
+        XCTAssertEqual(p.env["AIDER_ANALYTICS"], "false")
+        XCTAssertEqual(p.env["C11_AGENT_TYPE"], "aider")
+        XCTAssertNil(p.agentType)
+    }
+
+    func testCustomKindPromptFlagDelivery() throws {
+        let template = UserAgentLaunchTemplate(
+            command: "someagent",
+            modelFlag: nil,
+            effortFlag: nil,
+            effortValues: nil,
+            promptDelivery: "--prompt",
+            env: nil
+        )
+        let p = try plan(
+            AgentLaunchRequest(kind: "someagent", prompt: "go"),
+            userTemplate: template
+        ).get()
+        XCTAssertEqual(p.launchLine, "someagent --prompt 'go'")
+        XCTAssertNil(p.delayedPrompt)
+    }
+
+    func testUserTemplateKindValidation() {
+        XCTAssertTrue(UserAgentLaunchTemplate.isValidKind("my-agent-2"))
+        XCTAssertFalse(UserAgentLaunchTemplate.isValidKind("My-Agent"))
+        XCTAssertFalse(UserAgentLaunchTemplate.isValidKind("-bad"))
+        XCTAssertFalse(UserAgentLaunchTemplate.isValidKind(""))
+        XCTAssertFalse(UserAgentLaunchTemplate.isValidKind(String(repeating: "a", count: 33)))
+    }
+
+    // MARK: quoting
+
+    func testShellQuoteIfNeededBareForSafeValues() {
+        XCTAssertEqual(DefaultAgentResolver.shellQuoteIfNeeded("opus"), "opus")
+        XCTAssertEqual(DefaultAgentResolver.shellQuoteIfNeeded("gpt-5.2"), "gpt-5.2")
+        XCTAssertEqual(DefaultAgentResolver.shellQuoteIfNeeded("a/b:c,d@e+f=g%h"), "a/b:c,d@e+f=g%h")
+    }
+
+    func testShellQuoteIfNeededQuotesShellSignificantValues() {
+        XCTAssertEqual(DefaultAgentResolver.shellQuoteIfNeeded("a b"), "'a b'")
+        XCTAssertEqual(DefaultAgentResolver.shellQuoteIfNeeded("x;rm -rf"), "'x;rm -rf'")
+        XCTAssertEqual(DefaultAgentResolver.shellQuoteIfNeeded(""), "''")
     }
 }

--- a/docs/launch-agent-reference.md
+++ b/docs/launch-agent-reference.md
@@ -1,0 +1,231 @@
+# `c11 launch-agent` — launching typed agents
+
+The canonical reference for launching a typed coding agent into a c11 surface with
+one command: correct invocation for the agent's CLI, model/effort pinned, identity
+stamped at birth, machine-readable refs back to the caller.
+
+```
+c11 launch-agent --type <kind>
+    [--model <id>] [--effort <tier>] [--task <id>]
+    [--pane <ref> | --workspace <ref> | --new-workspace] [--cwd <path>]
+    [--prompt <text> | --prompt-file <path>]
+    [--title <text>] [--env KEY=VALUE ...] [--json]
+```
+
+`launch-agent` is the programmatic sibling of the A button. Where
+`c11 default-agent launch` launches *whatever the operator configured as the
+default*, `launch-agent` launches *a specific agent kind* — the primitive an
+external controller (a Stream Deck, a MIDI deck, another agent) needs to say
+"give me a Codex on gpt-5.2 in a new workspace, prompted with this brief."
+
+## Why one command
+
+Hand-composing agent launches means re-implementing, per caller: the claude PATH
+wrapper + `--dangerously-skip-permissions`, codex `--yolo` (never `exec` for a
+visible surface), per-CLI model/effort flag syntax, `C11_AGENT_TYPE/MODEL/TASK`
+env declaration, `set-agent` metadata, and tab naming. c11 already knows every one
+of these facts (`AgentRegistry`, `DefaultAgentConfigStore`,
+`DefaultAgentResolver`); `launch-agent` makes it own them at the launch site.
+
+## Semantics
+
+### Agent kind (`--type`, required)
+
+One of the built-in kinds — `claude-code`, `codex`, `grok`, `kimi`, `opencode`,
+`github-copilot`, `pi`, `omp` — or any kebab-case custom kind with a user launch
+template on disk (see [Custom kinds](#custom-kinds)). An unknown kind with no
+template is an error (`unknown_agent_type`), never a guess.
+
+### Base command resolution
+
+The launch line starts from the same command the A button would use, so
+`launch-agent` stays coherent with **Settings → Agents & Automation → Agent
+Launcher**:
+
+1. Project config `.c11/agents.json` entry for the kind (walk-up from the launch
+   cwd), else
+2. the operator's per-agent Settings command, else
+3. the registry factory command (`claude --dangerously-skip-permissions`,
+   `codex --yolo`, …).
+
+Operator `envOverrides` from the same config are applied to the spawn env.
+
+### Model and effort (`--model`, `--effort`)
+
+Injected as flags using the **launch template** for the kind (below) — the
+per-CLI syntax is data, not caller knowledge. Precedence per field:
+
+1. a flag the operator hardcoded into the configured command (never duplicated),
+2. the `--model` / `--effort` CLI argument,
+3. the model/effort pinned in Settings (project entry beats user entry),
+4. nothing — the agent's own ambient default.
+
+If the kind's template declares no model (or effort) syntax and the caller passed
+`--model` (or `--effort`), the launch fails with `model_flag_unsupported` /
+`effort_flag_unsupported` rather than silently dropping the request. When a
+template declares an allowed-values list (claude effort tiers, pi/omp thinking
+levels), the value is validated early with a friendly error; otherwise it is
+passed through and the agent CLI enforces.
+
+### Placement (`--pane` | `--workspace` | `--new-workspace`)
+
+- Default: a new surface in the caller's pane (from `$C11_PANE`/focused pane of
+  the current workspace — same target the A button would hit).
+- `--pane <ref>`: a new surface in that pane.
+- `--workspace <ref>`: a new surface in that workspace's focused pane.
+- `--new-workspace`: a fresh workspace whose first terminal is the agent
+  (uses `workspace.create` `initial_env` + `initial_command`, so identity and
+  command are present at PTY birth with no follow-up sends).
+
+`--cwd <path>` sets the working directory (resolved CLI-side relative to the
+caller, validated server-side). Placement never steals macOS focus (socket focus
+policy).
+
+### Identity at birth
+
+The new PTY spawns with `C11_AGENT_TYPE`, `C11_AGENT_MODEL`, `C11_AGENT_TASK`
+(and their `CMUX_*` legacy aliases) in its environment, and the surface metadata
+is stamped server-side before the launch line is typed: `terminal_type`, `model`,
+`task` (source `declare`), plus the tab title (`--title`, else the standard
+launch placeholder). The sidebar chip, title bar, and `c11 tree` are correct with
+zero post-hoc calls; wrappers and skill-driven self-reporting only refine from
+there.
+
+`--env KEY=VALUE` (repeatable) adds caller extras to the spawn env after the
+operator's configured overrides (caller wins on collision).
+
+### Prompt delivery (`--prompt` | `--prompt-file`)
+
+Delivered per the template's `promptDelivery`:
+
+- `positional` — appended to the launch argv, single-quoted (claude, codex, grok,
+  pi, omp, opencode's `run` form). One shot; no ready-state race.
+- `flag <name>` — appended as `<name> '<prompt>'` (for CLIs whose TUI takes an
+  initial prompt only via a named flag).
+- `post-boot` — typed into the TUI after a fixed delay (kimi, github-copilot),
+  the same best-effort rail `default-agent launch` uses today. Racy by nature;
+  prefer kinds with argv delivery for orchestration.
+
+`--prompt-file` reads the prompt from a file (use it for anything longer than a
+sentence — shell escaping of inline prompts is the caller's problem).
+
+### Output
+
+Human-readable by default; `--json` prints one object:
+
+```json
+{
+  "ok": true,
+  "agent": { "type": "codex", "model": "gpt-5.2", "effort": "high", "task": "sekhem-42" },
+  "command": "codex --yolo --model gpt-5.2 -c model_reasoning_effort=high",
+  "window_ref": "window:1",
+  "workspace_ref": "workspace:4",
+  "pane_ref": "pane:9",
+  "surface_ref": "surface:341",
+  "workspace_id": "…", "pane_id": "…", "surface_id": "…"
+}
+```
+
+Refs are immediately valid targets for `send`, `read-screen`, `set-*`.
+
+### Errors
+
+All errors are structured (`--json` gives `{"ok":false,"error":{"code":…,"message":…}}`):
+
+| code | when |
+|---|---|
+| `unknown_agent_type` | `--type` is not a built-in kind and no user template exists |
+| `binary_not_found` | the launch command's binary is not on the surface PATH |
+| `model_flag_unsupported` / `effort_flag_unsupported` | `--model`/`--effort` passed for a kind whose template declares no syntax for it |
+| `invalid_effort` | value outside the template's declared allowed list |
+| `prompt_flag_conflict` | both `--prompt` and `--prompt-file` |
+| `target_not_found` / `invalid_cwd` | bad `--pane`/`--workspace` ref or cwd |
+
+## Launch templates
+
+The per-kind launch facts are **data on the agent manifest**
+(`Sources/AgentManifest.swift` → `LaunchTemplate`), not code at call sites:
+
+```swift
+struct LaunchTemplate {
+    let modelArg: ArgSpec?      // how "--model <id>" renders for this CLI
+    let effortArg: ArgSpec?     // how "--effort <tier>" renders
+    let effortValues: [String]  // non-empty → validated early
+    let promptDelivery: PromptDelivery  // .positional | .flag(String) | .postBoot
+}
+enum ArgSpec { case flag(String)          // "--model" → `--model <v>`
+               case configKV(String) }    // "model_reasoning_effort" → `-c k=<v>`
+```
+
+### Built-in seeds
+
+| kind | model | effort | effort values | prompt |
+|---|---|---|---|---|
+| `claude-code` | `--model` | `--effort` | low, medium, high, xhigh, max | positional |
+| `codex` | `--model` | `-c model_reasoning_effort=` | (pass-through) | positional |
+| `grok` | `--model` | — | | positional |
+| `kimi` | `--model` | — | | post-boot |
+| `opencode` | `--model` (provider/model) | — | | positional (`run` form) |
+| `github-copilot` | `--model` | — | | post-boot |
+| `pi` | `--model` | `--thinking` | off, minimal, low, medium, high, xhigh | positional |
+| `omp` | `--model` | `--thinking` | off, minimal, low, medium, high, xhigh | positional |
+
+Notes: opencode's prompt is positional **because** its factory command is the
+`opencode run` form; an operator who reconfigures the base command to the bare
+TUI owns the delivery consequences. kimi's `--thinking` is boolean, not tiered,
+so it is not mapped to `--effort`.
+
+### Custom kinds
+
+A kebab-case kind that is not built-in resolves its template from
+`~/.config/c11/agents/<kind>.json`:
+
+```json
+{
+  "command": "aider --yes-always",
+  "modelFlag": "--model",
+  "effortFlag": null,
+  "effortValues": [],
+  "promptDelivery": "post-boot",
+  "env": { "AIDER_ANALYTICS": "false" }
+}
+```
+
+Only `command` is required. This file is the launch-template subset of the
+planned runtime agent manifest (`docs/agent-registry-design.md` §7); when full
+TOML manifests land, they subsume it. Custom kinds get env identity + metadata
+stamping like built-ins (`terminal_type` = the kind), but no branded chip, no
+detection, no resume.
+
+## Socket method
+
+CLI `launch-agent` is a thin client over one v2 method, `agent.launch`:
+
+```json
+{ "method": "agent.launch",
+  "params": { "type": "codex", "model": "gpt-5.2", "effort": "high",
+              "task": "sekhem-42", "prompt": "…", "title": "…",
+              "pane": "pane:9" | "workspace": "workspace:4" | "new_workspace": true,
+              "cwd": "/path", "env": {"K": "V"} } }
+```
+
+The handler performs resolution, surface creation, env injection, metadata
+stamping, and command typing **atomically server-side** — a caller never has to
+sequence create → stamp → send itself. Response is the JSON object above.
+Follows the socket threading policy (parse/validate off-main; UI mutation
+scheduled on main) and the no-focus-steal policy.
+
+## Relationship to existing commands
+
+- `c11 default-agent launch` — unchanged; still "launch the operator's default."
+  Internally both share `DefaultAgentResolver` + `DefaultAgentLaunchComposition`.
+- The A button — unchanged; same resolver, same stamping.
+- `$C11_DEFAULT_AGENT_LAUNCH` — unchanged; the per-shell export still reflects
+  the operator's default agent only.
+
+## Consumers
+
+First consumer: Sekhem Prime's provider/harness selector — deck knobs choose
+`{type, model, effort}`, Sweep A shells out to
+`c11 launch-agent --type … --model … --effort … --new-workspace --json` and
+tracks the returned refs.

--- a/docs/launch-agent-reference.md
+++ b/docs/launch-agent-reference.md
@@ -73,13 +73,17 @@ passed through and the agent CLI enforces.
   the current workspace — same target the A button would hit).
 - `--pane <ref>`: a new surface in that pane.
 - `--workspace <ref>`: a new surface in that workspace's focused pane.
-- `--new-workspace`: a fresh workspace whose first terminal is the agent
-  (uses `workspace.create` `initial_env` + `initial_command`, so identity and
-  command are present at PTY birth with no follow-up sends).
+- `--new-workspace`: a fresh workspace whose first terminal is the agent. The
+  identity env rides workspace creation (present at PTY birth); the launch
+  line is *typed* into the interactive shell (queue-until-ready), not baked as
+  the ghostty spawn command — a spawn command execs over the shell, so agent
+  exit would kill the surface, and it skips shell rc.
 
 `--cwd <path>` sets the working directory (resolved CLI-side relative to the
-caller, validated server-side). Placement never steals macOS focus (socket focus
-policy).
+caller, validated server-side). Launches never steal focus or selection — 
+`agent.launch` is not a focus-intent method under the socket focus policy, so
+the new surface is created unfocused regardless of flags (`--no-focus` is
+accepted as a no-op for symmetry with `new-surface`).
 
 ### Identity at birth
 
@@ -128,18 +132,25 @@ Human-readable by default; `--json` prints one object:
 
 Refs are immediately valid targets for `send`, `read-screen`, `set-*`.
 
-### Errors
+### Errors and warnings
 
-All errors are structured (`--json` gives `{"ok":false,"error":{"code":…,"message":…}}`):
+Errors are structured (`--json` gives `{"ok":false,"error":{"code":…,"message":…}}`):
 
 | code | when |
 |---|---|
 | `unknown_agent_type` | `--type` is not a built-in kind and no user template exists |
-| `binary_not_found` | the launch command's binary is not on the surface PATH |
+| `empty_command` | the kind resolved to an empty launch command (unconfigured `custom`/template) |
 | `model_flag_unsupported` / `effort_flag_unsupported` | `--model`/`--effort` passed for a kind whose template declares no syntax for it |
 | `invalid_effort` | value outside the template's declared allowed list |
-| `prompt_flag_conflict` | both `--prompt` and `--prompt-file` |
-| `target_not_found` / `invalid_cwd` | bad `--pane`/`--workspace` ref or cwd |
+| `invalid_params` | bad `cwd`, or `new_workspace` combined with `pane_id`/`workspace_id` |
+| `not_found` | target workspace or pane doesn't resolve |
+
+A conflicting `--prompt`/`--prompt-file` pair is rejected CLI-side before the
+socket call. A launch binary that can't be found is a **warning**, not an
+error — the app-process PATH is poorer than the login-shell PATH a pane
+actually gets, so the result carries `"warnings": ["binary '<x>' not found …"]`
+and the launch proceeds (a truly missing binary shows the shell error in the
+pane).
 
 ## Launch templates
 
@@ -147,14 +158,16 @@ The per-kind launch facts are **data on the agent manifest**
 (`Sources/AgentManifest.swift` → `LaunchTemplate`), not code at call sites:
 
 ```swift
-struct LaunchTemplate {
-    let modelArg: ArgSpec?      // how "--model <id>" renders for this CLI
-    let effortArg: ArgSpec?     // how "--effort <tier>" renders
-    let effortValues: [String]  // non-empty → validated early
-    let promptDelivery: PromptDelivery  // .positional | .flag(String) | .postBoot
+struct AgentLaunchTemplate {
+    let modelArg: AgentLaunchArgStyle?   // how "--model <id>" renders for this CLI
+    let effortArg: AgentLaunchArgStyle?  // how "--effort <tier>" renders
+    let effortValues: [String]           // non-empty → validated early
+    let promptDelivery: AgentPromptDelivery  // .positional | .flag(String) | .postBoot
 }
-enum ArgSpec { case flag(String)          // "--model" → `--model <v>`
-               case configKV(String) }    // "model_reasoning_effort" → `-c k=<v>`
+enum AgentLaunchArgStyle {
+    case flag(String)       // "--model" → `--model <v>`
+    case configKV(String)   // "model_reasoning_effort" → `-c k=<v>`
+}
 ```
 
 ### Built-in seeds
@@ -205,9 +218,13 @@ CLI `launch-agent` is a thin client over one v2 method, `agent.launch`:
 { "method": "agent.launch",
   "params": { "type": "codex", "model": "gpt-5.2", "effort": "high",
               "task": "sekhem-42", "prompt": "…", "title": "…",
-              "pane": "pane:9" | "workspace": "workspace:4" | "new_workspace": true,
+              "pane_id": "<uuid>" | "workspace_id": "<uuid>" | "new_workspace": true,
               "cwd": "/path", "env": {"K": "V"} } }
 ```
+
+`pane_id`/`workspace_id` take UUIDs — the CLI resolves `pane:N`/`workspace:N`
+short refs client-side before sending, and direct socket callers must do the
+same (resolve via `system.tree` or `c11 identify`).
 
 The handler performs resolution, surface creation, env injection, metadata
 stamping, and command typing **atomically server-side** — a caller never has to

--- a/docs/socket-api-reference.md
+++ b/docs/socket-api-reference.md
@@ -72,6 +72,10 @@ The `c11` CLI wraps these methods: e.g. `c11 list-workspaces` → `workspace.lis
 
 All dotted v2 methods, grouped by domain. Method names are stable identifiers; arguments travel in `params` and results in `result`. The `debug.*` domain is a set of test/automation hooks and is only meaningful on debug/tagged builds.
 
+### Agents (`agent.*`) — 1
+
+- `agent.launch` — launch a typed coding agent into a new surface or fresh workspace: per-kind invocation, model/effort flags, identity env + metadata at birth, refs returned. See `docs/launch-agent-reference.md`.
+
 ### System (`system.*`) — 5
 
 - `system.brand`

--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -40,7 +40,7 @@ c11 stamps your launch identity itself: the sidebar chip (agent type from proces
 - **Title = what the surface *is*** — generic, reusable. A filename for file-backed surfaces (`PHILOSOPHY.md`); a role for terminals (`Phase 2 agent`, `Log tail`).
 - **Description = why it's open *right now*** — one or two sentences of current context the operator can read without opening the surface.
 - **Refresh both when scope shifts** (plan → impl, ticket → ticket, file → file) — at the pivot, not at session end.
-- **Lineage for downstream panes:** chain parent → child with `::` in the title (`Login Button :: MA Review :: Claude`) and lead the description with a `Lineage:` breadcrumb. **Sibling** workers the operator drives directly are *not* downstream — use plain anchors (`Feature Left`, `Lattice Manager`), no chain. Before renaming, check `c11 get-titlebar-state`; if a chain exists, preserve the prefix and refine only the trailing segment.
+- **Lineage lives in the DESCRIPTION, not the title (revised 2026-07-20).** Titles are 2–3 words, role-first, DISTINCT — make the first word differ between sibling tabs; `::` parent-prefix chains are retired (at fleet scale every sibling truncates to the same parent prefix and the sidebar becomes unreadable — operator verdict). Lead the description with a `Lineage: <parent> → <role>` breadcrumb instead. Before renaming, check `c11 get-titlebar-state`; keep names short, keep the description's lineage line.
 
 ## What c11 can do — load the reference when you need it
 

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -115,6 +115,14 @@ c11 new-workspace [--cwd <path>] [--command <text>] [--title <text>] [--layout <
 c11 new-split <left|right|up|down> [--cwd <path|inherit>]   # Split any pane; the new pane is always a terminal
 c11 new-pane [--type <terminal|browser|markdown>] [--direction <dir>] [--url <url>] [--cwd <path|inherit>]
 c11 new-surface [--type <terminal|browser|markdown>] [--pane <id|ref>] [--workspace <id|ref>]
+c11 launch-agent --type <kind> [--model <id>] [--effort <tier>] [--task <id>] \
+    [--pane <id|ref> | --workspace <id|ref> | --new-workspace] [--cwd <path>] \
+    [--prompt <text> | --prompt-file <path>] [--title <text>] [--env K=V ...] [--json]
+    # Launch a typed agent (claude-code|codex|grok|kimi|opencode|github-copilot|pi|omp,
+    # or a custom kind with ~/.config/c11/agents/<kind>.json) into a new surface or a
+    # fresh workspace. One command owns the per-agent invocation quirks, model/effort
+    # flag syntax, identity-at-birth (env + metadata + title), and prompt delivery;
+    # --json returns the new refs. Canonical reference: docs/launch-agent-reference.md.
 
 # Navigate
 c11 select-workspace --workspace <id|ref>

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -42,26 +42,40 @@ Read `c11 tree` before reshaping — splits reshape the screen and disorient eve
 
 **Name every tab, including your own.** An unnamed "Claude Code" tab is an unidentifiable agent — useless when multiple agents are running. The sidebar truncates from the right; the full title shows in the title bar.
 
-### Lineage is the default
+### Titles are short and DISTINCT; lineage lives in the description
 
-When a pane is downstream of another — a sub-agent an orchestrator spawned, a code review spawned over a feature's work, a fix agent rooted in a review finding — the title must show the chain. Use `::` (double colon) as the separator, **parent first**. Multiple rungs chain in order:
+**(Revised 2026-07-20 after operator verdict on a real fleet run.)** The old rule here — chain
+`Parent :: Child` in the title, parent first — is an **anti-pattern at fleet scale** and is
+retired. When one orchestrator spawns six workers, parent-first titles make every sibling tab
+render as the same truncated prefix (`PostHog Orche…` × 7): the sidebar becomes a wall of
+identical strings and the operator can't tell any two agents apart. Exactly the information the
+title exists to carry — *which agent is this* — is what the shared prefix destroys.
 
-| Pane | Title |
-|------|-------|
-| Feature agent | `Login Button` |
-| Its multi-agent review | `Login Button :: MA Review` |
-| One reviewer inside that review | `Login Button :: MA Review :: Claude` |
-| A fix agent spawned from a review finding | `Login Button :: Fix Null Check` |
+The rules now:
 
-Parent-first groups siblings in the sidebar — they all truncate to the parent's leading word (`Login Bu…`), which is usually what the operator wants at a glance: "these panes are all Login Button family." The full chain survives in the title bar. Keep each segment short so the whole chain stays readable: `Login Button :: MA Review :: Claude` wraps cleanly; `Adding Login Button Feature :: Multi-Agent Code Review :: Claude Reviewer` will overflow.
+- **Title = 2–3 words, role-first, distinct.** Make the FIRST word differ between sibling tabs
+  wherever possible — the leading characters are all that survives sidebar truncation.
+  `F2 Routes`, `P2 SPA Plan`, `P4 ImportSync Plan` — not `PostHog Orchestrator :: F2 Impl`.
+- **No `::` chains, no shared prefixes in titles.** A run's family identity comes from the
+  workspace and from descriptions, not from repeating the parent's name in every child title.
+- **Lineage moves to the DESCRIPTION**, which was already mandatory: first line
+  `Lineage: <parent> → <child role>`, then current context. The operator hovers/opens for the
+  chain; the sidebar shows the distinct role.
 
-The user may override any tab name; lineage is the default, not a lock.
+| Pane | Title | Description first line |
+|------|-------|------------------------|
+| Epic orchestrator | `PostHog Orch` | — |
+| A lane's planner | `P2 SPA Plan` | `Lineage: PostHog Orch → P2 planner.` |
+| A lane's implementer | `F2 Routes` | `Lineage: PostHog Orch → F2 implementer.` |
+| A review spawned over it | `F2 Review` | `Lineage: PostHog Orch → F2 → reviewer.` |
+
+The user may override any tab name; these are defaults, not locks.
 
 ### Who writes the lineage
 
-- **Orchestrator spawning a sub-agent.** Name the child's tab immediately after `c11 new-surface` / `c11 new-split`, **before** launching the sub-agent or sending the prompt. The orchestrator knows the full lineage (its own title plus the child's role) so it's the right actor to compose. It also writes the description with a lineage breadcrumb — see below.
-- **Sub-agent orienting itself.** Before calling `c11 rename-tab`, read the existing title with `c11 get-titlebar-state`. If a chain is already there (orchestrator pre-named it), **preserve the prefix** and refine only the trailing segment if your role needs sharpening. If no title exists, extract lineage from your initial prompt (orchestrators should pass it explicitly) and compose `<parent> :: <your role>`. Only fall back to a lineage-free name when no parent exists.
-- **Solo agent (no parent).** Name with your mission, no `::` prefix.
+- **Orchestrator spawning a sub-agent.** Name the child's tab immediately after `c11 new-surface` / `c11 new-split`, **before** launching the sub-agent or sending the prompt — a short distinct role title, plus the description whose first line is the lineage breadcrumb. The orchestrator knows the lineage, so it writes it — into the description.
+- **Sub-agent orienting itself.** Before calling `c11 rename-tab`, read the existing title with `c11 get-titlebar-state`. If the orchestrator pre-named it, keep that name unless your role sharpened — and keep it SHORT and distinct, never re-expanding it into a `Parent :: Child` chain. Preserve the description's `Lineage:` line on every update.
+- **Solo agent (no parent).** Name with your mission.
 
 ### Description tells the story up the chain
 
@@ -78,10 +92,10 @@ The orchestrator writes the first lineage line when it spawns the child so the c
 
 - **Orchestrators / delegators:** name on startup. Role + project in 2–4 words.
   `c11 rename-tab "SIG Delegator"`, `c11 rename-tab "Review Orchestrator"`
-- **Sub-agents:** orchestrator composes lineage right after creating the surface:
-  `c11 rename-tab --workspace $WS --surface $SURF "Login Button :: Plan"`
-  `c11 rename-tab --workspace $WS --surface $SURF "Login Button :: Lint Fixes"`
-- **Solo agents (no parent):** mission only, no lineage prefix.
+- **Sub-agents:** orchestrator names them right after creating the surface — short, distinct, role-first; lineage goes in the description:
+  `c11 rename-tab --workspace $WS --surface $SURF "Login Plan"`
+  `c11 rename-tab --workspace $WS --surface $SURF "Lint Fixes"`
+- **Solo agents (no parent):** mission only.
   `c11 rename-tab "Fix Auth Tests"`, `c11 rename-tab "CSS Cleanup"`
 
 `c11 rename-tab` is an alias for `c11 set-title` — either command writes the canonical `title` metadata key on the target surface. The description (including the lineage breadcrumb) goes via `c11 set-description`.

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -88,6 +88,26 @@ The orchestrator writes the first lineage line when it spawns the child so the c
 
 ## Launching sub-agents in panes
 
+**The one-command path: `c11 launch-agent`.** For launching a *typed* agent —
+a specific kind, optionally with a pinned model/effort and an initial prompt —
+prefer the dedicated command over hand-composing the steps below:
+
+```bash
+c11 launch-agent --type codex --model gpt-5.2 --effort high \
+    --prompt-file /tmp/brief.md --title "Login Button :: Codex Impl" --json
+```
+
+It creates the surface (in a pane, a workspace, or `--new-workspace`), renders
+the right per-agent invocation (claude wrapper + skip-permissions, codex
+`--yolo` + `-c model_reasoning_effort=`, pi/omp `--thinking`, …), injects
+`C11_AGENT_TYPE/MODEL/TASK` into the spawn env, stamps sidebar identity at
+birth, and delivers the prompt one-shot via argv where the agent supports it —
+no ready-state race. `--json` returns the new surface/pane/workspace refs for
+follow-up `send`/`read-screen`. Full reference: `docs/launch-agent-reference.md`.
+
+The manual pattern below remains for launches into an *existing* surface, or
+when you need custom composition.
+
 Use **`claude --dangerously-skip-permissions`** — never bare `claude` (stalls on approvals) or `claude -p` (headless, breaks the auth chain):
 
 - **`claude -p` (headless)** breaks the c11 auth chain. The subprocess is reparented to `launchd` and cannot call any `c11` command. Sub-agents lose the ability to self-report.

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -108,7 +108,7 @@ prefer the dedicated command over hand-composing the steps below:
 
 ```bash
 c11 launch-agent --type codex --model gpt-5.2 --effort high \
-    --prompt-file /tmp/brief.md --title "Login Button :: Codex Impl" --json
+    --prompt-file /tmp/brief.md --title "Login Impl" --json
 ```
 
 It creates the surface (in a pane, a workspace, or `--new-workspace`), renders


### PR DESCRIPTION
## What

One command that owns launching a typed coding agent into a c11 surface — `c11 launch-agent` over a new atomic v2 socket method `agent.launch`. Canonical reference: `docs/launch-agent-reference.md`.

```
c11 launch-agent --type <kind> [--model <id>] [--effort <tier>] [--task <id>]
    [--pane <ref> | --workspace <ref> | --new-workspace] [--cwd <path>]
    [--prompt <text> | --prompt-file <path>] [--title <text>] [--env K=V ...] [--json]
```

- **Launch templates are data, not code**: `AgentLaunchTemplate` on each `AgentManifest` declares model-flag syntax, effort-flag syntax (+ allowed values), and prompt delivery. claude `--model/--effort`, codex `--model` + `-c model_reasoning_effort=`, pi/omp `--thinking`, opencode `provider/model`. Custom kebab kinds load the same shape from `~/.config/c11/agents/<kind>.json`.
- **`DefaultAgentResolver` generalized** to the template registry — claude output byte-identical; codex/pi/omp opt in via data (the seam the resolver always promised).
- **Identity at birth**: `C11_/CMUX_AGENT_TYPE/MODEL/TASK` in the spawn env, `terminal_type`/`model` (or `model_label` for non-kebab ids)/`task`/title stamped server-side at `declare` tier before the command is typed.
- **Prompt delivery** one-shot via argv where the CLI supports it (no ready-state race); post-boot send only for kimi/copilot.
- **`--json`** returns agent + composed command + window/workspace/pane/surface refs, immediately valid for `send`/`read-screen`.
- Structured error codes: `unknown_agent_type`, `model_flag_unsupported`, `effort_flag_unsupported`, `invalid_effort`, `empty_command`; missing binary is a warning (app PATH ≠ pane login-shell PATH).
- Precedence per field: operator-hardcoded flag in command > CLI arg > Settings/project pin > agent ambient default. Base command comes from the operator's Agent Launcher config (project `.c11/agents.json` > Settings > factory), so `launch-agent` matches the A button.

## Why

Sekhem Prime's deck-driven provider/harness selector (first consumer) needs to spawn `{type, model, effort}` agents programmatically; today every such consumer would re-implement per-agent quirks by hand. c11 already knows these facts — this makes it own them at the launch site.

## Tests

- 18 new `AgentLaunchPlannerTests` (composition per kind, precedence ladder, error codes, identity env, custom templates, quoting) + resolver tests updated to the template-driven contract. `c11-logic` narrow run: **61/61 green**.
- **Loopy validation in a tagged build** (`--tag launch-agent`, QA fresh): launched claude-code (sonnet low + haiku low — statusline shows `[sonnet-5 low]`, one-shot prompt answered), codex (`gpt-5.2 medium` in codex's own status bar — model + config-KV effort honored), opencode (bare + pinned model; composition correct — the pinned-model error was opencode's own server). All three error codes exercised; metadata stamps and `--json` refs verified via follow-up `get-metadata`/`read-screen`. Scratch workspaces + tagged artifacts cleaned.

Two real bugs were found and fixed by the validation pass (third commit): new-workspace launches now *type* the command (spawn-command exec'd over the shell → agent exit killed the surface, and skipped shell rc), and pane-path launches into unselected workspaces get the C11-121 background-start kick (lazily unattached surface never flushed the queued command).

## Skill sync

`skills/c11/references/api.md` + `orchestration.md` teach the one-command path; `scripts/sync-installed-skills.sh c11` run on this machine. `docs/socket-api-reference.md` indexes the new `agent.*` domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)