### PR TITLE
Launch composition overlay: config-first resolution, effectiveDefault, recordLaunch wiring

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		56D5F7E29DC4C9999E4EDA7B /* DefaultAgentProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */; };
 		573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		592E7B94FECC0B5AAB3B53B4 /* SidebarActivityProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0054553DCE5D3CED90037B0C /* SidebarActivityProjectorTests.swift */; };
+		5A86082FF691F6FBCBDE52CB /* AgentLaunchOverlayCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C8786B9F13542B2C4D9D35 /* AgentLaunchOverlayCompositionTests.swift */; };
 		5AE9C6CE7FCF928F695FE26D /* MainThreadHangMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB26BFF19A91FD51B78AF28E /* MainThreadHangMonitor.swift */; };
 		5AEB95ABF100C21BFCDB40E4 /* C11ThemeLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F015 /* C11ThemeLoaderTests.swift */; };
 		5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
@@ -679,6 +680,7 @@
 		AE86A069B4ECE7503CE20B95 /* Pi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/Strategies/Pi.swift; sourceTree = "<group>"; };
 		B03F186DDAF8E10C83FC63CF /* ScrapeCapturePipelineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrapeCapturePipelineTests.swift; sourceTree = "<group>"; };
 		B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OmnibarAndToolsTests.swift; sourceTree = "<group>"; };
+		B0C8786B9F13542B2C4D9D35 /* AgentLaunchOverlayCompositionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentLaunchOverlayCompositionTests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
 		B782D0384E99BB0E082FBBBF /* ConversationScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/Scrapers/ConversationScraper.swift; sourceTree = "<group>"; };
 		B7C0D996AACCF41CBCBC7D7C /* BrowserQueryHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BrowserQueryHandlers.swift; sourceTree = "<group>"; };
@@ -1385,6 +1387,7 @@
 				91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */,
 				271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */,
 				645F0E832571A928F52DDF40 /* AgentConfigLibraryStoreTests.swift */,
+				B0C8786B9F13542B2C4D9D35 /* AgentLaunchOverlayCompositionTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1723,6 +1726,7 @@
 				0D76F685D48115A43B14C5D5 /* EventLogTests.swift in Sources */,
 				8713E62944414CDC27EA1AD8 /* AgentLaunchStatsTests.swift in Sources */,
 				566B6BA784672EAB0E03523A /* AgentConfigLibraryStoreTests.swift in Sources */,
+				5A86082FF691F6FBCBDE52CB /* AgentLaunchOverlayCompositionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/DefaultAgentResolver.swift
+++ b/Sources/DefaultAgentResolver.swift
@@ -55,6 +55,132 @@ enum DefaultAgentResolver {
         ))
     }
 
+    // MARK: - Saved-config overlay (C11-179, design §1.3)
+
+    /// Resolve a launch from a saved-config **overlay** (`AgentConfigLibraryStore`)
+    /// layered over the harness Settings base. This is what the A-button
+    /// left-click launches (`effectiveDefault()`); the `resolve(explicitAgent:…)`
+    /// path above stays the raw-harness launcher used by the right-click "launch
+    /// this kind" affordance and the CLI.
+    ///
+    /// The overlay is applied by **flattening it onto the harness-base
+    /// `AgentConfig`** and then reusing `buildCommand`/`launcherCommand`
+    /// unchanged — so a pure-inherit overlay (every field `nil`) yields a merged
+    /// config identical to the base, hence a launch command byte-identical to
+    /// today's (the regression AC), and the existing per-field flag injection
+    /// (model/effort/system-prompt, with hardcoded-in-command detection) applies
+    /// to the overlaid values for free.
+    ///
+    /// Returns `nil` when the saved config's `harness` is not a built-in
+    /// `AgentType` (a custom kebab kind); the caller falls back to the
+    /// raw-harness `resolve` path (graceful degradation, design §5.6). The
+    /// returned `mergedConfig` exposes the overlay-resolved model/effort/
+    /// system-prompt scalars so the caller can stamp identity and record stats
+    /// without re-deriving them.
+    ///
+    /// - Important: the overlay-merged env lives ONLY in the returned
+    ///   `ResolvedAgentLaunch.envOverrides`; `mergedConfig.envMap` reflects the
+    ///   base env, NOT the overlay merge (see `mergeOverlay`). No caller may read
+    ///   `mergedConfig.envMap` for the resolved env.
+    static func resolveOverlay(
+        savedConfig: SavedAgentConfig,
+        userDefault: DefaultAgentConfig,
+        projectConfig: DefaultAgentConfig?
+    ) -> (agent: AgentType, mergedConfig: AgentConfig, launch: ResolvedAgentLaunch)? {
+        guard let agent = AgentType(rawValue: savedConfig.config.harness) else { return nil }
+        // Same per-agent base pick as `resolve` / the A button: project entry
+        // beats user Settings, factory fills the gaps. This base already equals
+        // `factory ◁ settings` (factory env is always empty).
+        let base = projectConfig?.agents[agent] ?? userDefault.config(for: agent)
+        let (merged, env) = mergeOverlay(savedConfig.config, onto: base)
+        let command = buildCommand(agent: agent, config: merged)
+        let bare = launcherCommand(agent: agent, config: merged)
+        return (agent, merged, ResolvedAgentLaunch(
+            command: command,
+            bareCommand: bare,
+            initialPrompt: merged.initialPrompt.trimmingCharacters(in: .whitespacesAndNewlines),
+            envOverrides: env
+        ))
+    }
+
+    /// Flatten a saved-config overlay onto a harness-base `AgentConfig` (design
+    /// §1.3 ladder), overlay winning per field; an unset (`nil`) overlay field
+    /// inherits the base. Pure — no store/AppKit dependency — so the ladder is
+    /// unit-locked field-by-field.
+    ///
+    /// Env is returned as a **separate merged dict** (`base.envMap` then
+    /// `overlay.env` per key, overlay wins → `factory ◁ settings ◁ config`, since
+    /// the base already folds factory under settings and factory env is empty).
+    /// It is deliberately NOT written back into the merged config's
+    /// `envOverridesText` — round-tripping a dict through that line-oriented text
+    /// is lossy — so `mergedConfig.envMap` is base-only and must not be read for
+    /// the resolved env. The resolved env is the second tuple element.
+    static func mergeOverlay(
+        _ overlay: AgentLaunchConfig,
+        onto base: AgentConfig
+    ) -> (config: AgentConfig, env: [String: String]) {
+        var env = base.envMap
+        if let overlayEnv = overlay.env {
+            for (key, value) in overlayEnv { env[key] = value }
+        }
+        let merged = AgentConfig(
+            command: overlay.command ?? base.command,
+            initialPrompt: overlay.initialPrompt ?? base.initialPrompt,
+            // Base env text is carried verbatim; the resolved env is the dict
+            // above, NOT this text (see doc comment). Do not read merged.envMap.
+            envOverridesText: base.envOverridesText,
+            model: overlay.model ?? base.model,
+            effort: overlay.effort ?? base.effort,
+            systemPrompt: overlay.systemPrompt ?? base.systemPrompt
+        )
+        return (merged, env)
+    }
+
+    /// The at-a-glance tooltip string for the A button (design §5.3 v1): the
+    /// resolved default config's `name · model · effort`, empty segments
+    /// omitted. Pure — visible for testing. `model`/`effort` are the
+    /// overlay-resolved values (what actually launches); `model` is mapped to
+    /// its Claude family display name when it matches, else shown verbatim.
+    static func formatAgentTooltip(name: String, model: String, effort: String) -> String {
+        let modelLabel = ClaudeModelFamily(rawValue: model)?.displayName ?? model
+        let segments = [name, modelLabel, effort]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let detail = segments.joined(separator: " · ")
+        let template = String(
+            localized: "workspace.tooltip.newAgent.resolved",
+            defaultValue: "Launch Agent — %@"
+        )
+        return String(format: template, locale: Locale.current, detail)
+    }
+
+    /// Resolve the A-button tooltip from the saved-config library: read
+    /// `effectiveDefault()`, resolve its overlay for the display model/effort,
+    /// and format. Falls back to the config's own name/harness when the harness
+    /// is a custom kind the overlay resolver can't materialize. Project config is
+    /// intentionally not consulted here — the tooltip is a workspace-agnostic
+    /// at-a-glance hint, and the library (name) is user-global; a project
+    /// override to the harness base affects the launch, not this hint (v1).
+    static func resolvedDefaultTooltip(
+        library: AgentConfigLibraryStore = .shared,
+        userDefault: DefaultAgentConfig
+    ) -> String {
+        let saved = library.effectiveDefault()
+        if let resolved = resolveOverlay(savedConfig: saved, userDefault: userDefault, projectConfig: nil) {
+            return formatAgentTooltip(
+                name: saved.name,
+                model: resolved.mergedConfig.model,
+                effort: resolved.mergedConfig.effort
+            )
+        }
+        // Custom/unknown harness: show the saved axes directly.
+        return formatAgentTooltip(
+            name: saved.name,
+            model: saved.config.model ?? "",
+            effort: saved.config.effort ?? ""
+        )
+    }
+
     /// Build the shell command line for an agent's config. For claude-code, an
     /// initial prompt is appended as a single-quoted positional argument
     /// (claude accepts that). For other agents the prompt is delivered via a

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5506,13 +5506,12 @@ final class Workspace: Identifiable, ObservableObject {
 
     private static func currentSplitButtonTooltips() -> BonsplitConfiguration.SplitButtonTooltips {
         BonsplitConfiguration.SplitButtonTooltips(
-            newAgent: {
-                let template = String(
-                    localized: "workspace.tooltip.newAgent",
-                    defaultValue: "Launch Agent (%@)"
-                )
-                return String(format: template, locale: Locale.current, DefaultAgentConfigStore.shared.current.defaultAgent.displayName)
-            }(),
+            // §5.3 v1: the A-button tooltip carries the resolved default config's
+            // name · model · effort (C11-179), read from the saved-config library
+            // and resolved through the overlay for the display axes.
+            newAgent: DefaultAgentResolver.resolvedDefaultTooltip(
+                userDefault: DefaultAgentConfigStore.shared.current
+            ),
             newTerminal: KeyboardShortcutSettings.Action.newSurface.tooltip(
                 String(localized: "workspace.tooltip.newTerminal", defaultValue: "New Terminal")
             ),
@@ -11960,60 +11959,140 @@ extension Workspace: BonsplitDelegate {
     func launchAgentSurface(inPane pane: PaneID, explicitAgent: AgentType? = nil, source: AgentLaunchSource = .aButton) {
         let userDefault = DefaultAgentConfigStore.shared.current
         let projectConfig = DefaultAgentProjectConfig.find(from: resolverCwdForAgentLaunch())
-        let resolved = DefaultAgentResolver.resolve(
-            explicitAgent: explicitAgent,
-            userDefault: userDefault,
-            projectConfig: projectConfig
-        )
-        guard !resolved.launch.command.isEmpty else { return }
+
+        // A plain left-click (no explicit agent) launches the saved-config
+        // library's `effectiveDefault()` through the overlay resolver (C11-179).
+        // An explicit agent (right-click "launch this kind" / socket) stays on
+        // the raw-harness path. A custom-harness overlay the resolver can't
+        // materialize falls back to the raw-harness default (design §5.6).
+        let agent: AgentType
+        let launch: ResolvedAgentLaunch
+        let resolvedModel: String
+        let resolvedEffort: String
+        let resolvedSystemPromptMode: String?
+        let savedConfigId: String?
+
+        // Only a plain left-click consults the saved-config library; an explicit
+        // agent keeps `nil` here and takes the raw-harness path below.
+        let overlaySaved: SavedAgentConfig? = explicitAgent == nil
+            ? AgentConfigLibraryStore.shared.effectiveDefault()
+            : nil
+        if let saved = overlaySaved,
+           let overlay = DefaultAgentResolver.resolveOverlay(
+               savedConfig: saved,
+               userDefault: userDefault,
+               projectConfig: projectConfig
+           ) {
+            agent = overlay.agent
+            launch = overlay.launch
+            resolvedModel = overlay.mergedConfig.model.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedEffort = overlay.mergedConfig.effort.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedSystemPromptMode = overlay.mergedConfig.systemPrompt?.mode.rawValue
+            savedConfigId = saved.id.isEmpty ? nil : saved.id
+        } else {
+            let resolved = DefaultAgentResolver.resolve(
+                explicitAgent: explicitAgent,
+                userDefault: userDefault,
+                projectConfig: projectConfig
+            )
+            agent = resolved.agent
+            launch = resolved.launch
+            let cfg = projectConfig?.agents[agent] ?? userDefault.config(for: agent)
+            resolvedModel = cfg.model.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedEffort = cfg.effort.trimmingCharacters(in: .whitespacesAndNewlines)
+            resolvedSystemPromptMode = cfg.systemPrompt?.mode.rawValue
+            savedConfigId = nil
+        }
+
+        guard !launch.command.isEmpty else { return }
         guard let panel = newTerminalSurface(
             inPane: pane,
-            startupEnvironment: resolved.launch.envOverrides
+            startupEnvironment: launch.envOverrides
         ) else { return }
         // By default no orientation prompt is baked (see `c11OrientPrompt`),
         // so the agent boots straight to ready with no dead-time. c11 stamps
         // the identity the sidebar needs itself — no agent round-trip: the
-        // type comes from `AgentDetector`, and we stamp the pinned model plus
-        // a placeholder title here. An operator who configured a launch prompt
-        // still gets it delivered below (baked positional for claude-code,
-        // post-ready sendText for other TUIs is a follow-up).
-        stampLaunchIdentity(
-            surfaceId: panel.id,
-            agent: resolved.agent,
-            userDefault: userDefault,
-            projectConfig: projectConfig
-        )
-        panel.sendText(resolved.launch.command + "\n")
-        // C11-178 rail-1: record the launch off the critical path. Mirror the
-        // resolver's per-agent config pick (as stampLaunchIdentity does) to
-        // recover the resolved model/effort scalars, which ResolvedAgentLaunch
-        // bakes into the command string rather than exposing.
+        // type comes from `AgentDetector`, and we stamp the overlay-resolved
+        // model plus a placeholder title here. An operator who configured a
+        // launch prompt still gets it delivered below (baked positional for
+        // claude-code, post-ready sendText for other TUIs is a follow-up).
+        stampLaunchIdentity(surfaceId: panel.id, resolvedModel: resolvedModel)
+        panel.sendText(launch.command + "\n")
+        // C11-178 rail-1: record the launch off the critical path, now with the
+        // overlay-resolved axes + `config_id` + system-prompt mode (C11-179).
         recordAgentLaunchStats(
-            agent: resolved.agent,
-            userDefault: userDefault,
-            projectConfig: projectConfig,
+            harness: agent.rawValue,
+            model: resolvedModel,
+            effort: resolvedEffort,
+            systemPromptMode: resolvedSystemPromptMode,
+            configId: savedConfigId,
             source: source
         )
+        // C11-179 (R2): keep the follow-recent pointer that `effectiveDefault()`
+        // reads — `recent` in `agent-configs.json` — live for A-button-lineage
+        // launches. (The stats rail's own `recent` in `agent-launch-stats.json`
+        // is durable-telemetry only and is NEVER read for resolution, so the two
+        // homes cannot cause a follow-recent divergence.) Off-main, best-effort.
+        recordOverlayRecent(
+            harness: agent.rawValue,
+            model: resolvedModel,
+            effort: resolvedEffort,
+            configId: savedConfigId
+        )
+        // The tooltip carries the resolved default (§5.3 v1); in follow-recent
+        // mode this launch changes what the next left-click launches, so refresh
+        // this workspace's A-button tooltip. Cheap: `refreshSplitButtonTooltips`
+        // diffs and no-ops when unchanged.
+        refreshSplitButtonTooltips()
     }
 
-    /// C11-178: emit a rail-1 launch-stats record for an A-button-lineage launch.
-    /// Config-only read; dispatched to a utility queue so no disk touches the
-    /// launch path. `nil` store (state dir unavailable) is a silent no-op.
+    /// C11-178/179: emit a rail-1 launch-stats record for an A-button-lineage
+    /// launch, carrying the overlay-resolved axes. Dispatched to a utility queue
+    /// so no disk touches the launch path. `nil` store (state dir unavailable)
+    /// is a silent no-op.
     private func recordAgentLaunchStats(
-        agent: AgentType,
-        userDefault: DefaultAgentConfig,
-        projectConfig: DefaultAgentConfig?,
+        harness: String,
+        model: String,
+        effort: String,
+        systemPromptMode: String?,
+        configId: String?,
         source: AgentLaunchSource
     ) {
         guard let store = AgentLaunchStatsStore.shared else { return }
-        let cfg = projectConfig?.agents[agent] ?? userDefault.config(for: agent)
         let resolved = ResolvedLaunch(
-            harness: agent.rawValue,
-            model: cfg.model,
-            effort: cfg.effort
+            harness: harness,
+            model: model,
+            effort: effort,
+            systemPromptMode: systemPromptMode,
+            configId: configId
         )
         DispatchQueue.global(qos: .utility).async {
             store.recordLaunch(resolved, source: source)
+        }
+    }
+
+    /// C11-179 (R2): persist the observed launch as `recent` in
+    /// `agent-configs.json` (the single home `effectiveDefault()`'s follow-recent
+    /// branch reads). Off-main, best-effort — a telemetry hiccup never fails a
+    /// launch. Empty `harness` is a no-op guard.
+    private func recordOverlayRecent(
+        harness: String,
+        model: String,
+        effort: String,
+        configId: String?
+    ) {
+        guard !harness.isEmpty else { return }
+        let recent = RecentAgentConfig(
+            configId: configId,
+            harness: harness,
+            model: model.isEmpty ? nil : model,
+            effort: effort.isEmpty ? nil : effort,
+            observedAt: Date(),
+            source: "launch",
+            fieldSources: ["model": "launch", "effort": "launch"]
+        )
+        DispatchQueue.global(qos: .utility).async {
+            try? AgentConfigLibraryStore.shared.recordRecent(recent)
         }
     }
 
@@ -12025,9 +12104,7 @@ extension Workspace: BonsplitDelegate {
     /// stamped here — `AgentDetector` owns it authoritatively.
     private func stampLaunchIdentity(
         surfaceId: UUID,
-        agent: AgentType,
-        userDefault: DefaultAgentConfig,
-        projectConfig: DefaultAgentConfig?
+        resolvedModel: String
     ) {
         var partial: [String: Any] = [
             MetadataKey.title: String(
@@ -12035,10 +12112,10 @@ extension Workspace: BonsplitDelegate {
                 defaultValue: "Awaiting first task"
             )
         ]
-        // Mirror the resolver's per-agent config pick so the chip shows the
-        // model c11 launched with. Reads config only; no mutation.
-        let cfg = projectConfig?.agents[agent] ?? userDefault.config(for: agent)
-        let model = cfg.model.trimmingCharacters(in: .whitespacesAndNewlines)
+        // `resolvedModel` is the overlay-resolved model the launch actually used
+        // (C11-179), so the chip shows what c11 launched with — including a
+        // saved-config override, not just the harness base pin.
+        let model = resolvedModel.trimmingCharacters(in: .whitespacesAndNewlines)
         if !model.isEmpty {
             partial[MetadataKey.model] = model
         }

--- a/c11Tests/AgentLaunchOverlayCompositionTests.swift
+++ b/c11Tests/AgentLaunchOverlayCompositionTests.swift
@@ -1,0 +1,377 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Behavioral tests for the saved-config **overlay** composition (C11-179,
+/// design §1.3): `DefaultAgentResolver.mergeOverlay(_:onto:)` /
+/// `resolveOverlay(...)` and the resolved-default tooltip formatter. The overlay
+/// is layered over the harness Settings base; a pure-inherit overlay reproduces
+/// today's launch byte-for-byte, and the existing per-field flag injection
+/// (model/effort/system-prompt, with hardcoded-in-command detection) applies to
+/// the overlaid values.
+///
+/// Pure logic — no `Workspace`/`TabManager`/AppKit construction (the documented
+/// NSApp-nil xctest crash), so these run under `c11LogicTests`, matching
+/// `DefaultAgentLaunchCompositionTests`.
+final class AgentLaunchOverlayCompositionTests: XCTestCase {
+
+    // A claude-code Settings base with a distinctive command so inherit-vs-
+    // override is unambiguous. claude-code declares model/effort/system-prompt
+    // axes, so every field exercises real injection.
+    private func claudeBase(
+        command: String = "claude --dangerously-skip-permissions",
+        initialPrompt: String = "",
+        env: String = "",
+        model: String = "opus",
+        effort: String = "",
+        systemPrompt: SystemPromptSetting? = nil
+    ) -> AgentConfig {
+        AgentConfig(
+            command: command,
+            initialPrompt: initialPrompt,
+            envOverridesText: env,
+            model: model,
+            effort: effort,
+            systemPrompt: systemPrompt
+        )
+    }
+
+    private func overlay(
+        harness: String = "claude-code",
+        model: String? = nil,
+        effort: String? = nil,
+        systemPrompt: SystemPromptSetting? = nil,
+        command: String? = nil,
+        initialPrompt: String? = nil,
+        env: [String: String]? = nil
+    ) -> AgentLaunchConfig {
+        AgentLaunchConfig(
+            harness: harness,
+            model: model,
+            effort: effort,
+            systemPrompt: systemPrompt,
+            command: command,
+            initialPrompt: initialPrompt,
+            env: env
+        )
+    }
+
+    private func saved(_ config: AgentLaunchConfig, name: String = "Test", id: String = "TESTID") -> SavedAgentConfig {
+        SavedAgentConfig(id: id, name: name, order: 0, config: config)
+    }
+
+    // MARK: - Per-field precedence ladder (design §1.3): overlay wins, nil inherits
+
+    func testCommandOverlayWinsElseInheritsBase() {
+        let base = claudeBase(command: "base-cmd")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(command: "over-cmd"), onto: base).config.command, "over-cmd")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(command: nil), onto: base).config.command, "base-cmd")
+    }
+
+    func testInitialPromptOverlayWinsElseInheritsBase() {
+        let base = claudeBase(initialPrompt: "base-prompt")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(initialPrompt: "over-prompt"), onto: base).config.initialPrompt, "over-prompt")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(initialPrompt: nil), onto: base).config.initialPrompt, "base-prompt")
+    }
+
+    func testModelOverlayWinsElseInheritsBase() {
+        let base = claudeBase(model: "opus")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(model: "sonnet"), onto: base).config.model, "sonnet")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(model: nil), onto: base).config.model, "opus")
+    }
+
+    func testEffortOverlayWinsElseInheritsBase() {
+        let base = claudeBase(effort: "high")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(effort: "low"), onto: base).config.effort, "low")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(effort: nil), onto: base).config.effort, "high")
+    }
+
+    func testSystemPromptOverlayWinsElseInheritsBase() {
+        let baseSetting = SystemPromptSetting(mode: .append, text: "base")
+        let base = claudeBase(systemPrompt: baseSetting)
+        let over = SystemPromptSetting(mode: .replace, text: "over")
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(systemPrompt: over), onto: base).config.systemPrompt, over)
+        XCTAssertEqual(DefaultAgentResolver.mergeOverlay(overlay(systemPrompt: nil), onto: base).config.systemPrompt, baseSetting)
+    }
+
+    // MARK: - env merge: factory ◁ settings ◁ config, overlay wins per key
+
+    func testEnvMergeOverlayWinsPerKeyAndUnionsKeys() {
+        let base = claudeBase(env: "A=base_a\nB=base_b")
+        let merged = DefaultAgentResolver.mergeOverlay(
+            overlay(env: ["B": "over_b", "C": "over_c"]),
+            onto: base
+        ).env
+        XCTAssertEqual(merged["A"], "base_a", "base-only key preserved")
+        XCTAssertEqual(merged["B"], "over_b", "overlay wins on collision")
+        XCTAssertEqual(merged["C"], "over_c", "overlay-only key added")
+    }
+
+    func testEnvNilOverlayInheritsBaseEnv() {
+        let base = claudeBase(env: "A=base_a")
+        let merged = DefaultAgentResolver.mergeOverlay(overlay(env: nil), onto: base).env
+        XCTAssertEqual(merged, ["A": "base_a"])
+    }
+
+    func testMergedConfigEnvMapIsBaseOnlyNotOverlayMerged() {
+        // Contract (MINOR-3): merged env lives ONLY in the returned dict; the
+        // merged AgentConfig.envMap reflects the base and must not be read for
+        // the resolved env.
+        let base = claudeBase(env: "A=base_a")
+        let result = DefaultAgentResolver.mergeOverlay(overlay(env: ["C": "over_c"]), onto: base)
+        XCTAssertNil(result.config.envMap["C"], "overlay env must not leak into merged.envMap")
+        XCTAssertEqual(result.env["C"], "over_c", "resolved env is the returned dict")
+    }
+
+    // MARK: - Byte-identical regression (the AC)
+
+    func testPureInheritOverlayIsByteIdenticalToHarnessBaseLaunch() {
+        // A pure-inherit overlay (every field nil) must reproduce the raw-harness
+        // launch exactly — the mechanism the regression AC governs.
+        let userDefault = DefaultAgentConfig.factory
+        let baseResolved = DefaultAgentResolver.resolve(
+            explicitAgent: .claudeCode, userDefault: userDefault, projectConfig: nil
+        )
+        let overlayResolved = DefaultAgentResolver.resolveOverlay(
+            savedConfig: saved(overlay(harness: "claude-code")),
+            userDefault: userDefault,
+            projectConfig: nil
+        )
+        XCTAssertNotNil(overlayResolved)
+        XCTAssertEqual(overlayResolved?.launch.command, baseResolved.launch.command)
+        XCTAssertEqual(overlayResolved?.launch.bareCommand, baseResolved.launch.bareCommand)
+    }
+
+    func testShippedFactorySeedResolvesToTodaysDefaultCommand() {
+        // O1 (orchestrator ruling): the shipped `Opus deep` seed is opus-only
+        // (no effort), so effectiveDefault()'s resolved command is byte-identical
+        // to today's default launch (`--model opus`, no `--effort`). Pins the
+        // ACTUAL shipped default, not just the synthetic pure-inherit proof.
+        let seed = AgentConfigLibraryFile.factory.configs[0]
+        XCTAssertNil(seed.config.effort, "factory seed must not pin effort (O1)")
+        let userDefault = DefaultAgentConfig.factory
+        let resolved = DefaultAgentResolver.resolveOverlay(
+            savedConfig: seed, userDefault: userDefault, projectConfig: nil
+        )
+        let today = DefaultAgentResolver.resolve(
+            explicitAgent: .claudeCode, userDefault: userDefault, projectConfig: nil
+        )
+        XCTAssertEqual(resolved?.launch.command, today.launch.command)
+        XCTAssertFalse(resolved?.launch.command.contains("--effort") ?? true, "default launch injects no --effort")
+    }
+
+    func testHardcodedModelInCommandIsNotDoubleInjectedByOverlay() {
+        // An operator who hardcoded --model in the base command owns the axis;
+        // an overlay model must not add a second flag (reuses existing detection).
+        let base = claudeBase(command: "claude --model sonnet", model: "")
+        let userDefault = DefaultAgentConfig(defaultAgent: .claudeCode, agents: [.claudeCode: base])
+        let resolved = DefaultAgentResolver.resolveOverlay(
+            savedConfig: saved(overlay(model: "opus")),
+            userDefault: userDefault,
+            projectConfig: nil
+        )
+        let occurrences = resolved?.launch.command.components(separatedBy: "--model").count ?? 0
+        XCTAssertEqual(occurrences, 2, "exactly one --model (split yields count 2); overlay did not double-inject")
+        XCTAssertTrue(resolved?.launch.command.contains("--model sonnet") ?? false, "hardcoded model wins")
+    }
+
+    // MARK: - Flag injection reuse for overlay values
+
+    func testOverlayModelAndEffortInjectViaTemplate() {
+        let userDefault = DefaultAgentConfig.factory
+        let resolved = DefaultAgentResolver.resolveOverlay(
+            savedConfig: saved(overlay(model: "sonnet", effort: "high")),
+            userDefault: userDefault,
+            projectConfig: nil
+        )
+        XCTAssertTrue(resolved?.launch.command.contains("--model sonnet") ?? false)
+        XCTAssertTrue(resolved?.launch.command.contains("--effort high") ?? false)
+    }
+
+    func testOverlayReplaceBlankSlateSystemPromptRendersEmptyFlag() {
+        let userDefault = DefaultAgentConfig.factory
+        let resolved = DefaultAgentResolver.resolveOverlay(
+            savedConfig: saved(overlay(systemPrompt: SystemPromptSetting(mode: .replace, text: ""))),
+            userDefault: userDefault,
+            projectConfig: nil
+        )
+        XCTAssertTrue(resolved?.launch.command.contains("--system-prompt ''") ?? false, "replace+\"\" is the blank slate")
+    }
+
+    // MARK: - Resolved scalars exposed on mergedConfig (feed stamp + stats)
+
+    func testMergedConfigExposesResolvedAxes() {
+        let userDefault = DefaultAgentConfig.factory
+        let resolved = DefaultAgentResolver.resolveOverlay(
+            savedConfig: saved(overlay(model: "sonnet", effort: "high", systemPrompt: SystemPromptSetting(mode: .append, text: "x"))),
+            userDefault: userDefault,
+            projectConfig: nil
+        )
+        XCTAssertEqual(resolved?.mergedConfig.model, "sonnet")
+        XCTAssertEqual(resolved?.mergedConfig.effort, "high")
+        XCTAssertEqual(resolved?.mergedConfig.systemPrompt?.mode, .append)
+    }
+
+    // MARK: - Custom/unknown harness → nil (caller falls back)
+
+    func testUnknownHarnessReturnsNil() {
+        let resolved = DefaultAgentResolver.resolveOverlay(
+            savedConfig: saved(overlay(harness: "totally-made-up-kind")),
+            userDefault: .factory,
+            projectConfig: nil
+        )
+        XCTAssertNil(resolved)
+    }
+
+    // MARK: - effectiveDefault() composition (store rooted at a temp dir)
+
+    private func tempStore() -> (AgentConfigLibraryStore, URL) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("c11-overlay-tests-\(UUID().uuidString)", isDirectory: true)
+        return (AgentConfigLibraryStore(directory: dir), dir)
+    }
+
+    func testEffectiveDefaultPinnedReturnsFactorySeedOnFreshStore() {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let eff = store.effectiveDefault()
+        XCTAssertEqual(eff.name, "Opus deep")
+        XCTAssertEqual(eff.config.model, "opus")
+        XCTAssertNil(eff.config.effort)
+    }
+
+    func testEffectiveDefaultPinnedFollowsSetDefault() throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let added = try store.add(saved(overlay(model: "sonnet"), name: "Sonnet mid", id: ""))
+        try store.setDefault(configId: added.id)
+        XCTAssertEqual(store.effectiveDefault().id, added.id)
+        XCTAssertEqual(store.effectiveDefault().config.model, "sonnet")
+    }
+
+    func testEffectiveDefaultFollowRecentResolvesRecentConfig() throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let added = try store.add(saved(overlay(model: "sonnet"), name: "Sonnet mid", id: ""))
+        try store.setMode(.followRecent)
+        try store.recordRecent(RecentAgentConfig(configId: added.id, harness: "claude-code", model: "sonnet", observedAt: Date(), source: "launch"))
+        XCTAssertEqual(store.effectiveDefault().id, added.id, "follow-recent resolves the recent config id")
+    }
+
+    func testEffectiveDefaultFollowRecentWithNoRecentFallsBackToPinned() throws {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try store.setMode(.followRecent)
+        // No recent recorded → pinned factory seed.
+        XCTAssertEqual(store.effectiveDefault().name, "Opus deep")
+    }
+
+    // MARK: - Tooltip formatter (§5.3 v1)
+
+    func testTooltipFormatsNameModelEffortWithFamilyDisplayName() {
+        let s = DefaultAgentResolver.formatAgentTooltip(name: "Opus deep", model: "opus", effort: "high")
+        XCTAssertEqual(s, "Launch Agent — Opus deep · Opus · high")
+    }
+
+    func testTooltipOmitsEmptyEffortSegment() {
+        let s = DefaultAgentResolver.formatAgentTooltip(name: "Opus deep", model: "opus", effort: "")
+        XCTAssertEqual(s, "Launch Agent — Opus deep · Opus")
+    }
+
+    func testTooltipShowsNonFamilyModelVerbatim() {
+        let s = DefaultAgentResolver.formatAgentTooltip(name: "Codex hi", model: "gpt-5.2", effort: "high")
+        XCTAssertEqual(s, "Launch Agent — Codex hi · gpt-5.2 · high")
+    }
+
+    func testResolvedDefaultTooltipFromFreshStoreShowsSeed() {
+        let (store, dir) = tempStore()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let s = DefaultAgentResolver.resolvedDefaultTooltip(library: store, userDefault: .factory)
+        XCTAssertEqual(s, "Launch Agent — Opus deep · Opus", "seed is opus-only → no effort segment")
+    }
+
+    // MARK: - Validation: rendered command matrix + sink data path (in_validation)
+
+    /// Renders the resolved launch line for a matrix of overlays over the same
+    /// claude-code base, proving the full composition end-to-end. The printed
+    /// lines are the validation evidence; the assertions pin the distinguishing
+    /// injected flags per row.
+    func testValidationCommandMatrixRendersThroughOverlay() {
+        let userDefault = DefaultAgentConfig.factory
+        let base = userDefault.config(for: .claudeCode)
+        func render(_ o: AgentLaunchConfig) -> String {
+            DefaultAgentResolver.resolveOverlay(savedConfig: saved(o), userDefault: userDefault, projectConfig: nil)!.launch.command
+        }
+
+        let inheritAll = render(overlay(harness: "claude-code"))
+        let modelOnly = render(overlay(model: "sonnet"))
+        let fullRecipe = render(overlay(
+            model: "sonnet", effort: "high",
+            systemPrompt: SystemPromptSetting(mode: .append, text: "be terse"),
+            command: "claude --dangerously-skip-permissions",
+            initialPrompt: "go"
+        ))
+        let blankSlate = render(overlay(systemPrompt: SystemPromptSetting(mode: .replace, text: "")))
+
+        print("=== C11-179 overlay command matrix ===")
+        print("inherit-all  : \(inheritAll)")
+        print("model-only   : \(modelOnly)")
+        print("full-recipe  : \(fullRecipe)")
+        print("blank-slate  : \(blankSlate)")
+
+        // inherit-all == raw harness base (byte-identical), no overlay flags.
+        let raw = DefaultAgentResolver.resolve(explicitAgent: .claudeCode, userDefault: userDefault, projectConfig: nil).launch.command
+        XCTAssertEqual(inheritAll, raw)
+        // model-only swaps the model, keeps everything else.
+        XCTAssertTrue(modelOnly.contains("--model sonnet"))
+        XCTAssertFalse(modelOnly.contains("--effort"))
+        // full-recipe injects model+effort+append-system-prompt+positional prompt.
+        XCTAssertTrue(fullRecipe.contains("--model sonnet"))
+        XCTAssertTrue(fullRecipe.contains("--effort high"))
+        XCTAssertTrue(fullRecipe.contains("--append-system-prompt 'be terse'"))
+        XCTAssertTrue(fullRecipe.hasSuffix("'go'"), "claude initial prompt rides as a trailing positional")
+        // blank-slate emits the empty replace flag.
+        XCTAssertTrue(blankSlate.contains("--system-prompt ''"))
+        // sanity: the base isn't accidentally mutated by any render.
+        XCTAssertEqual(userDefault.config(for: .claudeCode).command, base.command)
+    }
+
+    /// End-to-end data path for the A-button overlay launch → the C11-178 sink:
+    /// resolve the overlay, build the `ResolvedLaunch` the launch site records,
+    /// and confirm the persisted stats carry the overlay `config_id`, the
+    /// resolved model, and the launch source. Proves "recordLaunch fires with the
+    /// overlay-resolved config + source" for the path this ticket rewired.
+    func testValidationOverlayLaunchReachesStatsSinkWithConfigId() throws {
+        let userDefault = DefaultAgentConfig.factory
+        let savedCfg = saved(overlay(model: "sonnet", effort: "high"), name: "Sonnet hi", id: "CFGSONNETHI0000000000000A")
+        let resolved = try XCTUnwrap(
+            DefaultAgentResolver.resolveOverlay(savedConfig: savedCfg, userDefault: userDefault, projectConfig: nil)
+        )
+        // Mirror exactly what Workspace.launchAgentSurface builds for the sink.
+        let stats = ResolvedLaunch(
+            harness: resolved.agent.rawValue,
+            model: resolved.mergedConfig.model,
+            effort: resolved.mergedConfig.effort,
+            systemPromptMode: resolved.mergedConfig.systemPrompt?.mode.rawValue,
+            configId: savedCfg.id
+        )
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("c11-sink-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let sink = AgentLaunchStatsStore(directory: dir)
+        sink.recordLaunch(stats, source: .aButton)
+        sink.flush()
+
+        let recent = try XCTUnwrap(sink.recent())
+        XCTAssertEqual(recent.configId, "CFGSONNETHI0000000000000A", "overlay config_id reached the sink")
+        XCTAssertEqual(recent.model, "sonnet", "resolved model recorded")
+        XCTAssertEqual(recent.harness, "claude-code")
+        XCTAssertEqual(recent.provider, "anthropic", "provider derived in the sink")
+        XCTAssertEqual(sink.aggregate().totals.byModel["sonnet"], 1, "aggregate bumped for the resolved model")
+    }
+}

--- a/scripts/c11-179-register-files.rb
+++ b/scripts/c11-179-register-files.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# C11-179: register the overlay-composition test file in the Xcode project.
+# Pure logic → c11LogicTests ONLY (mirrors DefaultAgentLaunchCompositionTests;
+# adding a pure-logic test to the host c11Tests target buys no coverage and
+# adds DEV.app launch time). Idempotent.
+gem 'xcodeproj', '~> 1.27'
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../GhosttyTabs.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+c11_logic = project.targets.find { |t| t.name == 'c11LogicTests' } or abort 'c11LogicTests target not found'
+tests_group = project.main_group.find_subpath('c11Tests', false) or abort 'c11Tests group missing'
+
+TEST_FILES = %w[AgentLaunchOverlayCompositionTests.swift].freeze
+
+def ref_in(group, filename)
+  group.files.find { |f| f.path == filename } || group.new_reference(filename)
+end
+
+def ensure_member(target, ref)
+  return if target.source_build_phase.files.any? { |bf| bf.file_ref == ref }
+  target.source_build_phase.add_file_reference(ref)
+end
+
+TEST_FILES.each do |fn|
+  ref = ref_in(tests_group, fn)
+  ensure_member(c11_logic, ref)
+end
+
+project.save
+puts "OK — registered #{TEST_FILES.size} test(s) into c11LogicTests only"


### PR DESCRIPTION
Composes the three wave-1 parents of the C11-175 agent-config primitive run into the A-button launch path.

Ticket: **C11-179**. Design: `docs/agent-config-primitive-design.md` §1.3 (merge/precedence ladder), §3/§3.1 (default vs most-recent), §5.3 (at-a-glance tooltip), §7 (integration points).

## What this does
- **`DefaultAgentResolver.resolveOverlay` / `mergeOverlay`** — a saved-config overlay (`AgentLaunchConfig`) is applied by **flattening it onto the harness-base `AgentConfig`** (per-field `config ?? settings ?? factory`; env `factory ◁ settings ◁ config` per key), then reusing `buildCommand`/`launcherCommand` unchanged. A pure-inherit overlay is byte-identical to today's launch, and the existing model/effort/system-prompt injection (with hardcoded-in-command detection) applies to the overlaid values for free.
- **`Workspace.launchAgentSurface`** — a plain left-click launches `AgentConfigLibraryStore.effectiveDefault()` through the overlay; an explicit agent (right-click "launch this kind" / socket) keeps the raw-harness path; a custom harness the overlay can't materialize falls back to it (design §5.6).
- **`stampLaunchIdentity`** now stamps the overlay-resolved model, so the sidebar chip reflects a saved-config override, not just the harness pin.
- **`recordLaunch` (C11-178 sink)** fires from the A-button path with the resolved axes + `config_id` + system-prompt mode.
- **Most-recent (§3, R2 reconciliation):** `follow-recent` reads `recent` ONLY from `agent-configs.json`; every A-button-lineage launch calls `recordRecent` to keep that pointer live. The stats rail's own `recent` (`agent-launch-stats.json`) is durable-telemetry only and is never read for resolution — one reader, one file, so the two homes cannot cause a follow-recent divergence. (The stats-rail header comment explicitly deferred this reconciliation to C11-179.)
- **A-button tooltip (§5.3 v1):** resolved default `name · model · effort`, refreshed after each launch so follow-recent stays honest.

## O1 (orchestrator ruling)
The shipped `Opus deep` factory seed is **opus-only** — the C11-176 delegator dropped `effort=high` before its merge so the default launch stays **byte-identical to today** (design §2.2's `high` example overruled by the byte-identical regression AC; seed name kept). Pinned by `testShippedFactorySeedResolvesToTodaysDefaultCommand`.

## Tests (25 pure-logic, `c11LogicTests` only)
Per-field precedence ladder; env merge + `envMap`-is-base-only contract; byte-identical regression (synthetic pure-inherit **and** the actual shipped seed); hardcoded-flag no-double-inject; blank-slate system prompt; resolved-scalar exposure; unknown-harness → nil fallback; `effectiveDefault` mode branches (temp-dir store); tooltip formatting; a rendered command matrix; and an overlay→`recordLaunch` sink data-path test (config_id + resolved model + derived provider persisted). `Executed 25, 0 failures`.

Rendered command matrix (validation):
```
inherit-all : claude --dangerously-skip-permissions --model opus            # byte-identical to today
model-only  : claude --dangerously-skip-permissions --model sonnet
full-recipe : claude --dangerously-skip-permissions --model sonnet --effort high --append-system-prompt 'be terse' 'go'
blank-slate : claude --dangerously-skip-permissions --model opus --system-prompt ''
```

## Not in scope (downstream tickets)
Tier-1 popover / shortlist picker (C11-180), Settings Saved Configs editor + stats view (C11-181), `c11 config` CLI + `config.*` socket (C11-182), rails 2/3 (session-hook/scrape). This ticket wires the A-button **left-click** to `effectiveDefault` and the resolved-default tooltip.

## Follow-ups
- Localization: new key `workspace.tooltip.newAgent.resolved` (English authoritative) needs the six-locale translation pass.
- A future single-field `updateRecent` mutator on `AgentConfigLibraryStore` would tighten the last-writer-wins window (config edits are rare vs launches; within cfg-store's documented v1 contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)