### PR TITLE
A-button launch popover: shortlist picker (tier 1 of the model picker)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		38115B4DA9AAE3904F1B7871 /* ConfigCommandCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EBC71594BF2FF8B59D1AE28 /* ConfigCommandCore.swift */; };
 		39AF4F57C52E593EC8CF0680 /* MailboxSurfaceResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710BBF1A1B2C3D4E5F60718 /* MailboxSurfaceResolverTests.swift */; };
 		3A4B80EACD78ED4A40F5BB6E /* SidebarStalenessSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5E34AD8B3A4814F5DDD4B2D /* SidebarStalenessSettingsTests.swift */; };
+		3B379C73287446885D13948B /* AgentPickerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66D6015281A02515593B40AA /* AgentPickerModel.swift */; };
 		3D7DB8FD9FE7DECBA43949B6 /* MailboxLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7101BF1A1B2C3D4E5F60718 /* MailboxLayoutTests.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
 		442C70C79A00A668A6B29640 /* SurfaceLivenessDeriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 794F848890115B4BEF8AA94B /* SurfaceLivenessDeriver.swift */; };
@@ -102,6 +103,7 @@
 		6ADA7A21C4FA1DC2682E16B4 /* StatusBarButtonDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C36031 /* StatusBarButtonDisplayTests.swift */; };
 		6B3658A83D3C83E088A1FD10 /* SurfaceActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25359D87534E2AF54EA0E5F /* SurfaceActivityTests.swift */; };
 		6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */; };
+		6BA398A053EA878A1E1D2197 /* AgentPickerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */; };
 		6E7E7BF7FE70B34844D472DB /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
 		6F3E766AEE928B3A98ADC170 /* MailboxDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710FBF1A1B2C3D4E5F60718 /* MailboxDispatcherTests.swift */; };
 		712589D9F145582CB62150FF /* WorkspaceIdentityRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */; };
@@ -332,6 +334,7 @@
 		CC401009A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC401008A1B2C3D4E5F60719 /* CreateWorkspaceSheet.swift */; };
 		CC40100BA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC40100AA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift */; };
 		CFA9529EA1B3835E1A2586A2 /* DescriptionSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */; };
+		CFC9066EE8F234F5B82C0B63 /* AgentPickerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */; };
 		D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */; };
 		D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
 		D1510386129C337B5868E50D /* AgentLaunchStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */; };
@@ -392,6 +395,7 @@
 		DBF8F51099CEF804B8023B5D /* MailboxDispatchLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7109BF1A1B2C3D4E5F60718 /* MailboxDispatchLogTests.swift */; };
 		DE3972CB970228EE86CF9638 /* TerminalControllerTelemetryWorkerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH023BF1A1B2C3D4E5F60718 /* TerminalControllerTelemetryWorkerTests.swift */; };
 		DE686C76120208E59FAE152A /* PanelIdentityRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7003BF1A1B2C3D4E5F60718 /* PanelIdentityRestoreTests.swift */; };
+		DE7ECA78E4F2C589D4D91CBB /* AgentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4086104E408313BEAFE9EC11 /* AgentPickerView.swift */; };
 		DH001BF0A1B2C3D4E5F60718 /* HealthCommandCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH001BF1A1B2C3D4E5F60718 /* HealthCommandCore.swift */; };
 		DH001BF0A1B2C3D4E5F60719 /* HealthCommandCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH001BF1A1B2C3D4E5F60718 /* HealthCommandCore.swift */; };
 		DH002BF0A1B2C3D4E5F60719 /* HealthCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH002BF1A1B2C3D4E5F60719 /* HealthCommand.swift */; };
@@ -516,6 +520,7 @@
 		36B9B8C3641F9801C6A45757 /* ConversationStrategyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationStrategyTests.swift; sourceTree = "<group>"; };
 		37B204EF50A2AF07D922EFFA /* ShutdownSentinelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShutdownSentinelTests.swift; sourceTree = "<group>"; };
 		3BF9D5EC78046EDA9B54AC68 /* DefaultAgentConfigTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentConfigTests.swift; sourceTree = "<group>"; };
+		4086104E408313BEAFE9EC11 /* AgentPickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentPickerView.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
 		490D9000BC1B0741D6E2CF06 /* SidebarStalenessSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarStalenessSettings.swift; sourceTree = "<group>"; };
 		491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
@@ -537,6 +542,7 @@
 		AC0F16182ED0DE1000000003 /* AgentConfigEditorModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentConfigEditorModelTests.swift; sourceTree = "<group>"; };
 		64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventEnvelope.swift; path = Events/EventEnvelope.swift; sourceTree = "<group>"; };
 		660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationCrashRecoveryTests.swift; path = ConversationCrashRecoveryTests.swift; sourceTree = "<group>"; };
+		66D6015281A02515593B40AA /* AgentPickerModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentPickerModel.swift; sourceTree = "<group>"; };
 		6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PiConversationTests.swift; sourceTree = "<group>"; };
 		6EBC71594BF2FF8B59D1AE28 /* ConfigCommandCore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigCommandCore.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
@@ -886,6 +892,7 @@
 		F60C0DEA00000000000C0102 /* GitHubCopilot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GitHubCopilot.swift; path = Conversation/Strategies/GitHubCopilot.swift; sourceTree = "<group>"; };
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
 		F6B62D2ECDC52E5244D9C6E3 /* DefaultAgentConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentConfig.swift; sourceTree = "<group>"; };
+		F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentPickerModelTests.swift; sourceTree = "<group>"; };
 		F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
 		F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 		F81492660FA7D00E8115BD46 /* ConversationRefTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationRefTests.swift; sourceTree = "<group>"; };
@@ -1209,6 +1216,8 @@
 				06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */,
 				9A03BB65CC01C2029DF83337 /* AgentConfigLibraryStore.swift */,
 				6EBC71594BF2FF8B59D1AE28 /* ConfigCommandCore.swift */,
+				66D6015281A02515593B40AA /* AgentPickerModel.swift */,
+				4086104E408313BEAFE9EC11 /* AgentPickerView.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -1425,6 +1434,7 @@
 				AC0F16182ED0DE1000000003 /* AgentConfigEditorModelTests.swift */,
 				B0C8786B9F13542B2C4D9D35 /* AgentLaunchOverlayCompositionTests.swift */,
 				D4C7E212A580905DBF388D79 /* ConfigCommandCoreTests.swift */,
+				F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1767,6 +1777,7 @@
 				AC0F16182ED0DE1000000004 /* AgentConfigEditorModelTests.swift in Sources */,
 				5A86082FF691F6FBCBDE52CB /* AgentLaunchOverlayCompositionTests.swift in Sources */,
 				154C8F2336C14C870CB0C531 /* ConfigCommandCoreTests.swift in Sources */,
+				6BA398A053EA878A1E1D2197 /* AgentPickerModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1979,6 +1990,8 @@
 				BAEDB3843B3F408AB2B39E44 /* AgentConfigLibraryStore.swift in Sources */,
 				38115B4DA9AAE3904F1B7871 /* ConfigCommandCore.swift in Sources */,
 				E7B858CDF649114D83838A26 /* ConfigHandlers.swift in Sources */,
+				3B379C73287446885D13948B /* AgentPickerModel.swift in Sources */,
+				DE7ECA78E4F2C589D4D91CBB /* AgentPickerView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2077,6 +2090,7 @@
 				ACB000000000000000000103 /* BrowserCompanionWorkspaceTests.swift in Sources */,
 				ACB000000000000000000104 /* BrowserCompanionPortalTests.swift in Sources */,
 				ACB000000000000000000105 /* BrowserCompanionChromeTests.swift in Sources */,
+				CFC9066EE8F234F5B82C0B63 /* AgentPickerModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -942,6 +942,100 @@
         }
       }
     },
+    "agentPicker.chip.blank": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·blank·"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·空·"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·空白·"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·空白·"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·빈 값·"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·пусто·"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "·порожньо·"
+          }
+        }
+      }
+    },
+    "agentPicker.chip.systemPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sys:%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sys:%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sys:%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sys:%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sys:%@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sys:%@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "sys:%@"
+          }
+        }
+      }
+    },
     "agentPicker.footer.followRecent": {
       "extractionState": "manual",
       "localizations": {
@@ -1412,6 +1506,53 @@
         }
       }
     },
+    "agentPicker.model.inherit": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "inherit"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "継承"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "继承"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "繼承"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상속"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "наследовать"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "успадкувати"
+          }
+        }
+      }
+    },
     "agentPicker.notInstalled": {
       "extractionState": "manual",
       "localizations": {
@@ -1502,6 +1643,53 @@
           "stringUnit": {
             "state": "translated",
             "value": "Зробити типовим (⌥-клацання)"
+          }
+        }
+      }
+    },
+    "agentPicker.provider.router": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "router"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ルーター"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路由器"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "路由器"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "라우터"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "роутер"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "роутер"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -942,6 +942,1040 @@
         }
       }
     },
+    "agentPicker.footer.followRecent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Default follows most recent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトは直近の起動に追従"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认跟随最近启动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設跟隨最近啟動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값은 최근 실행을 따름"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "По умолчанию использовать последний запуск"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Типово використовувати останній запуск"
+          }
+        }
+      }
+    },
+    "agentPicker.footer.followRecent.hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A launches whatever you last launched"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A で最後に起動したものを起動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A 会启动你最近启动的项目"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A 會啟動你最近啟動的項目"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A는 마지막으로 실행한 항목을 실행"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A запускает то, что запускалось последним"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A запускає те, що запускали востаннє"
+          }
+        }
+      }
+    },
+    "agentPicker.footer.stats": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch stats"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "起動統計"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动统计"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動統計"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 통계"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статистика запусков"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статистика запусків"
+          }
+        }
+      }
+    },
+    "agentPicker.footer.viewAll": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View all models & configs…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのモデルと設定を表示…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看所有模型和配置…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢視所有模型與設定…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 모델 및 구성 보기…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Все модели и конфигурации…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переглянути всі моделі й конфігурації…"
+          }
+        }
+      }
+    },
+    "agentPicker.header.following": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "◉ following recent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "◉ 直近の起動に追従"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "◉ 跟随最近启动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "◉ 跟隨最近啟動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "◉ 최근 실행 따름"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "◉ использовать последний запуск"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "◉ стеження за останнім запуском"
+          }
+        }
+      }
+    },
+    "agentPicker.header.launchAgent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントを起動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动代理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動代理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 실행"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустить агента"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запустити агента"
+          }
+        }
+      }
+    },
+    "agentPicker.hint.launch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "launch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "起動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "запуск"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "запуск"
+          }
+        }
+      }
+    },
+    "agentPicker.hint.launchNth": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "launch nth"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "番号で起動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "按编号启动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依編號啟動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "번호로 실행"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "запуск по номеру"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "запуск за номером"
+          }
+        }
+      }
+    },
+    "agentPicker.hint.select": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "select"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選取"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "выбор"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "вибір"
+          }
+        }
+      }
+    },
+    "agentPicker.hint.setDefault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "set default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设为默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設為預設"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값으로 설정"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "задать по умолчанию"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "зробити типовим"
+          }
+        }
+      }
+    },
+    "agentPicker.notInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "NOT INSTALLED"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未インストール"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未安装"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未安裝"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설치되지 않음"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НЕ УСТАНОВЛЕНО"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "НЕ ВСТАНОВЛЕНО"
+          }
+        }
+      }
+    },
+    "agentPicker.pin.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set as default (⌥-click)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトに設定 (⌥-クリック)"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "设为默认 (⌥-点按)"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設為預設 (⌥-點按)"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값으로 설정 (⌥-클릭)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Задать по умолчанию (⌥-щелчок)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зробити типовим (⌥-клацання)"
+          }
+        }
+      }
+    },
+    "agentPicker.recent.adhoc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ad-hoc"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アドホック"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "临时"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "臨時"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "임시"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разовый"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Разовий"
+          }
+        }
+      }
+    },
+    "agentPicker.recent.daysAgo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldd ago"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld日前"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld天前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 天前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld일 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld дн. назад"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld дн. тому"
+          }
+        }
+      }
+    },
+    "agentPicker.recent.hoursAgo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldh ago"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld時間前"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld小时前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 小時前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld시간 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld ч назад"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld год тому"
+          }
+        }
+      }
+    },
+    "agentPicker.recent.justNow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "just now"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "たった今"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刚刚"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "剛剛"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "방금"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "только что"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "щойно"
+          }
+        }
+      }
+    },
+    "agentPicker.recent.liveHint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ does not report live model changes — this value was captured at launch. A mid-session /model switch inside the TUI is not observed."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ はモデルの変更をリアルタイムで報告しません — この値は起動時に取得されました。TUI 内でセッション中に /model を切り替えても検出されません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不会报告实时模型变更 — 此值在启动时捕获。无法观察到 TUI 内会话期间的 /model 切换。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不會回報即時模型變更 — 此值在啟動時擷取。無法觀察到 TUI 內工作階段期間的 /model 切換。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@에서는 실시간 모델 변경을 보고하지 않습니다 — 이 값은 실행 시 캡처되었습니다. TUI에서 세션 도중 /model을 전환해도 감지되지 않습니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ не сообщает об изменениях модели в реальном времени — это значение зафиксировано при запуске. Переключение /model внутри TUI во время сеанса не отслеживается."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ не повідомляє про зміни моделі наживо — це значення зафіксовано під час запуску. Перемикання /model посеред сеансу в TUI не відстежується."
+          }
+        }
+      }
+    },
+    "agentPicker.recent.minutesAgo": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldm ago"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld分前"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld分钟前"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 分鐘前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld분 전"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld мин назад"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld хв тому"
+          }
+        }
+      }
+    },
+    "agentPicker.recent.section": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "recent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최근"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "недавние"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "останні"
+          }
+        }
+      }
+    },
+    "agentPicker.stats.headline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%% %2$@ · %3$lld launches"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%% %2$@ · 起動 %3$lld回"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%% %2$@ · %3$lld 次启动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%% %2$@ · 啟動 %3$lld 次"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%% %2$@ · %3$lld회 실행"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%% %2$@ · запусков: %3$lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld%% %2$@ · запусків: %3$lld"
+          }
+        }
+      }
+    },
+    "agentPicker.tag.default": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "預設"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기본값"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "по умолчанию"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "типово"
+          }
+        }
+      }
+    },
+    "agentPicker.tag.recentDefault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "recent→default"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "直近→デフォルト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近→默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近→預設"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "최근→기본값"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "последний→по умолчанию"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "останній→типово"
+          }
+        }
+      }
+    },
     "agentSkills.action.envelope": {
       "extractionState": "manual",
       "localizations": {
@@ -27117,6 +28151,53 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перейти до робочого простору…"
+          }
+        }
+      }
+    },
+    "menu.file.launchAgentPicker": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Launch Agent Picker…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントピッカーを起動…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启动代理选择器…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟動代理選擇器…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 선택기 실행…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть выбор агента…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити вибір агента…"
           }
         }
       }

--- a/Sources/AgentPickerModel.swift
+++ b/Sources/AgentPickerModel.swift
@@ -1,0 +1,358 @@
+import Foundation
+
+// MARK: - Agent launch picker: pure view-model (C11-181, tier 1)
+//
+// The UI-agnostic heart of the A-button launch popover. It turns the saved-config
+// library (`AgentConfigLibraryFile`) into rendered shortlist + recent rows, derives
+// the display facets the manifest does not model (provider, live-ness, cost — design
+// §1.2/§8.4/§5.6), and runs the keyboard-navigation state machine (↑↓/⏎/⌥⏎/1–9/esc).
+//
+// No AppKit / SwiftUI: every dependency is injected via `AgentPickerEnvironment`, so
+// this whole file is exercised in `c11LogicTests` without constructing a Workspace or
+// touching NSApp. The SwiftUI layer (`AgentPickerView`) only renders this and forwards
+// key events; the presenter wires the real environment + action callbacks.
+//
+// Binding spec: `docs/design-prototypes/model-picker/index.html` (the `#popover`).
+
+/// The system-prompt chip a row shows (design §1.4). `nil` on the row means the
+/// config inherits (no chip). `blank` is the Gregorovich replace-empty case.
+enum PickerSysChip: Equatable {
+    /// `replace` mode with empty text — launches `--system-prompt ''`. Rendered `·blank·`.
+    case blank
+    /// A non-inherit mode carrying text, rendered `sys:append` / `sys:replace`.
+    case mode(String)
+
+    /// The gold chip label the view draws.
+    var label: String {
+        switch self {
+        case .blank: return "·blank·"
+        case .mode(let m): return "sys:\(m)"
+        }
+    }
+}
+
+/// One shortlist row — a full saved recipe (design §5.1 row anatomy). All display
+/// strings are precomputed so the view is a dumb renderer.
+struct AgentPickerRow: Equatable {
+    /// The launch / pin target this row acts on.
+    var config: SavedAgentConfig
+    /// The recipe name (bold).
+    var name: String
+    /// `harness · provider · model` sub-line (lowercased harness, per prototype).
+    var subLine: String
+    /// Effort chip text, or `nil` when the config inherits effort.
+    var effortChip: String?
+    /// System-prompt chip, or `nil` when inheriting.
+    var sysChip: PickerSysChip?
+    /// `$in/$out` per-Mtok cost, or `nil` when the catalog is absent (§5.6).
+    var cost: String?
+    /// 1–9 launch-badge number (1-based).
+    var keyBadge: Int
+    /// The pinned default (● pin-dot, `default` tag).
+    var isPinnedDefault: Bool
+    /// Marked when follow-recent resolves the effective default to this row
+    /// (`recent→default` tag).
+    var isRecentDefault: Bool
+    /// Harness installed on PATH. `false` → dim + "NOT INSTALLED", still pinnable.
+    var isInstalled: Bool
+}
+
+/// The RECENT row (design §5.1 / §8.4). `nil` config = ad-hoc launch with no saved id.
+struct AgentPickerRecentRow: Equatable {
+    /// The saved config the recent launch resolved to, or `nil` (ad-hoc).
+    var config: SavedAgentConfig?
+    /// Display name (config name, or "Ad-hoc").
+    var name: String
+    /// Relative time, e.g. "just now" / "2m ago".
+    var relativeTime: String
+    /// `harness · model[ · effort]` sub-line.
+    var subLine: String
+    /// Cost, or `nil` when the catalog is absent.
+    var cost: String?
+    /// Show the quiet ⓘ "does not report live model" hint — every non-claude-code
+    /// harness (design §8.4: only claude-code reports live).
+    var showLiveHint: Bool
+    /// Harness display name for the ⓘ tooltip.
+    var harnessDisplayName: String
+    /// Installed on PATH (dims the row when false).
+    var isInstalled: Bool
+}
+
+/// The full rendered content of the popover, independent of keyboard selection.
+struct AgentPickerContent: Equatable {
+    var shortlist: [AgentPickerRow]
+    var recent: AgentPickerRecentRow?
+    /// `follow-recent` mode is on (header shows "◉ following recent", footer checkbox on).
+    var followRecent: Bool
+    /// Inline "N% Model · M launches" headline on the Launch-stats row, or `nil`
+    /// when the stats store is unavailable / empty (degrade).
+    var statsHeadline: String?
+}
+
+/// A key the popover reacts to — decoupled from `NSEvent` so the state machine is
+/// unit-testable. The view translates real key events into these.
+enum PickerKey: Equatable {
+    case up
+    case down
+    case enter
+    case escape
+    case digit(Int) // 1...9
+}
+
+/// What a key/gesture resolves to. The presenter maps these onto the workspace.
+enum PickerAction: Equatable {
+    /// Launch this config now (row click / ⏎ / 1–9).
+    case launch(SavedAgentConfig)
+    /// Set this config as the pinned default without launching (pin glyph / ⌥-click / ⌥⏎).
+    case pin(SavedAgentConfig)
+    /// Flip the default's follow-recent mode.
+    case toggleFollowRecent
+    /// Open the tier-2 configure sheet (C11-182 seam).
+    case viewAll
+    /// Open the stats view (C11-182 seam).
+    case stats
+    /// Dismiss the popover.
+    case close
+    /// No-op (e.g. a number key past the shortlist, or a plain launch of a
+    /// not-installed harness — the caller may surface the shell-error hint).
+    case none
+}
+
+/// Injected environment — real impls live in the presenter, stubs in tests.
+struct AgentPickerEnvironment {
+    /// Harness key → English display name (real: `AgentRegistry`/`AgentType.displayName`).
+    var displayName: (String) -> String
+    /// Derived provider facet (real: `AgentLaunchStats.provider`). `nil` when unknown.
+    var provider: (String, String?) -> String?
+    /// Cached PATH probe (real: `which` on the harness command). Absent = dim row.
+    var isInstalled: (String) -> Bool
+    /// Per-model cost lookup (real: token-cost catalog when it exists; today always
+    /// `nil` → cost column omitted, design §5.6).
+    var costFor: (String?) -> (inUSD: Double, outUSD: Double)?
+    /// "Now" for relative-time formatting (injectable for deterministic tests).
+    var now: Date
+    /// Inline stats headline, precomputed by the caller from `AgentLaunchStatsStore`
+    /// (kept out of the pure model so it stays store-free). `nil` = omit.
+    var statsHeadline: String?
+}
+
+/// The keyboard-navigable picker state. Value type: the view holds it in `@State`
+/// and calls `handleKey`; arrows mutate `selectedIndex`, actions are returned.
+struct AgentPickerModel {
+    /// Shortlist configs in library `order` (the launch/pin targets, 1–9).
+    let configs: [SavedAgentConfig]
+    /// The recent launch's resolved config, if any (nav index == configs.count).
+    let recentConfig: SavedAgentConfig?
+    /// What ⏎ launches when nothing is keyboard-selected (design §5.1).
+    let effectiveDefault: SavedAgentConfig
+    /// Precomputed render content.
+    let content: AgentPickerContent
+
+    /// -1 = nothing focused (open state); 0..<configs.count = a shortlist row;
+    /// configs.count = the recent row.
+    var selectedIndex: Int = -1
+
+    // MARK: Build
+
+    init(library: AgentConfigLibraryFile, effectiveDefault: SavedAgentConfig, env: AgentPickerEnvironment) {
+        // Sort defensively by `order` so 1–9 badges are stable even if the on-disk
+        // array ever drifts from `order` (self-review F8).
+        let sorted = library.configs.sorted { $0.order < $1.order }
+        self.configs = sorted
+        self.effectiveDefault = effectiveDefault
+
+        let followRecent = library.default.mode == .followRecent
+        let pinnedId = library.default.mode == .pinned ? library.default.configId : nil
+        let recentCfgId = library.recent?.configId
+
+        var rows: [AgentPickerRow] = []
+        for (i, cfg) in sorted.enumerated() {
+            let isPinned = pinnedId == cfg.id
+            let isRecentDefault = followRecent && recentCfgId != nil && recentCfgId == cfg.id
+            rows.append(
+                AgentPickerRow(
+                    config: cfg,
+                    name: cfg.name,
+                    subLine: Self.subLine(for: cfg.config, env: env),
+                    effortChip: AgentPickerModel.nonEmpty(cfg.config.effort),
+                    sysChip: Self.sysChip(for: cfg.config.systemPrompt),
+                    cost: Self.costString(cfg.config.model, env: env),
+                    keyBadge: i + 1,
+                    isPinnedDefault: isPinned,
+                    isRecentDefault: isRecentDefault,
+                    isInstalled: env.isInstalled(cfg.config.harness)
+                )
+            )
+        }
+        self.content = AgentPickerContent(
+            shortlist: rows,
+            recent: Self.recentRow(from: library.recent, configs: sorted, env: env),
+            followRecent: followRecent,
+            statsHeadline: env.statsHeadline
+        )
+        // The recent nav target is the resolved saved config (ad-hoc = nil).
+        if let rid = recentCfgId, let match = sorted.first(where: { $0.id == rid }) {
+            self.recentConfig = match
+        } else {
+            self.recentConfig = nil
+        }
+    }
+
+    // MARK: Keyboard state machine
+
+    /// Whether the recent row participates in ↑↓ navigation.
+    private var hasRecent: Bool { content.recent != nil }
+
+    /// The highest valid nav index (recent row is one past the shortlist).
+    private var maxIndex: Int { configs.count - 1 + (hasRecent ? 1 : 0) }
+
+    /// The config currently focused, or `nil` when nothing is (index -1) or the
+    /// recent row (handled separately).
+    private var selectedConfig: SavedAgentConfig? {
+        guard selectedIndex >= 0, selectedIndex < configs.count else { return nil }
+        return configs[selectedIndex]
+    }
+
+    /// Apply a key. Arrows mutate `selectedIndex` and return `.none`; everything
+    /// else resolves to a `PickerAction`. `option` = the ⌥ modifier (⌥⏎ = pin).
+    mutating func handleKey(_ key: PickerKey, option: Bool = false) -> PickerAction {
+        switch key {
+        case .down:
+            guard maxIndex >= 0 else { return .none }
+            selectedIndex = min(maxIndex, selectedIndex + 1)
+            return .none
+        case .up:
+            // Clamp at 0; from -1 (nothing) the first Up selects row 0.
+            selectedIndex = max(0, selectedIndex - 1)
+            return .none
+        case .escape:
+            return .close
+        case .digit(let n):
+            guard n >= 1, n <= configs.count else { return .none }
+            let cfg = configs[n - 1]
+            return launchOrNoop(cfg) // installed → launch, else no-op (caller may hint)
+        case .enter:
+            // Recent row focused → launch the recent config.
+            if hasRecent, selectedIndex == configs.count {
+                if let rc = recentConfig { return .launch(rc) }
+                return .none
+            }
+            // A shortlist row focused → pin (⌥) or launch it.
+            if let cfg = selectedConfig {
+                return option ? .pin(cfg) : launchOrNoop(cfg)
+            }
+            // Nothing focused → act on the effective default (⌥ pins it if it is a
+            // real saved config; a transient effective default can't be pinned).
+            if option {
+                return effectiveDefault.id.isEmpty ? .none : .pin(effectiveDefault)
+            }
+            return .launch(effectiveDefault)
+        }
+    }
+
+    /// Launch iff installed; a plain launch of a not-installed harness is a no-op
+    /// the caller may turn into the "not installed" hint. Pin paths bypass this.
+    private func launchOrNoop(_ cfg: SavedAgentConfig) -> PickerAction {
+        if content.shortlist.first(where: { $0.config.id == cfg.id })?.isInstalled == false {
+            return .none
+        }
+        return .launch(cfg)
+    }
+
+    // MARK: Derivation helpers (pure)
+
+    static func nonEmpty(_ s: String?) -> String? {
+        guard let s = s?.trimmingCharacters(in: .whitespacesAndNewlines), !s.isEmpty else { return nil }
+        return s
+    }
+
+    /// `deepseek/deepseek-chat-v3.1` → `deepseek-chat-v3.1`; `opus` → `opus`;
+    /// `nil` → `inherit`.
+    static func modelLabel(_ model: String?) -> String {
+        guard let m = nonEmpty(model) else { return "inherit" }
+        if let slash = m.firstIndex(of: "/") { return String(m[m.index(after: slash)...]) }
+        return m
+    }
+
+    /// Display provider: the central `AgentLaunchStats.provider` result, capitalized
+    /// for the fixed harnesses, with a `router` fallback for router harnesses whose
+    /// model carries no `provider/` prefix, and "" for custom/unknown (prototype).
+    static func providerLabel(harness: String, model: String?, env: AgentPickerEnvironment) -> String {
+        if let p = env.provider(harness, model), !p.isEmpty {
+            return p.prefix(1).uppercased() + p.dropFirst()
+        }
+        // No derived provider. Router harnesses still read as "router"; everything
+        // else (custom / unknown) shows nothing.
+        switch harness {
+        case "opencode", "pi", "omp": return "router"
+        default: return ""
+        }
+    }
+
+    /// `harness · provider · model` (lowercased harness display, per the prototype).
+    static func subLine(for cfg: AgentLaunchConfig, env: AgentPickerEnvironment) -> String {
+        let harness = env.displayName(cfg.harness).lowercased()
+        let provider = providerLabel(harness: cfg.harness, model: cfg.model, env: env)
+        let model = modelLabel(cfg.model)
+        var parts = [harness]
+        if !provider.isEmpty { parts.append(provider) }
+        parts.append(model)
+        return parts.joined(separator: " · ")
+    }
+
+    static func sysChip(for setting: SystemPromptSetting?) -> PickerSysChip? {
+        guard let s = setting, s.mode != .inherit else { return nil }
+        if s.mode == .replace, s.text.isEmpty { return .blank }
+        return .mode(s.mode.rawValue)
+    }
+
+    static func costString(_ model: String?, env: AgentPickerEnvironment) -> String? {
+        guard let c = env.costFor(model) else { return nil }
+        return "$\(fmt(c.inUSD))/$\(fmt(c.outUSD))"
+    }
+
+    /// Prototype `fmt`: ≥1 drops a trailing zero on the .x0 case, <1 keeps two places.
+    static func fmt(_ n: Double) -> String {
+        if n >= 1 {
+            if n.truncatingRemainder(dividingBy: 1) == 0 { return String(Int(n)) }
+            let two = String(format: "%.2f", n)
+            return two.hasSuffix("0") ? String(two.dropLast()) : two
+        }
+        return String(format: "%.2f", n)
+    }
+
+    static func recentRow(from recent: RecentAgentConfig?, configs: [SavedAgentConfig], env: AgentPickerEnvironment) -> AgentPickerRecentRow? {
+        guard let recent, let harness = nonEmpty(recent.harness) else { return nil }
+        let cfg = recent.configId.flatMap { id in configs.first(where: { $0.id == id }) }
+        var subParts = [env.displayName(harness).lowercased(), modelLabel(recent.model)]
+        if let effort = nonEmpty(recent.effort) { subParts.append(effort) }
+        return AgentPickerRecentRow(
+            config: cfg,
+            name: cfg?.name ?? String(localized: "agentPicker.recent.adhoc", defaultValue: "Ad-hoc"),
+            relativeTime: relativeTime(from: recent.observedAt, now: env.now),
+            subLine: subParts.joined(separator: " · "),
+            cost: costString(recent.model, env: env),
+            showLiveHint: harness != AgentType.claudeCode.rawValue,
+            harnessDisplayName: env.displayName(harness),
+            isInstalled: env.isInstalled(harness)
+        )
+    }
+
+    /// "just now" (<45s) · "Nm ago" (<60m) · "Nh ago" (<24h) · "Nd ago". `nil`
+    /// observation → "just now".
+    static func relativeTime(from date: Date?, now: Date) -> String {
+        guard let date else { return String(localized: "agentPicker.recent.justNow", defaultValue: "just now") }
+        let secs = max(0, now.timeIntervalSince(date))
+        if secs < 45 { return String(localized: "agentPicker.recent.justNow", defaultValue: "just now") }
+        if secs < 3600 {
+            let m = Int((secs / 60).rounded())
+            return String(localized: "agentPicker.recent.minutesAgo", defaultValue: "\(m)m ago")
+        }
+        if secs < 86_400 {
+            let h = Int((secs / 3600).rounded())
+            return String(localized: "agentPicker.recent.hoursAgo", defaultValue: "\(h)h ago")
+        }
+        let d = Int((secs / 86_400).rounded())
+        return String(localized: "agentPicker.recent.daysAgo", defaultValue: "\(d)d ago")
+    }
+}

--- a/Sources/AgentPickerModel.swift
+++ b/Sources/AgentPickerModel.swift
@@ -214,8 +214,9 @@ struct AgentPickerModel {
     }
 
     /// Apply a key. Arrows mutate `selectedIndex` and return `.none`; everything
-    /// else resolves to a `PickerAction`. `option` = the ⌥ modifier (⌥⏎ = pin).
-    mutating func handleKey(_ key: PickerKey, option: Bool = false) -> PickerAction {
+    /// else resolves to a `PickerAction`. `option` = the ⌥ modifier (⌥⏎ = pin),
+    /// `command` = the ⌘ modifier (⌘⏎ = View all, never launches).
+    mutating func handleKey(_ key: PickerKey, option: Bool = false, command: Bool = false) -> PickerAction {
         switch key {
         case .down:
             guard maxIndex >= 0 else { return .none }
@@ -232,10 +233,15 @@ struct AgentPickerModel {
             let cfg = configs[n - 1]
             return launchOrNoop(cfg) // installed → launch, else no-op (caller may hint)
         case .enter:
-            // Recent row focused → launch the recent config.
+            // ⌘⏎ opens the tier-2 configure sheet (View all) — never launches
+            // (prototype: `if (e.metaKey){ openSheet(...); return; }`).
+            if command { return .viewAll }
+            // Recent row focused → pin (⌥) or launch it, honoring the installed
+            // guard exactly like the shortlist/digit paths (prototype: `if altKey
+            // pin; else if installed launch`).
             if hasRecent, selectedIndex == configs.count {
-                if let rc = recentConfig { return .launch(rc) }
-                return .none
+                guard let rc = recentConfig else { return .none }
+                return option ? .pin(rc) : launchOrNoop(rc)
             }
             // A shortlist row focused → pin (⌥) or launch it.
             if let cfg = selectedConfig {
@@ -246,7 +252,9 @@ struct AgentPickerModel {
             if option {
                 return effectiveDefault.id.isEmpty ? .none : .pin(effectiveDefault)
             }
-            return .launch(effectiveDefault)
+            // Plain launch runs through the installed guard too, so an uninstalled
+            // pinned default no-ops symmetrically with its 1–9 digit.
+            return launchOrNoop(effectiveDefault)
         }
     }
 
@@ -345,11 +353,13 @@ struct AgentPickerModel {
         let secs = max(0, now.timeIntervalSince(date))
         if secs < 45 { return String(localized: "agentPicker.recent.justNow", defaultValue: "just now") }
         if secs < 3600 {
-            let m = Int((secs / 60).rounded())
+            // Clamp so the top of the bucket (e.g. 59m59s) shows "59m ago", never
+            // "60m ago" — 3600s rolls cleanly to "1h ago".
+            let m = min(59, Int((secs / 60).rounded()))
             return String(localized: "agentPicker.recent.minutesAgo", defaultValue: "\(m)m ago")
         }
         if secs < 86_400 {
-            let h = Int((secs / 3600).rounded())
+            let h = min(23, Int((secs / 3600).rounded()))
             return String(localized: "agentPicker.recent.hoursAgo", defaultValue: "\(h)h ago")
         }
         let d = Int((secs / 86_400).rounded())

--- a/Sources/AgentPickerModel.swift
+++ b/Sources/AgentPickerModel.swift
@@ -25,8 +25,16 @@ enum PickerSysChip: Equatable {
     /// The gold chip label the view draws.
     var label: String {
         switch self {
-        case .blank: return "·blank·"
-        case .mode(let m): return "sys:\(m)"
+        case .blank:
+            return String(localized: "agentPicker.chip.blank", defaultValue: "·blank·")
+        case .mode(let mode):
+            return String(
+                format: String(
+                    localized: "agentPicker.chip.systemPrompt",
+                    defaultValue: "sys:%@"
+                ),
+                mode
+            )
         }
     }
 }
@@ -147,6 +155,9 @@ struct AgentPickerModel {
     let recentConfig: SavedAgentConfig?
     /// What ⏎ launches when nothing is keyboard-selected (design §5.1).
     let effectiveDefault: SavedAgentConfig
+    /// Installed state for the effective default, including transient
+    /// follow-recent recipes whose blank id cannot be found in the shortlist.
+    private let effectiveDefaultIsInstalled: Bool
     /// Precomputed render content.
     let content: AgentPickerContent
 
@@ -162,6 +173,7 @@ struct AgentPickerModel {
         let sorted = library.configs.sorted { $0.order < $1.order }
         self.configs = sorted
         self.effectiveDefault = effectiveDefault
+        self.effectiveDefaultIsInstalled = env.isInstalled(effectiveDefault.config.harness)
 
         let followRecent = library.default.mode == .followRecent
         let pinnedId = library.default.mode == .pinned ? library.default.configId : nil
@@ -275,7 +287,12 @@ struct AgentPickerModel {
     }
 
     private func launchOrNotInstalled(_ cfg: SavedAgentConfig) -> PickerAction {
-        if content.shortlist.first(where: { $0.config.id == cfg.id })?.isInstalled == false {
+        let shortlistInstalled = content.shortlist.first(where: {
+            !$0.config.id.isEmpty && $0.config.id == cfg.id
+        })?.isInstalled
+        let isInstalled = shortlistInstalled
+            ?? (cfg == effectiveDefault ? effectiveDefaultIsInstalled : true)
+        if !isInstalled {
             return .notInstalled(cfg)
         }
         return .launch(cfg)
@@ -291,7 +308,9 @@ struct AgentPickerModel {
     /// `deepseek/deepseek-chat-v3.1` → `deepseek-chat-v3.1`; `opus` → `opus`;
     /// `nil` → `inherit`.
     static func modelLabel(_ model: String?) -> String {
-        guard let m = nonEmpty(model) else { return "inherit" }
+        guard let m = nonEmpty(model) else {
+            return String(localized: "agentPicker.model.inherit", defaultValue: "inherit")
+        }
         if let slash = m.firstIndex(of: "/") { return String(m[m.index(after: slash)...]) }
         return m
     }
@@ -306,7 +325,8 @@ struct AgentPickerModel {
         // No derived provider. Router harnesses still read as "router"; everything
         // else (custom / unknown) shows nothing.
         switch harness {
-        case "opencode", "pi", "omp": return "router"
+        case "opencode", "pi", "omp":
+            return String(localized: "agentPicker.provider.router", defaultValue: "router")
         default: return ""
         }
     }
@@ -356,7 +376,11 @@ struct AgentPickerModel {
             cost: costString(recent.model, env: env),
             showLiveHint: harness != AgentType.claudeCode.rawValue,
             harnessDisplayName: env.displayName(harness),
-            isInstalled: env.isInstalled(harness)
+            // A saved recent row launches the saved recipe as it exists now
+            // (matching `effectiveDefault()`), so availability must follow that
+            // current harness too. The historical harness/model remain visible
+            // provenance in the sub-line.
+            isInstalled: env.isInstalled(cfg?.config.harness ?? harness)
         )
     }
 

--- a/Sources/AgentPickerModel.swift
+++ b/Sources/AgentPickerModel.swift
@@ -113,8 +113,10 @@ enum PickerAction: Equatable {
     case stats
     /// Dismiss the popover.
     case close
-    /// No-op (e.g. a number key past the shortlist, or a plain launch of a
-    /// not-installed harness — the caller may surface the shell-error hint).
+    /// A launch was requested for a harness that is not installed. The caller
+    /// keeps the picker open and surfaces the refusal.
+    case notInstalled(SavedAgentConfig)
+    /// No-op (for example, a number key past the shortlist).
     case none
 }
 
@@ -258,11 +260,23 @@ struct AgentPickerModel {
         }
     }
 
-    /// Launch iff installed; a plain launch of a not-installed harness is a no-op
-    /// the caller may turn into the "not installed" hint. Pin paths bypass this.
+    /// Pointer activation for the recent row follows the same installed guard as
+    /// keyboard activation.
+    func recentClickAction() -> PickerAction {
+        guard let recentConfig else { return .none }
+        return launchOrNotInstalled(recentConfig)
+    }
+
+    /// Launch iff installed; a plain launch of a not-installed harness returns an
+    /// explicit refusal so every input path can surface the same feedback. Pin
+    /// paths bypass this.
     private func launchOrNoop(_ cfg: SavedAgentConfig) -> PickerAction {
+        launchOrNotInstalled(cfg)
+    }
+
+    private func launchOrNotInstalled(_ cfg: SavedAgentConfig) -> PickerAction {
         if content.shortlist.first(where: { $0.config.id == cfg.id })?.isInstalled == false {
-            return .none
+            return .notInstalled(cfg)
         }
         return .launch(cfg)
     }

--- a/Sources/AgentPickerView.swift
+++ b/Sources/AgentPickerView.swift
@@ -1,0 +1,677 @@
+import SwiftUI
+import AppKit
+
+// MARK: - Agent launch picker: SwiftUI view + presenter (C11-181, tier 1)
+//
+// Renders `AgentPickerModel` (the pure view-model) as the A-button launch popover,
+// one-to-one with the binding prototype's `#popover`
+// (`docs/design-prototypes/model-picker/index.html`). Row click = launch now; the
+// pin glyph / ⌥-click = set default without launching. Keyboard ↑↓/⏎/⌥⏎/1–9/esc is
+// driven by a local NSEvent monitor the presenter installs while the popover is open.
+//
+// The popover host is pinned to `.darkAqua` so the void palette renders correctly in
+// either OS appearance (self-review F2); a live light-theme popover is the design's
+// stated follow-up. All colors come from `BrandColors` + the local `PickerPalette`
+// (the app's `surface2/surface3/goldGhost` have no shared token).
+
+/// Local palette for the tokens `BrandColors` does not expose (exact prototype hex),
+/// kept private so we never collide with another feature's shim.
+private enum PickerPalette {
+    /// #1f1f22
+    static let surface2 = Color(red: 0x1f / 255, green: 0x1f / 255, blue: 0x22 / 255)
+    /// #2d2d32
+    static let surface3 = Color(red: 0x2d / 255, green: 0x2d / 255, blue: 0x32 / 255)
+    /// gold @ 0.10 (the prototype's `--gold-ghost`)
+    static let goldGhost = BrandColors.goldSwiftUI.opacity(0.10)
+    /// sub-line provider segment brightness (prototype `rgba(232,232,232,0.55)`)
+    static let subProvider = BrandColors.whiteSwiftUI.opacity(0.55)
+    /// sub-line default segment (prototype `--dim`)
+    static let subDim = BrandColors.dimSwiftUI
+    static let popoverWidth: CGFloat = 462
+}
+
+// MARK: - Controller (ObservableObject bridging the value-type model to SwiftUI)
+
+/// Owns the mutable picker state and the action callbacks the presenter/workspace
+/// wire in. Reference type so the NSEvent key monitor can capture it safely.
+final class AgentPickerController: ObservableObject {
+    @Published var model: AgentPickerModel
+
+    /// Launch a specific config now (row click / ⏎ / 1–9 / recent).
+    var onLaunch: (SavedAgentConfig) -> Void = { _ in }
+    /// Pin a config as default without launching (pin glyph / ⌥-click / ⌥⏎).
+    var onPin: (SavedAgentConfig) -> Void = { _ in }
+    /// Flip follow-recent mode.
+    var onToggleFollowRecent: () -> Void = {}
+    /// Open the tier-2 configure sheet (C11-182 seam).
+    var onViewAll: () -> Void = {}
+    /// Open the stats view (C11-182 seam).
+    var onStats: () -> Void = {}
+    /// Surface the "not installed" hint for a plain launch of a dim row (§5.6).
+    var onNotInstalledHint: (AgentPickerRow) -> Void = { _ in }
+    /// Dismiss the popover (set by the presenter).
+    var onClose: () -> Void = {}
+    /// Rebuild the model from fresh store state (after a pin/toggle mutates disk),
+    /// so the ● default marker and header update live without closing. Returns
+    /// `nil` when the source is gone (workspace deallocated) — refresh is skipped.
+    var rebuild: () -> AgentPickerModel? = { nil }
+
+    init(model: AgentPickerModel) {
+        self.model = model
+    }
+
+    // MARK: Key + gesture handling
+
+    func handleKey(_ key: PickerKey, option: Bool) {
+        dispatch(model.handleKey(key, option: option))
+    }
+
+    /// A pointer click on a shortlist row: ⌥ pins, a plain click launches (or hints
+    /// when the harness is not installed).
+    func clickRow(_ row: AgentPickerRow, option: Bool) {
+        if option { pin(row.config); return }
+        guard row.isInstalled else { onNotInstalledHint(row); return }
+        onLaunch(row.config); onClose()
+    }
+
+    func clickPinGlyph(_ row: AgentPickerRow) { pin(row.config) }
+
+    func clickRecent() {
+        guard let cfg = model.recentConfig else { return }
+        onLaunch(cfg); onClose()
+    }
+
+    func toggleFollowRecent() {
+        onToggleFollowRecent(); refresh()
+    }
+
+    private func pin(_ config: SavedAgentConfig) {
+        onPin(config); refresh()
+    }
+
+    private func dispatch(_ action: PickerAction) {
+        switch action {
+        case .launch(let c): onLaunch(c); onClose()
+        case .pin(let c): pin(c)                     // stays open, ● moves (prototype)
+        case .toggleFollowRecent: toggleFollowRecent()
+        case .viewAll: onViewAll(); onClose()
+        case .stats: onStats(); onClose()
+        case .close: onClose()
+        case .none: break
+        }
+    }
+
+    /// Refresh the model in place (preserving the keyboard cursor) after a mutation.
+    private func refresh() {
+        guard var next = rebuild() else { return }
+        let sel = model.selectedIndex
+        next.selectedIndex = min(max(sel, -1), next.content.shortlist.count)
+        model = next
+    }
+}
+
+// MARK: - The popover view
+
+struct AgentPickerView: View {
+    @ObservedObject var controller: AgentPickerController
+
+    private var content: AgentPickerContent { controller.model.content }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            ForEach(Array(content.shortlist.enumerated()), id: \.element.config.id) { idx, row in
+                PickerRowView(
+                    row: row,
+                    isFocused: controller.model.selectedIndex == idx,
+                    followRecent: content.followRecent,
+                    onClick: { opt in controller.clickRow(row, option: opt) },
+                    onPin: { controller.clickPinGlyph(row) }
+                )
+                Divider().overlay(BrandColors.ruleSwiftUI.opacity(0.55))
+            }
+            if let recent = content.recent {
+                sectionRule(String(localized: "agentPicker.recent.section", defaultValue: "recent"))
+                RecentRowView(
+                    row: recent,
+                    isFocused: controller.model.selectedIndex == content.shortlist.count,
+                    onClick: { controller.clickRecent() }
+                )
+            }
+            footer
+            hintBar
+        }
+        .frame(width: PickerPalette.popoverWidth)
+        .background(BrandColors.surfaceSwiftUI)
+        .overlay(
+            RoundedRectangle(cornerRadius: 9).stroke(BrandColors.ruleSwiftUI, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 9))
+        .environment(\.colorScheme, .dark)
+    }
+
+    // MARK: Sections
+
+    private var header: some View {
+        HStack {
+            Text(String(localized: "agentPicker.header.launchAgent", defaultValue: "Launch agent"))
+                .ucLabel()
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.7))
+            Spacer()
+            if content.followRecent {
+                Text(String(localized: "agentPicker.header.following", defaultValue: "◉ following recent"))
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(BrandColors.goldSwiftUI)
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
+        .overlay(alignment: .bottom) { ruleLine }
+    }
+
+    private func sectionRule(_ label: String) -> some View {
+        HStack(spacing: 8) {
+            line
+            Text(label).ucLabel()
+            line
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 5)
+        .background(BrandColors.blackSwiftUI.opacity(0.5))
+    }
+
+    private var footer: some View {
+        VStack(spacing: 0) {
+            FooterRow(
+                icon: .checkbox(content.followRecent),
+                label: String(localized: "agentPicker.footer.followRecent", defaultValue: "Default follows most recent"),
+                trailingText: content.followRecent
+                    ? String(localized: "agentPicker.footer.followRecent.hint", defaultValue: "A launches whatever you last launched")
+                    : nil,
+                trailingKbd: nil,
+                action: { controller.toggleFollowRecent() }
+            )
+            FooterRow(
+                icon: .glyph("✎"),
+                label: String(localized: "agentPicker.footer.viewAll", defaultValue: "View all models & configs…"),
+                trailingText: nil,
+                trailingKbd: "⌘⏎",
+                action: { controller.onViewAll(); controller.onClose() }
+            )
+            FooterRow(
+                icon: .glyph("▤"),
+                label: String(localized: "agentPicker.footer.stats", defaultValue: "Launch stats"),
+                trailingText: content.statsHeadline,
+                trailingKbd: nil,
+                action: { controller.onStats(); controller.onClose() }
+            )
+        }
+        .background(BrandColors.blackSwiftUI.opacity(0.6))
+        .overlay(alignment: .top) { ruleLine }
+    }
+
+    private var hintBar: some View {
+        HStack(spacing: 6) {
+            KeyCap("↑↓"); hintText(String(localized: "agentPicker.hint.select", defaultValue: "select")); dot
+            KeyCap("⏎"); hintText(String(localized: "agentPicker.hint.launch", defaultValue: "launch")); dot
+            KeyCap("⌥⏎"); hintText(String(localized: "agentPicker.hint.setDefault", defaultValue: "set default")); dot
+            KeyCap("1–9"); hintText(String(localized: "agentPicker.hint.launchNth", defaultValue: "launch nth"))
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 7)
+        .background(BrandColors.blackSwiftUI.opacity(0.75))
+        .overlay(alignment: .top) { ruleLine }
+    }
+
+    // MARK: Bits
+
+    private func hintText(_ s: String) -> some View {
+        Text(s).font(.system(size: 10.5, design: .monospaced)).foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+    }
+    private var dot: some View {
+        Text("·").foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.25))
+    }
+    private var line: some View { Rectangle().fill(BrandColors.ruleSwiftUI).frame(height: 1) }
+    private var ruleLine: some View { Rectangle().fill(BrandColors.ruleSwiftUI).frame(height: 1) }
+}
+
+// MARK: - Shortlist row
+
+private struct PickerRowView: View {
+    let row: AgentPickerRow
+    let isFocused: Bool
+    let followRecent: Bool
+    let onClick: (Bool) -> Void
+    let onPin: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            PinCell(isDefault: row.isPinnedDefault, hovering: hovering, onPin: onPin)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 8) {
+                    Text(row.name)
+                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                        .foregroundStyle(BrandColors.whiteSwiftUI)
+                    if row.isRecentDefault && followRecent {
+                        DefaultTag(String(localized: "agentPicker.tag.recentDefault", defaultValue: "recent→default"))
+                    } else if row.isPinnedDefault {
+                        DefaultTag(String(localized: "agentPicker.tag.default", defaultValue: "default"))
+                    }
+                    if !row.isInstalled {
+                        Text(String(localized: "agentPicker.notInstalled", defaultValue: "NOT INSTALLED"))
+                            .font(.system(size: 8.5, design: .monospaced))
+                            .tracking(0.5)
+                            .foregroundStyle(BrandColors.dimSwiftUI)
+                    }
+                }
+                SubLine(row.subLine)
+            }
+            Spacer(minLength: 6)
+            HStack(spacing: 7) {
+                if let sys = row.sysChip { SysChipView(sys) }
+                if let effort = row.effortChip { EffortChipView(effort) }
+                Text(row.cost ?? "")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
+                    .frame(minWidth: 82, alignment: .trailing)
+                KeyCap("\(row.keyBadge)").frame(width: 16)
+            }
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 12)
+        .padding(.vertical, 8)
+        .opacity(row.isInstalled ? 1 : 0.42)
+        .background(rowBackground)
+        .overlay(alignment: .leading) {
+            if isFocused { Rectangle().fill(BrandColors.goldSwiftUI).frame(width: 2) }
+        }
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 && row.isInstalled }
+        .onTapGesture { onClick(NSEvent.modifierFlags.contains(.option)) }
+    }
+
+    private var rowBackground: some View {
+        Group {
+            if isFocused { BrandColors.goldFaintSwiftUI }
+            else if hovering { BrandColors.whiteSwiftUI.opacity(0.03) }
+            else { Color.clear }
+        }
+    }
+}
+
+// MARK: - Recent row
+
+private struct RecentRowView: View {
+    let row: AgentPickerRecentRow
+    let isFocused: Bool
+    let onClick: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text("↻")
+                .font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.55))
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(row.name)
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundStyle(BrandColors.whiteSwiftUI)
+                    Text(row.relativeTime)
+                        .font(.system(size: 9.5, design: .monospaced))
+                        .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+                }
+                SubLine(row.subLine)
+            }
+            Spacer(minLength: 6)
+            HStack(spacing: 7) {
+                if row.showLiveHint { LiveHintBadge(harness: row.harnessDisplayName) }
+                Text(row.cost ?? "")
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
+                    .frame(minWidth: 82, alignment: .trailing)
+            }
+        }
+        .padding(.leading, 10)
+        .padding(.trailing, 12)
+        .padding(.vertical, 8)
+        .opacity(row.isInstalled ? 1 : 0.42)
+        .background(isFocused ? BrandColors.goldFaintSwiftUI : (hovering ? BrandColors.whiteSwiftUI.opacity(0.03) : Color.clear))
+        .overlay(alignment: .leading) {
+            if isFocused { Rectangle().fill(BrandColors.goldSwiftUI).frame(width: 2) }
+        }
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        .onTapGesture { onClick() }
+    }
+}
+
+// MARK: - Small components
+
+private struct PinCell: View {
+    let isDefault: Bool
+    let hovering: Bool
+    let onPin: () -> Void
+
+    var body: some View {
+        ZStack {
+            if isDefault {
+                Text("●").font(.system(size: 11)).foregroundStyle(BrandColors.goldSwiftUI)
+            } else {
+                Text("○")
+                    .font(.system(size: 10))
+                    .foregroundStyle(hovering ? BrandColors.whiteSwiftUI.opacity(0.4) : Color.clear)
+                    .contentShape(Rectangle())
+                    .onTapGesture { onPin() }
+                    .help(String(localized: "agentPicker.pin.help", defaultValue: "Set as default (⌥-click)"))
+            }
+        }
+        .frame(width: 20)
+    }
+}
+
+private struct DefaultTag: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+    var body: some View {
+        Text(text)
+            .font(.system(size: 8.5, weight: .medium, design: .monospaced))
+            .tracking(0.8)
+            .foregroundStyle(BrandColors.goldSwiftUI)
+            .padding(.horizontal, 4).padding(.vertical, 0.5)
+            .overlay(RoundedRectangle(cornerRadius: 3).stroke(BrandColors.goldFaintSwiftUI, lineWidth: 0.5))
+    }
+}
+
+/// `harness · provider · model` with the provider segment brightened (prototype).
+private struct SubLine: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+    var body: some View {
+        let parts = text.components(separatedBy: " · ")
+        return HStack(spacing: 0) {
+            ForEach(Array(parts.enumerated()), id: \.offset) { i, part in
+                if i > 0 {
+                    Text(" · ").foregroundStyle(PickerPalette.subDim)
+                }
+                // Middle segment of a 3-part line is the provider.
+                Text(part).foregroundStyle(parts.count == 3 && i == 1 ? PickerPalette.subProvider : PickerPalette.subDim)
+            }
+        }
+        .font(.system(size: 10.5, design: .monospaced))
+        .lineLimit(1)
+    }
+}
+
+private struct EffortChipView: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9, weight: .medium, design: .monospaced))
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.75))
+            .padding(.horizontal, 5).padding(.vertical, 1)
+            .background(PickerPalette.surface3)
+            .overlay(RoundedRectangle(cornerRadius: 3).stroke(BrandColors.ruleSwiftUI, lineWidth: 0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}
+
+private struct SysChipView: View {
+    let sys: PickerSysChip
+    init(_ sys: PickerSysChip) { self.sys = sys }
+    var body: some View {
+        Text(sys.label)
+            .font(.system(size: 9, weight: .medium, design: .monospaced))
+            .foregroundStyle(BrandColors.goldSwiftUI)
+            .padding(.horizontal, 5).padding(.vertical, 1)
+            .background(PickerPalette.goldGhost)
+            .overlay(RoundedRectangle(cornerRadius: 3).stroke(BrandColors.goldFaintSwiftUI, lineWidth: 0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}
+
+private struct KeyCap: View {
+    let text: String
+    init(_ text: String) { self.text = text }
+    var body: some View {
+        Text(text)
+            .font(.system(size: 9.5, weight: .medium, design: .monospaced))
+            .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.78))
+            .padding(.horizontal, 4).padding(.vertical, 0.5)
+            .background(PickerPalette.surface3)
+            .overlay(RoundedRectangle(cornerRadius: 3).stroke(BrandColors.ruleSwiftUI, lineWidth: 0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}
+
+/// The quiet ⓘ hint on a non-claude recent row (design §8.4).
+private struct LiveHintBadge: View {
+    let harness: String
+    @State private var hovering = false
+    var body: some View {
+        Text("i")
+            .font(.system(size: 8.5, design: .monospaced))
+            .foregroundStyle(hovering ? BrandColors.goldSwiftUI : BrandColors.dimSwiftUI)
+            .frame(width: 13, height: 13)
+            .overlay(Circle().stroke(hovering ? BrandColors.goldFaintSwiftUI : BrandColors.ruleSwiftUI, lineWidth: 0.5))
+            .onHover { hovering = $0 }
+            .help(String(
+                localized: "agentPicker.recent.liveHint",
+                defaultValue: "\(harness) does not report live model changes — this value was captured at launch. A mid-session /model switch inside the TUI is not observed."
+            ))
+    }
+}
+
+// MARK: - Footer row
+
+private struct FooterRow: View {
+    enum Icon { case checkbox(Bool), glyph(String) }
+    let icon: Icon
+    let label: String
+    let trailingText: String?
+    let trailingKbd: String?
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        HStack(spacing: 9) {
+            iconView.frame(width: 16)
+            Text(label)
+                .font(.system(size: 11.5, design: .monospaced))
+                .foregroundStyle(hovering ? BrandColors.whiteSwiftUI : BrandColors.whiteSwiftUI.opacity(0.8))
+            Spacer(minLength: 6)
+            if let t = trailingText {
+                Text(t).font(.system(size: 10, design: .monospaced)).foregroundStyle(BrandColors.dimSwiftUI)
+            }
+            if let k = trailingKbd { KeyCap(k) }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .background(hovering ? BrandColors.whiteSwiftUI.opacity(0.03) : Color.clear)
+        .contentShape(Rectangle())
+        .onHover { hovering = $0 }
+        .onTapGesture { action() }
+    }
+
+    @ViewBuilder private var iconView: some View {
+        switch icon {
+        case .checkbox(let on): CheckboxGlyph(on: on)
+        case .glyph(let g):
+            Text(g).font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(hovering ? BrandColors.goldSwiftUI : BrandColors.dimSwiftUI)
+        }
+    }
+}
+
+private struct CheckboxGlyph: View {
+    let on: Bool
+    var body: some View {
+        RoundedRectangle(cornerRadius: 3)
+            .fill(on ? BrandColors.goldSwiftUI : Color.clear)
+            .frame(width: 13, height: 13)
+            .overlay(RoundedRectangle(cornerRadius: 3).stroke(on ? BrandColors.goldSwiftUI : BrandColors.dimSwiftUI, lineWidth: 1))
+            .overlay(
+                Text(on ? "✓" : "")
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .foregroundStyle(BrandColors.blackSwiftUI)
+            )
+    }
+}
+
+// MARK: - View helpers
+
+private extension View {
+    func ucLabel() -> some View {
+        self.font(.system(size: 9.5, weight: .medium, design: .monospaced))
+            .tracking(1.2)
+            .textCase(.uppercase)
+            .foregroundStyle(BrandColors.dimSwiftUI)
+    }
+}
+
+// MARK: - Harness install probe (best-effort PATH lookup, cached)
+
+/// Cached "is this harness on PATH?" probe (design §5.6). No such probe exists in
+/// the repo, so this is a small first cut: look up the harness's factory-command
+/// executable across the app PATH plus the usual user bin dirs. Biased toward
+/// "installed" (a GUI app's PATH is narrow; a spurious dim is worse than none — a
+/// forced launch still degrades to the shell's own error, and the row stays
+/// pinnable). Cached per kind for the session.
+enum AgentHarnessInstallProbe {
+    private static let lock = NSLock()
+    private static var cache: [String: Bool] = [:]
+
+    /// Extra dirs a login shell usually has but a Finder-launched GUI app may not.
+    private static let extraDirs: [String] = {
+        let home = NSHomeDirectory()
+        return [
+            "/opt/homebrew/bin", "/usr/local/bin", "/usr/bin", "/bin",
+            "\(home)/.local/bin", "\(home)/.bun/bin", "\(home)/.npm-global/bin",
+            "\(home)/.cargo/bin", "\(home)/go/bin",
+        ]
+    }()
+
+    static func isInstalled(_ harnessKind: String) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        if let cached = cache[harnessKind] { return cached }
+        let result = probe(harnessKind)
+        cache[harnessKind] = result
+        return result
+    }
+
+    private static func probe(_ harnessKind: String) -> Bool {
+        guard let manifest = AgentRegistry.shared.manifest(forKind: harnessKind) else {
+            return true // custom / unknown kind — let the shell surface any error
+        }
+        guard let exe = manifest.factoryCommand.split(separator: " ").first.map(String.init), !exe.isEmpty else {
+            return true
+        }
+        if exe.hasPrefix("/") { return FileManager.default.isExecutableFile(atPath: exe) }
+        let pathDirs = (ProcessInfo.processInfo.environment["PATH"] ?? "").split(separator: ":").map(String.init)
+        for dir in pathDirs + extraDirs {
+            let candidate = (dir as NSString).appendingPathComponent(exe)
+            if FileManager.default.isExecutableFile(atPath: candidate) { return true }
+        }
+        return false
+    }
+}
+
+// MARK: - Presenter (NSPopover host + key monitor)
+
+/// App-lifetime presenter that hosts the picker in an arrowless `NSPopover` anchored
+/// to a rect on the window's contentView, and owns the local keyDown monitor's
+/// install/teardown (self-review F3/F4).
+final class AgentPickerPresenter: NSObject, NSPopoverDelegate {
+    static let shared = AgentPickerPresenter()
+
+    private var popover: NSPopover?
+    private var keyMonitor: Any?
+    private weak var controller: AgentPickerController?
+
+    /// Present (or, if already open, toggle closed). `screenPoint` anchors under the
+    /// right-clicked A button; `nil` anchors at the window's top-trailing corner
+    /// (⌘⇧A / menu path).
+    func present(controller: AgentPickerController, in window: NSWindow, at screenPoint: NSPoint?) {
+        if let p = popover, p.isShown { dismiss(); return }
+        guard let contentView = window.contentView else { return }
+
+        self.controller = controller
+        controller.onClose = { [weak self] in self?.dismiss() }
+
+        let host = NSHostingController(rootView: AgentPickerView(controller: controller).fixedSize())
+        host.view.appearance = NSAppearance(named: .darkAqua)   // F2: void chrome in any OS mode
+        host.sizingOptions = [.preferredContentSize]
+
+        let pop = NSPopover()
+        pop.behavior = .transient
+        pop.animates = true
+        pop.appearance = NSAppearance(named: .darkAqua)
+        pop.setValue(true, forKeyPath: "shouldHideAnchor")      // arrowless
+        pop.contentViewController = host
+        pop.delegate = self
+        self.popover = pop
+
+        let rect: NSRect
+        if let sp = screenPoint {
+            let winPt = window.convertPoint(fromScreen: sp)
+            let cvPt = contentView.convert(winPt, from: nil)
+            rect = NSRect(x: cvPt.x, y: cvPt.y, width: 1, height: 1)
+        } else {
+            let b = contentView.bounds
+            // Top-trailing corner (contentView is a flipped NSHostingView: minY = top).
+            let topY = contentView.isFlipped ? b.minY : b.maxY
+            rect = NSRect(x: b.maxX - 130, y: topY, width: 1, height: 1)
+        }
+        pop.show(relativeTo: rect, of: contentView, preferredEdge: .maxY)
+        installKeyMonitor()
+    }
+
+    func dismiss() {
+        removeKeyMonitor()
+        popover?.performClose(nil)
+        popover = nil
+        controller = nil
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        removeKeyMonitor()
+        popover = nil
+        controller = nil
+    }
+
+    private func installKeyMonitor() {
+        removeKeyMonitor()
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self, let controller = self.controller, self.popover?.isShown == true else { return event }
+            let option = event.modifierFlags.contains(.option)
+            let key: PickerKey?
+            switch event.keyCode {
+            case 125: key = .down
+            case 126: key = .up
+            case 36, 76: key = .enter
+            case 53: key = .escape
+            default:
+                if let ch = event.charactersIgnoringModifiers, let n = Int(ch), (1...9).contains(n) {
+                    key = .digit(n)
+                } else {
+                    key = nil
+                }
+            }
+            guard let k = key else { return event }
+            controller.handleKey(k, option: option)
+            return nil // swallow handled keys
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let m = keyMonitor { NSEvent.removeMonitor(m); keyMonitor = nil }
+    }
+}

--- a/Sources/AgentPickerView.swift
+++ b/Sources/AgentPickerView.swift
@@ -48,7 +48,7 @@ final class AgentPickerController: ObservableObject {
     /// Open the stats view (C11-182 seam).
     var onStats: () -> Void = {}
     /// Surface the "not installed" hint for a plain launch of a dim row (§5.6).
-    var onNotInstalledHint: (AgentPickerRow) -> Void = { _ in }
+    var onNotInstalledHint: (SavedAgentConfig) -> Void = { _ in }
     /// Dismiss the popover (set by the presenter).
     var onClose: () -> Void = {}
     /// Rebuild the model from fresh store state (after a pin/toggle mutates disk),
@@ -70,15 +70,13 @@ final class AgentPickerController: ObservableObject {
     /// when the harness is not installed).
     func clickRow(_ row: AgentPickerRow, option: Bool) {
         if option { pin(row.config); return }
-        guard row.isInstalled else { onNotInstalledHint(row); return }
-        onLaunch(row.config); onClose()
+        dispatch(row.isInstalled ? .launch(row.config) : .notInstalled(row.config))
     }
 
     func clickPinGlyph(_ row: AgentPickerRow) { pin(row.config) }
 
     func clickRecent() {
-        guard let cfg = model.recentConfig else { return }
-        onLaunch(cfg); onClose()
+        dispatch(model.recentClickAction())
     }
 
     func toggleFollowRecent() {
@@ -93,6 +91,7 @@ final class AgentPickerController: ObservableObject {
         switch action {
         case .launch(let c): onLaunch(c); onClose()
         case .pin(let c): pin(c)                     // stays open, ● moves (prototype)
+        case .notInstalled(let c): onNotInstalledHint(c)
         case .toggleFollowRecent: toggleFollowRecent()
         case .viewAll: onViewAll(); onClose()
         case .stats: onStats(); onClose()
@@ -330,6 +329,12 @@ private struct RecentRowView: View {
                     Text(row.relativeTime)
                         .font(.system(size: 9.5, design: .monospaced))
                         .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+                    if !row.isInstalled {
+                        Text(String(localized: "agentPicker.notInstalled", defaultValue: "NOT INSTALLED"))
+                            .font(.system(size: 8.5, design: .monospaced))
+                            .tracking(0.5)
+                            .foregroundStyle(BrandColors.dimSwiftUI)
+                    }
                 }
                 SubLine(row.subLine, brightenProvider: false)
             }
@@ -348,7 +353,7 @@ private struct RecentRowView: View {
         .padding(.trailing, 12)
         .padding(.vertical, 8)
         .opacity(row.isInstalled ? 1 : 0.42)
-        .background(isFocused ? BrandColors.goldFaintSwiftUI : (hovering ? BrandColors.whiteSwiftUI.opacity(0.03) : Color.clear))
+        .background(isFocused ? BrandColors.goldFaintSwiftUI : (hovering && row.isInstalled ? BrandColors.whiteSwiftUI.opacity(0.03) : Color.clear))
         .overlay(alignment: .leading) {
             if isFocused { Rectangle().fill(BrandColors.goldSwiftUI).frame(width: 2) }
         }

--- a/Sources/AgentPickerView.swift
+++ b/Sources/AgentPickerView.swift
@@ -62,8 +62,8 @@ final class AgentPickerController: ObservableObject {
 
     // MARK: Key + gesture handling
 
-    func handleKey(_ key: PickerKey, option: Bool) {
-        dispatch(model.handleKey(key, option: option))
+    func handleKey(_ key: PickerKey, option: Bool, command: Bool = false) {
+        dispatch(model.handleKey(key, option: option, command: command))
     }
 
     /// A pointer click on a shortlist row: ⌥ pins, a plain click launches (or hints
@@ -105,7 +105,9 @@ final class AgentPickerController: ObservableObject {
     private func refresh() {
         guard var next = rebuild() else { return }
         let sel = model.selectedIndex
-        next.selectedIndex = min(max(sel, -1), next.content.shortlist.count)
+        // Max nav index = last shortlist row, plus the recent row when present.
+        let maxSel = next.content.shortlist.count - 1 + (next.content.recent != nil ? 1 : 0)
+        next.selectedIndex = min(max(sel, -1), maxSel)
         model = next
     }
 }
@@ -155,8 +157,7 @@ struct AgentPickerView: View {
     private var header: some View {
         HStack {
             Text(String(localized: "agentPicker.header.launchAgent", defaultValue: "Launch agent"))
-                .ucLabel()
-                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.7))
+                .ucLabel(color: BrandColors.whiteSwiftUI.opacity(0.7))
             Spacer()
             if content.followRecent {
                 Text(String(localized: "agentPicker.header.following", defaultValue: "◉ following recent"))
@@ -290,14 +291,17 @@ private struct PickerRowView: View {
             if isFocused { Rectangle().fill(BrandColors.goldSwiftUI).frame(width: 2) }
         }
         .contentShape(Rectangle())
-        .onHover { hovering = $0 && row.isInstalled }
+        // Hover is tracked even for not-installed rows so the pin ○ stays
+        // discoverable (they remain pinnable); only the background highlight is
+        // gated to installed rows (prototype: `.cfg-row.disabled:hover { transparent }`).
+        .onHover { hovering = $0 }
         .onTapGesture { onClick(NSEvent.modifierFlags.contains(.option)) }
     }
 
     private var rowBackground: some View {
         Group {
             if isFocused { BrandColors.goldFaintSwiftUI }
-            else if hovering { BrandColors.whiteSwiftUI.opacity(0.03) }
+            else if hovering && row.isInstalled { BrandColors.whiteSwiftUI.opacity(0.03) }
             else { Color.clear }
         }
     }
@@ -327,7 +331,7 @@ private struct RecentRowView: View {
                         .font(.system(size: 9.5, design: .monospaced))
                         .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
                 }
-                SubLine(row.subLine)
+                SubLine(row.subLine, brightenProvider: false)
             }
             Spacer(minLength: 6)
             HStack(spacing: 7) {
@@ -336,6 +340,8 @@ private struct RecentRowView: View {
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
                     .frame(minWidth: 82, alignment: .trailing)
+                // Empty key-cap slot so the recent cost aligns with shortlist costs.
+                Color.clear.frame(width: 16, height: 1)
             }
         }
         .padding(.leading, 10)
@@ -383,6 +389,7 @@ private struct DefaultTag: View {
         Text(text)
             .font(.system(size: 8.5, weight: .medium, design: .monospaced))
             .tracking(0.8)
+            .textCase(.uppercase)
             .foregroundStyle(BrandColors.goldSwiftUI)
             .padding(.horizontal, 4).padding(.vertical, 0.5)
             .overlay(RoundedRectangle(cornerRadius: 3).stroke(BrandColors.goldFaintSwiftUI, lineWidth: 0.5))
@@ -392,7 +399,14 @@ private struct DefaultTag: View {
 /// `harness · provider · model` with the provider segment brightened (prototype).
 private struct SubLine: View {
     let text: String
-    init(_ text: String) { self.text = text }
+    /// Shortlist sub-lines are `harness · provider · model` — brighten the middle
+    /// (provider). The recent sub-line is `harness · model · effort`, which has no
+    /// provider span, so it stays fully dim (prototype `.cfg-sub` with no `.prov`).
+    let brightenProvider: Bool
+    init(_ text: String, brightenProvider: Bool = true) {
+        self.text = text
+        self.brightenProvider = brightenProvider
+    }
     var body: some View {
         let parts = text.components(separatedBy: " · ")
         return HStack(spacing: 0) {
@@ -400,8 +414,7 @@ private struct SubLine: View {
                 if i > 0 {
                     Text(" · ").foregroundStyle(PickerPalette.subDim)
                 }
-                // Middle segment of a 3-part line is the provider.
-                Text(part).foregroundStyle(parts.count == 3 && i == 1 ? PickerPalette.subProvider : PickerPalette.subDim)
+                Text(part).foregroundStyle(brightenProvider && parts.count == 3 && i == 1 ? PickerPalette.subProvider : PickerPalette.subDim)
             }
         }
         .font(.system(size: 10.5, design: .monospaced))
@@ -529,11 +542,11 @@ private struct CheckboxGlyph: View {
 // MARK: - View helpers
 
 private extension View {
-    func ucLabel() -> some View {
+    func ucLabel(color: Color = BrandColors.dimSwiftUI) -> some View {
         self.font(.system(size: 9.5, weight: .medium, design: .monospaced))
             .tracking(1.2)
             .textCase(.uppercase)
-            .foregroundStyle(BrandColors.dimSwiftUI)
+            .foregroundStyle(color)
     }
 }
 
@@ -596,11 +609,18 @@ final class AgentPickerPresenter: NSObject, NSPopoverDelegate {
     private var keyMonitor: Any?
     private weak var controller: AgentPickerController?
 
-    /// Present (or, if already open, toggle closed). `screenPoint` anchors under the
-    /// right-clicked A button; `nil` anchors at the window's top-trailing corner
-    /// (⌘⇧A / menu path).
+    /// Present the picker. `screenPoint` anchors under the right-clicked A button
+    /// (pointer path); `nil` anchors at the window's top-trailing corner (⌘⇧A / menu).
+    ///
+    /// Re-entry policy: only the keyboard path (nil `screenPoint`) toggles closed —
+    /// pressing ⌘⇧A again dismisses. The pointer path is idempotent: if the popover
+    /// is already shown, a repeat present is a no-op, so a double-evaluated
+    /// `.contextMenu` builder within one right-click can't open-then-close (flicker).
     func present(controller: AgentPickerController, in window: NSWindow, at screenPoint: NSPoint?) {
-        if let p = popover, p.isShown { dismiss(); return }
+        if let p = popover, p.isShown {
+            if screenPoint == nil { dismiss() }
+            return
+        }
         guard let contentView = window.contentView else { return }
 
         self.controller = controller
@@ -642,6 +662,10 @@ final class AgentPickerPresenter: NSObject, NSPopoverDelegate {
     }
 
     func popoverDidClose(_ notification: Notification) {
+        // Ignore a delayed close callback for a popover we've already replaced —
+        // otherwise a rapid toggle/reopen inside the close animation would let the
+        // stale close tear down the NEW popover's key monitor + presenter state.
+        guard (notification.object as? NSPopover) === popover else { return }
         removeKeyMonitor()
         popover = nil
         controller = nil
@@ -650,8 +674,14 @@ final class AgentPickerPresenter: NSObject, NSPopoverDelegate {
     private func installKeyMonitor() {
         removeKeyMonitor()
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            // Gate on the popover being shown. (A tighter "event belongs to the
+            // popover's own window" check was considered but deferred: an .transient
+            // popover already auto-dismisses on outside interaction, so the
+            // shown-but-not-key window is negligible, and the window-identity
+            // assumption can't be verified without a runtime pass.)
             guard let self, let controller = self.controller, self.popover?.isShown == true else { return event }
             let option = event.modifierFlags.contains(.option)
+            let command = event.modifierFlags.contains(.command)
             let key: PickerKey?
             switch event.keyCode {
             case 125: key = .down
@@ -666,7 +696,7 @@ final class AgentPickerPresenter: NSObject, NSPopoverDelegate {
                 }
             }
             guard let k = key else { return event }
-            controller.handleKey(k, option: option)
+            controller.handleKey(k, option: option, command: command)
             return nil // swallow handled keys
         }
     }

--- a/Sources/AgentPickerView.swift
+++ b/Sources/AgentPickerView.swift
@@ -650,7 +650,11 @@ final class AgentPickerPresenter: NSObject, NSPopoverDelegate {
             let topY = contentView.isFlipped ? b.minY : b.maxY
             rect = NSRect(x: b.maxX - 130, y: topY, width: 1, height: 1)
         }
-        pop.show(relativeTo: rect, of: contentView, preferredEdge: .maxY)
+        // Drop the popover downward from the anchor in either coordinate convention:
+        // on a flipped view "below" is the maxY edge, on a non-flipped view it's minY.
+        // (NSPopover self-corrects if there's no room, but pick the right side first.)
+        let preferredEdge: NSRectEdge = contentView.isFlipped ? .maxY : .minY
+        pop.show(relativeTo: rect, of: contentView, preferredEdge: preferredEdge)
         installKeyMonitor()
     }
 

--- a/Sources/AgentPickerView.swift
+++ b/Sources/AgentPickerView.swift
@@ -613,6 +613,38 @@ final class AgentPickerPresenter: NSObject, NSPopoverDelegate {
     private var popover: NSPopover?
     private var keyMonitor: Any?
     private weak var controller: AgentPickerController?
+    private var editorClosedObserver: NSObjectProtocol?
+    private var returnToPicker: (() -> Void)?
+
+    private override init() {
+        super.init()
+        editorClosedObserver = NotificationCenter.default.addObserver(
+            forName: AgentConfigEditorRequest.closedName,
+            object: nil,
+            queue: .main
+        ) { [weak self] note in
+            guard let self else { return }
+            let reopen = self.returnToPicker
+            self.returnToPicker = nil
+            guard AgentConfigEditorRequest.shouldReturnToPopover(from: note) else { return }
+            DispatchQueue.main.async {
+                reopen?()
+            }
+        }
+    }
+
+    deinit {
+        if let editorClosedObserver {
+            NotificationCenter.default.removeObserver(editorClosedObserver)
+        }
+    }
+
+    /// Arm the one-shot route back from the tier-2 editor. A launch posts a
+    /// close with `returnToPopover == false`, which clears this action without
+    /// reopening; Back/Escape consumes it and restores the same pane/window.
+    func armReturnToPicker(_ action: @escaping () -> Void) {
+        returnToPicker = action
+    }
 
     /// Present the picker. `screenPoint` anchors under the right-clicked A button
     /// (pointer path); `nil` anchors at the window's top-trailing corner (⌘⇧A / menu).

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5513,9 +5513,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// focused pane (⌘⇧A / menu path). The picker anchors at the window's
     /// top-trailing corner when there's no click location.
     func presentAgentPickerForActiveWorkspace() {
-        guard let workspace = tabManager?.selectedWorkspace,
+        let preferredWindow = [NSApp.keyWindow, NSApp.mainWindow]
+            .compactMap { $0 }
+            .first(where: { isMainTerminalWindow($0) })
+        guard let manager = synchronizeActiveMainWindowContext(preferredWindow: preferredWindow),
+              let workspace = manager.selectedWorkspace,
               let pane = workspace.bonsplitController.focusedPaneId else { return }
-        workspace.presentAgentPicker(inPane: pane, at: nil)
+
+        let managerWindow = mainWindowContexts.values
+            .first(where: { $0.tabManager === manager })
+            .flatMap { $0.window ?? windowForMainWindowId($0.windowId) }
+        guard let window = preferredWindow ?? managerWindow else { return }
+        workspace.presentAgentPicker(inPane: pane, window: window, at: nil)
     }
 
     private func clearCommandPalettePendingOpen(for window: NSWindow?) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5509,6 +5509,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    /// C11-181: open the tier-1 agent launch picker for the active workspace's
+    /// focused pane (⌘⇧A / menu path). The picker anchors at the window's
+    /// top-trailing corner when there's no click location.
+    func presentAgentPickerForActiveWorkspace() {
+        guard let workspace = tabManager?.selectedWorkspace,
+              let pane = workspace.bonsplitController.focusedPaneId else { return }
+        workspace.presentAgentPicker(inPane: pane, at: nil)
+    }
+
     private func clearCommandPalettePendingOpen(for window: NSWindow?) {
         guard let window,
               let windowId = mainWindowId(for: window) else { return }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12450,7 +12450,7 @@ extension Workspace: BonsplitDelegate {
         controller.onStats = {
             AppDelegate.shared?.openAgentConfigEditor(focus: .stats, origin: .popover)
         }
-        controller.onNotInstalledHint = { _ in }
+        controller.onNotInstalledHint = { _ in NSSound.beep() }
 
         AgentPickerPresenter.shared.present(controller: controller, in: window, at: screenPoint)
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12437,11 +12437,19 @@ extension Workspace: BonsplitDelegate {
             let current = AgentConfigLibraryStore.shared.current.default.mode
             try? AgentConfigLibraryStore.shared.setMode(current == .followRecent ? .pinned : .followRecent)
         }
-        // Tier-2 (configure sheet / stats view) is C11-182; no seam exists on
-        // main yet, so these are no-ops today. The Launch-stats row still shows a
-        // real inline headline below.
-        controller.onViewAll = {}
-        controller.onStats = {}
+        // Tier-2 (configure sheet / stats view) is C11-182, now on main. "View
+        // all" opens the editor focused on the current default (or a new config
+        // when the effective default is a transient with no id); "Launch stats"
+        // opens the stats view. `origin: .popover` lets the sheet order Settings
+        // out on close. The Launch-stats row also shows a real inline headline.
+        controller.onViewAll = {
+            let eff = AgentConfigLibraryStore.shared.effectiveDefault()
+            let focus: AgentConfigEditorFocus = eff.id.isEmpty ? .new : .config(eff.id)
+            AppDelegate.shared?.openAgentConfigEditor(focus: focus, origin: .popover)
+        }
+        controller.onStats = {
+            AppDelegate.shared?.openAgentConfigEditor(focus: .stats, origin: .popover)
+        }
         controller.onNotInstalledHint = { _ in }
 
         AgentPickerPresenter.shared.present(controller: controller, in: window, at: screenPoint)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12144,6 +12144,10 @@ extension Workspace: BonsplitDelegate {
     /// `explicitAgent` lets the caller override the configured default —
     /// used by the right-click menu's "launch this one now" affordance and
     /// the `c11 default-agent launch --agent <type>` socket command.
+    /// `explicitConfig` (C11-181) launches a *specific* saved config now — the
+    /// A-button picker's "row click = launch". When set it takes precedence over
+    /// `effectiveDefault()`; when both it and `explicitAgent` are nil the plain
+    /// left-click path (launch `effectiveDefault()`) is unchanged.
     /// - Parameter source: launch-stats provenance (C11-178). Defaults to
     ///   `.aButton` (the real UI spawn button); the CLI `default-agent launch`
     ///   new-surface path passes `.launchAgent` so button-clicks and CLI launches
@@ -12170,10 +12174,10 @@ extension Workspace: BonsplitDelegate {
         let resolvedSystemPromptMode: String?
         let savedConfigId: String?
 
-        // A caller-chosen config (Settings "Save & Launch", C11-182) launches
-        // exactly that recipe. Otherwise a plain left-click consults the
-        // saved-config library's `effectiveDefault()`; an explicit agent keeps
-        // `nil` here and takes the raw-harness path below.
+        // A caller-chosen config (Settings "Save & Launch", C11-182; or the
+        // C11-181 A-button picker) launches exactly that recipe. Otherwise a plain
+        // left-click consults the saved-config library's `effectiveDefault()`; an
+        // explicit agent keeps `nil` here and takes the raw-harness path below.
         let overlaySaved: SavedAgentConfig?
         if let explicitConfig {
             overlaySaved = explicitConfig
@@ -12390,24 +12394,90 @@ extension Workspace: BonsplitDelegate {
 
     func splitTabBar(_ controller: BonsplitController, menuItemsForNewTabKind kind: String, inPane pane: PaneID) -> [BonsplitNewTabMenuItem] {
         guard kind == "agent" else { return [] }
-        let current = DefaultAgentConfigStore.shared.current.defaultAgent
-        return AgentType.allCases.map { type in
-            BonsplitNewTabMenuItem(
-                id: type.rawValue,
-                label: type.displayName,
-                isCurrent: type == current
-            )
+        // C11-181: a right-click on the A button opens the rich launch picker
+        // popover instead of a native menu — the picker replaces both the old
+        // 9-harness menu AND its click-sets-default gesture (design §5/§8.8). We
+        // reuse bonsplit's existing `.contextMenu` trigger with ZERO vendor edits:
+        // open the popover as a side-effect and return `[]` so no native menu is
+        // shown. Guard on a genuine right-mouse event so a SwiftUI eager
+        // menu-content diff (no right-click in flight) can't spuriously open it.
+        if let event = NSApp.currentEvent,
+           event.type == .rightMouseDown || event.type == .rightMouseUp {
+            let location = NSEvent.mouseLocation
+            DispatchQueue.main.async { [weak self] in
+                self?.presentAgentPicker(inPane: pane, at: location)
+            }
         }
+        return []
     }
 
     func splitTabBar(_ controller: BonsplitController, didSelectNewTabMenuItem itemId: String, forKind kind: String, inPane pane: PaneID) {
-        guard kind == "agent",
-              let chosen = AgentType(rawValue: itemId) else { return }
-        // Update the default only; the next left-click on A spawns the chosen
-        // agent. Launching here would contradict right-click semantics (a
-        // preference gesture, not an action gesture).
-        DefaultAgentConfigStore.shared.setDefaultAgent(chosen)
-        refreshSplitButtonTooltips()
+        // C11-181: unreachable — `menuItemsForNewTabKind` now returns `[]` and
+        // routes the right-click to the picker popover, which owns launch + pin.
+        // Kept for delegate conformance; no-op by design.
+    }
+
+    /// Present the tier-1 agent launch picker popover anchored to the A button
+    /// (design §5.1). `screenPoint` anchors under the right-clicked button; `nil`
+    /// (⌘⇧A / menu) anchors at the window's top-trailing corner. Row click =
+    /// launch now; pin / ⌥-click = set default without launching (C11-181).
+    func presentAgentPicker(inPane pane: PaneID, at screenPoint: NSPoint? = nil) {
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow else { return }
+
+        let controller = AgentPickerController(model: makeAgentPickerModel())
+        controller.rebuild = { [weak self] in self?.makeAgentPickerModel() }
+        controller.onLaunch = { [weak self] config in
+            self?.launchAgentSurface(inPane: pane, explicitConfig: config, source: .aButton)
+        }
+        controller.onPin = { [weak self] config in
+            try? AgentConfigLibraryStore.shared.setDefault(configId: config.id)
+            self?.refreshSplitButtonTooltips()
+        }
+        controller.onToggleFollowRecent = {
+            let current = AgentConfigLibraryStore.shared.current.default.mode
+            try? AgentConfigLibraryStore.shared.setMode(current == .followRecent ? .pinned : .followRecent)
+        }
+        // Tier-2 (configure sheet / stats view) is C11-182; no seam exists on
+        // main yet, so these are no-ops today. The Launch-stats row still shows a
+        // real inline headline below.
+        controller.onViewAll = {}
+        controller.onStats = {}
+        controller.onNotInstalledHint = { _ in }
+
+        AgentPickerPresenter.shared.present(controller: controller, in: window, at: screenPoint)
+    }
+
+    /// Build the picker view-model from the current library, registry, a cached
+    /// PATH install probe, the (absent-today) cost catalog, and the stats headline.
+    private func makeAgentPickerModel() -> AgentPickerModel {
+        let library = AgentConfigLibraryStore.shared.current
+        let effective = AgentConfigLibraryStore.shared.effectiveDefault()
+        let env = AgentPickerEnvironment(
+            displayName: { kind in
+                AgentRegistry.shared.manifest(forKind: kind)?.displayName
+                    ?? AgentType(rawValue: kind)?.displayName ?? kind
+            },
+            provider: { AgentLaunchStats.provider(harness: $0, model: $1) },
+            isInstalled: { AgentHarnessInstallProbe.isInstalled($0) },
+            costFor: { _ in nil }, // token-cost catalog is greenfield (design §5.6) → column omitted
+            now: Date(),
+            statsHeadline: Self.agentPickerStatsHeadline()
+        )
+        return AgentPickerModel(library: library, effectiveDefault: effective, env: env)
+    }
+
+    /// Inline "N% Model · M launches" from the lifetime stats aggregate (C11-178).
+    /// `nil` (no store / no launches) → the headline is omitted.
+    private static func agentPickerStatsHeadline() -> String? {
+        guard let store = AgentLaunchStatsStore.shared else { return nil }
+        let result = store.stats(window: .all, by: .model)
+        guard result.count > 0, let leader = result.tally.max(by: { $0.value < $1.value }) else { return nil }
+        let pct = Int((Double(leader.value) / Double(result.count) * 100).rounded())
+        let model = leader.key.prefix(1).uppercased() + leader.key.dropFirst()
+        return String(
+            localized: "agentPicker.stats.headline",
+            defaultValue: "\(pct)% \(model) · \(result.count) launches"
+        )
     }
 
     func splitTabBar(_ controller: BonsplitController, didRequestClosePane pane: PaneID) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12404,8 +12404,9 @@ extension Workspace: BonsplitDelegate {
         if let event = NSApp.currentEvent,
            event.type == .rightMouseDown || event.type == .rightMouseUp {
             let location = NSEvent.mouseLocation
+            let window = event.window
             DispatchQueue.main.async { [weak self] in
-                self?.presentAgentPicker(inPane: pane, at: location)
+                self?.presentAgentPicker(inPane: pane, window: window, at: location)
             }
         }
         return []
@@ -12421,8 +12422,17 @@ extension Workspace: BonsplitDelegate {
     /// (design §5.1). `screenPoint` anchors under the right-clicked button; `nil`
     /// (⌘⇧A / menu) anchors at the window's top-trailing corner. Row click =
     /// launch now; pin / ⌥-click = set default without launching (C11-181).
-    func presentAgentPicker(inPane pane: PaneID, at screenPoint: NSPoint? = nil) {
-        guard let window = NSApp.keyWindow ?? NSApp.mainWindow else { return }
+    func presentAgentPicker(
+        inPane pane: PaneID,
+        window requestedWindow: NSWindow? = nil,
+        at screenPoint: NSPoint? = nil
+    ) {
+        guard let window = requestedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow else { return }
+
+        // The A button belongs to a pane. Make that pane the launch target before
+        // building the picker so a right-click in an unfocused pane cannot create
+        // the selected agent as a hidden/background tab.
+        bonsplitController.focusPane(pane)
 
         let controller = AgentPickerController(model: makeAgentPickerModel())
         controller.rebuild = { [weak self] in self?.makeAgentPickerModel() }
@@ -12442,12 +12452,20 @@ extension Workspace: BonsplitDelegate {
         // when the effective default is a transient with no id); "Launch stats"
         // opens the stats view. `origin: .popover` lets the sheet order Settings
         // out on close. The Launch-stats row also shows a real inline headline.
+        let armEditorReturn = { [weak self, weak window] in
+            AgentPickerPresenter.shared.armReturnToPicker {
+                guard let self, let window else { return }
+                self.presentAgentPicker(inPane: pane, window: window, at: nil)
+            }
+        }
         controller.onViewAll = {
+            armEditorReturn()
             let eff = AgentConfigLibraryStore.shared.effectiveDefault()
             let focus: AgentConfigEditorFocus = eff.id.isEmpty ? .new : .config(eff.id)
             AppDelegate.shared?.openAgentConfigEditor(focus: focus, origin: .popover)
         }
         controller.onStats = {
+            armEditorReturn()
             AppDelegate.shared?.openAgentConfigEditor(focus: .stats, origin: .popover)
         }
         controller.onNotInstalledHint = { _ in NSSound.beep() }

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -487,6 +487,13 @@ struct cmuxApp: App {
                     NotificationCenter.default.post(name: .commandPaletteRequested, object: targetWindow)
                 }
                 .keyboardShortcut("p", modifiers: [.command, .shift])
+
+                // C11-181: open the A-button agent launch picker for the active
+                // workspace's focused pane.
+                Button(String(localized: "menu.file.launchAgentPicker", defaultValue: "Launch Agent Picker…")) {
+                    AppDelegate.shared?.presentAgentPickerForActiveWorkspace()
+                }
+                .keyboardShortcut("a", modifiers: [.command, .shift])
             }
 
             // AppKit auto-injects a Help menu (with its search field) whenever

--- a/c11Tests/AgentPickerModelTests.swift
+++ b/c11Tests/AgentPickerModelTests.swift
@@ -1,0 +1,362 @@
+import XCTest
+@testable import c11
+
+/// Pure-logic tests for the tier-1 agent launch picker view-model (C11-181).
+/// No Workspace / TabManager / NSApp — safe on the bare local `c11-logic` runner.
+/// Verifies the binding prototype's row anatomy, degrade paths (§5.6), and the
+/// keyboard state machine (↑↓/⏎/⌥⏎/1–9/esc).
+final class AgentPickerModelTests: XCTestCase {
+
+    // MARK: Builders
+
+    private func cfg(
+        _ id: String, _ name: String, order: Int,
+        harness: String, model: String? = nil, effort: String? = nil,
+        sys: SystemPromptSetting? = nil
+    ) -> SavedAgentConfig {
+        SavedAgentConfig(
+            id: id, name: name, order: order,
+            config: AgentLaunchConfig(harness: harness, model: model, effort: effort, systemPrompt: sys)
+        )
+    }
+
+    /// Deterministic display-name map (avoids String(localized:) nondeterminism).
+    private let names: (String) -> String = { h in
+        [
+            "claude-code": "Claude Code", "codex": "Codex", "grok": "Grok Build",
+            "kimi": "Kimi", "opencode": "OpenCode", "github-copilot": "GitHub Copilot",
+            "pi": "Pi", "omp": "oh-my-pi", "custom": "Custom",
+        ][h] ?? h
+    }
+
+    /// Environment using the REAL central provider helper (design §1.2), stubbing
+    /// the rest so the test is deterministic.
+    private func env(
+        installed: @escaping (String) -> Bool = { _ in true },
+        cost: @escaping (String?) -> (inUSD: Double, outUSD: Double)? = { _ in nil },
+        now: Date = Date(timeIntervalSince1970: 1_000_000),
+        statsHeadline: String? = nil
+    ) -> AgentPickerEnvironment {
+        AgentPickerEnvironment(
+            displayName: names,
+            provider: { AgentLaunchStats.provider(harness: $0, model: $1) },
+            isInstalled: installed,
+            costFor: cost,
+            now: now,
+            statsHeadline: statsHeadline
+        )
+    }
+
+    private func library(
+        _ configs: [SavedAgentConfig],
+        default def: AgentConfigDefault,
+        recent: RecentAgentConfig? = nil
+    ) -> AgentConfigLibraryFile {
+        AgentConfigLibraryFile(configs: configs, default: def, recent: recent)
+    }
+
+    // A representative library mirroring the prototype's mock data.
+    private func sampleConfigs() -> [SavedAgentConfig] {
+        [
+            cfg("c1", "Opus deep", order: 0, harness: "claude-code", model: "opus", effort: "high"),
+            cfg("c2", "Gregorovich", order: 1, harness: "claude-code", model: "opus",
+                sys: SystemPromptSetting(mode: .replace, text: "")),
+            cfg("c3", "Fable max", order: 2, harness: "claude-code", model: "fable", effort: "max"),
+            cfg("c4", "Codex hi", order: 3, harness: "codex", model: "gpt-5.2", effort: "high"),
+            cfg("c5", "Cheap router", order: 4, harness: "omp", model: "deepseek/deepseek-chat-v3.1"),
+        ]
+    }
+
+    // MARK: 1. Ordering + count
+
+    func testShortlistFollowsOrderAndCount() {
+        // Deliberately out-of-array-order `order` values to prove the model sorts.
+        let configs = [
+            cfg("b", "Second", order: 1, harness: "claude-code", model: "opus"),
+            cfg("a", "First", order: 0, harness: "codex", model: "gpt-5.2"),
+        ]
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "a")),
+            effectiveDefault: configs[1], env: env()
+        )
+        XCTAssertEqual(m.content.shortlist.map(\.name), ["First", "Second"])
+        XCTAssertEqual(m.content.shortlist.map(\.keyBadge), [1, 2])
+        XCTAssertEqual(m.content.shortlist.count, 2)
+    }
+
+    // MARK: 2. Default marking (pinned + follow-recent)
+
+    func testPinnedDefaultMarked() {
+        let configs = sampleConfigs()
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertTrue(m.content.shortlist[0].isPinnedDefault)
+        XCTAssertFalse(m.content.shortlist[0].isRecentDefault)
+        XCTAssertFalse(m.content.shortlist[1].isPinnedDefault)
+        XCTAssertFalse(m.content.followRecent)
+    }
+
+    func testFollowRecentMarksRecentConfig() {
+        let configs = sampleConfigs()
+        let recent = RecentAgentConfig(configId: "c4", harness: "codex", model: "gpt-5.2", effort: "high")
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .followRecent, configId: "c1"), recent: recent),
+            effectiveDefault: configs[3], env: env()
+        )
+        XCTAssertTrue(m.content.followRecent)
+        XCTAssertTrue(m.content.shortlist[3].isRecentDefault) // c4
+        XCTAssertFalse(m.content.shortlist[3].isPinnedDefault) // not pinned when following
+        // In follow-recent mode nothing carries the pinned dot.
+        XCTAssertTrue(m.content.shortlist.allSatisfy { !$0.isPinnedDefault })
+    }
+
+    // MARK: 3. Provider derivation (real helper) + sub-line
+
+    func testProviderAndSubLine() {
+        let configs = sampleConfigs()
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertEqual(m.content.shortlist[0].subLine, "claude code · Anthropic · opus")
+        XCTAssertEqual(m.content.shortlist[3].subLine, "codex · Openai · gpt-5.2")
+        // Router harness: provider rides the model prefix.
+        XCTAssertEqual(m.content.shortlist[4].subLine, "oh-my-pi · Deepseek · deepseek-chat-v3.1")
+    }
+
+    func testRouterFallbackWhenNoPrefix() {
+        // A router harness whose model carries no `provider/` prefix → "router".
+        let configs = [cfg("c1", "Loose", order: 0, harness: "omp", model: "some-model")]
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertEqual(m.content.shortlist[0].subLine, "oh-my-pi · router · some-model")
+    }
+
+    func testCustomHarnessHasNoProviderSegment() {
+        let configs = [cfg("c1", "Bespoke", order: 0, harness: "custom", model: nil)]
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        // custom → no provider, model inherits.
+        XCTAssertEqual(m.content.shortlist[0].subLine, "custom · inherit")
+    }
+
+    // MARK: 4. modelLabel
+
+    func testModelLabel() {
+        XCTAssertEqual(AgentPickerModel.modelLabel(nil), "inherit")
+        XCTAssertEqual(AgentPickerModel.modelLabel("  "), "inherit")
+        XCTAssertEqual(AgentPickerModel.modelLabel("opus"), "opus")
+        XCTAssertEqual(AgentPickerModel.modelLabel("deepseek/deepseek-chat-v3.1"), "deepseek-chat-v3.1")
+        XCTAssertEqual(AgentPickerModel.modelLabel("anthropic/claude-opus-4-8"), "claude-opus-4-8")
+    }
+
+    // MARK: 5. Chips + cost
+
+    func testEffortAndSystemPromptChips() {
+        let configs = sampleConfigs()
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertEqual(m.content.shortlist[0].effortChip, "high")     // Opus deep
+        XCTAssertNil(m.content.shortlist[1].effortChip)               // Gregorovich (no effort)
+        XCTAssertEqual(m.content.shortlist[1].sysChip, .blank)        // replace + empty = ·blank·
+        XCTAssertNil(m.content.shortlist[0].sysChip)                  // inherit → no chip
+    }
+
+    func testSysChipAppendMode() {
+        let configs = [cfg("c1", "Appender", order: 0, harness: "claude-code", model: "opus",
+                           sys: SystemPromptSetting(mode: .append, text: "be terse"))]
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertEqual(m.content.shortlist[0].sysChip, .mode("append"))
+        XCTAssertEqual(m.content.shortlist[0].sysChip?.label, "sys:append")
+    }
+
+    func testCostPresentAndAbsent() {
+        let configs = [cfg("c1", "Opus deep", order: 0, harness: "claude-code", model: "opus")]
+        // Absent catalog → no cost column.
+        let absent = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertNil(absent.content.shortlist[0].cost)
+        // Present catalog → formatted "$5/$25" per the prototype's fmt rules.
+        let present = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0],
+            env: env(cost: { $0 == "opus" ? (5.0, 25.0) : nil })
+        )
+        XCTAssertEqual(present.content.shortlist[0].cost, "$5/$25")
+    }
+
+    func testCostFormatting() {
+        XCTAssertEqual(AgentPickerModel.fmt(5.0), "5")
+        XCTAssertEqual(AgentPickerModel.fmt(25.0), "25")
+        XCTAssertEqual(AgentPickerModel.fmt(0.30), "0.30")
+        XCTAssertEqual(AgentPickerModel.fmt(1.75), "1.75")
+        XCTAssertEqual(AgentPickerModel.fmt(2.50), "2.5")   // trailing zero dropped ≥1
+    }
+
+    // MARK: 6. Recent row
+
+    func testRecentRowFieldsAndLiveHint() {
+        let configs = sampleConfigs()
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let recent = RecentAgentConfig(
+            configId: "c4", harness: "codex", model: "gpt-5.2", effort: "high",
+            observedAt: now.addingTimeInterval(-120) // 2 minutes ago
+        )
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1"), recent: recent),
+            effectiveDefault: configs[0], env: env(now: now)
+        )
+        let r = try! XCTUnwrap(m.content.recent)
+        XCTAssertEqual(r.name, "Codex hi")
+        XCTAssertEqual(r.relativeTime, "2m ago")
+        XCTAssertEqual(r.subLine, "codex · gpt-5.2 · high")
+        XCTAssertTrue(r.showLiveHint)                    // codex is not live
+        XCTAssertEqual(r.harnessDisplayName, "Codex")
+    }
+
+    func testRecentRowClaudeHasNoLiveHint() {
+        let configs = sampleConfigs()
+        let recent = RecentAgentConfig(configId: "c1", harness: "claude-code", model: "opus")
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1"), recent: recent),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertFalse(try XCTUnwrap(m.content.recent).showLiveHint) // claude-code IS live
+    }
+
+    func testNoRecentYieldsNilRow() {
+        let configs = sampleConfigs()
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertNil(m.content.recent)
+    }
+
+    func testRelativeTimeBuckets() {
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-10), now: now), "just now")
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-300), now: now), "5m ago")
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-7200), now: now), "2h ago")
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-172_800), now: now), "2d ago")
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: nil, now: now), "just now")
+    }
+
+    // MARK: 7. Keyboard state machine
+
+    func testArrowNavigationClampsAcrossRecent() {
+        let configs = sampleConfigs() // 5 configs
+        let recent = RecentAgentConfig(configId: "c4", harness: "codex", model: "gpt-5.2")
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1"), recent: recent),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertEqual(m.selectedIndex, -1)
+        _ = m.handleKey(.down); XCTAssertEqual(m.selectedIndex, 0)
+        for _ in 0..<10 { _ = m.handleKey(.down) }
+        XCTAssertEqual(m.selectedIndex, 5) // 5 shortlist (0..4) + recent (5), clamped
+        _ = m.handleKey(.up); XCTAssertEqual(m.selectedIndex, 4)
+        for _ in 0..<10 { _ = m.handleKey(.up) }
+        XCTAssertEqual(m.selectedIndex, 0) // clamps at 0, never back to -1
+    }
+
+    func testEnterLaunchesSelectedElseEffectiveDefault() {
+        let configs = sampleConfigs()
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        // Nothing selected → effective default.
+        XCTAssertEqual(m.handleKey(.enter), .launch(configs[0]))
+        _ = m.handleKey(.down); _ = m.handleKey(.down) // select index 1
+        XCTAssertEqual(m.handleKey(.enter), .launch(configs[1]))
+    }
+
+    func testOptionEnterPinsSelected() {
+        let configs = sampleConfigs()
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        _ = m.handleKey(.down) // select index 0
+        XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[0]))
+    }
+
+    func testEnterOnRecentRowLaunchesRecent() {
+        let configs = sampleConfigs()
+        let recent = RecentAgentConfig(configId: "c4", harness: "codex", model: "gpt-5.2")
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1"), recent: recent),
+            effectiveDefault: configs[0], env: env()
+        )
+        for _ in 0..<6 { _ = m.handleKey(.down) } // land on recent row (index 5)
+        XCTAssertEqual(m.selectedIndex, 5)
+        XCTAssertEqual(m.handleKey(.enter), .launch(configs[3])) // c4
+    }
+
+    func testDigitKeysLaunchNth() {
+        let configs = sampleConfigs()
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertEqual(m.handleKey(.digit(1)), .launch(configs[0]))
+        XCTAssertEqual(m.handleKey(.digit(5)), .launch(configs[4]))
+        XCTAssertEqual(m.handleKey(.digit(6)), .none) // past the shortlist
+    }
+
+    func testEscapeCloses() {
+        let configs = sampleConfigs()
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        XCTAssertEqual(m.handleKey(.escape), .close)
+    }
+
+    // MARK: 8. Not-installed
+
+    func testNotInstalledRowStillPinsButPlainLaunchNoops() {
+        let configs = sampleConfigs()
+        // codex (c4, index 3) is not installed.
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0],
+            env: env(installed: { $0 != "codex" })
+        )
+        XCTAssertFalse(m.content.shortlist[3].isInstalled)
+        // Digit launch of the not-installed row → no-op.
+        XCTAssertEqual(m.handleKey(.digit(4)), .none)
+        // ⌥⏎ still pins it.
+        _ = m.handleKey(.down); _ = m.handleKey(.down); _ = m.handleKey(.down); _ = m.handleKey(.down) // idx 3
+        XCTAssertEqual(m.selectedIndex, 3)
+        XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[3]))
+        // A plain ⏎ on it is a no-op (installed check).
+        XCTAssertEqual(m.handleKey(.enter), .none)
+    }
+
+    // MARK: 9. Stats headline passthrough
+
+    func testStatsHeadlineSurfaced() {
+        let configs = sampleConfigs()
+        let m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0],
+            env: env(statsHeadline: "87% Opus · 474 launches")
+        )
+        XCTAssertEqual(m.content.statsHeadline, "87% Opus · 474 launches")
+    }
+}

--- a/c11Tests/AgentPickerModelTests.swift
+++ b/c11Tests/AgentPickerModelTests.swift
@@ -359,4 +359,63 @@ final class AgentPickerModelTests: XCTestCase {
         )
         XCTAssertEqual(m.content.statsHeadline, "87% Opus · 474 launches")
     }
+
+    // MARK: 10. Review-regression: recent-row + default Enter honor pin/installed (F1/F2)
+
+    func testOptionEnterOnRecentRowPinsNotLaunch() {
+        let configs = sampleConfigs()
+        let recent = RecentAgentConfig(configId: "c4", harness: "codex", model: "gpt-5.2")
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1"), recent: recent),
+            effectiveDefault: configs[0], env: env()
+        )
+        for _ in 0..<6 { _ = m.handleKey(.down) } // recent row (index 5)
+        XCTAssertEqual(m.selectedIndex, 5)
+        // ⌥⏎ on the recent row PINS (was: silently launched).
+        XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[3]))
+    }
+
+    func testEnterOnNotInstalledRecentRowNoops() {
+        let configs = sampleConfigs()
+        let recent = RecentAgentConfig(configId: "c4", harness: "codex", model: "gpt-5.2")
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1"), recent: recent),
+            effectiveDefault: configs[0],
+            env: env(installed: { $0 != "codex" }) // codex not installed
+        )
+        for _ in 0..<6 { _ = m.handleKey(.down) }
+        XCTAssertEqual(m.handleKey(.enter), .none)                 // plain ⏎ no-ops (was: launched)
+        XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[3])) // ⌥⏎ still pins
+    }
+
+    func testEnterDefaultRespectsInstalledGuard() {
+        let configs = sampleConfigs() // default c1 = claude-code
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0],
+            env: env(installed: { $0 != "claude-code" }) // default's harness not installed
+        )
+        XCTAssertEqual(m.selectedIndex, -1)
+        XCTAssertEqual(m.handleKey(.enter), .none) // was .launch(default) before the fix
+    }
+
+    func testRelativeTimeBucketTopsClamp() {
+        let now = Date(timeIntervalSince1970: 3_000_000)
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-3599), now: now), "59m ago")   // not "60m ago"
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-86_399), now: now), "23h ago") // not "24h ago"
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-3600), now: now), "1h ago")
+        XCTAssertEqual(AgentPickerModel.relativeTime(from: now.addingTimeInterval(-86_400), now: now), "1d ago")
+    }
+
+    func testCommandEnterOpensViewAllNeverLaunches() {
+        let configs = sampleConfigs()
+        var m = AgentPickerModel(
+            library: library(configs, default: .init(mode: .pinned, configId: "c1")),
+            effectiveDefault: configs[0], env: env()
+        )
+        // ⌘⏎ = View all, from any selection state — never launches.
+        XCTAssertEqual(m.handleKey(.enter, command: true), .viewAll)
+        _ = m.handleKey(.down) // select row 0
+        XCTAssertEqual(m.handleKey(.enter, command: true), .viewAll)
+    }
 }

--- a/c11Tests/AgentPickerModelTests.swift
+++ b/c11Tests/AgentPickerModelTests.swift
@@ -390,6 +390,40 @@ final class AgentPickerModelTests: XCTestCase {
         XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[3])) // ⌥⏎ still pins
     }
 
+    func testRecentAvailabilityFollowsCurrentSavedRecipeHarness() throws {
+        let current = cfg(
+            "c1",
+            "Edited since launch",
+            order: 0,
+            harness: "kimi",
+            model: "k2.5"
+        )
+        let recent = RecentAgentConfig(
+            configId: "c1",
+            harness: "claude-code",
+            model: "opus"
+        )
+        var m = AgentPickerModel(
+            library: library(
+                [current],
+                default: .init(mode: .followRecent, configId: "c1"),
+                recent: recent
+            ),
+            effectiveDefault: current,
+            env: env(installed: { $0 != "kimi" })
+        )
+
+        // The row keeps historical launch axes as provenance, but its disabled
+        // state and activation follow the current saved recipe that will launch.
+        let row = try XCTUnwrap(m.content.recent)
+        XCTAssertEqual(row.subLine, "claude code · opus")
+        XCTAssertFalse(row.isInstalled)
+        _ = m.handleKey(.down) // shortlist
+        _ = m.handleKey(.down) // recent
+        XCTAssertEqual(m.handleKey(.enter), .notInstalled(current))
+        XCTAssertEqual(m.recentClickAction(), .notInstalled(current))
+    }
+
     func testEnterDefaultRespectsInstalledGuard() {
         let configs = sampleConfigs() // default c1 = claude-code
         var m = AgentPickerModel(
@@ -399,6 +433,33 @@ final class AgentPickerModelTests: XCTestCase {
         )
         XCTAssertEqual(m.selectedIndex, -1)
         XCTAssertEqual(m.handleKey(.enter), .notInstalled(configs[0]))
+    }
+
+    func testTransientFollowRecentDefaultRespectsInstalledGuard() {
+        let configs = sampleConfigs()
+        let transient = cfg(
+            "",
+            "Recent router",
+            order: -1,
+            harness: "opencode",
+            model: "openai/gpt-5.2"
+        )
+        var m = AgentPickerModel(
+            library: library(
+                configs,
+                default: .init(mode: .followRecent, configId: "c1"),
+                recent: RecentAgentConfig(
+                    configId: nil,
+                    harness: "opencode",
+                    model: "openai/gpt-5.2"
+                )
+            ),
+            effectiveDefault: transient,
+            env: env(installed: { $0 != "opencode" })
+        )
+
+        XCTAssertEqual(m.selectedIndex, -1)
+        XCTAssertEqual(m.handleKey(.enter), .notInstalled(transient))
     }
 
     func testRelativeTimeBucketTopsClamp() {

--- a/c11Tests/AgentPickerModelTests.swift
+++ b/c11Tests/AgentPickerModelTests.swift
@@ -329,7 +329,7 @@ final class AgentPickerModelTests: XCTestCase {
 
     // MARK: 8. Not-installed
 
-    func testNotInstalledRowStillPinsButPlainLaunchNoops() {
+    func testNotInstalledRowStillPinsButPlainLaunchRefuses() {
         let configs = sampleConfigs()
         // codex (c4, index 3) is not installed.
         var m = AgentPickerModel(
@@ -338,14 +338,14 @@ final class AgentPickerModelTests: XCTestCase {
             env: env(installed: { $0 != "codex" })
         )
         XCTAssertFalse(m.content.shortlist[3].isInstalled)
-        // Digit launch of the not-installed row → no-op.
-        XCTAssertEqual(m.handleKey(.digit(4)), .none)
+        // Digit launch of the not-installed row → explicit refusal.
+        XCTAssertEqual(m.handleKey(.digit(4)), .notInstalled(configs[3]))
         // ⌥⏎ still pins it.
         _ = m.handleKey(.down); _ = m.handleKey(.down); _ = m.handleKey(.down); _ = m.handleKey(.down) // idx 3
         XCTAssertEqual(m.selectedIndex, 3)
         XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[3]))
-        // A plain ⏎ on it is a no-op (installed check).
-        XCTAssertEqual(m.handleKey(.enter), .none)
+        // A plain ⏎ on it returns the same explicit refusal.
+        XCTAssertEqual(m.handleKey(.enter), .notInstalled(configs[3]))
     }
 
     // MARK: 9. Stats headline passthrough
@@ -371,11 +371,12 @@ final class AgentPickerModelTests: XCTestCase {
         )
         for _ in 0..<6 { _ = m.handleKey(.down) } // recent row (index 5)
         XCTAssertEqual(m.selectedIndex, 5)
+        XCTAssertEqual(m.recentClickAction(), .launch(configs[3]))
         // ⌥⏎ on the recent row PINS (was: silently launched).
         XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[3]))
     }
 
-    func testEnterOnNotInstalledRecentRowNoops() {
+    func testNotInstalledRecentRowRefusesKeyboardAndPointerLaunch() {
         let configs = sampleConfigs()
         let recent = RecentAgentConfig(configId: "c4", harness: "codex", model: "gpt-5.2")
         var m = AgentPickerModel(
@@ -384,7 +385,8 @@ final class AgentPickerModelTests: XCTestCase {
             env: env(installed: { $0 != "codex" }) // codex not installed
         )
         for _ in 0..<6 { _ = m.handleKey(.down) }
-        XCTAssertEqual(m.handleKey(.enter), .none)                 // plain ⏎ no-ops (was: launched)
+        XCTAssertEqual(m.handleKey(.enter), .notInstalled(configs[3]))
+        XCTAssertEqual(m.recentClickAction(), .notInstalled(configs[3]))
         XCTAssertEqual(m.handleKey(.enter, option: true), .pin(configs[3])) // ⌥⏎ still pins
     }
 
@@ -396,7 +398,7 @@ final class AgentPickerModelTests: XCTestCase {
             env: env(installed: { $0 != "claude-code" }) // default's harness not installed
         )
         XCTAssertEqual(m.selectedIndex, -1)
-        XCTAssertEqual(m.handleKey(.enter), .none) // was .launch(default) before the fix
+        XCTAssertEqual(m.handleKey(.enter), .notInstalled(configs[0]))
     }
 
     func testRelativeTimeBucketTopsClamp() {

--- a/scripts/c11-181-register-files.rb
+++ b/scripts/c11-181-register-files.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+# C11-181: register the agent-launch-picker source + test files in the Xcode project.
+# The picker is AppKit/SwiftUI UI → sources compile into the `c11` app target ONLY
+# (NOT c11-cli). The model test is pure logic → c11LogicTests (+ c11Tests host) for the
+# fast local loop, mirroring c11-178/179. Idempotent.
+gem 'xcodeproj', '~> 1.27'
+require 'xcodeproj'
+
+PROJECT_PATH = File.expand_path('../GhosttyTabs.xcodeproj', __dir__)
+project = Xcodeproj::Project.open(PROJECT_PATH)
+
+c11        = project.targets.find { |t| t.name == 'c11' }            or abort 'c11 target not found'
+c11_tests  = project.targets.find { |t| t.name == 'c11Tests' }       or abort 'c11Tests target not found'
+c11_logic  = project.targets.find { |t| t.name == 'c11LogicTests' }  or abort 'c11LogicTests target not found'
+
+sources_group = project.main_group.find_subpath('Sources', false) or abort 'Sources group missing'
+tests_group   = project.main_group.find_subpath('c11Tests', false) or abort 'c11Tests group missing'
+
+# AgentPickerView.swift is added by a later pass (it depends on the view being on disk).
+SOURCE_FILES = %w[AgentPickerModel.swift AgentPickerView.swift].freeze
+TEST_FILES   = %w[AgentPickerModelTests.swift].freeze
+
+def ref_in(group, filename)
+  group.files.find { |f| f.path == filename } || group.new_reference(filename)
+end
+
+def ensure_member(target, ref)
+  return if target.source_build_phase.files.any? { |bf| bf.file_ref == ref }
+  target.source_build_phase.add_file_reference(ref)
+end
+
+# Only register sources that already exist on disk, so a partial run never breaks the build.
+SOURCE_FILES.each do |fn|
+  next unless File.exist?(File.expand_path("../Sources/#{fn}", __dir__))
+  ref = ref_in(sources_group, fn)
+  ensure_member(c11, ref)
+end
+
+TEST_FILES.each do |fn|
+  next unless File.exist?(File.expand_path("../c11Tests/#{fn}", __dir__))
+  ref = ref_in(tests_group, fn)
+  ensure_member(c11_tests, ref)
+  ensure_member(c11_logic, ref)
+end
+
+project.save
+puts 'OK — registered existing picker source(s) into c11, test(s) into c11Tests + c11LogicTests'


### PR DESCRIPTION
Implements **C11-181** — tier 1 of the model picker: a c11-owned popover anchored to the A button that launches saved agent configs. It follows the approved `#popover` route in `docs/design-prototypes/model-picker/index.html` and the contract in `docs/agent-config-primitive-design.md` §5.1–5.3, §5.6, §8.2/§8.8.

## Gesture and keyboard contract

- **Row click = launch that config now.**
- **Pin glyph / ⌥-click / ⌥⏎ = set default without launching.**
- ↑↓ select · ⏎ launch · ⌥⏎ set default · 1–9 launch nth · esc close.
- Installed-harness checks are identical for pointer, Return, digit, default, and recent-row paths. An unavailable harness is visibly marked **NOT INSTALLED**, refuses launch without dismissing the picker, and remains pinnable.

## Triggers

- Right-click either A button opens the picker and suppresses the native menu.
- ⌘⇧A / c11 → **Launch Agent Picker…** routes to the focused pane.
- The arrowless `NSPopover` anchors to the window content view at the click point, or top-trailing for the keyboard path.
- No `vendor/bonsplit` change is required.

## Popover contents

- Saved-config shortlist with name, harness/provider/model line, effort and system-prompt chips, cost seam, 1–9 badge, default state, and pin affordance.
- Recent config with relative time and non-live hint, plus follow-recent mode.
- **View All** and **Launch Stats** route into the tier-2 settings/editor surfaces now present on `main`; the footer also carries real launch statistics.
- Void-palette styling via `BrandColors` and a picker-local palette.

## Architecture

- `AgentPickerModel`: pure Foundation view model and keyboard state machine.
- `AgentPickerView` / `AgentPickerController` / `AgentPickerPresenter`: SwiftUI + `NSPopover` host with a lifecycle-bound local key monitor.
- `Workspace.launchAgentSurface(explicitConfig:)`: launches a specific recipe while preserving the existing nil/default path.
- `AgentHarnessInstallProbe`: cached best-effort executable probe.

## Localization

The 27 new keys (26 `agentPicker.*` plus `menu.file.launchAgentPicker`) ship in English, Japanese, Ukrainian, Korean, Simplified Chinese, Traditional Chinese, and Russian. All seven catalogs compile with `xcstringstool`; placeholder/token and key-use audits pass.

## Deliberate limitation

The cost column remains behind an injected seam because c11 has no token-cost catalog yet. The light-theme-specific treatment remains a future design pass; this picker intentionally uses the approved dark/void palette.

## Validation

- Repaired exact head: `af8d2303b36bbfba6ca216900785eec884ff110c` on `main` `506e8abdf07733111aacb645adc966f93ca9c928`.
- `AgentPickerModelTests`: **30/30 passed** after the rebase.
- Full `c11-logic`: **1,571 tests passed**, 3 existing skips, 0 failures.
- JSON parse, all-locale `xcstringstool` compile, placeholder/token audit, `xcodebuild -list`, and `git diff --check`: passed.

This began as a taste-gated ticket. For the release sweep, the operator explicitly requested that open PRs be merged as safely as possible and that visual review happen on the resulting staging build. The PR still requires an independent exact-head code review and green CI before merge; visual taste remains a staging smoke item.

🤖 Generated with Claude Code and Codex


