### PR TITLE
System-prompt launch axis: template flag, tri-mode setting, claude-code delivery

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2224,9 +2224,39 @@ struct CMUXCLI {
                     launchEnvIdx += 1
                 }
             }
+            // System-prompt axis: --system-prompt-mode gates the axis; the text
+            // rides --system-prompt (inline) or --system-prompt-file (path),
+            // mutually exclusive like --prompt. Empty text is allowed (blank
+            // slate on replace), so --system-prompt-file does not reject an
+            // empty file the way --prompt-file rejects an empty prompt.
+            let sysPromptModeRaw = optionValue(commandArgs, name: "--system-prompt-mode")
+            let sysPromptInline = optionValue(commandArgs, name: "--system-prompt")
+            let sysPromptFile = optionValue(commandArgs, name: "--system-prompt-file")
+            if sysPromptInline != nil && sysPromptFile != nil {
+                throw CLIError(message: "launch-agent: --system-prompt and --system-prompt-file are mutually exclusive")
+            }
+            var sysPromptText = sysPromptInline
+            if let sysPromptFile {
+                let path = resolvePath(sysPromptFile)
+                guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+                    throw CLIError(message: "launch-agent: failed to read --system-prompt-file: \(path)")
+                }
+                sysPromptText = contents
+            }
+
             var params: [String: Any] = ["type": agentKind]
             if let v = optionValue(commandArgs, name: "--model") { params["model"] = v }
             if let v = optionValue(commandArgs, name: "--effort") { params["effort"] = v }
+            if let sysPromptModeRaw {
+                let mode = sysPromptModeRaw.lowercased()
+                guard ["inherit", "append", "replace"].contains(mode) else {
+                    throw CLIError(message: "launch-agent: --system-prompt-mode must be inherit|append|replace (got: \(sysPromptModeRaw))")
+                }
+                params["system_prompt_mode"] = mode
+                if let sysPromptText { params["system_prompt"] = sysPromptText }
+            } else if sysPromptText != nil {
+                throw CLIError(message: "launch-agent: --system-prompt/--system-prompt-file requires --system-prompt-mode append|replace")
+            }
             if let v = optionValue(commandArgs, name: "--task") { params["task"] = v }
             if let v = optionValue(commandArgs, name: "--title") { params["title"] = v }
             if let launchPrompt { params["prompt"] = launchPrompt }
@@ -8589,6 +8619,16 @@ struct CMUXCLI {
                                        ~/.config/c11/agents/<kind>.json
               --model <id>             Model to pin (rendered per the kind's template)
               --effort <tier>          Effort/thinking tier (errors if the kind has none)
+              --system-prompt-mode <m> inherit | append | replace. append/replace
+                                       inject the kind's system-prompt flag (errors
+                                       if the kind has no system-prompt axis;
+                                       claude-code only in v1)
+              --system-prompt <text>   System-prompt text (append adds to the
+                                       default; replace supplants it; empty +
+                                       replace = blank slate)
+              --system-prompt-file <p> Read the system-prompt text from a file
+                                       (mutually exclusive with --system-prompt;
+                                       an empty file is allowed = blank slate)
               --task <id>              Task identifier for sidebar telemetry
               --pane <id|ref>          Target pane (default: focused pane)
               --workspace <id|ref>     Target workspace (default: $C11_WORKSPACE_ID)
@@ -8607,6 +8647,10 @@ struct CMUXCLI {
               c11 launch-agent --type claude-code --model opus --effort high
               c11 launch-agent --type codex --model gpt-5.2 --new-workspace --json
               c11 launch-agent --type opencode --prompt-file /tmp/brief.md --pane pane:2
+              c11 launch-agent --type claude-code --system-prompt-mode append \\
+                --system-prompt 'Prefer terse answers.'
+              c11 launch-agent --type claude-code --system-prompt-mode replace \\
+                --system-prompt ''      # Gregorovich blank slate
             """
         case "new-surface":
             return """
@@ -16593,7 +16637,7 @@ struct CMUXCLI {
           claude-hook <session-start|stop|notification> [--workspace <id|ref>] [--surface <id|ref>]
           set-agent --type <terminal_type> [--model <id>] [--task <id>] [--role <id>] [--surface <id|ref>] [--workspace <id|ref>]
           default-agent {get | set <type> | launch [--in-surface <id|ref> | --pane <id>] [--agent <type>] [--cwd <path>] [--prompt <text> | --prompt-file <path>]}
-          launch-agent --type <kind> [--model <id>] [--effort <tier>] [--task <id>] [--pane <id|ref> | --workspace <id|ref> | --new-workspace] [--cwd <path>] [--prompt <text> | --prompt-file <path>] [--title <text>] [--env K=V ...] [--json]
+          launch-agent --type <kind> [--model <id>] [--effort <tier>] [--system-prompt-mode inherit|append|replace] [--system-prompt <text> | --system-prompt-file <path>] [--task <id>] [--pane <id|ref> | --workspace <id|ref> | --new-workspace] [--cwd <path>] [--prompt <text> | --prompt-file <path>] [--title <text>] [--env K=V ...] [--json]
           set-metadata (--json '{...}' | --key <K> --value <V> [--type string|number|bool|json]) [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>] [--mode merge|replace] [--source <src>]
           get-metadata [--key <K> ...] [--sources] [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]
           clear-metadata [--key <K> ...] [--source <src>] [--surface <id|ref> | --pane <id|ref>] [--workspace <id|ref>]

--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -124,6 +124,60 @@ enum AgentLaunchArgStyle: Sendable, Equatable {
     }
 }
 
+/// An operator's system-prompt choice for a launch: which of the three modes,
+/// and the prompt text (ignored for `.inherit`; `""` + `.replace` is the
+/// intentional blank-slate launch). This is the primitive the launch axis
+/// consumes; the sibling config-overlay stores it on a saved config.
+struct SystemPromptSetting: Codable, Equatable, Sendable {
+    /// `inherit` leaves the harness default untouched (no flag injected);
+    /// `append` adds `text` on top of the default; `replace` supplants the
+    /// default with `text` (empty `text` = blank slate).
+    enum Mode: String, Codable, Sendable, CaseIterable { case inherit, append, replace }
+    var mode: Mode
+    /// The system-prompt text. Ignored when `mode == .inherit`; an empty string
+    /// with `.replace` is the Gregorovich blank-slate launch (still emits the
+    /// flag with an empty value).
+    var text: String
+
+    init(mode: Mode, text: String = "") {
+        self.mode = mode
+        self.text = text
+    }
+}
+
+/// How a system-prompt override renders onto an agent's command line. Unlike
+/// model/effort (one flag each), the system-prompt axis has two delivery flags —
+/// append (adds to the harness default) and replace (supplants it) — so it is
+/// its own arg style rather than an `AgentLaunchArgStyle`. `nil` on a template
+/// means the axis is disabled for that harness (v1: only claude-code declares
+/// it), the same gating pattern `effortArg == nil` uses.
+struct AgentSystemPromptArg: Sendable, Equatable {
+    /// Flag that appends to the harness default (claude `--append-system-prompt`),
+    /// or `nil` when the CLI has no append form.
+    let appendFlag: String?
+    /// Flag that replaces the harness default (claude `--system-prompt`), or
+    /// `nil` when the CLI has no replace form. An empty value is allowed — the
+    /// blank-slate launch.
+    let replaceFlag: String?
+
+    /// The flag to render for a given mode, or `nil` when the mode is
+    /// `.inherit` or the CLI has no form for it.
+    func flag(for mode: SystemPromptSetting.Mode) -> String? {
+        switch mode {
+        case .inherit: return nil
+        case .append: return appendFlag
+        case .replace: return replaceFlag
+        }
+    }
+
+    /// Substrings whose presence in the operator's configured command means a
+    /// system prompt is already pinned there — c11 must not inject one on top.
+    /// Both flags count: an operator who hardcoded either form owns the axis.
+    var detectTokens: [String] {
+        [appendFlag, replaceFlag].compactMap { $0 }
+    }
+}
+
 /// How an initial prompt reaches the agent at launch.
 enum AgentPromptDelivery: Sendable, Equatable {
     /// Appended to the launch argv as a single-quoted positional argument —
@@ -153,6 +207,11 @@ struct AgentLaunchTemplate: Sendable, Equatable {
     /// error; empty → passed through and the agent CLI enforces.
     let effortValues: [String]
     let promptDelivery: AgentPromptDelivery
+    /// System-prompt flag syntax (append/replace), or `nil` when the CLI has no
+    /// system-prompt axis c11 knows — a non-inherit system-prompt request for
+    /// such a kind errors instead of guessing. v1 seeds this for claude-code
+    /// only; every other built-in is `nil` (same gating shape as `effortArg`).
+    let systemPromptArg: AgentSystemPromptArg?
 }
 
 /// How a captured session is resumed on restart. Mirrors today's
@@ -212,7 +271,14 @@ struct AgentRegistry: Sendable {
                 modelArg: .flag("--model"),
                 effortArg: .flag("--effort"),
                 effortValues: ["low", "medium", "high", "xhigh", "max"],
-                promptDelivery: .positional
+                promptDelivery: .positional,
+                // The only harness with a system-prompt axis in v1: append adds
+                // to the c11/Claude default, replace supplants it (empty text =
+                // the Gregorovich blank slate).
+                systemPromptArg: AgentSystemPromptArg(
+                    appendFlag: "--append-system-prompt",
+                    replaceFlag: "--system-prompt"
+                )
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -234,7 +300,8 @@ struct AgentRegistry: Sendable {
             // config-override syntax. Values pass through (codex enforces).
                 effortArg: .configKV("model_reasoning_effort"),
                 effortValues: [],
-                promptDelivery: .positional
+                promptDelivery: .positional,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -254,7 +321,8 @@ struct AgentRegistry: Sendable {
                 modelArg: .flag("--model"),
                 effortArg: nil,
                 effortValues: [],
-                promptDelivery: .positional
+                promptDelivery: .positional,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -275,7 +343,8 @@ struct AgentRegistry: Sendable {
             // kimi's --thinking is boolean, not tiered — no effort axis.
                 effortArg: nil,
                 effortValues: [],
-                promptDelivery: .postBoot
+                promptDelivery: .postBoot,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -298,7 +367,8 @@ struct AgentRegistry: Sendable {
             // Positional because the factory command is the `opencode run`
             // form, whose message is positional. An operator who rebases
             // the command onto the bare TUI owns the delivery consequences.
-                promptDelivery: .positional
+                promptDelivery: .positional,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -319,7 +389,8 @@ struct AgentRegistry: Sendable {
                 modelArg: .flag("--model"),
                 effortArg: nil,
                 effortValues: [],
-                promptDelivery: .postBoot
+                promptDelivery: .postBoot,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -348,7 +419,8 @@ struct AgentRegistry: Sendable {
                 modelArg: .flag("--model"),
                 effortArg: .flag("--thinking"),
                 effortValues: ["off", "minimal", "low", "medium", "high", "xhigh"],
-                promptDelivery: .positional
+                promptDelivery: .positional,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -375,7 +447,8 @@ struct AgentRegistry: Sendable {
                 modelArg: .flag("--model"),
                 effortArg: .flag("--thinking"),
                 effortValues: ["off", "minimal", "low", "medium", "high", "xhigh"],
-                promptDelivery: .positional
+                promptDelivery: .positional,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: true,
             hasConversationStrategy: true
@@ -395,7 +468,8 @@ struct AgentRegistry: Sendable {
                 modelArg: nil,
                 effortArg: nil,
                 effortValues: [],
-                promptDelivery: .postBoot
+                promptDelivery: .postBoot,
+                systemPromptArg: nil
             ),
             isCanonicalTerminalType: false,
             hasConversationStrategy: false
@@ -452,7 +526,10 @@ struct UserAgentLaunchTemplate: Codable, Equatable {
                 case .some(let s) where s.hasPrefix("-"): return .flag(s)
                 default: return .postBoot
                 }
-            }()
+            }(),
+            // Custom kinds have no system-prompt axis in v1 (the axis is
+            // claude-code-only; other harnesses land in v2).
+            systemPromptArg: nil
         )
     }
 

--- a/Sources/DefaultAgentConfig.swift
+++ b/Sources/DefaultAgentConfig.swift
@@ -152,13 +152,20 @@ struct AgentConfig: Codable, Equatable {
     /// Claude Code). Empty means "don't pin" — inherit the agent's ambient
     /// effort. An effort the operator hardcoded into `command` always wins.
     var effort: String
+    /// Pinned system-prompt override (append/replace/inherit), or `nil` to
+    /// inherit the harness default. Injected at launch for agents whose
+    /// manifest declares a system-prompt axis (v1: Claude Code only); a system
+    /// prompt the operator hardcoded into `command` always wins. `nil` — the
+    /// default — reproduces prior launch behavior byte-for-byte.
+    var systemPrompt: SystemPromptSetting?
 
-    init(command: String, initialPrompt: String, envOverridesText: String, model: String = "", effort: String = "") {
+    init(command: String, initialPrompt: String, envOverridesText: String, model: String = "", effort: String = "", systemPrompt: SystemPromptSetting? = nil) {
         self.command = command
         self.initialPrompt = initialPrompt
         self.envOverridesText = envOverridesText
         self.model = model
         self.effort = effort
+        self.systemPrompt = systemPrompt
     }
 
     init(from decoder: Decoder) throws {
@@ -170,6 +177,9 @@ struct AgentConfig: Codable, Equatable {
         // decode to "" (inherit), preserving prior launch behavior.
         self.model = (try? c.decode(String.self, forKey: .model)) ?? ""
         self.effort = (try? c.decode(String.self, forKey: .effort)) ?? ""
+        // Absent in configs written before the system-prompt axis existed →
+        // nil (inherit), preserving prior launch behavior byte-for-byte.
+        self.systemPrompt = try? c.decodeIfPresent(SystemPromptSetting.self, forKey: .systemPrompt)
     }
 
     /// Factory defaults for a given agent type.
@@ -202,7 +212,7 @@ struct AgentConfig: Codable, Equatable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case command, initialPrompt, envOverridesText, model, effort
+        case command, initialPrompt, envOverridesText, model, effort, systemPrompt
     }
 }
 

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -88,6 +88,12 @@ enum DefaultAgentResolver {
         if let flag = effortFlag(agent: agent, config: config, command: result) {
             result += " \(flag)"
         }
+        // System-prompt flag rides after model/effort but before claude-code's
+        // positional prompt (baked later in buildCommand), matching the launch
+        // line the planner composes.
+        if let flag = systemPromptFlag(agent: agent, config: config, command: result) {
+            result += " \(flag)"
+        }
         return result
     }
 
@@ -129,6 +135,51 @@ enum DefaultAgentResolver {
         return arg.render(effort)
     }
 
+    /// Whether c11 injects a system-prompt flag for this agent kind — driven by
+    /// the kind's launch template (`AgentManifest.launch.systemPromptArg`), the
+    /// same data-gated shape as `supportsModelFlag`/`supportsEffortFlag`.
+    static func supportsSystemPromptFlag(_ agent: AgentType) -> Bool {
+        AgentRegistry.shared.manifest(for: agent)?.launch.systemPromptArg != nil
+    }
+
+    /// The system-prompt flag to append for a launch, or `nil` when none should
+    /// be injected: the agent declares no system-prompt syntax, the setting is
+    /// `nil`/`.inherit`, the CLI has no flag for the requested mode, or the
+    /// operator already put a system-prompt flag in the command (their choice
+    /// wins, and we must not pass one on top). `replace` with empty text still
+    /// emits the flag with an empty value — the intentional blank-slate launch.
+    /// Visible for testing.
+    static func systemPromptFlag(agent: AgentType, config: AgentConfig, command: String) -> String? {
+        renderSystemPromptFlag(
+            AgentRegistry.shared.manifest(for: agent)?.launch.systemPromptArg,
+            setting: config.systemPrompt,
+            command: command
+        )
+    }
+
+    /// Template-based core of system-prompt injection, shared by the resolver
+    /// (`AgentType`-keyed) and the planner (`AgentLaunchTemplate`-keyed, so it
+    /// serves custom kebab kinds too). Pure; visible for testing.
+    static func renderSystemPromptFlag(
+        _ arg: AgentSystemPromptArg?,
+        setting: SystemPromptSetting?,
+        command: String
+    ) -> String? {
+        guard let arg,
+              let setting,
+              setting.mode != .inherit,
+              let flag = arg.flag(for: setting.mode) else { return nil }
+        // An operator who hardcoded *either* system-prompt flag owns the axis —
+        // c11 injects nothing on top (mirrors model/effort hardcoded detection).
+        let lower = command.lowercased()
+        if arg.detectTokens.contains(where: { lower.contains($0.lowercased()) }) { return nil }
+        // System-prompt text is free-form prose, so it is always single-quoted —
+        // the same treatment as the positional initial prompt (`shellQuote`),
+        // not the constrained-flag-value `shellQuoteIfNeeded`. `.replace` + ""
+        // therefore renders `--system-prompt ''`, the intended blank slate.
+        return "\(flag) \(shellQuote(setting.text))"
+    }
+
     /// Single-quote a value for /bin/sh, escaping embedded single quotes via
     /// the standard `'\''` close-reopen trick. Visible for testing.
     static func shellQuote(_ value: String) -> String {
@@ -165,6 +216,12 @@ struct AgentLaunchRequest: Equatable {
     var effort: String?
     var task: String?
     var prompt: String?
+    /// The caller's system-prompt choice (`--system-prompt-mode` + text on
+    /// `launch-agent`), or `nil` to fall back to the pinned Settings base (which
+    /// is itself `nil`/inherit by default). A non-inherit mode on a kind whose
+    /// template declares no system-prompt axis fails `system_prompt_unsupported`,
+    /// mirroring `--model`/`--effort` on an unsupported kind.
+    var systemPrompt: SystemPromptSetting?
     var extraEnv: [String: String] = [:]
 }
 
@@ -175,6 +232,7 @@ enum AgentLaunchPlanError: Error, Equatable {
     case emptyCommand(String)
     case modelFlagUnsupported(String)
     case effortFlagUnsupported(String)
+    case systemPromptUnsupported(String)
     case invalidEffort(value: String, allowed: [String])
 
     var code: String {
@@ -183,6 +241,7 @@ enum AgentLaunchPlanError: Error, Equatable {
         case .emptyCommand: return "empty_command"
         case .modelFlagUnsupported: return "model_flag_unsupported"
         case .effortFlagUnsupported: return "effort_flag_unsupported"
+        case .systemPromptUnsupported: return "system_prompt_unsupported"
         case .invalidEffort: return "invalid_effort"
         }
     }
@@ -198,6 +257,8 @@ enum AgentLaunchPlanError: Error, Equatable {
             return "agent '\(kind)' declares no model-flag syntax; --model is not supported for it"
         case .effortFlagUnsupported(let kind):
             return "agent '\(kind)' declares no effort-flag syntax; --effort is not supported for it"
+        case .systemPromptUnsupported(let kind):
+            return "agent '\(kind)' declares no system-prompt-flag syntax; --system-prompt-mode is not supported for it"
         case .invalidEffort(let value, let allowed):
             return "invalid effort '\(value)' — allowed: \(allowed.joined(separator: ", "))"
         }
@@ -242,6 +303,7 @@ enum AgentLaunchPlanner {
         let baseEnv: [String: String]
         let pinnedModel: String
         let pinnedEffort: String
+        let pinnedSystemPrompt: SystemPromptSetting?
 
         if let agentType {
             guard let manifest = AgentRegistry.shared.manifest(for: agentType) else {
@@ -255,12 +317,14 @@ enum AgentLaunchPlanner {
             baseEnv = config.envMap
             pinnedModel = config.model.trimmingCharacters(in: .whitespacesAndNewlines)
             pinnedEffort = config.effort.trimmingCharacters(in: .whitespacesAndNewlines)
+            pinnedSystemPrompt = config.systemPrompt
         } else if let userTemplate {
             template = userTemplate.template
             baseCommand = userTemplate.command.trimmingCharacters(in: .whitespacesAndNewlines)
             baseEnv = userTemplate.env ?? [:]
             pinnedModel = ""
             pinnedEffort = ""
+            pinnedSystemPrompt = nil
         } else {
             return .failure(.unknownAgentType(kind))
         }
@@ -311,6 +375,28 @@ enum AgentLaunchPlanner {
                 }
                 line += " \(arg.render(value))"
                 resolvedEffort = value
+            }
+        }
+
+        // System prompt: same precedence + hardcoded-wins ladder as model/effort.
+        // A caller-requested non-inherit mode on a kind with no system-prompt
+        // axis errors (parity with --model/--effort); a silent pinned base on
+        // such a kind never errors. The flag rides after model/effort, before
+        // the positional prompt below.
+        let requestedSystemPrompt = request.systemPrompt
+        if let requested = requestedSystemPrompt, requested.mode != .inherit, template.systemPromptArg == nil {
+            return .failure(.systemPromptUnsupported(kind))
+        }
+        if let arg = template.systemPromptArg {
+            let hardcoded = arg.detectTokens.contains { baseCommand.lowercased().contains($0.lowercased()) }
+            if hardcoded {
+                if let requested = requestedSystemPrompt, requested.mode != .inherit {
+                    warnings.append("configured command already pins a system prompt; --system-prompt-mode \(requested.mode.rawValue) ignored")
+                }
+            } else if let flag = DefaultAgentResolver.renderSystemPromptFlag(
+                arg, setting: requestedSystemPrompt ?? pinnedSystemPrompt, command: baseCommand
+            ) {
+                line += " \(flag)"
             }
         }
 

--- a/Sources/SocketHandlers/SocketDispatch.swift
+++ b/Sources/SocketHandlers/SocketDispatch.swift
@@ -949,12 +949,23 @@ extension TerminalController {
         let userTemplate: UserAgentLaunchTemplate? =
             AgentType(rawValue: kindRaw) == nil ? UserAgentLaunchTemplate.load(kind: kindRaw) : nil
 
+        // System prompt (append/replace/inherit + free-form text). The mode
+        // gates the axis; text may be empty (blank slate on replace). An
+        // unparseable mode string maps to nil (no override) rather than erroring
+        // here — the planner is the single validation authority for the axis.
+        var systemPromptSetting: SystemPromptSetting?
+        if let modeRaw = v2RawString(params, "system_prompt_mode")?.trimmingCharacters(in: .whitespacesAndNewlines),
+           let mode = SystemPromptSetting.Mode(rawValue: modeRaw.lowercased()) {
+            systemPromptSetting = SystemPromptSetting(mode: mode, text: v2RawString(params, "system_prompt") ?? "")
+        }
+
         let request = AgentLaunchRequest(
             kind: kindRaw,
             model: v2RawString(params, "model"),
             effort: v2RawString(params, "effort"),
             task: v2RawString(params, "task"),
             prompt: v2RawString(params, "prompt"),
+            systemPrompt: systemPromptSetting,
             extraEnv: v2StringMap(params, "env") ?? [:]
         )
         let plan: AgentLaunchPlan

--- a/c11Tests/AgentManifestTests.swift
+++ b/c11Tests/AgentManifestTests.swift
@@ -118,6 +118,30 @@ final class AgentManifestTests: XCTestCase {
         }
     }
 
+    /// System-prompt axis seed: claude-code declares both flags; every other
+    /// built-in has no system-prompt axis in v1 (`systemPromptArg == nil`), the
+    /// same gating shape as `effortArg`. Locks the per-harness seed so a new
+    /// harness that quietly grows a system-prompt flag (or claude losing one) is
+    /// caught here.
+    func testSystemPromptAxisSeed() {
+        for m in registry.all {
+            if m.kind == "claude-code" {
+                let arg = m.launch.systemPromptArg
+                XCTAssertNotNil(arg, "claude-code must declare a system-prompt axis")
+                XCTAssertEqual(arg?.appendFlag, "--append-system-prompt")
+                XCTAssertEqual(arg?.replaceFlag, "--system-prompt")
+                XCTAssertEqual(arg?.flag(for: .append), "--append-system-prompt")
+                XCTAssertEqual(arg?.flag(for: .replace), "--system-prompt")
+                XCTAssertNil(arg?.flag(for: .inherit))
+                XCTAssertEqual(Set(arg?.detectTokens ?? []),
+                               ["--append-system-prompt", "--system-prompt"])
+            } else {
+                XCTAssertNil(m.launch.systemPromptArg,
+                             "\(m.kind) must have no system-prompt axis in v1")
+            }
+        }
+    }
+
     /// Spot-check the literal claude resume string (the cd-prefixed branch),
     /// so a regression in the shared evaluator is caught even if phase1 drifts
     /// in lockstep.

--- a/c11Tests/DefaultAgentResolverTests.swift
+++ b/c11Tests/DefaultAgentResolverTests.swift
@@ -380,6 +380,150 @@ final class DefaultAgentResolverTests: XCTestCase {
         )
     }
 
+    // MARK: - system-prompt axis
+
+    private func claudeConfig(
+        command: String = "claude --dangerously-skip-permissions",
+        model: String = "",
+        effort: String = "",
+        systemPrompt: SystemPromptSetting? = nil
+    ) -> AgentConfig {
+        AgentConfig(command: command, initialPrompt: "", envOverridesText: "",
+                    model: model, effort: effort, systemPrompt: systemPrompt)
+    }
+
+    func testSystemPromptAppendRendersBeforePositionalPrompt() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions", initialPrompt: "go",
+            envOverridesText: "",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "Prefer terse answers.")
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --append-system-prompt 'Prefer terse answers.' 'go'"
+        )
+    }
+
+    func testSystemPromptReplaceRenders() {
+        let cfg = claudeConfig(systemPrompt: SystemPromptSetting(mode: .replace, text: "You are a shell."))
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --system-prompt 'You are a shell.'"
+        )
+    }
+
+    func testSystemPromptReplaceEmptyIsBlankSlate() {
+        // The Gregorovich blank slate: replace + "" still emits the flag with an
+        // empty single-quoted value.
+        let cfg = claudeConfig(systemPrompt: SystemPromptSetting(mode: .replace, text: ""))
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --system-prompt ''"
+        )
+    }
+
+    func testSystemPromptInheritInjectsNothing() {
+        let cfg = claudeConfig(systemPrompt: SystemPromptSetting(mode: .inherit, text: "ignored"))
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions"
+        )
+    }
+
+    func testSystemPromptNilInjectsNothingByteIdentical() {
+        // The AC's byte-identical regression: nil systemPrompt renders exactly
+        // today's line (the default for every existing config).
+        let cfg = claudeConfig(model: "opus", systemPrompt: nil)
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus"
+        )
+    }
+
+    func testSystemPromptNotInjectedForAxislessHarness() {
+        // codex has no system-prompt axis — a stray setting must be ignored,
+        // never guessed into a flag.
+        let cfg = AgentConfig(
+            command: "codex --yolo", initialPrompt: "", envOverridesText: "",
+            systemPrompt: SystemPromptSetting(mode: .replace, text: "nope")
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .codex, config: cfg),
+            "codex --yolo"
+        )
+    }
+
+    func testSystemPromptHardcodedReplaceFlagWins() {
+        // Operator hardcoded --system-prompt — c11 injects nothing on top.
+        let cfg = claudeConfig(
+            command: "claude --dangerously-skip-permissions --system-prompt 'mine'",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "extra")
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --system-prompt 'mine'"
+        )
+    }
+
+    func testSystemPromptHardcodedAppendFlagWins() {
+        let cfg = claudeConfig(
+            command: "claude --dangerously-skip-permissions --append-system-prompt 'mine'",
+            systemPrompt: SystemPromptSetting(mode: .replace, text: "extra")
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --append-system-prompt 'mine'"
+        )
+    }
+
+    func testSystemPromptOrdersAfterModelAndEffortBeforePrompt() {
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions", initialPrompt: "go",
+            envOverridesText: "", model: "opus", effort: "high",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "hi")
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus --effort high --append-system-prompt 'hi' 'go'"
+        )
+    }
+
+    func testSystemPromptEscapesSingleQuote() {
+        let cfg = claudeConfig(systemPrompt: SystemPromptSetting(mode: .replace, text: "don't"))
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            #"claude --dangerously-skip-permissions --system-prompt 'don'\''t'"#
+        )
+    }
+
+    func testSystemPromptRidesLauncherForBareExport() {
+        // The bare export (C11_DEFAULT_AGENT_LAUNCH) carries the system-prompt
+        // flag but never the positional prompt.
+        let cfg = AgentConfig(
+            command: "claude --dangerously-skip-permissions", initialPrompt: "some prompt",
+            envOverridesText: "",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "hi")
+        )
+        XCTAssertEqual(
+            DefaultAgentResolver.launcherCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --append-system-prompt 'hi'"
+        )
+    }
+
+    func testSystemPromptByteIdenticalThroughDecodedLegacyConfig() throws {
+        // A config JSON written before the axis existed decodes systemPrompt=nil
+        // → inherit → today's exact line.
+        let cfg = try JSONDecoder().decode(
+            AgentConfig.self,
+            from: Data(#"{"command":"claude --dangerously-skip-permissions","initialPrompt":"","envOverridesText":"","model":"opus"}"#.utf8)
+        )
+        XCTAssertNil(cfg.systemPrompt)
+        XCTAssertEqual(
+            DefaultAgentResolver.buildCommand(agent: .claudeCode, config: cfg),
+            "claude --dangerously-skip-permissions --model opus"
+        )
+    }
+
     func testShellQuoteEmpty() {
         XCTAssertEqual(DefaultAgentResolver.shellQuote(""), "''")
     }
@@ -717,6 +861,140 @@ final class AgentLaunchPlannerTests: XCTestCase {
         XCTAssertFalse(UserAgentLaunchTemplate.isValidKind("-bad"))
         XCTAssertFalse(UserAgentLaunchTemplate.isValidKind(""))
         XCTAssertFalse(UserAgentLaunchTemplate.isValidKind(String(repeating: "a", count: 33)))
+    }
+
+    // MARK: system-prompt axis
+
+    func testPlannerSystemPromptAppendRenders() throws {
+        // The factory pins claude-code to --model opus; the system-prompt flag
+        // renders after it.
+        let p = try plan(AgentLaunchRequest(
+            kind: "claude-code",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "be terse")
+        )).get()
+        XCTAssertEqual(
+            p.launchLine,
+            "claude --dangerously-skip-permissions --model opus --append-system-prompt 'be terse'"
+        )
+    }
+
+    func testPlannerSystemPromptReplaceBlankSlate() throws {
+        let p = try plan(AgentLaunchRequest(
+            kind: "claude-code",
+            systemPrompt: SystemPromptSetting(mode: .replace, text: "")
+        )).get()
+        XCTAssertEqual(p.launchLine, "claude --dangerously-skip-permissions --model opus --system-prompt ''")
+    }
+
+    func testPlannerSystemPromptRidesAfterModelEffortBeforePrompt() throws {
+        let p = try plan(AgentLaunchRequest(
+            kind: "claude-code", model: "opus", effort: "high", prompt: "do it",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "hi")
+        )).get()
+        XCTAssertEqual(
+            p.launchLine,
+            "claude --dangerously-skip-permissions --model opus --effort high --append-system-prompt 'hi' 'do it'"
+        )
+    }
+
+    func testPlannerSystemPromptInheritInjectsNothing() throws {
+        let p = try plan(AgentLaunchRequest(
+            kind: "claude-code",
+            systemPrompt: SystemPromptSetting(mode: .inherit, text: "ignored")
+        )).get()
+        // inherit adds no system-prompt flag; the factory model pin still rides.
+        XCTAssertEqual(p.launchLine, "claude --dangerously-skip-permissions --model opus")
+    }
+
+    func testPlannerSystemPromptUnsupportedFails() {
+        guard case .failure(let err) = plan(AgentLaunchRequest(
+            kind: "grok",
+            systemPrompt: SystemPromptSetting(mode: .replace, text: "x")
+        )) else {
+            return XCTFail("expected failure")
+        }
+        XCTAssertEqual(err.code, "system_prompt_unsupported")
+    }
+
+    func testPlannerSystemPromptInheritOnAxislessHarnessSucceeds() throws {
+        // An explicit inherit is a no-op even on a harness with no axis — only a
+        // non-inherit request errors.
+        let p = try plan(AgentLaunchRequest(
+            kind: "grok",
+            systemPrompt: SystemPromptSetting(mode: .inherit, text: "")
+        )).get()
+        XCTAssertEqual(p.launchLine, "grok --always-approve")
+    }
+
+    func testPlannerRequestSystemPromptBeatsPinnedBase() throws {
+        var cfg = DefaultAgentConfig.factory
+        cfg.agents[.claudeCode] = AgentConfig(
+            command: "claude --dangerously-skip-permissions", initialPrompt: "",
+            envOverridesText: "",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "pinned")
+        )
+        let p = try plan(
+            AgentLaunchRequest(
+                kind: "claude-code",
+                systemPrompt: SystemPromptSetting(mode: .replace, text: "requested")
+            ),
+            userDefault: cfg
+        ).get()
+        XCTAssertEqual(
+            p.launchLine,
+            "claude --dangerously-skip-permissions --system-prompt 'requested'"
+        )
+    }
+
+    func testPlannerPinnedSystemPromptAppliesWhenRequestOmits() throws {
+        var cfg = DefaultAgentConfig.factory
+        cfg.agents[.claudeCode] = AgentConfig(
+            command: "claude --dangerously-skip-permissions", initialPrompt: "",
+            envOverridesText: "",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "pinned")
+        )
+        let p = try plan(AgentLaunchRequest(kind: "claude-code"), userDefault: cfg).get()
+        XCTAssertEqual(
+            p.launchLine,
+            "claude --dangerously-skip-permissions --append-system-prompt 'pinned'"
+        )
+    }
+
+    func testPlannerHardcodedSystemPromptWinsWithWarning() throws {
+        var cfg = DefaultAgentConfig.factory
+        cfg.agents[.claudeCode] = AgentConfig(
+            command: "claude --dangerously-skip-permissions --system-prompt 'mine'",
+            initialPrompt: "", envOverridesText: ""
+        )
+        let p = try plan(
+            AgentLaunchRequest(
+                kind: "claude-code",
+                systemPrompt: SystemPromptSetting(mode: .append, text: "extra")
+            ),
+            userDefault: cfg
+        ).get()
+        XCTAssertFalse(p.launchLine.contains("extra"))
+        XCTAssertEqual(p.launchLine, "claude --dangerously-skip-permissions --system-prompt 'mine'")
+        XCTAssertEqual(p.warnings.count, 1)
+    }
+
+    func testPlannerCustomKindRejectsSystemPrompt() {
+        // Custom kinds have no system-prompt axis in v1 → a non-inherit request
+        // errors rather than silently dropping.
+        let template = UserAgentLaunchTemplate(
+            command: "aider --yes-always", modelFlag: "--model", effortFlag: nil,
+            effortValues: nil, promptDelivery: "post-boot", env: nil
+        )
+        guard case .failure(let err) = plan(
+            AgentLaunchRequest(
+                kind: "aider",
+                systemPrompt: SystemPromptSetting(mode: .replace, text: "x")
+            ),
+            userTemplate: template
+        ) else {
+            return XCTFail("expected failure")
+        }
+        XCTAssertEqual(err.code, "system_prompt_unsupported")
     }
 
     // MARK: quoting

--- a/docs/launch-agent-reference.md
+++ b/docs/launch-agent-reference.md
@@ -6,7 +6,10 @@ stamped at birth, machine-readable refs back to the caller.
 
 ```
 c11 launch-agent --type <kind>
-    [--model <id>] [--effort <tier>] [--task <id>]
+    [--model <id>] [--effort <tier>]
+    [--system-prompt-mode inherit|append|replace]
+    [--system-prompt <text> | --system-prompt-file <path>]
+    [--task <id>]
     [--pane <ref> | --workspace <ref> | --new-workspace] [--cwd <path>]
     [--prompt <text> | --prompt-file <path>]
     [--title <text>] [--env KEY=VALUE ...] [--json]
@@ -66,6 +69,41 @@ If the kind's template declares no model (or effort) syntax and the caller passe
 template declares an allowed-values list (claude effort tiers, pi/omp thinking
 levels), the value is validated early with a friendly error; otherwise it is
 passed through and the agent CLI enforces.
+
+### System prompt (`--system-prompt-mode`, `--system-prompt` / `--system-prompt-file`)
+
+A launch-time override of the agent's system prompt, injected as a flag using
+the kind's launch template — data, not caller knowledge. Three modes:
+
+- `inherit` (the absence of the flag): leave the harness default untouched — no
+  flag injected. This is the default when `--system-prompt-mode` is omitted.
+- `append`: add the text on top of the harness default (claude
+  `--append-system-prompt '<text>'`).
+- `replace`: supplant the default with the text (claude `--system-prompt
+  '<text>'`). An **empty** text is allowed and intentional — the blank-slate
+  launch (`--system-prompt ''`).
+
+The text rides `--system-prompt <text>` (inline) or `--system-prompt-file
+<path>` (mutually exclusive, for prompts longer than a sentence). Unlike
+`--prompt-file`, an **empty** system-prompt file is accepted (it is the blank
+slate). System-prompt text is free-form prose and is always single-quoted, the
+same treatment as the positional initial prompt.
+
+Precedence, top wins (mirrors `--model`/`--effort`):
+
+1. a system-prompt flag the operator hardcoded into the configured command
+   (either `--append-system-prompt` or `--system-prompt` — c11 injects nothing
+   on top, with a warning if a mode was also requested),
+2. the `--system-prompt-mode` CLI request,
+3. the system prompt pinned in Settings (the config base layer),
+4. nothing — inherit.
+
+If the kind's template declares no system-prompt syntax and the caller passed a
+non-`inherit` `--system-prompt-mode`, the launch fails with
+`system_prompt_unsupported` rather than silently dropping the request. **v1 seeds
+the axis for `claude-code` only**; every other built-in (and custom kinds) has no
+system-prompt axis, so a non-inherit request for them errors. The system-prompt
+flag renders after `--model`/`--effort` and before the positional prompt.
 
 ### Placement (`--pane` | `--workspace` | `--new-workspace`)
 
@@ -141,6 +179,7 @@ Errors are structured (`--json` gives `{"ok":false,"error":{"code":…,"message"
 | `unknown_agent_type` | `--type` is not a built-in kind and no user template exists |
 | `empty_command` | the kind resolved to an empty launch command (unconfigured `custom`/template) |
 | `model_flag_unsupported` / `effort_flag_unsupported` | `--model`/`--effort` passed for a kind whose template declares no syntax for it |
+| `system_prompt_unsupported` | a non-inherit `--system-prompt-mode` passed for a kind whose template declares no system-prompt syntax |
 | `invalid_effort` | value outside the template's declared allowed list |
 | `invalid_params` | bad `cwd`, or `new_workspace` combined with `pane_id`/`workspace_id` |
 | `not_found` | target workspace or pane doesn't resolve |
@@ -163,25 +202,34 @@ struct AgentLaunchTemplate {
     let effortArg: AgentLaunchArgStyle?  // how "--effort <tier>" renders
     let effortValues: [String]           // non-empty → validated early
     let promptDelivery: AgentPromptDelivery  // .positional | .flag(String) | .postBoot
+    let systemPromptArg: AgentSystemPromptArg?  // append/replace flags, or nil (no axis)
 }
 enum AgentLaunchArgStyle {
     case flag(String)       // "--model" → `--model <v>`
     case configKV(String)   // "model_reasoning_effort" → `-c k=<v>`
 }
+struct AgentSystemPromptArg {
+    let appendFlag: String?   // append mode → `<appendFlag> '<text>'`
+    let replaceFlag: String?  // replace mode → `<replaceFlag> '<text>'` (empty allowed)
+}
 ```
 
 ### Built-in seeds
 
-| kind | model | effort | effort values | prompt |
-|---|---|---|---|---|
-| `claude-code` | `--model` | `--effort` | low, medium, high, xhigh, max | positional |
-| `codex` | `--model` | `-c model_reasoning_effort=` | (pass-through) | positional |
-| `grok` | `--model` | — | | positional |
-| `kimi` | `--model` | — | | post-boot |
-| `opencode` | `--model` (provider/model) | — | | positional (`run` form) |
-| `github-copilot` | `--model` | — | | post-boot |
-| `pi` | `--model` | `--thinking` | off, minimal, low, medium, high, xhigh | positional |
-| `omp` | `--model` | `--thinking` | off, minimal, low, medium, high, xhigh | positional |
+| kind | model | effort | effort values | system prompt | prompt |
+|---|---|---|---|---|---|
+| `claude-code` | `--model` | `--effort` | low, medium, high, xhigh, max | `--append-system-prompt` / `--system-prompt` | positional |
+| `codex` | `--model` | `-c model_reasoning_effort=` | (pass-through) | — | positional |
+| `grok` | `--model` | — | | — | positional |
+| `kimi` | `--model` | — | | — | post-boot |
+| `opencode` | `--model` (provider/model) | — | | — | positional (`run` form) |
+| `github-copilot` | `--model` | — | | — | post-boot |
+| `pi` | `--model` | `--thinking` | off, minimal, low, medium, high, xhigh | — | positional |
+| `omp` | `--model` | `--thinking` | off, minimal, low, medium, high, xhigh | — | positional |
+
+The system-prompt axis is claude-code-only in v1 (other harnesses map to their
+equivalent flag in a later phase, the same way effort was staged); a non-inherit
+system-prompt request for a kind with `—` errors `system_prompt_unsupported`.
 
 Notes: opencode's prompt is positional **because** its factory command is the
 `opencode run` form; an operator who reconfigures the base command to the bare
@@ -217,10 +265,17 @@ CLI `launch-agent` is a thin client over one v2 method, `agent.launch`:
 ```json
 { "method": "agent.launch",
   "params": { "type": "codex", "model": "gpt-5.2", "effort": "high",
+              "system_prompt_mode": "append", "system_prompt": "…",
               "task": "sekhem-42", "prompt": "…", "title": "…",
               "pane_id": "<uuid>" | "workspace_id": "<uuid>" | "new_workspace": true,
               "cwd": "/path", "env": {"K": "V"} } }
 ```
+
+`system_prompt_mode` ∈ `inherit | append | replace` gates the axis;
+`system_prompt` carries the text (empty allowed on `replace` = blank slate). An
+unparseable mode is treated as no override; the planner is the single validation
+authority (it emits `system_prompt_unsupported` for a non-inherit mode on a kind
+with no axis).
 
 `pane_id`/`workspace_id` take UUIDs — the CLI resolves `pane:N`/`workspace:N`
 short refs client-side before sending, and direct socket callers must do the

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -115,14 +115,18 @@ c11 new-workspace [--cwd <path>] [--command <text>] [--title <text>] [--layout <
 c11 new-split <left|right|up|down> [--cwd <path|inherit>]   # Split any pane; the new pane is always a terminal
 c11 new-pane [--type <terminal|browser|markdown>] [--direction <dir>] [--url <url>] [--cwd <path|inherit>]
 c11 new-surface [--type <terminal|browser|markdown>] [--pane <id|ref>] [--workspace <id|ref>]
-c11 launch-agent --type <kind> [--model <id>] [--effort <tier>] [--task <id>] \
-    [--pane <id|ref> | --workspace <id|ref> | --new-workspace] [--cwd <path>] \
+c11 launch-agent --type <kind> [--model <id>] [--effort <tier>] \
+    [--system-prompt-mode inherit|append|replace] [--system-prompt <text> | --system-prompt-file <path>] \
+    [--task <id>] [--pane <id|ref> | --workspace <id|ref> | --new-workspace] [--cwd <path>] \
     [--prompt <text> | --prompt-file <path>] [--title <text>] [--env K=V ...] [--json]
     # Launch a typed agent (claude-code|codex|grok|kimi|opencode|github-copilot|pi|omp,
     # or a custom kind with ~/.config/c11/agents/<kind>.json) into a new surface or a
     # fresh workspace. One command owns the per-agent invocation quirks, model/effort
     # flag syntax, identity-at-birth (env + metadata + title), and prompt delivery;
     # --json returns the new refs. Canonical reference: docs/launch-agent-reference.md.
+    # --system-prompt-mode append|replace injects the kind's system-prompt flag
+    # (claude-code only in v1; replace + empty text = blank slate). errors
+    # system_prompt_unsupported for a kind with no system-prompt axis.
 
 # Navigate
 c11 select-workspace --workspace <id|ref>


### PR DESCRIPTION
Implements **C11-177** in the C11-175 agent-config-primitive run. Adds the **system-prompt axis** to the launch primitive, mirroring the shipped model/effort axes at every seam. Design: `docs/agent-config-primitive-design.md` §1.4, §7 (AgentLaunchTemplate row), §8.5; CLI/socket per `docs/launch-agent-reference.md`.

## What ships
- **`AgentLaunchTemplate.systemPromptArg`** (`AgentSystemPromptArg{appendFlag, replaceFlag}`), seeded for **claude-code** (`--append-system-prompt` / `--system-prompt`) and **nil for every other harness** — axis disabled, same data-gating shape as `effortArg`.
- **`SystemPromptSetting{mode: inherit|append|replace, text}`** primitive + the pure `renderSystemPromptFlag` core. Free-form prose is always single-quoted (like the positional prompt), so `replace` + `""` → `--system-prompt ''` — the Gregorovich blank slate — falls out with no special-casing.
- **Injection in both paths**, gated by the axis with the existing hardcoded-in-command detection:
  - `DefaultAgentResolver.launcherCommand` reads the base-layer `AgentConfig.systemPrompt` (nil = inherit = byte-identical). *(Forward-wiring for the sibling overlay ticket, which owns the Settings UI that sets it; validated by unit tests in v1.)*
  - `AgentLaunchPlanner` — request overrides pinned base; `system_prompt_unsupported` for a non-inherit request on an axis-less kind (parity with `model_flag_unsupported`); a hardcoded flag wins with a warning. Flag renders after model/effort, before the positional prompt.
- **`c11 launch-agent` / `agent.launch`**: `--system-prompt-mode`, `--system-prompt` / `--system-prompt-file` (empty file allowed = blank slate); socket params `system_prompt_mode` / `system_prompt` (parsed off-main; planner is the single validation authority).
- **Docs + skill**: `launch-agent-reference.md` (semantics, seed table, `system_prompt_unsupported` row, socket params) and `skills/c11/references/api.md`. `scripts/sync-installed-skills.sh c11` was run on the maintainer's machine (installed api.md carries the new flag).

## Acceptance criteria — all met
- ✅ Rendered command lines for all 3 modes incl. blank slate (`--system-prompt ''`)
- ✅ No injection when the axis is nil (codex/grok setting ignored; non-inherit request → `system_prompt_unsupported`)
- ✅ Hardcoded flag wins (either `--system-prompt` or `--append-system-prompt` in the command → c11 injects nothing)
- ✅ Existing launches byte-identical when the setting is inherit (tested two ways, incl. a decoded legacy config with no key)

## Tests — 84/84 c11-logic green (pure logic)
`AgentManifestTests` (axis seed) + `DefaultAgentResolverTests`/`AgentLaunchPlannerTests` (all modes, blank slate, nil-axis, hardcoded-wins, precedence, byte-identical regression). Extended in-place — no pbxproj churn, no new test file. No `dlog`, no new SwiftUI strings.

## Reviews
- Plan-review **PASS** (`art_01KY10JBKG9MQ3WW8N7DSMV7W3`); its quoting finding (always-quote prose) applied.
- Code-review **PASS** (`art_01KY11PZP4YSNC318WQDACHMH6`); findings were process reminders. Live-path gate closed: installed `claude` 2.1.216 `--help` confirms `--append-system-prompt`/`--system-prompt` are real with the intended append/replace semantics.

Discovered small in-scope work absorbed: none beyond the ticket. The `orchestration.md` launch-agent example was deliberately left unextended (reviewer-sanctioned; discoverability via the reference link + `api.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)