### PR TITLE
Agent config library store: full-recipe library, default mode, persisted recent

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		55741FF81E130E9AB8AE64FB /* WorkspaceSnapshotConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8008BF1A1B2C3D4E5F60718 /* WorkspaceSnapshotConverterTests.swift */; };
 		55A25D62B29EA263FABD5931 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 		56240252C16E6E32305412E0 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
+		566B6BA784672EAB0E03523A /* AgentConfigLibraryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645F0E832571A928F52DDF40 /* AgentConfigLibraryStoreTests.swift */; };
 		56D5F7E29DC4C9999E4EDA7B /* DefaultAgentProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */; };
 		573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		592E7B94FECC0B5AAB3B53B4 /* SidebarActivityProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0054553DCE5D3CED90037B0C /* SidebarActivityProjectorTests.swift */; };
@@ -113,6 +114,7 @@
 		8713E62944414CDC27EA1AD8 /* AgentLaunchStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */; };
 		88A8E702E9D54BBCAD7025C7 /* EventEmitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00B9399C201ED734873E67B9 /* EventEmitter.swift */; };
 		88C381A879AAF75295A60C34 /* Omp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 287F0DED724227677C7B8512 /* Omp.swift */; };
+		8AA1B79D6D4CFC42CF277864 /* AgentConfigLibraryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A03BB65CC01C2029DF83337 /* AgentConfigLibraryStore.swift */; };
 		8AEBED793B56A7A254FD0502 /* NotificationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5688157C3C8FA45CD382A3FD /* NotificationHandlers.swift */; };
 		8B6BA07B09D5E9E01F141A44 /* BrowserChromeSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F01C /* BrowserChromeSnapshotTests.swift */; };
 		8B85A633AA2D415C37FD4727 /* ShutdownSentinel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D3CB3B7B4231D786E8883E /* ShutdownSentinel.swift */; };
@@ -276,6 +278,7 @@
 		B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
 		B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */; };
 		BAE105919F0262DEA7D0DE0C /* MailboxIOTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7104BF1A1B2C3D4E5F60718 /* MailboxIOTests.swift */; };
+		BAEDB3843B3F408AB2B39E44 /* AgentConfigLibraryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A03BB65CC01C2029DF83337 /* AgentConfigLibraryStore.swift */; };
 		BF71609E6CC93D0CB7FE632D /* EventEnvelope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */; };
 		BFBD47384819D160EF689A52 /* WorkspaceBlueprintMarkdownTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8019BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintMarkdownTests.swift */; };
 		C0AE6CCEF674AD50CCEEACE9 /* BrowserHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4C57DBBB7C3C6C27357EBA8 /* BrowserHandlers.swift */; };
@@ -516,6 +519,7 @@
 		6068E3FCA0467699A1ADD6FD /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/Cocoa.framework; sourceTree = DEVELOPER_DIR; };
 		6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
 		640DC1629D340031E0516DA5 /* ConversationHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationHandlers.swift; sourceTree = "<group>"; };
+		645F0E832571A928F52DDF40 /* AgentConfigLibraryStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentConfigLibraryStoreTests.swift; sourceTree = "<group>"; };
 		64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventEnvelope.swift; path = Events/EventEnvelope.swift; sourceTree = "<group>"; };
 		660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationCrashRecoveryTests.swift; path = ConversationCrashRecoveryTests.swift; sourceTree = "<group>"; };
 		6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PiConversationTests.swift; sourceTree = "<group>"; };
@@ -537,6 +541,7 @@
 		93B19DC55D6C39A2387147C3 /* NewWorkspaceTitleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWorkspaceTitleTests.swift; sourceTree = "<group>"; };
 		96951AF465673123431D362B /* ConversationStoreFailureModeTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationStoreFailureModeTests.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
+		9A03BB65CC01C2029DF83337 /* AgentConfigLibraryStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentConfigLibraryStore.swift; sourceTree = "<group>"; };
 		9A99FEE21A45CCAB920CC627 /* WorkspaceDerivedActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceDerivedActivityTests.swift; sourceTree = "<group>"; };
 		9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarSelectionState.swift; sourceTree = "<group>"; };
 		9BFB0FCD7F3834654919F820 /* ConversationScraperRegistry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/Scrapers/ConversationScraperRegistry.swift; sourceTree = "<group>"; };
@@ -1172,6 +1177,7 @@
 				CE575BF7FF16088778D40E17 /* EventLog.swift */,
 				00B9399C201ED734873E67B9 /* EventEmitter.swift */,
 				06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */,
+				9A03BB65CC01C2029DF83337 /* AgentConfigLibraryStore.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1378,6 +1384,7 @@
 				36732611CC1BEFB8D99BB606 /* SocketSurfaceRefRejectionWiringTests.swift */,
 				91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */,
 				271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */,
+				645F0E832571A928F52DDF40 /* AgentConfigLibraryStoreTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1715,6 +1722,7 @@
 				F26F83DDD9A2554D8FC6E8CE /* SocketSurfaceRefValidatorTests.swift in Sources */,
 				0D76F685D48115A43B14C5D5 /* EventLogTests.swift in Sources */,
 				8713E62944414CDC27EA1AD8 /* AgentLaunchStatsTests.swift in Sources */,
+				566B6BA784672EAB0E03523A /* AgentConfigLibraryStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1921,6 +1929,7 @@
 				1FD750B08EDEB2C775C05971 /* EventLog.swift in Sources */,
 				88A8E702E9D54BBCAD7025C7 /* EventEmitter.swift in Sources */,
 				9CFE781967963703AEA37DB8 /* AgentLaunchStats.swift in Sources */,
+				BAEDB3843B3F408AB2B39E44 /* AgentConfigLibraryStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1943,6 +1952,7 @@
 				75B580E4A1859423B310E203 /* EventLogLayout.swift in Sources */,
 				365F4BE2806EC0D12A9336BD /* EventEnvelope.swift in Sources */,
 				D1510386129C337B5868E50D /* AgentLaunchStats.swift in Sources */,
+				8AA1B79D6D4CFC42CF277864 /* AgentConfigLibraryStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/AgentConfigLibraryStore.swift
+++ b/Sources/AgentConfigLibraryStore.swift
@@ -1,0 +1,681 @@
+import Foundation
+
+// MARK: - System prompt
+
+/// An operator's system-prompt choice: which of the three modes (design §1.4),
+/// and the prompt text. `inherit` keeps the harness default untouched, `append`
+/// adds to it, `replace` swaps it — and `replace` with empty `text` is the
+/// Gregorovich blank-slate case (strip the default to nothing).
+///
+/// This is the single canonical definition of the primitive, shared by the
+/// launch/sysprompt axis (`AgentSystemPromptArg` in AgentManifest, which
+/// consumes it) and this config-overlay store (which persists it on a saved
+/// config). It lives in this file because this file is a member of **both** the
+/// app and CLI targets, so the CLI-compiled store resolves the type without
+/// pulling in app-only AgentManifest. Per-harness flag delivery is owned by the
+/// sysprompt axis, not this store.
+struct SystemPromptSetting: Codable, Equatable, Sendable {
+    /// `inherit` leaves the harness default untouched (no flag injected);
+    /// `append` adds `text` on top of the default; `replace` supplants the
+    /// default with `text` (empty `text` = blank slate).
+    enum Mode: String, Codable, Sendable, CaseIterable { case inherit, append, replace }
+    var mode: Mode
+    /// Ignored for `.inherit`. For `.replace`, an empty string is meaningful:
+    /// it is the blank-slate prompt, not "unset".
+    var text: String
+
+    init(mode: Mode, text: String = "") {
+        self.mode = mode
+        self.text = text
+    }
+}
+
+// MARK: - Launch recipe
+
+/// The full launch recipe a saved config carries (design §1.3). Every field
+/// except `harness` is optional; a `nil` field means *inherit the harness
+/// base* (the per-harness Settings config, or factory). Composition/merge and
+/// flag injection are owned by the launch-composition layer downstream; this
+/// type is pure data.
+///
+/// `provider` is deliberately absent — it is a derived facet (fixed map or
+/// model-id prefix, design §1.2) and is never persisted.
+struct AgentLaunchConfig: Codable, Equatable {
+    /// `AgentType.rawValue` (e.g. `"claude-code"`). Required; a recipe is
+    /// always anchored to one harness. Stored as a `String` so this file stays
+    /// free of the app-only `AgentType` and compiles into the CLI target.
+    var harness: String
+    /// `nil` = inherit the harness model.
+    var model: String?
+    /// `nil` = inherit the harness effort.
+    var effort: String?
+    /// `nil` = inherit; see `SystemPromptSetting`.
+    var systemPrompt: SystemPromptSetting?
+    /// `nil` = inherit the harness's configured/factory launch command.
+    var command: String?
+    /// `nil` = inherit the harness initial prompt.
+    var initialPrompt: String?
+    /// `nil` = inherit. Merged over the harness env downstream (config wins per
+    /// key); this store only persists the overlay verbatim.
+    var env: [String: String]?
+
+    init(
+        harness: String,
+        model: String? = nil,
+        effort: String? = nil,
+        systemPrompt: SystemPromptSetting? = nil,
+        command: String? = nil,
+        initialPrompt: String? = nil,
+        env: [String: String]? = nil
+    ) {
+        self.harness = harness
+        self.model = model
+        self.effort = effort
+        self.systemPrompt = systemPrompt
+        self.command = command
+        self.initialPrompt = initialPrompt
+        self.env = env
+    }
+}
+
+/// A named launch recipe in the library. On disk the recipe fields are
+/// **flat** — `id`/`name`/`order` sit alongside `harness`/`model`/… in one
+/// object (design §2.1), not nested under a `config` key — so `Codable` is
+/// custom to flatten the inner `AgentLaunchConfig`.
+///
+/// `id` is a `String` (ULID-shaped), not a `UUID`: the §2.1 examples use
+/// ULID-style ids and `default.config_id` / `recent.config_id` cross-reference
+/// them, so a `String` round-trips the on-disk shape faithfully and matches
+/// the repo's ULID convention.
+struct SavedAgentConfig: Codable, Equatable {
+    var id: String
+    var name: String
+    var order: Int
+    var config: AgentLaunchConfig
+
+    init(id: String, name: String, order: Int, config: AgentLaunchConfig) {
+        self.id = id
+        self.name = name
+        self.order = order
+        self.config = config
+    }
+
+    // Flat on-disk shape. `systemPrompt` is intentionally camelCase — it is the
+    // one camelCase key in the §2.1 `configs[]` example and the doc is the
+    // schema contract; every other key is snake/kebab. Unset optionals are
+    // omitted (absent = inherit).
+    private enum CodingKeys: String, CodingKey {
+        case id, name, order
+        case harness, model, effort
+        case systemPrompt
+        case command
+        case initialPrompt = "initial_prompt"
+        case env
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(String.self, forKey: .id)
+        self.name = try c.decode(String.self, forKey: .name)
+        self.order = try c.decode(Int.self, forKey: .order)
+        self.config = AgentLaunchConfig(
+            harness: try c.decode(String.self, forKey: .harness),
+            model: try c.decodeIfPresent(String.self, forKey: .model),
+            effort: try c.decodeIfPresent(String.self, forKey: .effort),
+            systemPrompt: try c.decodeIfPresent(SystemPromptSetting.self, forKey: .systemPrompt),
+            command: try c.decodeIfPresent(String.self, forKey: .command),
+            initialPrompt: try c.decodeIfPresent(String.self, forKey: .initialPrompt),
+            env: try c.decodeIfPresent([String: String].self, forKey: .env)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encode(order, forKey: .order)
+        try c.encode(config.harness, forKey: .harness)
+        try c.encodeIfPresent(config.model, forKey: .model)
+        try c.encodeIfPresent(config.effort, forKey: .effort)
+        try c.encodeIfPresent(config.systemPrompt, forKey: .systemPrompt)
+        try c.encodeIfPresent(config.command, forKey: .command)
+        try c.encodeIfPresent(config.initialPrompt, forKey: .initialPrompt)
+        try c.encodeIfPresent(config.env, forKey: .env)
+    }
+}
+
+// MARK: - Default pointer + mode
+
+/// The default pointer (design §2.2). `config_id` is always a saved config's
+/// id; the mode decides what a plain left-click launches.
+struct AgentConfigDefault: Codable, Equatable {
+    enum Mode: String, Codable {
+        /// Left-click launches the explicitly chosen config.
+        case pinned
+        /// Left-click launches whatever `recent` holds.
+        case followRecent = "follow-recent"
+    }
+
+    var mode: Mode
+    var configId: String
+
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case configId = "config_id"
+    }
+
+    init(mode: Mode, configId: String) {
+        self.mode = mode
+        self.configId = configId
+    }
+}
+
+// MARK: - Most-recent
+
+/// The most-recent observed launch (design §2.3), persisted across relaunch so
+/// `follow-recent` resumes where the operator left off. Carries `field_sources`
+/// so the UI can distinguish live-observed from launch-captured fields (§4).
+///
+/// This store persists and returns `recent`; it never *produces* it — the
+/// launch-composition layer calls `recordRecent` with a resolved observation.
+struct RecentAgentConfig: Codable, Equatable {
+    var configId: String?
+    var harness: String?
+    var model: String?
+    var effort: String?
+    var observedAt: Date?
+    /// `launch` | `sessionHook` | `scrape` (design §4.4), free-form here.
+    var source: String?
+    /// Per-field provenance, e.g. `{ "model": "launch", "effort": "launch" }`.
+    var fieldSources: [String: String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case configId = "config_id"
+        case harness, model, effort
+        case observedAt = "observed_at"
+        case source
+        case fieldSources = "field_sources"
+    }
+
+    init(
+        configId: String? = nil,
+        harness: String? = nil,
+        model: String? = nil,
+        effort: String? = nil,
+        observedAt: Date? = nil,
+        source: String? = nil,
+        fieldSources: [String: String]? = nil
+    ) {
+        self.configId = configId
+        self.harness = harness
+        self.model = model
+        self.effort = effort
+        self.observedAt = observedAt
+        self.source = source
+        self.fieldSources = fieldSources
+    }
+}
+
+// MARK: - The file
+
+/// The whole `agent-configs.json` document: the library, the default pointer,
+/// and the persisted most-recent (design §2.1).
+struct AgentConfigLibraryFile: Codable, Equatable {
+    /// The only schema version this store reads/writes. A file carrying any
+    /// other value is treated as corrupt and heals to `.factory` (see
+    /// `AgentConfigLibraryStore.current`); a refuse-to-overwrite-newer guard is
+    /// deferred until a v2 schema actually exists.
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var configs: [SavedAgentConfig]
+    var `default`: AgentConfigDefault
+    var recent: RecentAgentConfig?
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case configs
+        case `default`
+        case recent
+    }
+
+    init(
+        schemaVersion: Int = AgentConfigLibraryFile.currentSchemaVersion,
+        configs: [SavedAgentConfig],
+        default: AgentConfigDefault,
+        recent: RecentAgentConfig? = nil
+    ) {
+        self.schemaVersion = schemaVersion
+        self.configs = configs
+        self.default = `default`
+        self.recent = recent
+    }
+
+    // MARK: Factory seed
+
+    /// Stable id for the seeded config: a fixed 26-char sentinel (readable, not
+    /// a generated ULID) so the factory file is byte-deterministic across
+    /// processes and the default pointer always resolves. 26 chars to match the
+    /// `AgentConfigID` id width.
+    static let factorySeedConfigId = "0000000000AGENTOPUSDEEP001"
+
+    /// Factory shape: one pinned config, `Opus deep`, seeded **model=opus with
+    /// effort UNSET** so it is byte-identical to today's pin (claude-code with
+    /// `--model opus` and no `--effort` flag). This deviates from design §2.2's
+    /// literal example (which shows `effort: high`): the governing intent is the
+    /// §2.2 "(matching today's pin)" parenthetical plus C11-179's
+    /// byte-identical-launch regression AC, and today's pin injects no effort
+    /// flag. `effort: nil` = inherit → no `--effort` at launch. No recent yet.
+    static let factory = AgentConfigLibraryFile(
+        schemaVersion: currentSchemaVersion,
+        configs: [
+            SavedAgentConfig(
+                id: factorySeedConfigId,
+                name: "Opus deep",
+                order: 0,
+                config: AgentLaunchConfig(harness: "claude-code", model: "opus")
+            )
+        ],
+        default: AgentConfigDefault(mode: .pinned, configId: factorySeedConfigId),
+        recent: nil
+    )
+
+    /// Whether this file is internally coherent enough to trust. A file whose
+    /// pinned `config_id` names no existing config is not fatal (resolution
+    /// heals), but a wrong schema version is treated as corrupt upstream.
+    var hasResolvablePinnedDefault: Bool {
+        configs.contains { $0.id == `default`.configId }
+    }
+}
+
+// MARK: - Id generation
+
+/// Self-contained ULID-shaped id generator for saved configs. Mirrors the
+/// repo's `WorkspaceSnapshotID` layout (26 chars, Crockford base32,
+/// time-ordered prefix) but is defined here so this file stays Foundation-only
+/// and free of any app-only coupling — it compiles into the CLI target
+/// unchanged. Not a full ULID; sufficient for unique, sortable config ids.
+enum AgentConfigID {
+    private static let alphabet: [Character] = Array("0123456789ABCDEFGHJKMNPQRSTVWXYZ")
+
+    static func generate(
+        now: Date = Date(),
+        random: () -> UInt64 = AgentConfigID.defaultRandom
+    ) -> String {
+        let millis = UInt64(max(0, now.timeIntervalSince1970) * 1000)
+        var out = ""
+        out.reserveCapacity(26)
+        var t = millis
+        var timeChars = Array(repeating: Character("0"), count: 10)
+        for i in (0..<10).reversed() {
+            timeChars[i] = alphabet[Int(t & 0x1F)]
+            t >>= 5
+        }
+        for c in timeChars { out.append(c) }
+        // 80 bits of random across two 40-bit halves so no shift exceeds range.
+        let r1 = random()
+        let r2 = random()
+        let upper40: UInt64 = r1 >> 24
+        let lower40: UInt64 = ((r1 & 0xFFFFFF) << 16) | (r2 >> 48)
+        var randChars = Array(repeating: Character("0"), count: 16)
+        var accLower = lower40
+        for i in (8..<16).reversed() {
+            randChars[i] = alphabet[Int(accLower & 0x1F)]
+            accLower >>= 5
+        }
+        var accUpper = upper40
+        for i in (0..<8).reversed() {
+            randChars[i] = alphabet[Int(accUpper & 0x1F)]
+            accUpper >>= 5
+        }
+        for c in randChars { out.append(c) }
+        return out
+    }
+
+    private static func defaultRandom() -> UInt64 {
+        var rng = SystemRandomNumberGenerator()
+        return rng.next()
+    }
+}
+
+// MARK: - Store
+
+/// File-backed store for `agent-configs.json` at the c11 state root.
+///
+/// **Shape.** A `Sendable` value type over an injected `directory` (the
+/// `WorkspaceSnapshotStore` template), with a computed `current` that
+/// recomputes from disk on every access (the `DefaultAgentConfigStore`
+/// recompute-on-access ergonomic) so socket-driven writes from another path
+/// propagate without any in-memory cache to invalidate. `static let shared`
+/// on a `Sendable` value type is concurrency-safe with no `@unchecked` escape.
+///
+/// **Persistence.** Atomic writes (`Data.write(to:options:.atomic)`), state
+/// directory created on demand, typed `StoreError` modeled on
+/// `WorkspaceSnapshotStore` (a stable `code` plus a human `description`).
+/// Foundation-only, not `@MainActor`; safe to call off the main thread. The
+/// file is the contract — every reader/writer goes through this one path, and
+/// the CLI reads it with the app down.
+///
+/// **Concurrency contract.** Mutators are load → mutate → atomic-save with **no
+/// cross-mutator serialization**: the contract is **last-writer-wins**, exactly
+/// as `WorkspaceSnapshotStore` / `DefaultAgentConfigStore`. Two concurrent
+/// mutators can lose one update; v1 accepts this.
+///
+/// **Corruption.** A missing, unreadable, malformed, or wrong-`schema_version`
+/// file resolves to `AgentConfigLibraryFile.factory` (design §5.6) — reads
+/// never throw into a launch path.
+struct AgentConfigLibraryStore: Sendable {
+
+    /// Filename at the state root.
+    static let fileName = "agent-configs.json"
+
+    private let directory: URL
+    private let fileManager: FileManager
+
+    /// Default instance rooted at the resolved c11 state root
+    /// (`EventLogLayout.defaultStateURL`, which already runs
+    /// `StateDirectoryMigration.ensureMigrated`). Falls back to the app-support
+    /// path directly if the resolver throws so `shared` is always usable.
+    static let shared = AgentConfigLibraryStore()
+
+    init(directory: URL? = nil, fileManager: FileManager = .default) {
+        if let directory {
+            self.directory = directory
+        } else {
+            self.directory = AgentConfigLibraryStore.defaultDirectory(fileManager: fileManager)
+        }
+        self.fileManager = fileManager
+    }
+
+    /// Resolve the state root the same way the events tree does, so
+    /// `agent-configs.json` lands beside the mailbox/events trees under the
+    /// migration latch.
+    static func defaultDirectory(fileManager: FileManager = .default) -> URL {
+        if let url = try? EventLogLayout.defaultStateURL(fileManager: fileManager) {
+            return url
+        }
+        // Extremely defensive fallback; `defaultStateURL` only throws when
+        // application-support is unavailable, which effectively never happens
+        // on a real macOS session.
+        let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.homeDirectoryForCurrentUser
+        return base.appendingPathComponent(EventLogLayout.stateDirectoryName, isDirectory: true)
+    }
+
+    var fileURL: URL {
+        directory.appendingPathComponent(Self.fileName, isDirectory: false)
+    }
+
+    // MARK: Errors
+
+    enum StoreError: Error, Equatable, CustomStringConvertible {
+        case createDirectoryFailed(String, underlying: String)
+        case encodeFailed(String)
+        case writeFailed(String, underlying: String)
+        case configNotFound(String)
+        case indexOutOfRange(Int)
+
+        var code: String {
+            switch self {
+            case .createDirectoryFailed: return "agent_config_dir_create_failed"
+            case .encodeFailed:          return "agent_config_encode_failed"
+            case .writeFailed:           return "agent_config_write_failed"
+            case .configNotFound:        return "agent_config_not_found"
+            case .indexOutOfRange:       return "agent_config_index_out_of_range"
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .createDirectoryFailed(let path, let err):
+                return "agent-configs dir create failed at \(path): \(err)"
+            case .encodeFailed(let detail):
+                return "agent-configs encode failed: \(detail)"
+            case .writeFailed(let path, let err):
+                return "agent-configs write failed at \(path): \(err)"
+            case .configNotFound(let id):
+                return "agent config '\(id)' not found"
+            case .indexOutOfRange(let index):
+                return "reorder index \(index) out of range"
+            }
+        }
+    }
+
+    // MARK: Codec
+
+    /// ISO-8601 with fractional seconds. A local copy of the
+    /// `workspaceSnapshotDateFormatter` idiom so this file carries no coupling
+    /// to the snapshot store (which is app-target-only).
+    private static let dateFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(Self.dateFormatter.string(from: date))
+        }
+        return encoder
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            if let date = Self.dateFormatter.date(from: raw) { return date }
+            let legacy = ISO8601DateFormatter()
+            legacy.formatOptions = [.withInternetDateTime]
+            if let date = legacy.date(from: raw) { return date }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Expected ISO-8601 date string, got '\(raw)'"
+            )
+        }
+        return decoder
+    }
+
+    // MARK: Read
+
+    /// The current library, recomputed from disk on every access. A missing,
+    /// unreadable, malformed, or wrong-`schema_version` file heals to
+    /// `.factory` — this never throws (design §5.6).
+    var current: AgentConfigLibraryFile {
+        guard let data = try? Data(contentsOf: fileURL) else {
+            return .factory
+        }
+        guard let file = try? Self.makeDecoder().decode(AgentConfigLibraryFile.self, from: data),
+              file.schemaVersion == AgentConfigLibraryFile.currentSchemaVersion else {
+            return .factory
+        }
+        return file
+    }
+
+    /// The config a plain left-click launches (design §3):
+    ///
+    ///     effectiveDefault = (mode == .followRecent && recent != nil)
+    ///                        ? <config from recent> : <pinned config>
+    ///
+    /// - `pinned`: the config whose id equals `default.config_id`; if that id
+    ///   names no config, fall back to the factory seed (never crash).
+    /// - `follow-recent` with a `recent.config_id` still present in the
+    ///   library: that saved config.
+    /// - `follow-recent` with recent axes but no resolvable config id:
+    ///   synthesize a transient config from the observed axes (design §8
+    ///   residual: recent-row with no config id shows resolved axes, no name).
+    /// - `follow-recent` with no recent at all: the pinned config.
+    func effectiveDefault() -> SavedAgentConfig {
+        let file = current
+        switch file.default.mode {
+        case .pinned:
+            return pinnedConfig(in: file)
+        case .followRecent:
+            guard let recent = file.recent else {
+                return pinnedConfig(in: file)
+            }
+            if let id = recent.configId, let match = file.configs.first(where: { $0.id == id }) {
+                return match
+            }
+            // No resolvable saved config: build a transient recipe from the
+            // observed axes. Requires at least a harness to be meaningful;
+            // otherwise fall back to the pinned config.
+            guard let harness = recent.harness else {
+                return pinnedConfig(in: file)
+            }
+            let name = [recent.model, recent.effort]
+                .compactMap { $0 }
+                .joined(separator: " · ")
+            // Transient, not a persisted library entry: blank the id (the
+            // `recent.config_id` it came from dangles) and mark `order: -1` so
+            // no consumer mistakes it for a re-resolvable saved config.
+            return SavedAgentConfig(
+                id: "",
+                name: name.isEmpty ? harness : name,
+                order: -1,
+                config: AgentLaunchConfig(
+                    harness: harness,
+                    model: recent.model,
+                    effort: recent.effort
+                )
+            )
+        }
+    }
+
+    /// The pinned config, or the factory seed if the pointer dangles.
+    private func pinnedConfig(in file: AgentConfigLibraryFile) -> SavedAgentConfig {
+        if let match = file.configs.first(where: { $0.id == file.default.configId }) {
+            return match
+        }
+        return AgentConfigLibraryFile.factory.configs[0]
+    }
+
+    // MARK: Write
+
+    private func save(_ file: AgentConfigLibraryFile) throws {
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            throw StoreError.createDirectoryFailed(directory.path, underlying: "\(error)")
+        }
+        let data: Data
+        do {
+            data = try Self.makeEncoder().encode(file)
+        } catch {
+            throw StoreError.encodeFailed("\(error)")
+        }
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            throw StoreError.writeFailed(fileURL.path, underlying: "\(error)")
+        }
+    }
+
+    /// Overwrite the whole file. Exposed for callers that compose a full
+    /// document; mutators below are the ergonomic path.
+    func write(_ file: AgentConfigLibraryFile) throws {
+        try save(file)
+    }
+
+    // MARK: Mutators (load → mutate → atomic-save; last-writer-wins)
+
+    /// Append a config. If `config.id` is empty a fresh ULID-shaped id is
+    /// assigned; `order` is set to the next free slot. Returns the stored
+    /// config (with its resolved id/order).
+    @discardableResult
+    func add(_ config: SavedAgentConfig) throws -> SavedAgentConfig {
+        var file = current
+        var stored = config
+        if stored.id.isEmpty {
+            stored.id = AgentConfigID.generate()
+        }
+        let nextOrder = (file.configs.map { $0.order }.max() ?? -1) + 1
+        stored.order = nextOrder
+        file.configs.append(stored)
+        try save(file)
+        return stored
+    }
+
+    /// Remove a config by id. Throws `.configNotFound` if absent. Reindexes the
+    /// remaining configs to keep `order` dense (0-based). If the removed config
+    /// was the pinned default, the pointer is repointed at the lowest-ordered
+    /// surviving config (or the factory seed if the library becomes empty).
+    func remove(id: String) throws {
+        var file = current
+        guard file.configs.contains(where: { $0.id == id }) else {
+            throw StoreError.configNotFound(id)
+        }
+        file.configs.removeAll { $0.id == id }
+        reindex(&file.configs)
+        if file.configs.isEmpty {
+            // Library emptied (reachable via a `write()`-composed document even
+            // when the removed id wasn't the pinned one): reseed the factory
+            // config so the pointer always resolves.
+            let seed = AgentConfigLibraryFile.factory.configs[0]
+            file.configs = [seed]
+            file.default = AgentConfigDefault(mode: file.default.mode, configId: seed.id)
+        } else if file.default.configId == id {
+            // Removed the pinned config: repoint at the lowest-ordered survivor.
+            if let first = file.configs.min(by: { $0.order < $1.order }) {
+                file.default.configId = first.id
+            }
+        }
+        try save(file)
+    }
+
+    /// Move a config to a new position and reindex `order` to match the new
+    /// sequence. Valid range is `[0, count-1]`; an out-of-range `index` throws
+    /// `.indexOutOfRange` (no clamping).
+    func reorder(id: String, to index: Int) throws {
+        var file = current
+        var ordered = file.configs.sorted { $0.order < $1.order }
+        guard let from = ordered.firstIndex(where: { $0.id == id }) else {
+            throw StoreError.configNotFound(id)
+        }
+        guard index >= 0 && index <= ordered.count - 1 else {
+            throw StoreError.indexOutOfRange(index)
+        }
+        let moved = ordered.remove(at: from)
+        ordered.insert(moved, at: index)
+        reindex(&ordered)
+        file.configs = ordered
+        try save(file)
+    }
+
+    /// Pin a config as the default (mode → `.pinned`). Throws if the id names
+    /// no config.
+    func setDefault(configId: String) throws {
+        var file = current
+        guard file.configs.contains(where: { $0.id == configId }) else {
+            throw StoreError.configNotFound(configId)
+        }
+        file.default = AgentConfigDefault(mode: .pinned, configId: configId)
+        try save(file)
+    }
+
+    /// Switch the default mode without changing which config is pinned.
+    func setMode(_ mode: AgentConfigDefault.Mode) throws {
+        var file = current
+        file.default.mode = mode
+        try save(file)
+    }
+
+    /// Persist the most-recent observation (design §2.3/§4). The
+    /// launch-composition layer calls this with a resolved observation; the
+    /// store only writes it.
+    func recordRecent(_ recent: RecentAgentConfig) throws {
+        var file = current
+        file.recent = recent
+        try save(file)
+    }
+
+    /// Re-densify `order` to 0-based sequence following array order.
+    private func reindex(_ configs: inout [SavedAgentConfig]) {
+        for i in configs.indices {
+            configs[i].order = i
+        }
+    }
+}

--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -124,26 +124,13 @@ enum AgentLaunchArgStyle: Sendable, Equatable {
     }
 }
 
-/// An operator's system-prompt choice for a launch: which of the three modes,
-/// and the prompt text (ignored for `.inherit`; `""` + `.replace` is the
-/// intentional blank-slate launch). This is the primitive the launch axis
-/// consumes; the sibling config-overlay stores it on a saved config.
-struct SystemPromptSetting: Codable, Equatable, Sendable {
-    /// `inherit` leaves the harness default untouched (no flag injected);
-    /// `append` adds `text` on top of the default; `replace` supplants the
-    /// default with `text` (empty `text` = blank slate).
-    enum Mode: String, Codable, Sendable, CaseIterable { case inherit, append, replace }
-    var mode: Mode
-    /// The system-prompt text. Ignored when `mode == .inherit`; an empty string
-    /// with `.replace` is the Gregorovich blank-slate launch (still emits the
-    /// flag with an empty value).
-    var text: String
-
-    init(mode: Mode, text: String = "") {
-        self.mode = mode
-        self.text = text
-    }
-}
+// `SystemPromptSetting` (the operator's three-mode system-prompt choice) is
+// defined in `AgentConfigLibraryStore.swift` — the single canonical home, a
+// member of both the app and CLI targets so the config store resolves it
+// without importing app-only AgentManifest. The launch/sysprompt axis
+// (`AgentSystemPromptArg` below) and the config-overlay store share that one
+// definition. (C11-176/C11-177 wave-1 reconciliation: both tickets landed the
+// same design §1.4 primitive; the duplicate that lived here was removed.)
 
 /// How a system-prompt override renders onto an agent's command line. Unlike
 /// model/effort (one flag each), the system-prompt axis has two delivery flags —

--- a/c11Tests/AgentConfigLibraryStoreTests.swift
+++ b/c11Tests/AgentConfigLibraryStoreTests.swift
@@ -1,0 +1,405 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Pure-logic tests for the agent-config library store (C11-176). No
+/// Workspace/TabManager construction — safe for the bare `c11-logic` runner.
+/// Each test injects a fresh temp directory so the real state root never leaks.
+final class AgentConfigLibraryStoreTests: XCTestCase {
+
+    private var tempDir: URL!
+    private var store: AgentConfigLibraryStore!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("agent-config-tests-\(UUID().uuidString)", isDirectory: true)
+        store = AgentConfigLibraryStore(directory: tempDir)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir, FileManager.default.fileExists(atPath: tempDir.path) {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        store = nil
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - AC #1: §2.1 schema round-trips
+
+    func testFactoryFileRoundTrips() throws {
+        let factory = AgentConfigLibraryFile.factory
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(factory)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(AgentConfigLibraryFile.self, from: data)
+        XCTAssertEqual(decoded, factory)
+    }
+
+    func testFactoryOnDiskShapeMatchesSchema() throws {
+        try store.write(.factory)
+        let raw = try Data(contentsOf: store.fileURL)
+        let json = try XCTUnwrap(try JSONSerialization.jsonObject(with: raw) as? [String: Any])
+
+        XCTAssertEqual(json["schema_version"] as? Int, 1)
+        let configs = try XCTUnwrap(json["configs"] as? [[String: Any]])
+        XCTAssertEqual(configs.count, 1)
+        let opus = configs[0]
+        XCTAssertEqual(opus["name"] as? String, "Opus deep")
+        XCTAssertEqual(opus["harness"] as? String, "claude-code")
+        XCTAssertEqual(opus["model"] as? String, "opus")
+        XCTAssertEqual(opus["order"] as? Int, 0)
+        // Unset recipe fields are absent (inherit), not null. Effort is UNSET
+        // on the seed (byte-identical to today's pin: no --effort flag).
+        XCTAssertNil(opus["effort"])
+        XCTAssertNil(opus["command"])
+        XCTAssertNil(opus["initial_prompt"])
+        XCTAssertNil(opus["systemPrompt"])
+        XCTAssertNil(opus["env"])
+
+        let def = try XCTUnwrap(json["default"] as? [String: Any])
+        XCTAssertEqual(def["mode"] as? String, "pinned")
+        XCTAssertEqual(def["config_id"] as? String, opus["id"] as? String)
+        // recent unset → absent.
+        XCTAssertNil(json["recent"])
+    }
+
+    /// A hand-authored §2.1 fixture: follow-recent default, a blank-slate
+    /// (`replace` + "") config, `field_sources`, and `initial_prompt`/`env`
+    /// overlays. The `systemPrompt` key is camelCase exactly as §2.1 writes it.
+    func testAuthoredSchemaFixtureRoundTrips() throws {
+        let fixture = """
+        {
+          "schema_version": 1,
+          "configs": [
+            { "id": "01JOPUS", "name": "Opus deep", "order": 0,
+              "harness": "claude-code", "model": "opus", "effort": "high",
+              "systemPrompt": { "mode": "inherit", "text": "" } },
+            { "id": "01JGREG", "name": "Gregorovich", "order": 1,
+              "harness": "claude-code", "model": "opus",
+              "systemPrompt": { "mode": "replace", "text": "" },
+              "initial_prompt": "hello",
+              "env": { "FOO": "bar" } },
+            { "id": "01JCDX", "name": "Codex hi", "order": 2,
+              "harness": "codex", "model": "gpt-5.2", "effort": "high" }
+          ],
+          "default": { "mode": "follow-recent", "config_id": "01JOPUS" },
+          "recent": { "config_id": "01JCDX", "harness": "codex", "model": "gpt-5.2",
+                      "effort": "high", "observed_at": "2026-07-20T21:14:00.000Z",
+                      "source": "launch",
+                      "field_sources": { "model": "launch", "effort": "launch" } }
+        }
+        """.data(using: .utf8)!
+
+        // Decode through the store's own decoder path by writing then reading.
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try fixture.write(to: store.fileURL, options: .atomic)
+        let file = store.current
+
+        XCTAssertEqual(file.schemaVersion, 1)
+        XCTAssertEqual(file.configs.count, 3)
+        XCTAssertEqual(file.default.mode, .followRecent)
+
+        // Blank-slate case actually decodes: replace + empty text, not nil.
+        let greg = try XCTUnwrap(file.configs.first { $0.name == "Gregorovich" })
+        XCTAssertEqual(greg.config.systemPrompt?.mode, .replace)
+        XCTAssertEqual(greg.config.systemPrompt?.text, "")
+        XCTAssertEqual(greg.config.initialPrompt, "hello")
+        XCTAssertEqual(greg.config.env, ["FOO": "bar"])
+        // Inherit config: systemPrompt present but inert.
+        let opus = try XCTUnwrap(file.configs.first { $0.name == "Opus deep" })
+        XCTAssertEqual(opus.config.systemPrompt?.mode, .inherit)
+        XCTAssertNil(opus.config.command)
+
+        XCTAssertEqual(file.recent?.configId, "01JCDX")
+        XCTAssertEqual(file.recent?.model, "gpt-5.2")
+        XCTAssertEqual(file.recent?.fieldSources?["model"], "launch")
+
+        // Re-encode and re-read: stable.
+        try store.write(file)
+        XCTAssertEqual(store.current, file)
+    }
+
+    func testBlankSlateSurvivesStoreRoundTrip() throws {
+        let blank = SavedAgentConfig(
+            id: "BLANK1", name: "Greg", order: 0,
+            config: AgentLaunchConfig(
+                harness: "claude-code",
+                systemPrompt: SystemPromptSetting(mode: .replace, text: "")
+            )
+        )
+        let file = AgentConfigLibraryFile(
+            configs: [blank],
+            default: AgentConfigDefault(mode: .pinned, configId: "BLANK1")
+        )
+        try store.write(file)
+        let back = try XCTUnwrap(store.current.configs.first)
+        XCTAssertEqual(back.config.systemPrompt, SystemPromptSetting(mode: .replace, text: ""))
+    }
+
+    // MARK: - AC #2: §3 effectiveDefault branch
+
+    func testEffectiveDefaultPinnedReturnsPinnedConfig() throws {
+        try store.write(.factory)
+        let resolved = store.effectiveDefault()
+        XCTAssertEqual(resolved.name, "Opus deep")
+        XCTAssertEqual(resolved.config.harness, "claude-code")
+        XCTAssertEqual(resolved.config.model, "opus")
+    }
+
+    /// The seed must resolve to today's exact launch axes: claude-code +
+    /// model=opus + NO effort (byte-identical to the current pin; C11-179
+    /// regression AC). Effort UNSET means no `--effort` flag is injected.
+    func testFactorySeedIsByteIdenticalToTodaysPin() {
+        let seed = AgentConfigLibraryFile.factory.configs[0]
+        XCTAssertEqual(seed.config.harness, "claude-code")
+        XCTAssertEqual(seed.config.model, "opus")
+        XCTAssertNil(seed.config.effort)          // no --effort at launch
+        XCTAssertNil(seed.config.command)         // inherit factory command
+        XCTAssertNil(seed.config.systemPrompt)    // inherit system prompt
+        XCTAssertNil(seed.config.initialPrompt)
+        XCTAssertNil(seed.config.env)
+    }
+
+    func testEffectiveDefaultFollowRecentReturnsRecentConfig() throws {
+        let opus = SavedAgentConfig(id: "OPUS", name: "Opus deep", order: 0,
+            config: AgentLaunchConfig(harness: "claude-code", model: "opus", effort: "high"))
+        let codex = SavedAgentConfig(id: "CDX", name: "Codex hi", order: 1,
+            config: AgentLaunchConfig(harness: "codex", model: "gpt-5.2", effort: "high"))
+        let file = AgentConfigLibraryFile(
+            configs: [opus, codex],
+            default: AgentConfigDefault(mode: .followRecent, configId: "OPUS"),
+            recent: RecentAgentConfig(configId: "CDX", harness: "codex", model: "gpt-5.2")
+        )
+        try store.write(file)
+        let resolved = store.effectiveDefault()
+        XCTAssertEqual(resolved.id, "CDX")
+        XCTAssertEqual(resolved.config.harness, "codex")
+    }
+
+    func testEffectiveDefaultFollowRecentNilRecentFallsBackToPinned() throws {
+        let opus = SavedAgentConfig(id: "OPUS", name: "Opus deep", order: 0,
+            config: AgentLaunchConfig(harness: "claude-code", model: "opus"))
+        let file = AgentConfigLibraryFile(
+            configs: [opus],
+            default: AgentConfigDefault(mode: .followRecent, configId: "OPUS"),
+            recent: nil
+        )
+        try store.write(file)
+        XCTAssertEqual(store.effectiveDefault().id, "OPUS")
+    }
+
+    func testEffectiveDefaultFollowRecentSynthesizesWhenConfigMissing() throws {
+        let opus = SavedAgentConfig(id: "OPUS", name: "Opus deep", order: 0,
+            config: AgentLaunchConfig(harness: "claude-code", model: "opus"))
+        // recent points at a config id no longer in the library, but carries axes.
+        let file = AgentConfigLibraryFile(
+            configs: [opus],
+            default: AgentConfigDefault(mode: .followRecent, configId: "OPUS"),
+            recent: RecentAgentConfig(configId: "GONE", harness: "codex", model: "gpt-5.2", effort: "high")
+        )
+        try store.write(file)
+        let resolved = store.effectiveDefault()
+        XCTAssertEqual(resolved.config.harness, "codex")
+        XCTAssertEqual(resolved.config.model, "gpt-5.2")
+        XCTAssertEqual(resolved.config.effort, "high")
+        // Synthesized transient: no library order, blank id (the dangling
+        // recent.config_id is not carried through as a re-resolvable id).
+        XCTAssertEqual(resolved.order, -1)
+        XCTAssertEqual(resolved.id, "")
+        XCTAssertTrue(resolved.name.contains("gpt-5.2"))
+    }
+
+    func testEffectiveDefaultPinnedDanglingIdFallsBackToFactory() throws {
+        let file = AgentConfigLibraryFile(
+            configs: [SavedAgentConfig(id: "REAL", name: "Real", order: 0,
+                config: AgentLaunchConfig(harness: "codex"))],
+            default: AgentConfigDefault(mode: .pinned, configId: "DANGLING")
+        )
+        try store.write(file)
+        // Pointer dangles → factory seed, never a crash.
+        let resolved = store.effectiveDefault()
+        XCTAssertEqual(resolved.name, "Opus deep")
+        XCTAssertEqual(resolved.config.model, "opus")
+    }
+
+    // MARK: - AC #3: corrupt/missing → factory (§5.6)
+
+    func testMissingFileFallsBackToFactory() {
+        // Fresh temp dir, nothing written.
+        XCTAssertEqual(store.current, .factory)
+    }
+
+    func testGarbageFileFallsBackToFactory() throws {
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try Data("not json {{{".utf8).write(to: store.fileURL, options: .atomic)
+        XCTAssertEqual(store.current, .factory)
+    }
+
+    func testWrongSchemaVersionFallsBackToFactory() throws {
+        let future = """
+        { "schema_version": 2, "configs": [], "default": { "mode": "pinned", "config_id": "x" } }
+        """.data(using: .utf8)!
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        try future.write(to: store.fileURL, options: .atomic)
+        XCTAssertEqual(store.current, .factory)
+    }
+
+    func testDanglingDefaultStillResolvesToValidConfig() throws {
+        // A structurally-valid file whose pinned id names no config: current is
+        // returned as-is (not corrupt), but effectiveDefault heals.
+        let file = AgentConfigLibraryFile(
+            configs: [SavedAgentConfig(id: "A", name: "A", order: 0,
+                config: AgentLaunchConfig(harness: "codex"))],
+            default: AgentConfigDefault(mode: .pinned, configId: "MISSING")
+        )
+        try store.write(file)
+        XCTAssertFalse(store.current.hasResolvablePinnedDefault)
+        XCTAssertEqual(store.effectiveDefault().name, "Opus deep")  // factory heal
+    }
+
+    // MARK: - AC #4: mutators + file-is-the-contract
+
+    func testAddAssignsIdAndOrderAndPersists() throws {
+        try store.write(.factory)
+        let added = try store.add(SavedAgentConfig(
+            id: "", name: "Cheap router", order: 999,
+            config: AgentLaunchConfig(harness: "omp", model: "deepseek/deepseek-chat-v3.1")))
+        XCTAssertFalse(added.id.isEmpty)
+        XCTAssertEqual(added.order, 1)  // next slot after the seed's order 0
+
+        // A fresh store instance over the same dir sees it (recompute-on-access).
+        let reopened = AgentConfigLibraryStore(directory: tempDir)
+        XCTAssertEqual(reopened.current.configs.count, 2)
+        XCTAssertTrue(reopened.current.configs.contains { $0.name == "Cheap router" })
+    }
+
+    func testRemoveReindexesAndRepointsDefault() throws {
+        let a = SavedAgentConfig(id: "A", name: "A", order: 0, config: AgentLaunchConfig(harness: "codex"))
+        let b = SavedAgentConfig(id: "B", name: "B", order: 1, config: AgentLaunchConfig(harness: "grok"))
+        try store.write(AgentConfigLibraryFile(
+            configs: [a, b], default: AgentConfigDefault(mode: .pinned, configId: "A")))
+        try store.remove(id: "A")
+        let file = store.current
+        XCTAssertEqual(file.configs.count, 1)
+        XCTAssertEqual(file.configs[0].id, "B")
+        XCTAssertEqual(file.configs[0].order, 0)  // reindexed dense
+        XCTAssertEqual(file.default.configId, "B")  // repointed off the removed pin
+    }
+
+    func testRemoveLastConfigReseedsFactory() throws {
+        let a = SavedAgentConfig(id: "A", name: "A", order: 0, config: AgentLaunchConfig(harness: "codex"))
+        try store.write(AgentConfigLibraryFile(
+            configs: [a], default: AgentConfigDefault(mode: .pinned, configId: "A")))
+        try store.remove(id: "A")
+        let file = store.current
+        XCTAssertEqual(file.configs.count, 1)
+        XCTAssertEqual(file.configs[0].name, "Opus deep")
+        XCTAssertTrue(file.hasResolvablePinnedDefault)
+    }
+
+    func testRemoveMissingThrows() throws {
+        try store.write(.factory)
+        XCTAssertThrowsError(try store.remove(id: "nope")) { error in
+            XCTAssertEqual(error as? AgentConfigLibraryStore.StoreError,
+                           .configNotFound("nope"))
+        }
+    }
+
+    func testReorderReindexesSequence() throws {
+        let configs = (0..<3).map { i in
+            SavedAgentConfig(id: "C\(i)", name: "C\(i)", order: i, config: AgentLaunchConfig(harness: "codex"))
+        }
+        try store.write(AgentConfigLibraryFile(
+            configs: configs, default: AgentConfigDefault(mode: .pinned, configId: "C0")))
+        try store.reorder(id: "C0", to: 2)
+        let ordered = store.current.configs.sorted { $0.order < $1.order }
+        XCTAssertEqual(ordered.map { $0.id }, ["C1", "C2", "C0"])
+        XCTAssertEqual(ordered.map { $0.order }, [0, 1, 2])
+    }
+
+    func testReorderOutOfRangeThrows() throws {
+        try store.write(.factory)
+        XCTAssertThrowsError(try store.reorder(id: AgentConfigLibraryFile.factorySeedConfigId, to: 5)) { error in
+            XCTAssertEqual(error as? AgentConfigLibraryStore.StoreError, .indexOutOfRange(5))
+        }
+    }
+
+    func testSetDefaultPinsAndSetModeToggles() throws {
+        let a = SavedAgentConfig(id: "A", name: "A", order: 0, config: AgentLaunchConfig(harness: "codex"))
+        let b = SavedAgentConfig(id: "B", name: "B", order: 1, config: AgentLaunchConfig(harness: "grok"))
+        try store.write(AgentConfigLibraryFile(
+            configs: [a, b], default: AgentConfigDefault(mode: .followRecent, configId: "A")))
+        try store.setDefault(configId: "B")
+        XCTAssertEqual(store.current.default.mode, .pinned)  // setDefault forces pinned
+        XCTAssertEqual(store.current.default.configId, "B")
+
+        try store.setMode(.followRecent)
+        XCTAssertEqual(store.current.default.mode, .followRecent)
+        XCTAssertEqual(store.current.default.configId, "B")  // config unchanged
+    }
+
+    func testSetDefaultMissingThrows() throws {
+        try store.write(.factory)
+        XCTAssertThrowsError(try store.setDefault(configId: "ghost")) { error in
+            XCTAssertEqual(error as? AgentConfigLibraryStore.StoreError, .configNotFound("ghost"))
+        }
+    }
+
+    func testRecordRecentPersists() throws {
+        try store.write(.factory)
+        let recent = RecentAgentConfig(
+            configId: "CDX", harness: "codex", model: "gpt-5.2", effort: "high",
+            observedAt: Date(timeIntervalSince1970: 1_768_000_000), source: "launch",
+            fieldSources: ["model": "launch"])
+        try store.recordRecent(recent)
+        let reopened = AgentConfigLibraryStore(directory: tempDir)
+        XCTAssertEqual(reopened.current.recent?.configId, "CDX")
+        XCTAssertEqual(reopened.current.recent?.source, "launch")
+        XCTAssertEqual(reopened.current.recent?.fieldSources?["model"], "launch")
+        // Pin the store's fractional-seconds ISO-8601 date path directly.
+        XCTAssertEqual(reopened.current.recent?.observedAt, recent.observedAt)
+    }
+
+    func testRemoveLastConfigReseedsEvenWhenPinDangles() throws {
+        // A write()-composed document whose pinned id already dangles; removing
+        // the only real config must still reseed (not leave configs empty).
+        let a = SavedAgentConfig(id: "A", name: "A", order: 0, config: AgentLaunchConfig(harness: "codex"))
+        try store.write(AgentConfigLibraryFile(
+            configs: [a], default: AgentConfigDefault(mode: .pinned, configId: "DANGLING")))
+        try store.remove(id: "A")
+        let file = store.current
+        XCTAssertFalse(file.configs.isEmpty)
+        XCTAssertEqual(file.configs[0].name, "Opus deep")
+        XCTAssertTrue(file.hasResolvablePinnedDefault)
+    }
+
+    // MARK: - Atomicity smoke
+
+    func testSequentialSavesLeaveOneValidFile() throws {
+        try store.write(.factory)
+        try store.add(SavedAgentConfig(id: "", name: "One", order: 0, config: AgentLaunchConfig(harness: "codex")))
+        try store.add(SavedAgentConfig(id: "", name: "Two", order: 0, config: AgentLaunchConfig(harness: "grok")))
+        // Exactly one file, last write wins, decodes cleanly.
+        let contents = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
+        XCTAssertEqual(contents.filter { $0 == AgentConfigLibraryStore.fileName }.count, 1)
+        XCTAssertEqual(store.current.configs.count, 3)
+    }
+
+    // MARK: - Id generator
+
+    func testGeneratedIdsAreDistinctAnd26Chars() {
+        let a = AgentConfigID.generate()
+        let b = AgentConfigID.generate()
+        XCTAssertEqual(a.count, 26)
+        XCTAssertEqual(b.count, 26)
+        XCTAssertNotEqual(a, b)
+    }
+}


### PR DESCRIPTION
Implements **C11-176** — the pure-logic data layer for the agent-config primitive (design `docs/agent-config-primitive-design.md` §1.3, §1.4, §2.1–2.3, §3, §5.6, §8.1/8.3/8.5).

## What ships
- **`AgentLaunchConfig`** — the full launch recipe (§1.3). `harness` required; `model`/`effort`/`systemPrompt`/`command`/`initialPrompt`/`env` optional (`nil` = inherit the harness base). `provider` is derived, never stored.
- **`SystemPromptSetting`** — three modes (§1.4): `inherit`/`append`/`replace`; `replace` + `""` = Gregorovich blank slate. **Single canonical definition** shared by the launch/sysprompt axis and this store (see reconciliation below).
- **`SavedAgentConfig`** — `id`/`name`/`order` + recipe, **flat** on-disk Codable per §2.1 (recipe fields inline, unset fields absent = inherit; `systemPrompt` key camelCase matching §2.1).
- **`AgentConfigDefault` / `RecentAgentConfig` / `AgentConfigLibraryFile`** — the `agent-configs.json` document: `schema_version` 1, `default{mode: pinned|follow-recent, config_id}`, `recent{… field_sources}` (§2.1–2.3).
- **`AgentConfigLibraryStore`** — a `Sendable` value type over an injected state-root directory (`EventLogLayout.defaultStateURL` → `StateDirectoryMigration.ensureMigrated`). Atomic writes + typed `StoreError` modeled on `WorkspaceSnapshotStore`; recompute-on-access `current` like `DefaultAgentConfigStore`. `effectiveDefault()` resolves §3 (pinned / follow-recent → recent / synth-transient / dangling-heal). Corrupt / missing / wrong-`schema_version` file heals to the factory seed (§5.6) — a read never throws into a launch path. Foundation-only; compiled into **both** the app and CLI targets.

## Wave-1 reconciliation (touches `AgentManifest.swift`, +/-27 lines)
C11-177 (sysprompt-axis, already merged) landed its own copy of the same design §1.4 `SystemPromptSetting` in the **app-only** `AgentManifest.swift`. Because this store compiles into the **CLI** target too, the canonical definition moves to this dual-target file and the AgentManifest duplicate is removed — its `AgentSystemPromptArg` consumer and all app-side users (`DefaultAgentResolver`, `DefaultAgentConfig`, `SocketDispatch`) resolve to the one shared type. Verified: exactly one `SystemPromptSetting` in the tree; app + `c11-cli` both `BUILD SUCCEEDED`.

## Deviations from the design doc (flagged)
1. **Factory seed = `model=opus`, effort UNSET** (not §2.2's literal `effort: high`). Per the orchestrator design ruling: the governing intent is §2.2's "(matching today's pin)" parenthetical + C11-179's byte-identical-launch regression AC — today's pin injects no `--effort` flag, so seeding `high` would break byte-identical launch. Pinned by `testFactorySeedIsByteIdenticalToTodaysPin` and documented at the seed site.
2. **`SavedAgentConfig.id` is `String`** (ULID-shaped), not the doc sketch's `UUID` — matches the §2.1 `config_id` cross-references and the repo's ULID convention.
3. **`SavedAgentConfig` JSON is flat**, not nested under a `config` key (matches §2.1's actual example).

## Concurrency
Mutators are load → mutate → atomic-save with **no cross-mutator serialization**: last-writer-wins, exactly as `WorkspaceSnapshotStore` / `DefaultAgentConfigStore`. `schema_version != 1` heals to factory; a refuse-to-overwrite-newer guard is deferred until a v2 schema exists.

## Absorbed review findings (profile max)
- Empty-library reseed now keyed on `configs.isEmpty` (reachable via the exposed `write()` + `remove()` path even when the removed id wasn't the pinned one) — with a dedicated dangling-pin test.
- Synthesized transient config blanks its `id` (the dangling `recent.config_id` is not carried through as re-resolvable).
- Factory seed id padded to the 26-char id width; `reorder` doc comment corrected (throws, no clamp); direct `observed_at` date-round-trip assertion added.

## Follow-ups flagged for dependent tickets (not this ticket's remit)
- **env is persisted plaintext** at the state root. The launch-composition / CLI tickets that populate `env` should consider redaction and `0600` file mode if secrets are anticipated.
- `add()` does not dedup a caller-supplied non-empty `id`; the CLI ticket (C11-180) should mint ids rather than pass literals.

## Tests / validation
- **26 pure-logic tests** (`c11LogicTests/AgentConfigLibraryStoreTests`): §2.1 round-trip + on-disk shape, full §3 `effectiveDefault` branch matrix, §5.6 corrupt/missing/wrong-version, mutators with reload-via-fresh-instance (file-is-the-contract), empty-library reseed incl. dangling-pin, blank-slate survival, byte-identical seed, date round-trip, id generation. `** TEST SUCCEEDED **`.
- **Real-artifact validation** (beyond XCTest): the shipped store source was compiled standalone via `swiftc` and driven through write → reload-via-new-instance → corrupt → factory-fallback against a temp state root — all 17 checks passed; the real on-disk `agent-configs.json` was inspected (evidence attached to the ticket).
- App + `c11-cli` targets both `BUILD SUCCEEDED`.

Closes C11-176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)