### PR TITLE
Launch stats rail: agent-launches.jsonl, rolled-up aggregate, recordLaunch sink

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -45,7 +45,6 @@
 		2E31BAE909C0A3DD44589F3E /* HealthIPSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */; };
 		3175B7C8AE075F8D71BFA104 /* CLIAdvisoryConnectivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D70B3BF1A1B2C3D4E5F60720 /* CLIAdvisoryConnectivityTests.swift */; };
 		33575F7E4C63569F35E154A9 /* NewWorkspaceTitleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */; };
-		C1170BD1AA000000000A0001 /* TabOrdinalDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1170BD1AA000000000F0001 /* TabOrdinalDisplayTests.swift */; };
 		352C25FFD890137B5F7A23B3 /* AgentManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBA0F437E5CCBA5E90C3EC3F /* AgentManifestTests.swift */; };
 		365F4BE2806EC0D12A9336BD /* EventEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */; };
 		39AF4F57C52E593EC8CF0680 /* MailboxSurfaceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710BBF1A1B2C3D4E5F60718 /* MailboxSurfaceResolverTests.swift */; };
@@ -111,6 +110,7 @@
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
 		8574E0DF636A7359989C51A4 /* ConversationScraper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */; };
 		864B59A6AAF8E002451F50CB /* ThemedValueParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F008 /* ThemedValueParserTests.swift */; };
+		8713E62944414CDC27EA1AD8 /* AgentLaunchStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */; };
 		88A8E702E9D54BBCAD7025C7 /* EventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B9399C201ED734873E67B9 /* EventEmitter.swift */; };
 		88C381A879AAF75295A60C34 /* Omp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F0DED724227677C7B8512 /* Omp.swift */; };
 		8AEBED793B56A7A254FD0502 /* NotificationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5688157C3C8FA45CD382A3FD /* NotificationHandlers.swift */; };
@@ -123,10 +123,12 @@
 		9112C6C26F5FA76D26214579 /* BrowserQueryHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C0D996AACCF41CBCBC7D7C /* BrowserQueryHandlers.swift */; };
 		9267DDD60A813FBEF3F59F99 /* MailboxDispatcherGCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7113BF1A1B2C3D4E5F60718 /* MailboxDispatcherGCTests.swift */; };
 		928593E0CB8B058E6599C4A4 /* StrategyRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3B59DC588DFAF89D0678B39 /* StrategyRegistry.swift */; };
+		92D7F825153B237CA8984784 /* AgentLaunchStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */; };
 		92F2476565CF0E718D736491 /* WindowHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BEB5FF9085ED9C3E77A0F9 /* WindowHandlers.swift */; };
 		949D60897130D3A2A359CC20 /* CommandPaletteSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008382 /* CommandPaletteSearchEngineTests.swift */; };
 		9B5A20F1BAE65BF29D60D115 /* WorkspaceBlueprintStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8015BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintStoreTests.swift */; };
 		9C51A1CE6AEEBF2E0B4C3E61 /* ChromeScaleTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */; };
+		9CFE781967963703AEA37DB8 /* AgentLaunchStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */; };
 		9E41ED7321B6C6644A698D8C /* WorkspaceDerivedActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A99FEE21A45CCAB920CC627 /* WorkspaceDerivedActivityTests.swift */; };
 		A056D19646BEEAE184A3016B /* MarkdownFeedbackHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFAF4E88F20968661D2D0886 /* MarkdownFeedbackHandlers.swift */; };
 		A11C0DE0000000000040051F /* UpdateInstallerFailureMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0DE0000000000040052F /* UpdateInstallerFailureMappingTests.swift */; };
@@ -295,6 +297,7 @@
 		C1133000000000000000A001 /* CwdParamResolutionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1133000000000000000A002 /* CwdParamResolutionTests.swift */; };
 		C1133000000000000000B001 /* DefaultAgentLaunchCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1133000000000000000B002 /* DefaultAgentLaunchCompositionTests.swift */; };
 		C116000100A1B2C3D4E5F010 /* ChromeScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000200A1B2C3D4E5F010 /* ChromeScale.swift */; };
+		C1170BD1AA000000000A0001 /* TabOrdinalDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1170BD1AA000000000F0001 /* TabOrdinalDisplayTests.swift */; };
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
 		C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1CDE00001A1B2C3D4E5F719 /* codex */; };
 		C1F1E00002A1B2C3D4E5F719 /* pi in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F1E00001A1B2C3D4E5F719 /* pi */; };
@@ -315,6 +318,7 @@
 		CFA9529EA1B3835E1A2586A2 /* DescriptionSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */; };
 		D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */; };
 		D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
+		D1510386129C337B5868E50D /* AgentLaunchStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */; };
 		D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */ = {isa = PBXBuildFile; fileRef = D1BEF00001A1B2C3D4E5F719 /* open */; };
 		D315C25B997B06679DD201C1 /* SnapshotHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01822B693A5DD01EFE28F75F /* SnapshotHandlers.swift */; };
 		D3A97DA994E2DA451F6020CF /* DefaultAgentConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B62D2ECDC52E5244D9C6E3 /* DefaultAgentConfig.swift */; };
@@ -476,6 +480,7 @@
 		00B9399C201ED734873E67B9 /* EventEmitter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventEmitter.swift; path = Events/EventEmitter.swift; sourceTree = "<group>"; };
 		01822B693A5DD01EFE28F75F /* SnapshotHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotHandlers.swift; sourceTree = "<group>"; };
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
+		06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentLaunchStats.swift; sourceTree = "<group>"; };
 		0AC6B52BF66E258E170A6B92 /* c11LogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11LogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 		14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/ScrapeCapturePipeline.swift; sourceTree = "<group>"; };
@@ -485,6 +490,7 @@
 		1BBF9629DC09C0F27A0A7F64 /* DebugHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DebugHandlers.swift; sourceTree = "<group>"; };
 		1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceManualUnreadTests.swift; sourceTree = "<group>"; };
 		20BC9700748D344154CAF30D /* SurfaceLivenessDeriverTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceLivenessDeriverTests.swift; sourceTree = "<group>"; };
+		271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentLaunchStatsTests.swift; sourceTree = "<group>"; };
 		287F0DED724227677C7B8512 /* Omp.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Omp.swift; path = Conversation/Strategies/Omp.swift; sourceTree = "<group>"; };
 		2B58906AF9FEEF1C9EBDEFC2 /* SystemHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SystemHandlers.swift; sourceTree = "<group>"; };
 		3536E1F26D365D81206EFAAC /* SnapshotBridge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SnapshotBridge.swift; path = Conversation/SnapshotBridge.swift; sourceTree = "<group>"; };
@@ -529,7 +535,6 @@
 		8FF3E8B8443DEA778BA817BB /* SurfaceTypeAvailability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceTypeAvailability.swift; sourceTree = "<group>"; };
 		91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EventLogTests.swift; sourceTree = "<group>"; };
 		93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWorkspaceTitleTests.swift; sourceTree = "<group>"; };
-		C1170BD1AA000000000F0001 /* TabOrdinalDisplayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabOrdinalDisplayTests.swift; sourceTree = "<group>"; };
 		96951AF465673123431D362B /* ConversationStoreFailureModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationStoreFailureModeTests.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
 		9A99FEE21A45CCAB920CC627 /* WorkspaceDerivedActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceDerivedActivityTests.swift; sourceTree = "<group>"; };
@@ -709,6 +714,7 @@
 		C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleTokensTests.swift; sourceTree = "<group>"; };
 		C116000800A1B2C3D4E5F013 /* ChromeScaleObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChromeScaleObserverTests.swift; sourceTree = "<group>"; };
 		C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceApplyChromeScaleTests.swift; sourceTree = "<group>"; };
+		C1170BD1AA000000000F0001 /* TabOrdinalDisplayTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TabOrdinalDisplayTests.swift; sourceTree = "<group>"; };
 		C1ADE00001A1B2C3D4E5F719 /* claude */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/claude; sourceTree = SOURCE_ROOT; };
 		C1CDE00001A1B2C3D4E5F719 /* codex */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/codex; sourceTree = SOURCE_ROOT; };
 		C1F1E00001A1B2C3D4E5F719 /* pi */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/pi; sourceTree = SOURCE_ROOT; };
@@ -1165,6 +1171,7 @@
 				64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */,
 				CE575BF7FF16088778D40E17 /* EventLog.swift */,
 				00B9399C201ED734873E67B9 /* EventEmitter.swift */,
+				06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1370,6 +1377,7 @@
 				EE5E15A4988E33E201CBAE37 /* SocketSurfaceRefValidatorTests.swift */,
 				36732611CC1BEFB8D99BB606 /* SocketSurfaceRefRejectionWiringTests.swift */,
 				91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */,
+				271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1706,6 +1714,7 @@
 				592E7B94FECC0B5AAB3B53B4 /* SidebarActivityProjectorTests.swift in Sources */,
 				F26F83DDD9A2554D8FC6E8CE /* SocketSurfaceRefValidatorTests.swift in Sources */,
 				0D76F685D48115A43B14C5D5 /* EventLogTests.swift in Sources */,
+				8713E62944414CDC27EA1AD8 /* AgentLaunchStatsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1911,6 +1920,7 @@
 				BF71609E6CC93D0CB7FE632D /* EventEnvelope.swift in Sources */,
 				1FD750B08EDEB2C775C05971 /* EventLog.swift in Sources */,
 				88A8E702E9D54BBCAD7025C7 /* EventEmitter.swift in Sources */,
+				9CFE781967963703AEA37DB8 /* AgentLaunchStats.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1932,6 +1942,7 @@
 				D70B3BF0A1B2C3D4E5F60719 /* CLIAdvisoryConnectivity.swift in Sources */,
 				75B580E4A1859423B310E203 /* EventLogLayout.swift in Sources */,
 				365F4BE2806EC0D12A9336BD /* EventEnvelope.swift in Sources */,
+				D1510386129C337B5868E50D /* AgentLaunchStats.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2001,6 +2012,7 @@
 				573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */,
 				90204B2AA277D990B450D7E9 /* AgentManifestTests.swift in Sources */,
 				2DAD13E51CF90A021D8893D5 /* SocketSurfaceRefRejectionWiringTests.swift in Sources */,
+				92D7F825153B237CA8984784 /* AgentLaunchStatsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AgentLaunchStats.swift
+++ b/Sources/AgentLaunchStats.swift
@@ -587,12 +587,13 @@ public final class AgentLaunchStatsStore: @unchecked Sendable {
         do {
             if appendHandle == nil {
                 try ensureDirectoryLocked()
-                if !FileManager.default.fileExists(atPath: jsonlURL.path) {
-                    FileManager.default.createFile(atPath: jsonlURL.path, contents: nil)
-                }
-                let fh = try FileHandle(forWritingTo: jsonlURL)
-                try fh.seekToEnd()
-                appendHandle = fh
+                // Open with O_APPEND so every write() is kernel-serialized to the
+                // file's true end — atomic even if a second c11 instance shares the
+                // state root. No manual seekToEnd (a cached offset can lag the real
+                // end across writers); the kernel repositions to EOF per write.
+                let fd = open(jsonlURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+                guard fd >= 0 else { return }
+                appendHandle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
             }
             try appendHandle?.write(contentsOf: lineData)
         } catch {

--- a/Sources/AgentLaunchStats.swift
+++ b/Sources/AgentLaunchStats.swift
@@ -378,9 +378,20 @@ public final class AgentLaunchStatsStore: @unchecked Sendable {
             fieldSources: nil
         )
         queue.sync {
+            // The jsonl is authoritative — append first (O_APPEND, atomic).
             appendLineLocked(record)
-            var agg = loadAggregateLocked()
-            bumpLocked(&agg, with: record)
+            var agg: AgentLaunchStatsAggregate
+            if var clean = loadDecodableAggregateLocked() {
+                // Fast path: cleanly-decoded aggregate → O(1) incremental bump.
+                bumpLocked(&clean, with: record)
+                agg = clean
+            } else {
+                // Fresh install or corrupt aggregate: the post-append jsonl is the
+                // ground truth and already includes this record, so rescan rather
+                // than bump (bumping on top of a rescan would double-count). This
+                // recovers all-time counts from a corrupt file instead of resetting.
+                agg = rescanAggregateLocked(preservingRecent: nil)
+            }
             applyRecentLocked(&agg, incoming: observation)
             try? writeAggregateLocked(agg)
         }
@@ -465,14 +476,20 @@ public final class AgentLaunchStatsStore: @unchecked Sendable {
     @discardableResult
     public func rebuildAggregate() -> AgentLaunchStatsAggregate {
         queue.sync {
-            let existingRecent = loadAggregateLocked().recent
-            let records = scanRecordsLocked()
-            var agg = AgentLaunchStatsAggregate.empty
-            agg.recent = existingRecent
-            for r in records { bumpLocked(&agg, with: r) }
+            let agg = rescanAggregateLocked(preservingRecent: loadAggregateLocked().recent)
             try? writeAggregateLocked(agg)
             return agg
         }
+    }
+
+    /// Recompute totals/count/since/last_ts purely from the jsonl ground truth.
+    /// Read-only (no write); callers persist if they want to. Recent cannot be
+    /// derived from the jsonl (it lives only in the aggregate), so it is passed in.
+    private func rescanAggregateLocked(preservingRecent recent: RecentObservation?) -> AgentLaunchStatsAggregate {
+        var agg = AgentLaunchStatsAggregate.empty
+        agg.recent = recent
+        for r in scanRecordsLocked() { bumpLocked(&agg, with: r) }
+        return agg
     }
 
     /// Test/shutdown barrier: block until all queued work has drained and close
@@ -532,16 +549,20 @@ public final class AgentLaunchStatsStore: @unchecked Sendable {
         return true
     }
 
-    private func loadAggregateLocked() -> AgentLaunchStatsAggregate {
-        guard let data = try? Data(contentsOf: aggregateURL), !data.isEmpty else {
-            return .empty
-        }
-        guard let agg = try? AgentLaunchStatsDate.makeDecoder().decode(AgentLaunchStatsAggregate.self, from: data) else {
-            // Corrupt aggregate: fall back to empty. The jsonl remains ground
-            // truth; rebuildAggregate() can restore all-time counts.
-            return .empty
+    /// Cleanly-decoded aggregate, or nil if the file is absent, empty, or corrupt.
+    private func loadDecodableAggregateLocked() -> AgentLaunchStatsAggregate? {
+        guard let data = try? Data(contentsOf: aggregateURL), !data.isEmpty,
+              let agg = try? AgentLaunchStatsDate.makeDecoder().decode(AgentLaunchStatsAggregate.self, from: data) else {
+            return nil
         }
         return agg
+    }
+
+    /// Query/rebuild-facing load: the cleanly-decoded aggregate, else a value
+    /// recovered from the jsonl ground truth (empty on fresh install; full counts
+    /// on a corrupt file) so `.all` never silently reports zero for a corrupt file.
+    private func loadAggregateLocked() -> AgentLaunchStatsAggregate {
+        loadDecodableAggregateLocked() ?? rescanAggregateLocked(preservingRecent: nil)
     }
 
     private func writeAggregateLocked(_ agg: AgentLaunchStatsAggregate) throws {

--- a/Sources/AgentLaunchStats.swift
+++ b/Sources/AgentLaunchStats.swift
@@ -1,0 +1,609 @@
+// AgentLaunchStats.swift
+//
+// The launch-stats rail (C11-178, design §2.4 / §4.1 / §4.4 / §1.2).
+//
+// One `recordLaunch(resolved, source)` sink that, for every launch c11 itself
+// performs (rail 1), (a) appends one line to `agent-launches.jsonl`, (b) bumps
+// the `agent-launch-stats.json` aggregate, and (c) updates a source-ranked
+// "most-recent" observation. Windowed queries scan the jsonl; the aggregate
+// answers all-time in O(1). The log stores only resolved axes + system-prompt
+// mode — NEVER prompt or command text — so it stays lean and non-sensitive.
+//
+// Files live at the c11 state root (`EventLogLayout.defaultStateURL()`), are
+// written atomically, and are readable by the CLI with the app down (this file
+// is compiled into both the `c11` app and `c11-cli` targets, mirroring
+// `EventLogLayout`; it takes no app-only dependency).
+//
+// Coordination (C11-178 ↔ C11-176): the design homes `recent` inside
+// `agent-configs.json`, which C11-176 owns. To keep this ticket's writes off
+// that shared file, `recent` lives here in `agent-launch-stats.json`. The
+// overlay ticket C11-179 reconciles the two homes.
+
+import Foundation
+
+// MARK: - Axis / source vocabulary
+
+/// The call-site tag written to each jsonl line's `source` field (design §2.4).
+public enum AgentLaunchSource: String, Codable, Sendable, CaseIterable {
+    case aButton = "a-button"
+    case launchAgent = "launch-agent"
+    case socket
+    case blueprint
+    case fader
+}
+
+/// The ingestion rail that produced a most-recent observation. Used only for
+/// the recency tiebreak (design §4.4): a fresh launch is never clobbered by a
+/// lagging scrape. Rail 1 (this ticket) only ever emits `.launch`; the
+/// `.sessionHook` / `.scrape` cases are the seam Rails 2/3 use in v2.
+public enum RecentObservationSource: String, Codable, Sendable {
+    case launch
+    case sessionHook
+    case scrape
+
+    /// Higher wins a genuine timestamp tie. `launch ≥ sessionHook ≥ scrape`.
+    var rank: Int {
+        switch self {
+        case .launch: return 3
+        case .sessionHook: return 2
+        case .scrape: return 1
+        }
+    }
+}
+
+// MARK: - Input to the sink
+
+/// The resolved launch axes known at a rail-1 launch site. `provider` is derived
+/// inside the sink (never passed in), so a call site supplies only what it holds.
+/// Blank strings are normalized to nil so the aggregate never gains a `""` key.
+public struct ResolvedLaunch: Equatable, Sendable {
+    public var harness: String
+    public var model: String?
+    public var effort: String?
+    public var systemPromptMode: String?   // inherit|append|replace; nil in v1 (no per-launch selection yet)
+    public var configId: String?           // OPTIONAL — ad-hoc launches carry none
+
+    public init(
+        harness: String,
+        model: String? = nil,
+        effort: String? = nil,
+        systemPromptMode: String? = nil,
+        configId: String? = nil
+    ) {
+        self.harness = harness
+        self.model = AgentLaunchStats.nilIfBlank(model)
+        self.effort = AgentLaunchStats.nilIfBlank(effort)
+        self.systemPromptMode = AgentLaunchStats.nilIfBlank(systemPromptMode)
+        self.configId = AgentLaunchStats.nilIfBlank(configId)
+    }
+}
+
+// MARK: - Persisted record shapes
+
+/// One line in `agent-launches.jsonl`. Resolved axes only; no prompt/command text.
+public struct LaunchRecord: Codable, Equatable, Sendable {
+    public var ts: Date
+    public var harness: String
+    public var model: String?
+    public var effort: String?
+    public var provider: String?
+    public var configId: String?
+    public var systemPromptMode: String?
+    public var source: String
+
+    enum CodingKeys: String, CodingKey {
+        case ts, harness, model, effort, provider
+        case configId = "config_id"
+        case systemPromptMode = "system_prompt_mode"
+        case source
+    }
+}
+
+/// The most-recent observation. Homed in `agent-launch-stats.json` for this
+/// ticket (see coordination note above).
+public struct RecentObservation: Codable, Equatable, Sendable {
+    public var configId: String?
+    public var harness: String
+    public var model: String?
+    public var effort: String?
+    public var provider: String?
+    public var systemPromptMode: String?
+    public var observedAt: Date
+    public var source: String   // RecentObservationSource.rawValue
+    public var fieldSources: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case configId = "config_id"
+        case harness, model, effort, provider
+        case systemPromptMode = "system_prompt_mode"
+        case observedAt = "observed_at"
+        case source
+        case fieldSources = "field_sources"
+    }
+}
+
+/// The three all-time tallies, nested under `totals` to match design §2.4 verbatim
+/// (C11-179's `c11 config stats` reader consumes this exact shape).
+public struct AggregateTotals: Codable, Equatable, Sendable {
+    public var byModel: [String: Int]
+    public var byHarness: [String: Int]
+    public var byProvider: [String: Int]
+
+    enum CodingKeys: String, CodingKey {
+        case byModel = "by_model"
+        case byHarness = "by_harness"
+        case byProvider = "by_provider"
+    }
+
+    public static let empty = AggregateTotals(byModel: [:], byHarness: [:], byProvider: [:])
+}
+
+/// `agent-launch-stats.json` — the rolled-up aggregate for O(1) all-time queries,
+/// plus this ticket's home for `recent`.
+public struct AgentLaunchStatsAggregate: Codable, Equatable, Sendable {
+    public var schemaVersion: Int
+    public var since: Date?
+    public var totals: AggregateTotals
+    public var count: Int
+    public var lastTs: Date?
+    public var recent: RecentObservation?
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case since
+        case totals
+        case count
+        case lastTs = "last_ts"
+        case recent
+    }
+
+    public static let currentSchemaVersion = 1
+
+    public static var empty: AgentLaunchStatsAggregate {
+        AgentLaunchStatsAggregate(
+            schemaVersion: currentSchemaVersion,
+            since: nil,
+            totals: .empty,
+            count: 0,
+            lastTs: nil,
+            recent: nil
+        )
+    }
+}
+
+// MARK: - Windowed query result
+
+public enum StatsWindow: Equatable, Sendable {
+    case today
+    case days(Int)
+    case all
+}
+
+public enum StatsAxis: String, Sendable {
+    case model
+    case harness
+    case provider
+}
+
+/// The answer to a windowed query.
+public struct LaunchStatsResult: Equatable, Sendable {
+    public var window: StatsWindow
+    public var axis: StatsAxis
+    public var tally: [String: Int]
+    public var count: Int
+    public var lastTs: Date?
+}
+
+// MARK: - Provider derivation + shared helpers (design §1.2)
+
+public enum AgentLaunchStats {
+    /// `nil` for empty/whitespace-only strings, else the trimmed value. Keeps the
+    /// aggregate free of `""` keys and normalizes inherit-blank axes to absent.
+    static func nilIfBlank(_ s: String?) -> String? {
+        guard let s = s?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return nil }
+        return s
+    }
+
+    /// Derive the provider facet from the harness (design §1.2). Fixed harnesses
+    /// map to a constant; router harnesses (opencode/pi/omp) take the model-id
+    /// prefix before the first `/`. Unknown/no-slash → nil (never wrong-but-confident).
+    public static func provider(harness: String, model: String?) -> String? {
+        switch harness {
+        case "claude-code": return "anthropic"
+        case "codex": return "openai"
+        case "grok": return "xai"
+        case "kimi": return "moonshot"
+        case "github-copilot": return "github"
+        case "opencode", "pi", "omp":
+            guard let m = nilIfBlank(model), let slash = m.firstIndex(of: "/") else { return nil }
+            let prefix = String(m[..<slash])
+            return nilIfBlank(prefix)
+        default:
+            return nil
+        }
+    }
+}
+
+// MARK: - ISO8601 coding
+
+/// Fractional-second ISO8601, matching `WorkspaceSnapshotStore`'s human/CLI-readable
+/// date convention. Encodes with `Z`; decodes with or without fractional seconds.
+enum AgentLaunchStatsDate {
+    static let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+    static let plainFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    static func string(from date: Date) -> String { formatter.string(from: date) }
+
+    static func date(from string: String) -> Date? {
+        formatter.date(from: string) ?? plainFormatter.date(from: string)
+    }
+
+    static func makeEncoder() -> JSONEncoder {
+        let e = JSONEncoder()
+        e.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        e.dateEncodingStrategy = .custom { date, encoder in
+            var c = encoder.singleValueContainer()
+            try c.encode(string(from: date))
+        }
+        return e
+    }
+
+    static func makeDecoder() -> JSONDecoder {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .custom { decoder in
+            let c = try decoder.singleValueContainer()
+            let s = try c.decode(String.self)
+            guard let date = AgentLaunchStatsDate.date(from: s) else {
+                throw DecodingError.dataCorruptedError(in: c, debugDescription: "bad ISO8601 date: \(s)")
+            }
+            return date
+        }
+        return d
+    }
+}
+
+// MARK: - Errors
+
+public enum LaunchStatsStoreError: Error, Equatable, CustomStringConvertible {
+    case stateDirectoryUnavailable
+    case createDirectoryFailed(String)
+    case encodeFailed(String)
+    case writeFailed(String)
+
+    public var code: String {
+        switch self {
+        case .stateDirectoryUnavailable: return "launch_stats_state_dir_unavailable"
+        case .createDirectoryFailed: return "launch_stats_create_dir_failed"
+        case .encodeFailed: return "launch_stats_encode_failed"
+        case .writeFailed: return "launch_stats_write_failed"
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .stateDirectoryUnavailable: return "launch stats: state directory unavailable"
+        case .createDirectoryFailed(let p): return "launch stats: failed to create directory \(p)"
+        case .encodeFailed(let e): return "launch stats: encode failed: \(e)"
+        case .writeFailed(let p): return "launch stats: write failed: \(p)"
+        }
+    }
+}
+
+// MARK: - The store / sink
+
+/// Owns the two files and the record → append + aggregate + recent pipeline.
+/// A single private serial queue serializes all three mutations so the jsonl
+/// line, the aggregate bump, and the recent update never tear against each other.
+///
+/// Safe to call off-main. Reads tolerate missing files (fresh install → empty).
+public final class AgentLaunchStatsStore: @unchecked Sendable {
+    public static let jsonlName = "agent-launches.jsonl"
+    public static let aggregateName = "agent-launch-stats.json"
+
+    private let directory: URL
+    private let clock: () -> Date
+    private let calendar: Calendar
+    private let queue = DispatchQueue(label: "com.stage11.c11.agent-launch-stats")
+    private var appendHandle: FileHandle?
+
+    /// - Parameters:
+    ///   - directory: state root holding the two files. Defaults to
+    ///     `EventLogLayout.defaultStateURL()` (the c11 state root).
+    ///   - clock: injectable time source (tests pin it).
+    ///   - calendar: calendar for the `.today` day boundary. Defaults to
+    ///     `.current` (the operator's local day); tests inject a fixed-timezone
+    ///     calendar so the boundary is deterministic.
+    public init(directory: URL, clock: @escaping () -> Date = { Date() }, calendar: Calendar = .current) {
+        self.directory = directory
+        self.clock = clock
+        self.calendar = calendar
+    }
+
+    /// Process-wide store rooted at the c11 state directory. `nil` only if the
+    /// state directory is unresolvable (e.g. sandboxed test host with no app
+    /// support dir); rail-1 call sites no-op through the optional in that case.
+    public static let shared: AgentLaunchStatsStore? = try? makeDefault()
+
+    /// Production convenience: resolve the c11 state root. Throws if unavailable.
+    public static func makeDefault(clock: @escaping () -> Date = { Date() }) throws -> AgentLaunchStatsStore {
+        let root: URL
+        do {
+            root = try EventLogLayout.defaultStateURL()
+        } catch {
+            throw LaunchStatsStoreError.stateDirectoryUnavailable
+        }
+        return AgentLaunchStatsStore(directory: root, clock: clock)
+    }
+
+    private var jsonlURL: URL { directory.appendingPathComponent(Self.jsonlName) }
+    private var aggregateURL: URL { directory.appendingPathComponent(Self.aggregateName) }
+
+    // MARK: Sink
+
+    /// The one sink every rail-1 launch calls. Appends a jsonl line, bumps the
+    /// aggregate, and updates `recent` (source `.launch`, so it outranks any
+    /// lagging scrape). Best-effort: append/aggregate failures are swallowed so a
+    /// telemetry hiccup never fails a launch; the two are still consistent within
+    /// a successful call because both run under the serial queue.
+    public func recordLaunch(_ resolved: ResolvedLaunch, source: AgentLaunchSource) {
+        let ts = clock()
+        let provider = AgentLaunchStats.provider(harness: resolved.harness, model: resolved.model)
+        let record = LaunchRecord(
+            ts: ts,
+            harness: resolved.harness,
+            model: resolved.model,
+            effort: resolved.effort,
+            provider: provider,
+            configId: resolved.configId,
+            systemPromptMode: resolved.systemPromptMode,
+            source: source.rawValue
+        )
+        let observation = RecentObservation(
+            configId: resolved.configId,
+            harness: resolved.harness,
+            model: resolved.model,
+            effort: resolved.effort,
+            provider: provider,
+            systemPromptMode: resolved.systemPromptMode,
+            observedAt: ts,
+            source: RecentObservationSource.launch.rawValue,
+            fieldSources: nil
+        )
+        queue.sync {
+            appendLineLocked(record)
+            var agg = loadAggregateLocked()
+            bumpLocked(&agg, with: record)
+            applyRecentLocked(&agg, incoming: observation)
+            try? writeAggregateLocked(agg)
+        }
+    }
+
+    /// Source-ranked update of `recent`. Also the seam Rails 2/3 use in v2.
+    /// Returns true if the stored observation was replaced.
+    @discardableResult
+    public func updateRecent(_ incoming: RecentObservation) -> Bool {
+        queue.sync {
+            var agg = loadAggregateLocked()
+            let replaced = applyRecentLocked(&agg, incoming: incoming)
+            if replaced { try? writeAggregateLocked(agg) }
+            return replaced
+        }
+    }
+
+    /// Should `incoming` replace `stored`? Recency dominates; rank breaks a
+    /// genuine timestamp tie. A stale (older) observation never wins — so a
+    /// lagging scrape can never clobber a newer launch (design §4.4).
+    static func shouldReplace(stored: RecentObservation?, incoming: RecentObservation) -> Bool {
+        guard let stored = stored else { return true }
+        if incoming.observedAt > stored.observedAt { return true }
+        if incoming.observedAt == stored.observedAt {
+            let incomingRank = RecentObservationSource(rawValue: incoming.source)?.rank ?? 0
+            let storedRank = RecentObservationSource(rawValue: stored.source)?.rank ?? 0
+            return incomingRank >= storedRank
+        }
+        return false
+    }
+
+    // MARK: Queries
+
+    /// Load the current aggregate (all-time O(1) source of truth).
+    public func aggregate() -> AgentLaunchStatsAggregate {
+        queue.sync { loadAggregateLocked() }
+    }
+
+    /// The current most-recent observation, if any.
+    public func recent() -> RecentObservation? {
+        queue.sync { loadAggregateLocked().recent }
+    }
+
+    /// Windowed query. `.all` reads the aggregate (no scan); `.today`/`.days`
+    /// scan the jsonl and tally by the chosen axis. `now` is injectable for tests.
+    public func stats(window: StatsWindow, by axis: StatsAxis, now: Date? = nil) -> LaunchStatsResult {
+        queue.sync {
+            let reference = now ?? clock()
+            switch window {
+            case .all:
+                let agg = loadAggregateLocked()
+                return LaunchStatsResult(
+                    window: .all,
+                    axis: axis,
+                    tally: tally(from: agg.totals, axis: axis),
+                    count: agg.count,
+                    lastTs: agg.lastTs
+                )
+            case .today, .days:
+                let cutoff = cutoffDate(window: window, now: reference)
+                let records = scanRecordsLocked().filter { $0.ts >= cutoff }
+                var tally: [String: Int] = [:]
+                var last: Date?
+                for r in records {
+                    if let key = axisKey(r, axis: axis) { tally[key, default: 0] += 1 }
+                    if last == nil || r.ts > last! { last = r.ts }
+                }
+                return LaunchStatsResult(
+                    window: window,
+                    axis: axis,
+                    tally: tally,
+                    count: records.count,
+                    lastTs: last
+                )
+            }
+        }
+    }
+
+    /// Rescan the whole jsonl and rewrite the aggregate from scratch (drift
+    /// recovery — design §2.4 anticipates this since `.all` reads the aggregate,
+    /// not the jsonl). Preserves the existing `recent`. Returns the rebuilt value.
+    @discardableResult
+    public func rebuildAggregate() -> AgentLaunchStatsAggregate {
+        queue.sync {
+            let existingRecent = loadAggregateLocked().recent
+            let records = scanRecordsLocked()
+            var agg = AgentLaunchStatsAggregate.empty
+            agg.recent = existingRecent
+            for r in records { bumpLocked(&agg, with: r) }
+            try? writeAggregateLocked(agg)
+            return agg
+        }
+    }
+
+    /// Test/shutdown barrier: block until all queued work has drained and close
+    /// the append handle.
+    public func flush() {
+        queue.sync {
+            try? appendHandle?.close()
+            appendHandle = nil
+        }
+    }
+
+    // MARK: - Locked internals (queue-confined)
+
+    private func cutoffDate(window: StatsWindow, now: Date) -> Date {
+        switch window {
+        case .today:
+            return calendar.startOfDay(for: now)
+        case .days(let n):
+            return now.addingTimeInterval(-Double(max(0, n)) * 86_400)
+        case .all:
+            return .distantPast
+        }
+    }
+
+    private func tally(from totals: AggregateTotals, axis: StatsAxis) -> [String: Int] {
+        switch axis {
+        case .model: return totals.byModel
+        case .harness: return totals.byHarness
+        case .provider: return totals.byProvider
+        }
+    }
+
+    private func axisKey(_ r: LaunchRecord, axis: StatsAxis) -> String? {
+        switch axis {
+        case .model: return AgentLaunchStats.nilIfBlank(r.model)
+        case .harness: return AgentLaunchStats.nilIfBlank(r.harness)
+        case .provider: return AgentLaunchStats.nilIfBlank(r.provider)
+        }
+    }
+
+    private func bumpLocked(_ agg: inout AgentLaunchStatsAggregate, with record: LaunchRecord) {
+        if agg.since == nil { agg.since = record.ts }
+        if let m = AgentLaunchStats.nilIfBlank(record.model) { agg.totals.byModel[m, default: 0] += 1 }
+        if let h = AgentLaunchStats.nilIfBlank(record.harness) { agg.totals.byHarness[h, default: 0] += 1 }
+        if let p = AgentLaunchStats.nilIfBlank(record.provider) { agg.totals.byProvider[p, default: 0] += 1 }
+        agg.count += 1
+        if agg.lastTs == nil || record.ts > agg.lastTs! { agg.lastTs = record.ts }
+    }
+
+    @discardableResult
+    private func applyRecentLocked(_ agg: inout AgentLaunchStatsAggregate, incoming: RecentObservation) -> Bool {
+        guard Self.shouldReplace(stored: agg.recent, incoming: incoming) else { return false }
+        agg.recent = incoming
+        return true
+    }
+
+    private func loadAggregateLocked() -> AgentLaunchStatsAggregate {
+        guard let data = try? Data(contentsOf: aggregateURL), !data.isEmpty else {
+            return .empty
+        }
+        guard let agg = try? AgentLaunchStatsDate.makeDecoder().decode(AgentLaunchStatsAggregate.self, from: data) else {
+            // Corrupt aggregate: fall back to empty. The jsonl remains ground
+            // truth; rebuildAggregate() can restore all-time counts.
+            return .empty
+        }
+        return agg
+    }
+
+    private func writeAggregateLocked(_ agg: AgentLaunchStatsAggregate) throws {
+        try ensureDirectoryLocked()
+        let data: Data
+        do {
+            data = try AgentLaunchStatsDate.makeEncoder().encode(agg)
+        } catch {
+            throw LaunchStatsStoreError.encodeFailed("\(error)")
+        }
+        do {
+            try data.write(to: aggregateURL, options: .atomic)
+        } catch {
+            throw LaunchStatsStoreError.writeFailed(aggregateURL.path)
+        }
+    }
+
+    private func scanRecordsLocked() -> [LaunchRecord] {
+        guard let data = try? Data(contentsOf: jsonlURL), !data.isEmpty,
+              let text = String(data: data, encoding: .utf8) else {
+            return []
+        }
+        let decoder = AgentLaunchStatsDate.makeDecoder()
+        var out: [LaunchRecord] = []
+        text.enumerateLines { line, _ in
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty, let lineData = trimmed.data(using: .utf8) else { return }
+            // Tolerant: skip unparseable lines rather than throwing.
+            if let record = try? decoder.decode(LaunchRecord.self, from: lineData) {
+                out.append(record)
+            }
+        }
+        return out
+    }
+
+    private func appendLineLocked(_ record: LaunchRecord) {
+        guard let data = try? AgentLaunchStatsDate.makeEncoder().encode(record),
+              var line = String(data: data, encoding: .utf8) else {
+            return
+        }
+        line += "\n"
+        guard let lineData = line.data(using: .utf8) else { return }
+        do {
+            if appendHandle == nil {
+                try ensureDirectoryLocked()
+                if !FileManager.default.fileExists(atPath: jsonlURL.path) {
+                    FileManager.default.createFile(atPath: jsonlURL.path, contents: nil)
+                }
+                let fh = try FileHandle(forWritingTo: jsonlURL)
+                try fh.seekToEnd()
+                appendHandle = fh
+            }
+            try appendHandle?.write(contentsOf: lineData)
+        } catch {
+            // Best-effort: drop the handle so the next call reopens from scratch.
+            try? appendHandle?.close()
+            appendHandle = nil
+        }
+    }
+
+    private func ensureDirectoryLocked() throws {
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            throw LaunchStatsStoreError.createDirectoryFailed(directory.path)
+        }
+    }
+}

--- a/Sources/AgentLaunchStats.swift
+++ b/Sources/AgentLaunchStats.swift
@@ -514,7 +514,10 @@ public final class AgentLaunchStatsStore: @unchecked Sendable {
     }
 
     private func bumpLocked(_ agg: inout AgentLaunchStatsAggregate, with record: LaunchRecord) {
-        if agg.since == nil { agg.since = record.ts }
+        // `since` = earliest observed launch. min() (not first-write) so an
+        // out-of-order stamp (clock skew, or a rebuild scanning non-chronological
+        // file order) still yields the true minimum, matching the design's intent.
+        if agg.since == nil || record.ts < agg.since! { agg.since = record.ts }
         if let m = AgentLaunchStats.nilIfBlank(record.model) { agg.totals.byModel[m, default: 0] += 1 }
         if let h = AgentLaunchStats.nilIfBlank(record.harness) { agg.totals.byHarness[h, default: 0] += 1 }
         if let p = AgentLaunchStats.nilIfBlank(record.provider) { agg.totals.byProvider[p, default: 0] += 1 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6526,6 +6526,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                         injected.surfaces[idx].metadata = meta
                     }
                 }
+                // C11-178 rail-1: an agent command was actually injected into this
+                // surface → record the blueprint launch. Config-only read,
+                // dispatched off the launch path.
+                if let store = AgentLaunchStatsStore.shared {
+                    let stats = ResolvedLaunch(harness: resolved.agent.rawValue, model: cfg.model, effort: cfg.effort)
+                    DispatchQueue.global(qos: .utility).async { store.recordLaunch(stats, source: .blueprint) }
+                }
             }
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6526,10 +6526,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                         injected.surfaces[idx].metadata = meta
                     }
                 }
-                // C11-178 rail-1: an agent command was actually injected into this
-                // surface → record the blueprint launch. Config-only read,
-                // dispatched off the launch path.
-                if let store = AgentLaunchStatsStore.shared {
+                // C11-178 rail-1: record the blueprint launch, but only when a
+                // real command resolved — matches site 1's
+                // `guard !command.isEmpty` contract so an empty-resolvable agent
+                // (which injects a bare "\n") never logs a phantom launch.
+                if !command.isEmpty, let store = AgentLaunchStatsStore.shared {
                     let stats = ResolvedLaunch(harness: resolved.agent.rawValue, model: cfg.model, effort: cfg.effort)
                     DispatchQueue.global(qos: .utility).async { store.recordLaunch(stats, source: .blueprint) }
                 }

--- a/Sources/SocketHandlers/SocketDispatch.swift
+++ b/Sources/SocketHandlers/SocketDispatch.swift
@@ -1093,6 +1093,15 @@ extension TerminalController {
                 "surface_ref": self.v2Ref(kind: .surface, uuid: panel.id),
                 "warnings": warnings
             ])
+
+            // C11-178 rail-1: record the resolved launch. `plan` exposes model/
+            // effort as scalars ("" = inherit → normalized to nil). Tagged
+            // `.launchAgent`; raw-socket vs CLI is indistinguishable here without
+            // a wire param (deferred to C11-179). Dispatched off-main.
+            if let store = AgentLaunchStatsStore.shared {
+                let stats = ResolvedLaunch(harness: plan.kind, model: plan.model, effort: plan.effort)
+                DispatchQueue.global(qos: .utility).async { store.recordLaunch(stats, source: .launchAgent) }
+            }
         }) != nil else {
             return .err(code: "main_thread_timeout", message: "main thread did not respond within deadline", data: nil)
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8915,13 +8915,22 @@ class TerminalController {
         }
 
         if let inSurfaceArg {
-            return launchInExistingSurface(
+            let outcome = launchInExistingSurface(
                 surfaceArg: inSurfaceArg,
                 agent: resolved.agent,
                 bareCommand: resolved.launch.bareCommand,
                 cwd: cwdArg,
                 prompt: promptText
             )
+            // C11-178 rail-1: record only a successful launch. `--in-surface` is
+            // CLI-originated → `.launchAgent`. Re-derive cfg the same way sites 1
+            // and 4 do (the composition plan doesn't carry model/effort scalars).
+            if !outcome.hasPrefix("ERROR"), let store = AgentLaunchStatsStore.shared {
+                let cfg = projectConfig?.agents[resolved.agent] ?? userDefault.config(for: resolved.agent)
+                let stats = ResolvedLaunch(harness: resolved.agent.rawValue, model: cfg.model, effort: cfg.effort)
+                DispatchQueue.global(qos: .utility).async { store.recordLaunch(stats, source: .launchAgent) }
+            }
+            return outcome
         } else {
             // A-button mimic: create a new surface in a pane. Prompt args are
             // ignored on this path (the operator's configured initial prompt
@@ -8950,7 +8959,9 @@ class TerminalController {
                     result = "ERROR: Pane not found"
                     return
                 }
-                tab.launchAgentSurface(inPane: pane, explicitAgent: explicitAgent)
+                // CLI-originated launch → tag `.launchAgent` (not `.aButton`), so
+                // the stats rail distinguishes button-clicks from CLI launches.
+                tab.launchAgentSurface(inPane: pane, explicitAgent: explicitAgent, source: .launchAgent)
                 result = "OK"
             }
             return result

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11953,7 +11953,11 @@ extension Workspace: BonsplitDelegate {
     /// `explicitAgent` lets the caller override the configured default —
     /// used by the right-click menu's "launch this one now" affordance and
     /// the `c11 default-agent launch --agent <type>` socket command.
-    func launchAgentSurface(inPane pane: PaneID, explicitAgent: AgentType? = nil) {
+    /// - Parameter source: launch-stats provenance (C11-178). Defaults to
+    ///   `.aButton` (the real UI spawn button); the CLI `default-agent launch`
+    ///   new-surface path passes `.launchAgent` so button-clicks and CLI launches
+    ///   are honestly distinguished in the stats rail.
+    func launchAgentSurface(inPane pane: PaneID, explicitAgent: AgentType? = nil, source: AgentLaunchSource = .aButton) {
         let userDefault = DefaultAgentConfigStore.shared.current
         let projectConfig = DefaultAgentProjectConfig.find(from: resolverCwdForAgentLaunch())
         let resolved = DefaultAgentResolver.resolve(
@@ -11980,6 +11984,37 @@ extension Workspace: BonsplitDelegate {
             projectConfig: projectConfig
         )
         panel.sendText(resolved.launch.command + "\n")
+        // C11-178 rail-1: record the launch off the critical path. Mirror the
+        // resolver's per-agent config pick (as stampLaunchIdentity does) to
+        // recover the resolved model/effort scalars, which ResolvedAgentLaunch
+        // bakes into the command string rather than exposing.
+        recordAgentLaunchStats(
+            agent: resolved.agent,
+            userDefault: userDefault,
+            projectConfig: projectConfig,
+            source: source
+        )
+    }
+
+    /// C11-178: emit a rail-1 launch-stats record for an A-button-lineage launch.
+    /// Config-only read; dispatched to a utility queue so no disk touches the
+    /// launch path. `nil` store (state dir unavailable) is a silent no-op.
+    private func recordAgentLaunchStats(
+        agent: AgentType,
+        userDefault: DefaultAgentConfig,
+        projectConfig: DefaultAgentConfig?,
+        source: AgentLaunchSource
+    ) {
+        guard let store = AgentLaunchStatsStore.shared else { return }
+        let cfg = projectConfig?.agents[agent] ?? userDefault.config(for: agent)
+        let resolved = ResolvedLaunch(
+            harness: agent.rawValue,
+            model: cfg.model,
+            effort: cfg.effort
+        )
+        DispatchQueue.global(qos: .utility).async {
+            store.recordLaunch(resolved, source: source)
+        }
     }
 
     /// Populate a freshly launched agent surface with the identity the sidebar

--- a/c11Tests/AgentLaunchStatsTests.swift
+++ b/c11Tests/AgentLaunchStatsTests.swift
@@ -288,6 +288,21 @@ final class AgentLaunchStatsTests: XCTestCase {
         XCTAssertEqual(rebuilt.since, live.since)
     }
 
+    func testSinceIsEarliestTimestampEvenOutOfOrder() {
+        // Records stamped in non-chronological order (a later ts written before an
+        // earlier one) must still yield the minimum ts as `since`.
+        var t = iso("2026-07-20T15:00:00.000Z")
+        let store = AgentLaunchStatsStore(directory: tempDir, clock: { t })
+        store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus"), source: .aButton)   // 15:00 first
+        t = iso("2026-07-20T09:00:00.000Z")
+        store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "sonnet"), source: .aButton) // 09:00 second
+        store.flush()
+        XCTAssertEqual(store.aggregate().since, iso("2026-07-20T09:00:00.000Z"))
+        XCTAssertEqual(store.aggregate().lastTs, iso("2026-07-20T15:00:00.000Z"))
+        // Rebuild (scans file/append order 15:00 then 09:00) must agree.
+        XCTAssertEqual(store.rebuildAggregate().since, iso("2026-07-20T09:00:00.000Z"))
+    }
+
     func testRebuildPreservesRecent() {
         let now = iso("2026-07-20T21:14:00.000Z")
         let store = makeStore(now: now)

--- a/c11Tests/AgentLaunchStatsTests.swift
+++ b/c11Tests/AgentLaunchStatsTests.swift
@@ -318,6 +318,32 @@ final class AgentLaunchStatsTests: XCTestCase {
         XCTAssertEqual(rebuilt.recent, recentBefore)
     }
 
+    // MARK: - Corrupt aggregate recovery
+
+    func testCorruptAggregateRecoversCountsFromJsonl() throws {
+        let now = iso("2026-07-20T21:14:00.000Z")
+        let store = makeStore(now: now)
+        // Seed three real launches (jsonl = ground truth).
+        for m in ["opus", "opus", "sonnet"] {
+            store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: m), source: .aButton)
+        }
+        store.flush()
+        XCTAssertEqual(store.aggregate().count, 3)
+
+        // Corrupt the aggregate file (non-empty, undecodable).
+        let aggURL = tempDir.appendingPathComponent(AgentLaunchStatsStore.aggregateName)
+        try "{ this is not valid json".write(to: aggURL, atomically: true, encoding: .utf8)
+
+        // A recordLaunch through the corrupt file must NOT reset to count == 1:
+        // counts recover from the jsonl (3) then bump to 4.
+        store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus"), source: .aButton)
+        store.flush()
+        let agg = store.aggregate()
+        XCTAssertEqual(agg.count, 4, "corrupt aggregate must recover from jsonl, not reset")
+        XCTAssertEqual(agg.totals.byModel["opus"], 3)
+        XCTAssertEqual(agg.totals.byModel["sonnet"], 1)
+    }
+
     // MARK: - Fresh install
 
     func testFreshInstallEmptyAndNoThrow() {

--- a/c11Tests/AgentLaunchStatsTests.swift
+++ b/c11Tests/AgentLaunchStatsTests.swift
@@ -92,10 +92,12 @@ final class AgentLaunchStatsTests: XCTestCase {
             provider: "anthropic", configId: nil, systemPromptMode: nil, source: "a-button"
         )
         let data = try AgentLaunchStatsDate.makeEncoder().encode(record)
-        let json = String(data: data, encoding: .utf8)!
-        XCTAssertTrue(json.contains("\"system_prompt_mode\"") == false, "nil mode should be omitted")
-        XCTAssertTrue(json.contains("\"config_id\"") == false, "nil config_id should be omitted")
-        XCTAssertTrue(json.contains("\"source\":\"a-button\""))
+        // Decode into a raw object and assert the exact key set + snake_case
+        // (codec output shape is the on-disk contract C11-179 consumes).
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(Set(obj.keys), Set(["ts", "harness", "model", "effort", "provider", "source"]),
+                       "nil config_id / system_prompt_mode must be omitted; present axes use snake_case")
+        XCTAssertEqual(obj["source"] as? String, "a-button")
         let back = try AgentLaunchStatsDate.makeDecoder().decode(LaunchRecord.self, from: data)
         XCTAssertEqual(back, record)
     }
@@ -109,10 +111,13 @@ final class AgentLaunchStatsTests: XCTestCase {
         agg.since = iso("2026-07-01T00:00:00.000Z")
         agg.lastTs = iso("2026-07-20T21:14:00.000Z")
         let data = try AgentLaunchStatsDate.makeEncoder().encode(agg)
-        let json = String(data: data, encoding: .utf8)!
-        XCTAssertTrue(json.contains("\"totals\""), "tallies must nest under totals (design §2.4)")
-        XCTAssertTrue(json.contains("\"by_model\""))
-        XCTAssertTrue(json.contains("\"schema_version\":1"))
+        // Assert the nested `totals` envelope + snake_case via the decoded object
+        // shape — this is the file contract C11-179's `c11 config stats` reads.
+        let obj = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(obj["schema_version"] as? Int, 1)
+        let totals = try XCTUnwrap(obj["totals"] as? [String: Any], "tallies must nest under totals (design §2.4)")
+        XCTAssertEqual(Set(totals.keys), Set(["by_model", "by_harness", "by_provider"]))
+        XCTAssertEqual((totals["by_model"] as? [String: Int])?["opus"], 3)
         let back = try AgentLaunchStatsDate.makeDecoder().decode(AgentLaunchStatsAggregate.self, from: data)
         XCTAssertEqual(back, agg)
     }

--- a/c11Tests/AgentLaunchStatsTests.swift
+++ b/c11Tests/AgentLaunchStatsTests.swift
@@ -1,0 +1,330 @@
+// AgentLaunchStatsTests.swift
+//
+// Pure-logic tests for the C11-178 launch-stats rail. No Workspace/TabManager
+// construction (bare-runner NSApp-nil crash) — everything runs against an
+// injected temp directory and a pinned clock.
+
+import XCTest
+@testable import c11
+
+final class AgentLaunchStatsTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-launch-stats-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir { try? FileManager.default.removeItem(at: tempDir) }
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: helpers
+
+    /// Fixed-UTC calendar so `.today` boundaries are deterministic regardless of
+    /// the host machine's timezone.
+    private var utcCalendar: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+
+    private func makeStore(now: Date) -> AgentLaunchStatsStore {
+        AgentLaunchStatsStore(directory: tempDir, clock: { now }, calendar: utcCalendar)
+    }
+
+    private func iso(_ s: String) -> Date {
+        guard let d = AgentLaunchStatsDate.date(from: s) else {
+            fatalError("bad test date \(s)")
+        }
+        return d
+    }
+
+    private func jsonlLines() -> [String] {
+        let url = tempDir.appendingPathComponent(AgentLaunchStatsStore.jsonlName)
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        return text.split(separator: "\n").map(String.init).filter { !$0.isEmpty }
+    }
+
+    // MARK: - Provider derivation (§1.2)
+
+    func testProviderFixedHarnesses() {
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "claude-code", model: "opus"), "anthropic")
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "codex", model: "gpt-5.2"), "openai")
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "grok", model: nil), "xai")
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "kimi", model: "k2"), "moonshot")
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "github-copilot", model: nil), "github")
+    }
+
+    func testProviderFixedHarnessIgnoresModel() {
+        // Provider is the harness constant even with an empty/nil model.
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "claude-code", model: ""), "anthropic")
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "claude-code", model: "  "), "anthropic")
+    }
+
+    func testProviderRouterPrefixParse() {
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "omp", model: "deepseek/deepseek-chat-v3.1"), "deepseek")
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "pi", model: "anthropic/claude"), "anthropic")
+        XCTAssertEqual(AgentLaunchStats.provider(harness: "opencode", model: "openai/gpt-5.2"), "openai")
+    }
+
+    func testProviderRouterNoSlashOrEmptyIsNil() {
+        XCTAssertNil(AgentLaunchStats.provider(harness: "omp", model: "deepseek-chat"))  // no slash
+        XCTAssertNil(AgentLaunchStats.provider(harness: "pi", model: nil))
+        XCTAssertNil(AgentLaunchStats.provider(harness: "opencode", model: "/leading-slash")) // empty prefix
+    }
+
+    func testProviderCustomUnknownIsNil() {
+        XCTAssertNil(AgentLaunchStats.provider(harness: "custom", model: "whatever"))
+        XCTAssertNil(AgentLaunchStats.provider(harness: "totally-unknown", model: "x"))
+    }
+
+    // MARK: - Codec round-trips
+
+    func testLaunchRecordSnakeCaseAndOptionalOmission() throws {
+        let record = LaunchRecord(
+            ts: iso("2026-07-20T21:14:00.000Z"),
+            harness: "claude-code", model: "opus", effort: "high",
+            provider: "anthropic", configId: nil, systemPromptMode: nil, source: "a-button"
+        )
+        let data = try AgentLaunchStatsDate.makeEncoder().encode(record)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(json.contains("\"system_prompt_mode\"") == false, "nil mode should be omitted")
+        XCTAssertTrue(json.contains("\"config_id\"") == false, "nil config_id should be omitted")
+        XCTAssertTrue(json.contains("\"source\":\"a-button\""))
+        let back = try AgentLaunchStatsDate.makeDecoder().decode(LaunchRecord.self, from: data)
+        XCTAssertEqual(back, record)
+    }
+
+    func testAggregateRoundTripWithTotalsEnvelope() throws {
+        var agg = AgentLaunchStatsAggregate.empty
+        agg.totals.byModel = ["opus": 3]
+        agg.totals.byHarness = ["claude-code": 3]
+        agg.totals.byProvider = ["anthropic": 3]
+        agg.count = 3
+        agg.since = iso("2026-07-01T00:00:00.000Z")
+        agg.lastTs = iso("2026-07-20T21:14:00.000Z")
+        let data = try AgentLaunchStatsDate.makeEncoder().encode(agg)
+        let json = String(data: data, encoding: .utf8)!
+        XCTAssertTrue(json.contains("\"totals\""), "tallies must nest under totals (design §2.4)")
+        XCTAssertTrue(json.contains("\"by_model\""))
+        XCTAssertTrue(json.contains("\"schema_version\":1"))
+        let back = try AgentLaunchStatsDate.makeDecoder().decode(AgentLaunchStatsAggregate.self, from: data)
+        XCTAssertEqual(back, agg)
+    }
+
+    // MARK: - Append + aggregate consistency
+
+    func testAppendAndAggregateConsistency() {
+        let now = iso("2026-07-20T21:14:00.000Z")
+        let store = makeStore(now: now)
+        store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus", effort: "high"), source: .aButton)
+        store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus", effort: "high"), source: .blueprint)
+        store.recordLaunch(ResolvedLaunch(harness: "codex", model: "gpt-5.2", effort: "high"), source: .launchAgent)
+        store.recordLaunch(ResolvedLaunch(harness: "omp", model: "deepseek/deepseek-chat-v3.1"), source: .socket)
+        store.flush()
+
+        XCTAssertEqual(jsonlLines().count, 4, "one jsonl line per launch")
+
+        let agg = store.aggregate()
+        XCTAssertEqual(agg.count, 4)
+        XCTAssertEqual(agg.totals.byModel["opus"], 2)
+        XCTAssertEqual(agg.totals.byModel["gpt-5.2"], 1)
+        XCTAssertEqual(agg.totals.byModel["deepseek/deepseek-chat-v3.1"], 1)
+        XCTAssertEqual(agg.totals.byHarness["claude-code"], 2)
+        XCTAssertEqual(agg.totals.byHarness["codex"], 1)
+        XCTAssertEqual(agg.totals.byHarness["omp"], 1)
+        XCTAssertEqual(agg.totals.byProvider["anthropic"], 2)
+        XCTAssertEqual(agg.totals.byProvider["openai"], 1)
+        XCTAssertEqual(agg.totals.byProvider["deepseek"], 1)  // router prefix parsed
+        // by_model sums equal count
+        XCTAssertEqual(agg.totals.byModel.values.reduce(0, +), 4)
+        XCTAssertEqual(agg.lastTs, now)
+        XCTAssertEqual(agg.since, now)
+    }
+
+    func testNilAxesDoNotProduceBlankKeys() {
+        let store = makeStore(now: iso("2026-07-20T21:14:00.000Z"))
+        // custom harness → nil provider; empty model/effort → normalized to nil.
+        store.recordLaunch(ResolvedLaunch(harness: "custom", model: "", effort: "  "), source: .aButton)
+        store.flush()
+        let agg = store.aggregate()
+        XCTAssertEqual(agg.count, 1)
+        XCTAssertNil(agg.totals.byModel[""])
+        XCTAssertNil(agg.totals.byProvider[""])
+        XCTAssertTrue(agg.totals.byModel.isEmpty)
+        XCTAssertTrue(agg.totals.byProvider.isEmpty)
+        XCTAssertEqual(agg.totals.byHarness["custom"], 1)
+    }
+
+    // MARK: - Windowing
+
+    func testWindowingMath() {
+        // now = mid-day 2026-07-20 (UTC calendar → deterministic day boundary)
+        let now = iso("2026-07-20T12:00:00.000Z")
+        let store = AgentLaunchStatsStore(directory: tempDir, clock: { now }, calendar: utcCalendar)
+        // Writers use a moving clock closure to stamp records at controlled times.
+        var t = iso("2026-07-20T09:00:00.000Z")  // today
+        let s1 = AgentLaunchStatsStore(directory: tempDir, clock: { t })
+        s1.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus"), source: .aButton)  // today
+        t = iso("2026-07-10T09:00:00.000Z")  // within 30d, not today
+        s1.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "sonnet"), source: .aButton)
+        t = iso("2026-05-01T09:00:00.000Z")  // >30d
+        s1.recordLaunch(ResolvedLaunch(harness: "codex", model: "gpt-5.2"), source: .launchAgent)
+        s1.flush()
+
+        let all = store.stats(window: .all, by: .model, now: now)
+        XCTAssertEqual(all.count, 3)
+        XCTAssertEqual(all.tally["opus"], 1)
+        XCTAssertEqual(all.tally["sonnet"], 1)
+        XCTAssertEqual(all.tally["gpt-5.2"], 1)
+
+        let today = store.stats(window: .today, by: .model, now: now)
+        XCTAssertEqual(today.count, 1)
+        XCTAssertEqual(today.tally["opus"], 1)
+        XCTAssertNil(today.tally["sonnet"])
+
+        let d30 = store.stats(window: .days(30), by: .model, now: now)
+        XCTAssertEqual(d30.count, 2, "opus (today) + sonnet (10 days ago), not the May record")
+        XCTAssertEqual(d30.tally["opus"], 1)
+        XCTAssertEqual(d30.tally["sonnet"], 1)
+        XCTAssertNil(d30.tally["gpt-5.2"])
+    }
+
+    func testAllWindowMatchesAggregateWithoutScan() {
+        let now = iso("2026-07-20T12:00:00.000Z")
+        let store = AgentLaunchStatsStore(directory: tempDir, clock: { now })
+        for _ in 0..<5 {
+            store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus"), source: .aButton)
+        }
+        store.flush()
+        let all = store.stats(window: .all, by: .harness, now: now)
+        XCTAssertEqual(all.count, store.aggregate().count)
+        XCTAssertEqual(all.tally, store.aggregate().totals.byHarness)
+    }
+
+    // MARK: - Source-rank tiebreak (§4.4)
+
+    private func obs(_ ts: String, source: RecentObservationSource, model: String) -> RecentObservation {
+        RecentObservation(
+            configId: nil, harness: "claude-code", model: model, effort: nil,
+            provider: "anthropic", systemPromptMode: nil,
+            observedAt: iso(ts), source: source.rawValue, fieldSources: nil
+        )
+    }
+
+    func testShouldReplaceRules() {
+        let launchFresh = obs("2026-07-20T21:14:00.000Z", source: .launch, model: "opus")
+
+        // nil stored → always replace
+        XCTAssertTrue(AgentLaunchStatsStore.shouldReplace(stored: nil, incoming: launchFresh))
+
+        // stale scrape (older ts) never clobbers a newer launch
+        let staleScrape = obs("2026-07-20T21:00:00.000Z", source: .scrape, model: "sonnet")
+        XCTAssertFalse(AgentLaunchStatsStore.shouldReplace(stored: launchFresh, incoming: staleScrape))
+
+        // newer ts wins regardless of source
+        let newerScrape = obs("2026-07-20T21:20:00.000Z", source: .scrape, model: "sonnet")
+        XCTAssertTrue(AgentLaunchStatsStore.shouldReplace(stored: launchFresh, incoming: newerScrape))
+
+        // genuine ts tie → higher rank wins
+        let tieScrape = obs("2026-07-20T21:14:00.000Z", source: .scrape, model: "sonnet")
+        XCTAssertFalse(AgentLaunchStatsStore.shouldReplace(stored: launchFresh, incoming: tieScrape),
+                       "scrape must not clobber launch at equal ts (lower rank)")
+        let tieHook = obs("2026-07-20T21:14:00.000Z", source: .sessionHook, model: "sonnet")
+        XCTAssertFalse(AgentLaunchStatsStore.shouldReplace(stored: launchFresh, incoming: tieHook),
+                       "sessionHook (rank 2) must not clobber launch (rank 3) at equal ts")
+        let tieLaunch = obs("2026-07-20T21:14:00.000Z", source: .launch, model: "sonnet")
+        XCTAssertTrue(AgentLaunchStatsStore.shouldReplace(stored: launchFresh, incoming: tieLaunch),
+                      "equal rank at equal ts replaces (>=)")
+    }
+
+    func testUpdateRecentPersistsAndRanks() {
+        let store = AgentLaunchStatsStore(directory: tempDir, clock: { self.iso("2026-07-20T21:14:00.000Z") })
+        XCTAssertTrue(store.updateRecent(obs("2026-07-20T21:14:00.000Z", source: .launch, model: "opus")))
+        XCTAssertEqual(store.recent()?.model, "opus")
+        // stale scrape rejected, recent unchanged
+        XCTAssertFalse(store.updateRecent(obs("2026-07-20T21:00:00.000Z", source: .scrape, model: "sonnet")))
+        XCTAssertEqual(store.recent()?.model, "opus")
+        // newer launch accepted
+        XCTAssertTrue(store.updateRecent(obs("2026-07-20T22:00:00.000Z", source: .launch, model: "haiku")))
+        XCTAssertEqual(store.recent()?.model, "haiku")
+    }
+
+    func testRecordLaunchUpdatesRecentAsLaunchSource() {
+        let now = iso("2026-07-20T21:14:00.000Z")
+        let store = makeStore(now: now)
+        store.recordLaunch(ResolvedLaunch(harness: "codex", model: "gpt-5.2", effort: "high", configId: "cfg-1"), source: .launchAgent)
+        store.flush()
+        let recent = store.recent()
+        XCTAssertEqual(recent?.model, "gpt-5.2")
+        XCTAssertEqual(recent?.provider, "openai")
+        XCTAssertEqual(recent?.source, RecentObservationSource.launch.rawValue)
+        XCTAssertEqual(recent?.configId, "cfg-1")
+        XCTAssertEqual(recent?.observedAt, now)
+    }
+
+    // MARK: - Rebuild / drift
+
+    func testRebuildAggregateMatchesLiveAfterNLaunches() {
+        var t = iso("2026-07-20T09:00:00.000Z")
+        let store = AgentLaunchStatsStore(directory: tempDir, clock: { t })
+        let models = ["opus", "opus", "sonnet", "gpt-5.2"]
+        let harnesses = ["claude-code", "claude-code", "claude-code", "codex"]
+        for i in 0..<models.count {
+            t = iso(String(format: "2026-07-20T09:%02d:00.000Z", i))
+            store.recordLaunch(ResolvedLaunch(harness: harnesses[i], model: models[i]), source: .aButton)
+        }
+        store.flush()
+        let live = store.aggregate()
+        let rebuilt = store.rebuildAggregate()
+        XCTAssertEqual(rebuilt.count, live.count)
+        XCTAssertEqual(rebuilt.totals, live.totals)
+        XCTAssertEqual(rebuilt.lastTs, live.lastTs)
+        XCTAssertEqual(rebuilt.since, live.since)
+    }
+
+    func testRebuildPreservesRecent() {
+        let now = iso("2026-07-20T21:14:00.000Z")
+        let store = makeStore(now: now)
+        store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus"), source: .aButton)
+        store.flush()
+        let recentBefore = store.recent()
+        let rebuilt = store.rebuildAggregate()
+        XCTAssertEqual(rebuilt.recent, recentBefore)
+    }
+
+    // MARK: - Fresh install
+
+    func testFreshInstallEmptyAndNoThrow() {
+        let store = AgentLaunchStatsStore(directory: tempDir, clock: { self.iso("2026-07-20T12:00:00.000Z") })
+        let agg = store.aggregate()
+        XCTAssertEqual(agg.count, 0)
+        XCTAssertTrue(agg.totals.byModel.isEmpty)
+        XCTAssertNil(store.recent())
+        let all = store.stats(window: .all, by: .model)
+        XCTAssertEqual(all.count, 0)
+        let today = store.stats(window: .today, by: .model)
+        XCTAssertEqual(today.count, 0)
+    }
+
+    // MARK: - No prompt/command text ever
+
+    func testRecordNeverContainsPromptOrCommandText() {
+        let now = iso("2026-07-20T21:14:00.000Z")
+        let store = makeStore(now: now)
+        // ResolvedLaunch has no field for prompt/command — this test guards the
+        // jsonl surface stays limited to resolved axes.
+        store.recordLaunch(ResolvedLaunch(harness: "claude-code", model: "opus", effort: "high", configId: "cfg"), source: .aButton)
+        store.flush()
+        let line = jsonlLines().first ?? ""
+        let allowedKeys = Set(["ts", "harness", "model", "effort", "provider", "config_id", "system_prompt_mode", "source"])
+        let obj = try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
+        let keys = Set((obj ?? [:]).keys)
+        XCTAssertTrue(keys.isSubset(of: allowedKeys), "jsonl keys \(keys) must be within \(allowedKeys)")
+    }
+}

--- a/scripts/c11-178-register-files.rb
+++ b/scripts/c11-178-register-files.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+# C11-178: register the launch-stats-rail source + test files in the Xcode project.
+# Source compiles into BOTH c11 (app) and c11-cli (app-down CLI-readable); the
+# test file joins c11Tests + c11LogicTests (pure logic → fast local loop). Idempotent.
+gem 'xcodeproj', '~> 1.27'
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../GhosttyTabs.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+c11        = project.targets.find { |t| t.name == 'c11' }            or abort 'c11 target not found'
+c11_cli    = project.targets.find { |t| t.name == 'c11-cli' }        or abort 'c11-cli target not found'
+c11_tests  = project.targets.find { |t| t.name == 'c11Tests' }       or abort 'c11Tests target not found'
+c11_logic  = project.targets.find { |t| t.name == 'c11LogicTests' }  or abort 'c11LogicTests target not found'
+
+sources_group = project.main_group.find_subpath('Sources', false) or abort 'Sources group missing'
+tests_group   = project.main_group.find_subpath('c11Tests', false) or abort 'c11Tests group missing'
+
+SOURCE_FILES = %w[AgentLaunchStats.swift].freeze
+TEST_FILES   = %w[AgentLaunchStatsTests.swift].freeze
+
+def ref_in(group, filename)
+  group.files.find { |f| f.path == filename } || group.new_reference(filename)
+end
+
+def ensure_member(target, ref)
+  return if target.source_build_phase.files.any? { |bf| bf.file_ref == ref }
+  target.source_build_phase.add_file_reference(ref)
+end
+
+SOURCE_FILES.each do |fn|
+  ref = ref_in(sources_group, fn)
+  ensure_member(c11, ref)
+  ensure_member(c11_cli, ref)
+end
+
+TEST_FILES.each do |fn|
+  ref = ref_in(tests_group, fn)
+  ensure_member(c11_tests, ref)
+  ensure_member(c11_logic, ref)
+end
+
+project.save
+puts "OK — registered #{SOURCE_FILES.size} source(s) into c11 + c11-cli, #{TEST_FILES.size} test(s) into c11Tests + c11LogicTests"


### PR DESCRIPTION
## What & why

Implements the **launch-stats rail** for the C11-175 agent-config primitive (ticket **C11-178**). Design: `docs/agent-config-primitive-design.md` §1.2, §2.4, §4.1, §4.4, §8.6.

One `recordLaunch(resolved, source)` sink that, for every launch c11 itself performs (rail 1):
1. **Appends** one line to `agent-launches.jsonl` (durable, all-time, resolved axes only).
2. **Bumps** the `agent-launch-stats.json` aggregate (`totals.by_model` / `by_harness` / `by_provider`, `count`, `last_ts`) for O(1) all-time queries.
3. **Updates** a source-ranked most-recent observation (`launch ≥ sessionHook ≥ scrape`, so a stale scrape never clobbers a newer launch — design §4.4).

Windowed queries (`today` / `days(n)` / `all`) scan the jsonl; `.all` answers from the aggregate. `rebuildAggregate()` rescans the jsonl to recover from drift or corruption. **The log stores only resolved axes + system-prompt mode — never prompt or command text.**

**Provider is derived** (design §1.2): fixed harness map (`claude-code→anthropic`, `codex→openai`, `grok→xai`, `kimi→moonshot`, `github-copilot→github`) or the model-id prefix for router harnesses (`opencode`/`pi`/`omp`, e.g. `deepseek/deepseek-chat-v3.1 → deepseek`); no-slash / unknown → nil, never wrong-but-confident.

Files live at the c11 state root (`EventLogLayout.defaultStateURL()`), are written atomically (aggregate) / `O_APPEND` (jsonl), and `AgentLaunchStats.swift` compiles into **both** the `c11` app and `c11-cli` targets so the files are app-down CLI-readable.

## Rail-1 wiring (records once per launch, off-main)

| Site | File | `source` |
|---|---|---|
| A-button (UI) | `Workspace.launchAgentSurface` | `.aButton` |
| `default-agent launch` new-surface (CLI) | `TerminalController` → `launchAgentSurface(source:)` | `.launchAgent` |
| `default-agent launch --in-surface` (CLI) | `TerminalController` | `.launchAgent` |
| `agent.launch` socket / `c11 launch-agent` | `SocketDispatch.v2AgentLaunch` | `.launchAgent` |
| Blueprint / new-workspace spawn | `AppDelegate.applyWorkspacePlanInPreferredMainWindow` | `.blueprint` |

Each records only on a real, successful launch (blueprint/`--in-surface` gate on a non-empty command / non-error outcome); the new-surface path delegates to `launchAgentSurface`, so no path double-counts.

## Coordination with C11-176

The design homes `recent` in `agent-configs.json`, which **C11-176** owns. To keep this diff off the shared file, `recent` is homed in this ticket's own `agent-launch-stats.json`; `config_id` stays optional. **C11-179** reconciles the two homes and adds the `c11 config stats` CLI / `config.*` socket that read this file — the `totals` envelope shape matches the design verbatim for that reader.

## Validation

- **20/20** `AgentLaunchStatsTests` pass on `c11-logic` (0.13s), incl. corrupt-aggregate recovery, source-rank tiebreak, windowing math (UTC-injected calendar), rebuild-equals-rescan, and a privacy guard (jsonl key set ⊆ 8 allowed axes).
- **Real-behavior harness**: compiled the shipped source into a standalone driver and exercised `recordLaunch` end-to-end against real files — printed jsonl lines + aggregate agree; all provider/windowing/source-rank/privacy checks passed.
- `c11-cli` target builds (dual-target / app-down-CLI-readable AC).

## Review

Four headless code-review passes (all PASS). Addressed every actionable finding: `totals` envelope kept verbatim; honest `source` tagging (button vs CLI); `since` = min(ts) not first-write; `O_APPEND` for kernel-serialized appends; corrupt-aggregate recovery from the jsonl instead of silent reset; blueprint empty-command guard; exact-key-set codec assertions (test policy).

**Documented, accepted tradeoffs** (self-healing via `rebuildAggregate()`; design-anticipated): a persistent aggregate-write failure while the jsonl append succeeds leaves `.all` briefly under-reporting until a rebuild; the single `agent-launches.jsonl` is single-owner-safe (c11 owns the state root) rather than multi-process-additive — concurrent aggregate writes are last-writer-wins, recovered by a rebuild; windowed scans are O(n) over the jsonl (design §2.4), with rotation a future concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)