### PR TITLE
Settings Saved Configs editor + launch stats view (tier 2 of the model picker)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		55A25D62B29EA263FABD5931 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 		56240252C16E6E32305412E0 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
 		566B6BA784672EAB0E03523A /* AgentConfigLibraryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 645F0E832571A928F52DDF40 /* AgentConfigLibraryStoreTests.swift */; };
+		AC0F16182ED0DE1000000004 /* AgentConfigEditorModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0F16182ED0DE1000000003 /* AgentConfigEditorModelTests.swift */; };
 		56D5F7E29DC4C9999E4EDA7B /* DefaultAgentProjectConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */; };
 		573FC5E8BE58AFF9E421E3B6 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		592E7B94FECC0B5AAB3B53B4 /* SidebarActivityProjectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0054553DCE5D3CED90037B0C /* SidebarActivityProjectorTests.swift */; };
@@ -79,6 +80,8 @@
 		5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		5E5FA83B76AB6FA59171D8C2 /* HealthFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */; };
 		5F20D96106D7E1D0215F6D66 /* DefaultAgentSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C80718F1B0DC883CC3D99 /* DefaultAgentSettingsView.swift */; };
+		AC0F16182ED0DE1000000002 /* AgentConfigEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0F16182ED0DE1000000001 /* AgentConfigEditorModel.swift */; };
+		AC0F16182ED0DE1000000006 /* AgentConfigEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC0F16182ED0DE1000000005 /* AgentConfigEditorSheet.swift */; };
 		60785E8E82CF86BCF4A26738 /* Opencode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54017DD4C9F6BE7CFA98C2F7 /* Opencode.swift */; };
 		60C99BCDF095711E213AAF1C /* BrowserImportMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */; };
 		629F9C54FEC34F811A25CC65 /* DefaultAgentResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F39832E954005AB276046A4 /* DefaultAgentResolverTests.swift */; };
@@ -521,6 +524,7 @@
 		6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
 		640DC1629D340031E0516DA5 /* ConversationHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationHandlers.swift; sourceTree = "<group>"; };
 		645F0E832571A928F52DDF40 /* AgentConfigLibraryStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentConfigLibraryStoreTests.swift; sourceTree = "<group>"; };
+		AC0F16182ED0DE1000000003 /* AgentConfigEditorModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentConfigEditorModelTests.swift; sourceTree = "<group>"; };
 		64628D6D2B44E2D7DCDCB79E /* EventEnvelope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventEnvelope.swift; path = Events/EventEnvelope.swift; sourceTree = "<group>"; };
 		660A6F747C53032181B954F7 /* ConversationCrashRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConversationCrashRecoveryTests.swift; path = ConversationCrashRecoveryTests.swift; sourceTree = "<group>"; };
 		6B79605DD09AE47DB4B228AD /* PiConversationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PiConversationTests.swift; sourceTree = "<group>"; };
@@ -823,6 +827,8 @@
 		D801BBF1A1B2C3D4E5F60718 /* WorkspaceSnapshotSetCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSnapshotSetCodableTests.swift; sourceTree = "<group>"; };
 		D8F4243F7A7CB36FB59072E8 /* SidebarDecayClock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarDecayClock.swift; sourceTree = "<group>"; };
 		DA2C80718F1B0DC883CC3D99 /* DefaultAgentSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentSettingsView.swift; sourceTree = "<group>"; };
+		AC0F16182ED0DE1000000001 /* AgentConfigEditorModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentConfigEditorModel.swift; sourceTree = "<group>"; };
+		AC0F16182ED0DE1000000005 /* AgentConfigEditorSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentConfigEditorSheet.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		DA7A10CA710E000000000005 /* welcome.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = welcome.md; sourceTree = "<group>"; };
@@ -1138,6 +1144,8 @@
 				3566F50A753107233CC16743 /* DefaultAgentResolver.swift */,
 				76375733F860DAB840D28800 /* DefaultAgentProjectConfig.swift */,
 				DA2C80718F1B0DC883CC3D99 /* DefaultAgentSettingsView.swift */,
+				AC0F16182ED0DE1000000001 /* AgentConfigEditorModel.swift */,
+				AC0F16182ED0DE1000000005 /* AgentConfigEditorSheet.swift */,
 				C2BBF3CDB766B1FCF30BB765 /* LaunchResumePicker.swift */,
 				A8C9388437A24EE58C8AAA71 /* Ref.swift */,
 				4979C511C7C076498CDF3515 /* ResumeAction.swift */,
@@ -1387,6 +1395,7 @@
 				91488CE83CF7CEC3B741B1E5 /* EventLogTests.swift */,
 				271383F43816B35E14402874 /* AgentLaunchStatsTests.swift */,
 				645F0E832571A928F52DDF40 /* AgentConfigLibraryStoreTests.swift */,
+				AC0F16182ED0DE1000000003 /* AgentConfigEditorModelTests.swift */,
 				B0C8786B9F13542B2C4D9D35 /* AgentLaunchOverlayCompositionTests.swift */,
 			);
 			path = c11Tests;
@@ -1726,6 +1735,7 @@
 				0D76F685D48115A43B14C5D5 /* EventLogTests.swift in Sources */,
 				8713E62944414CDC27EA1AD8 /* AgentLaunchStatsTests.swift in Sources */,
 				566B6BA784672EAB0E03523A /* AgentConfigLibraryStoreTests.swift in Sources */,
+				AC0F16182ED0DE1000000004 /* AgentConfigEditorModelTests.swift in Sources */,
 				5A86082FF691F6FBCBDE52CB /* AgentLaunchOverlayCompositionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1879,6 +1889,8 @@
 				AEFAF44A763C596E3C066BC6 /* DefaultAgentResolver.swift in Sources */,
 				56D5F7E29DC4C9999E4EDA7B /* DefaultAgentProjectConfig.swift in Sources */,
 				5F20D96106D7E1D0215F6D66 /* DefaultAgentSettingsView.swift in Sources */,
+				AC0F16182ED0DE1000000002 /* AgentConfigEditorModel.swift in Sources */,
+				AC0F16182ED0DE1000000006 /* AgentConfigEditorSheet.swift in Sources */,
 				78EC4CE4D9938FD4611E1664 /* LaunchResumePicker.swift in Sources */,
 				AB10CF281929477FAAAC51F4 /* Ref.swift in Sources */,
 				D9466179A4666A164E142B98 /* ResumeAction.swift in Sources */,

--- a/Sources/AgentConfigEditorModel.swift
+++ b/Sources/AgentConfigEditorModel.swift
@@ -259,6 +259,13 @@ enum AgentConfigAxes {
         return sp.mode == .replace && sp.text.isEmpty
     }
 
+    /// The library row sub-line: `describe` plus a ` · ·blank·` suffix for the
+    /// blank-slate case. The single source of truth for both the sheet's rail
+    /// and the Settings subsection row.
+    static func subline(_ config: AgentLaunchConfig) -> String {
+        isBlankSlate(config) ? "\(describe(config)) · ·blank·" : describe(config)
+    }
+
     /// The model a `.families` harness inherits when its recipe model is unset —
     /// the harness's per-harness Settings base, defaulting to `opus` for
     /// claude-code (matching the factory pin). `nil` when there is no base.
@@ -303,7 +310,7 @@ struct StatsBarRow: Equatable {
     let isLeader: Bool
 }
 
-enum AgentLaunchStatsView {
+enum LaunchStatsBars {
     /// Turn a windowed query result into sorted bar rows (descending by count,
     /// ties broken by label for determinism). Empty tally → `[]`.
     static func statsBars(from result: LaunchStatsResult) -> [StatsBarRow] {

--- a/Sources/AgentConfigEditorModel.swift
+++ b/Sources/AgentConfigEditorModel.swift
@@ -1,0 +1,325 @@
+import Foundation
+
+// MARK: - Agent-config editor model (C11-182, design §1.2)
+//
+// Pure, view-model-free logic for the Saved Configs editor (tier 2 of the
+// model picker). Everything here derives from `AgentRegistry.shared` (the
+// manifest source of truth) plus a few static seed catalogs; nothing touches
+// SwiftUI, AppKit, or `NSApp`, so it is unit-tested directly in `c11-logic`.
+//
+// The prototype's `HARNESSES` map is mock data; these functions compute the
+// same axes from the real manifest, so a manifest change flows through without
+// a parallel table to keep in sync.
+
+// MARK: Axis descriptors (design §1.2)
+
+/// How the model control renders for a harness. Provider is a *derived* facet,
+/// never a stored field: fixed harnesses carry a constant, router harnesses
+/// take the model-id prefix (design §1.2 / §8.7).
+enum ModelAxis: Equatable {
+    /// No `--model` flag (custom): the harness launches whatever its own config selects.
+    case none
+    /// Claude family aliases, picked from a list with an explicit Inherit row.
+    case families([ClaudeModelFamily])
+    /// A single fixed provider (codex/grok/kimi/github-copilot): freeform id + suggestion chips.
+    case freeform(providerLabel: String)
+    /// OpenRouter family (opencode/pi/omp): a filterable list grouped by provider prefix.
+    case router
+}
+
+/// How the effort control renders for a harness.
+enum EffortAxis: Equatable {
+    /// No effort flag (grok/kimi/opencode/github-copilot/custom).
+    case none
+    /// A closed set of tiers validated early (claude, pi, omp).
+    case tiers([String])
+    /// A flag whose values pass through to the CLI (codex's `-c model_reasoning_effort=`).
+    case passthrough
+}
+
+/// Whether the system-prompt control is available for a harness (design §1.4).
+enum SystemPromptAxis: Equatable {
+    /// The CLI has no system-prompt flag c11 knows — control disabled.
+    case none
+    /// Supported; carries the append/replace flag names for the blank-slate note.
+    case supported(appendFlag: String?, replaceFlag: String?)
+}
+
+/// The provider-identity class of a harness (design §1.2). Drives the harness
+/// card's provider sub-line and whether provider is a label (fixed) or lives in
+/// the model prefix (router).
+enum AgentProviderClass: Equatable {
+    /// One provider, shown as a label (never a control). Carries the brand name.
+    case fixed(label: String)
+    /// OpenRouter family: provider rides the model-id prefix.
+    case router
+    /// Operator-defined custom kind: no provider identity.
+    case custom
+}
+
+/// Namespace of pure derivations over the agent registry + static seeds.
+enum AgentConfigAxes {
+
+    // MARK: Provider identity (static map, design §1.2)
+
+    /// Brand label for a fixed-provider harness (proper noun, not localized).
+    /// Router → "OpenRouter"; custom/unknown → "".
+    static func providerDisplayLabel(forHarness harness: String) -> String {
+        switch harness {
+        case "claude-code":    return "Anthropic"
+        case "codex":          return "OpenAI"
+        case "grok":           return "xAI"
+        case "kimi":           return "Moonshot"
+        case "github-copilot": return "GitHub"
+        case "opencode", "pi", "omp": return "OpenRouter"
+        default:               return ""
+        }
+    }
+
+    static func providerClass(forHarness harness: String) -> AgentProviderClass {
+        switch harness {
+        case "opencode", "pi", "omp":
+            return .router
+        case "custom":
+            return .custom
+        default:
+            // Fixed provider iff we know a brand label; unknown custom kinds → .custom.
+            let label = providerDisplayLabel(forHarness: harness)
+            return label.isEmpty ? .custom : .fixed(label: label)
+        }
+    }
+
+    // MARK: Model axis (derived from the manifest)
+
+    static func modelAxis(forHarness harness: String) -> ModelAxis {
+        guard let manifest = AgentRegistry.shared.manifest(forKind: harness) else {
+            return .none
+        }
+        guard manifest.launch.modelArg != nil else { return .none }
+        if harness == "claude-code" {
+            return .families(ClaudeModelFamily.allCases)
+        }
+        switch providerClass(forHarness: harness) {
+        case .router:
+            return .router
+        case .fixed(let label):
+            return .freeform(providerLabel: label)
+        case .custom:
+            // A custom kind that nonetheless declares a model flag: freeform, unlabeled.
+            return .freeform(providerLabel: "")
+        }
+    }
+
+    // MARK: Effort axis (derived from the manifest)
+
+    static func effortAxis(forHarness harness: String) -> EffortAxis {
+        guard let manifest = AgentRegistry.shared.manifest(forKind: harness),
+              manifest.launch.effortArg != nil else {
+            return .none
+        }
+        let values = manifest.launch.effortValues
+        return values.isEmpty ? .passthrough : .tiers(values)
+    }
+
+    /// The chip values shown for the effort control: the tier set for `.tiers`,
+    /// a small suggestion set for `.passthrough` (codex accepts these, and the
+    /// value is stored free-form so exotic values remain reachable via CLI),
+    /// and `[]` for `.none` (no chips rendered).
+    static func effortChipValues(forHarness harness: String) -> [String] {
+        switch effortAxis(forHarness: harness) {
+        case .tiers(let values):
+            return values
+        case .passthrough:
+            return passthroughEffortSuggestions(forHarness: harness)
+        case .none:
+            return []
+        }
+    }
+
+    private static func passthroughEffortSuggestions(forHarness harness: String) -> [String] {
+        switch harness {
+        case "codex": return ["low", "medium", "high"]
+        default:      return []
+        }
+    }
+
+    // MARK: System-prompt axis (derived from the manifest)
+
+    static func systemPromptAxis(forHarness harness: String) -> SystemPromptAxis {
+        guard let manifest = AgentRegistry.shared.manifest(forKind: harness),
+              let arg = manifest.launch.systemPromptArg else {
+            return .none
+        }
+        return .supported(appendFlag: arg.appendFlag, replaceFlag: arg.replaceFlag)
+    }
+
+    // MARK: Static seed catalogs (v1 — pending the real OpenRouter catalog)
+
+    /// Router model list grouped by provider prefix (design §5.4). A curated v1
+    /// seed mirroring the binding prototype; superseded when the sibling
+    /// token-cost / model catalog lands. Order is stable for deterministic UI.
+    static let routerModelCatalog: [(provider: String, models: [String])] = [
+        ("anthropic",  ["anthropic/claude-fable-5", "anthropic/claude-opus-4-8", "anthropic/claude-sonnet-5"]),
+        ("openai",     ["openai/gpt-5.2", "openai/gpt-5.2-codex", "openai/gpt-5.2-mini"]),
+        ("deepseek",   ["deepseek/deepseek-chat-v3.1", "deepseek/deepseek-r1"]),
+        ("moonshotai", ["moonshotai/kimi-k2"]),
+        ("google",     ["google/gemini-3-pro"]),
+        ("x-ai",       ["x-ai/grok-4"]),
+    ]
+
+    /// Suggestion chips for freeform-model harnesses (design §5.4). Static v1 seed.
+    static func freeformSuggestions(forHarness harness: String) -> [String] {
+        switch harness {
+        case "codex":          return ["gpt-5.2", "gpt-5.2-codex", "gpt-5.2-mini"]
+        case "grok":           return ["grok-4", "grok-4-fast"]
+        case "kimi":           return ["kimi-k2"]
+        case "github-copilot": return ["gpt-5.2", "claude-sonnet-5"]
+        default:               return []
+        }
+    }
+
+    // MARK: Harness-switch reconciliation (prototype index.html:1042-1053)
+
+    /// When the operator picks a different harness, null out any recipe fields
+    /// that no longer make sense for the new harness's axes (model incompatible
+    /// with the new model axis, effort outside the new tier set, system-prompt
+    /// unsupported). Mirrors the prototype's reconciliation exactly.
+    static func reconcileHarnessSwitch(_ config: AgentLaunchConfig, to newHarness: String) -> AgentLaunchConfig {
+        var c = config
+        c.harness = newHarness
+
+        switch modelAxis(forHarness: newHarness) {
+        case .none:
+            c.model = nil
+        case .families(let families):
+            if let m = c.model, !families.map(\.rawValue).contains(m) { c.model = nil }
+        case .router:
+            if let m = c.model, !m.contains("/") { c.model = nil }
+        case .freeform:
+            if let m = c.model, m.contains("/") { c.model = nil }
+        }
+
+        switch effortAxis(forHarness: newHarness) {
+        case .none:
+            c.effort = nil
+        case .tiers(let tiers):
+            if let e = c.effort, !tiers.contains(e) { c.effort = nil }
+        case .passthrough:
+            break // passthrough accepts arbitrary values — keep whatever is set
+        }
+
+        switch systemPromptAxis(forHarness: newHarness) {
+        case .none:
+            c.systemPrompt = nil
+        case .supported:
+            if c.systemPrompt == nil { c.systemPrompt = SystemPromptSetting(mode: .inherit) }
+        }
+
+        return c
+    }
+
+    // MARK: Naming + description (prototype autoName / describe)
+
+    /// The short model label: `nil` model → "inherit"; a `provider/model` id →
+    /// its suffix; otherwise the raw model string.
+    static func modelLabel(_ config: AgentLaunchConfig) -> String {
+        guard let m = config.model, !m.isEmpty else { return "inherit" }
+        if let slash = m.firstIndex(of: "/") { return String(m[m.index(after: slash)...]) }
+        return m
+    }
+
+    /// A generated fallback name when the operator leaves the name blank —
+    /// `<first word of display name> <model label>` (e.g. "Claude opus"),
+    /// falling back to the display name alone.
+    static func autoName(for config: AgentLaunchConfig) -> String {
+        let display = AgentRegistry.shared.manifest(forKind: config.harness)?.displayName
+            ?? config.harness
+        let firstWord = display.split(separator: " ").first.map(String.init) ?? display
+        let label = modelLabel(config)
+        let composed = (label == "inherit") ? firstWord : "\(firstWord) \(label)"
+        let trimmed = composed.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? display : trimmed
+    }
+
+    /// The "harness · model · effort" sub-line (prototype `describe`). Harness is
+    /// rendered kind-style (lowercased, spaces → hyphens) to match the prototype.
+    static func describe(_ config: AgentLaunchConfig) -> String {
+        let display = AgentRegistry.shared.manifest(forKind: config.harness)?.displayName
+            ?? config.harness
+        let kind = display.lowercased().replacingOccurrences(of: " ", with: "-")
+        var bits = [kind, modelLabel(config)]
+        if let e = config.effort, !e.isEmpty { bits.append(e) }
+        return bits.joined(separator: " · ")
+    }
+
+    /// Whether this recipe is the Gregorovich blank-slate case (system prompt
+    /// `.replace` with empty text). Drives the gold `·blank·` chip.
+    static func isBlankSlate(_ config: AgentLaunchConfig) -> Bool {
+        guard let sp = config.systemPrompt else { return false }
+        return sp.mode == .replace && sp.text.isEmpty
+    }
+
+    /// The model a `.families` harness inherits when its recipe model is unset —
+    /// the harness's per-harness Settings base, defaulting to `opus` for
+    /// claude-code (matching the factory pin). `nil` when there is no base.
+    /// Pure: the base config is injected so this is unit-testable.
+    static func inheritedModelBase(forHarness harness: String, from base: DefaultAgentConfig) -> String? {
+        guard let agent = AgentType(rawValue: harness) else { return nil }
+        let model = base.config(for: agent).model
+        if !model.isEmpty { return model }
+        return harness == "claude-code" ? ClaudeModelFamily.opus.rawValue : nil
+    }
+
+    // MARK: Installed-probe core
+
+    /// The binary name a harness command launches — the first whitespace token
+    /// of the command. `nil` for an empty command (custom). This is the pure
+    /// core; the actual PATH lookup (login-shell, cached, degrade-to-installed)
+    /// lives app-side in `AgentInstalledProbe`.
+    static func firstBinaryToken(_ command: String) -> String? {
+        for token in command.split(whereSeparator: { $0 == " " || $0 == "\t" }) {
+            let t = String(token)
+            // Skip a leading `KEY=value` env assignment or an `env` shim.
+            if t == "env" { continue }
+            if t.contains("=") && !t.hasPrefix("-") { continue }
+            return t
+        }
+        return nil
+    }
+}
+
+// MARK: - Stats bars (design §5.5)
+
+/// One horizontal bar in the launch-stats view. `widthOfMax` drives the bar
+/// fill (the leader is full width); `shareOfTotal` drives the "N%" label.
+struct StatsBarRow: Equatable {
+    let label: String
+    let count: Int
+    /// Fraction of the window total, for the percentage label (0…1).
+    let shareOfTotal: Double
+    /// Fraction of the leader's count, for the bar width (0…1).
+    let widthOfMax: Double
+    /// The top row (drawn with the gold gradient).
+    let isLeader: Bool
+}
+
+enum AgentLaunchStatsView {
+    /// Turn a windowed query result into sorted bar rows (descending by count,
+    /// ties broken by label for determinism). Empty tally → `[]`.
+    static func statsBars(from result: LaunchStatsResult) -> [StatsBarRow] {
+        let total = result.count
+        let sorted = result.tally.sorted { lhs, rhs in
+            lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key
+        }
+        let maxCount = sorted.first?.value ?? 0
+        return sorted.enumerated().map { index, entry in
+            StatsBarRow(
+                label: entry.key,
+                count: entry.value,
+                shareOfTotal: total > 0 ? Double(entry.value) / Double(total) : 0,
+                widthOfMax: maxCount > 0 ? Double(entry.value) / Double(maxCount) : 0,
+                isLeader: index == 0
+            )
+        }
+    }
+}

--- a/Sources/AgentConfigEditorModel.swift
+++ b/Sources/AgentConfigEditorModel.swift
@@ -212,9 +212,23 @@ enum AgentConfigAxes {
         case .none:
             c.systemPrompt = nil
         case .supported:
-            if c.systemPrompt == nil { c.systemPrompt = SystemPromptSetting(mode: .inherit) }
+            // Leave as-is: nil is the true "inherit" (C11-179 contract: nil =
+            // inherit the base). The editor renders `?? .inherit` for display, so
+            // seeding a non-nil `.inherit` here would clobber a configured base
+            // system prompt through mergeOverlay.
+            break
         }
 
+        return c
+    }
+
+    /// Normalize a recipe for persistence so it faithfully round-trips the
+    /// nil=inherit contract: an explicit `.inherit` system-prompt setting (a
+    /// transient editor working state) collapses to `nil`, so a saved "inherit"
+    /// config never overrides a configured base system prompt at launch.
+    static func normalizedForPersistence(_ config: AgentLaunchConfig) -> AgentLaunchConfig {
+        var c = config
+        if c.systemPrompt?.mode == .inherit { c.systemPrompt = nil }
         return c
     }
 

--- a/Sources/AgentConfigEditorSheet.swift
+++ b/Sources/AgentConfigEditorSheet.swift
@@ -86,39 +86,53 @@ enum AgentConfigEditorRequest {
 final class AgentInstalledProbe: ObservableObject {
     static let shared = AgentInstalledProbe()
 
-    /// nil = not yet resolved (treat as installed); non-nil = the resolved PATH dirs.
-    @Published private(set) var pathDirs: [String]?
+    /// Per-harness installed verdict, computed once when the PATH resolves. An
+    /// absent key = unresolved (treat as installed); the render path only reads
+    /// this dict, never the filesystem.
+    @Published private(set) var verdicts: [String: Bool] = [:]
     private var didStart = false
 
-    /// Kick the async login-shell PATH capture once. Safe to call repeatedly.
+    /// Kick the async login-shell PATH capture + verdict computation once. Safe
+    /// to call repeatedly.
     func startIfNeeded() {
         guard !didStart else { return }
         didStart = true
         Task.detached(priority: .utility) {
             let dirs = Self.captureLoginShellPath()
-            await MainActor.run { self.pathDirs = dirs }
+            let verdicts = Self.computeVerdicts(pathDirs: dirs)
+            await MainActor.run { self.verdicts = verdicts }
         }
     }
 
-    /// Whether the harness's binary resolves on the captured PATH. Returns
-    /// `true` while the PATH is still resolving or on any failure (degrade-never-block).
+    /// Whether the harness's binary resolves on the captured PATH. Returns `true`
+    /// while the PATH is still resolving or on any failure (degrade-never-block).
+    /// A pure dictionary read — no filesystem stat on the render path.
     func isInstalled(harness: String) -> Bool {
-        guard let dirs = pathDirs, !dirs.isEmpty else { return true }
-        let command = AgentRegistry.shared.manifest(forKind: harness)?.factoryCommand ?? ""
-        guard let bin = AgentConfigAxes.firstBinaryToken(command) else { return true }
-        // An absolute path: check it directly.
-        if bin.contains("/") {
-            return FileManager.default.isExecutableFile(atPath: bin)
-        }
-        for dir in dirs {
-            if FileManager.default.isExecutableFile(atPath: dir + "/" + bin) { return true }
-        }
-        return false
+        verdicts[harness] ?? true
     }
 
-    /// Run the user's login shell once to capture their real PATH. Returns nil on
-    /// any failure so callers degrade to "installed". `nonisolated` so the
-    /// detached capture task can call it off the main actor.
+    /// Stat each harness's binary against the captured PATH once, off-main. An
+    /// empty/unresolved PATH yields `[:]` so every harness reads as installed.
+    private nonisolated static func computeVerdicts(pathDirs: [String]?) -> [String: Bool] {
+        guard let dirs = pathDirs, !dirs.isEmpty else { return [:] }
+        let fm = FileManager.default
+        var out: [String: Bool] = [:]
+        for type in AgentType.allCases {
+            let command = AgentRegistry.shared.manifest(forKind: type.rawValue)?.factoryCommand ?? ""
+            guard let bin = AgentConfigAxes.firstBinaryToken(command) else { out[type.rawValue] = true; continue }
+            if bin.contains("/") {
+                out[type.rawValue] = fm.isExecutableFile(atPath: bin)
+            } else {
+                out[type.rawValue] = dirs.contains { fm.isExecutableFile(atPath: $0 + "/" + bin) }
+            }
+        }
+        return out
+    }
+
+    /// Run the user's login shell once to capture their real PATH, killing it
+    /// after a short deadline so a prompting rc file can't hang the task. Returns
+    /// nil on any failure/timeout so callers degrade to "installed". `nonisolated`
+    /// so the detached capture task can call it off the main actor.
     private nonisolated static func captureLoginShellPath() -> [String]? {
         let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
         let process = Process()
@@ -127,13 +141,18 @@ final class AgentInstalledProbe: ObservableObject {
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = FileHandle.nullDevice
+        let done = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in done.signal() }
         do {
             try process.run()
         } catch {
             return nil
         }
+        if done.wait(timeout: .now() + 3.0) == .timedOut {
+            process.terminate()
+            return nil
+        }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
         guard process.terminationStatus == 0,
               let raw = String(data: data, encoding: .utf8) else { return nil }
         let dirs = raw.split(separator: ":").map { String($0).trimmingCharacters(in: .whitespaces) }
@@ -209,10 +228,14 @@ final class AgentConfigLibraryViewModel: ObservableObject {
     func move(fromOffsets source: IndexSet, toOffset destination: Int) {
         var ordered = configs
         ordered.move(fromOffsets: source, toOffset: destination)
-        // Persist the new order by reindexing through the store one move at a time.
-        for (index, config) in ordered.enumerated() {
-            try? store.reorder(id: config.id, to: index)
+        // Compose the new order once and write the whole file atomically, so a
+        // mid-drop failure can never persist a partially-applied order.
+        let orderById = Dictionary(uniqueKeysWithValues: ordered.enumerated().map { ($1.id, $0) })
+        var file = store.current
+        for i in file.configs.indices {
+            if let newOrder = orderById[file.configs[i].id] { file.configs[i].order = newOrder }
         }
+        try? store.write(file)
         reload()
     }
 
@@ -279,6 +302,7 @@ struct AgentConfigEditorSheet: View {
     @State private var advancedOpen = false
     @State private var modelFilter = ""
     @State private var savedFlashId: String?
+    @State private var launchFeedback: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -297,6 +321,14 @@ struct AgentConfigEditorSheet: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
             if !statsMode {
+                if let launchFeedback {
+                    HStack {
+                        Text(launchFeedback).font(.system(size: 10.5))
+                            .foregroundStyle(BrandColors.goldSwiftUI)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 22).padding(.top, 6)
+                }
                 Divider().overlay(BrandColors.ruleSwiftUI)
                 footer
             }
@@ -433,9 +465,7 @@ struct AgentConfigEditorSheet: View {
     }
 
     private func sublineText(_ config: AgentLaunchConfig) -> String {
-        var s = AgentConfigAxes.describe(config)
-        if AgentConfigAxes.isBlankSlate(config) { s += " · ·blank·" }
-        return s
+        AgentConfigAxes.subline(config)
     }
 
     // MARK: Editor (imported from AgentConfigRecipeEditorContent to keep body small)
@@ -520,7 +550,7 @@ struct AgentConfigEditorSheet: View {
             if let match = library.configs.first(where: { $0.id == id }) { selectConfig(match) }
             else { newConfig() }
         case .new:
-            if let first = library.configs.first { selectConfig(first) } else { newConfig() }
+            newConfig()
         case .stats:
             statsMode = true
         }
@@ -531,6 +561,7 @@ struct AgentConfigEditorSheet: View {
         draft = .from(config)
         advancedOpen = false
         modelFilter = ""
+        launchFeedback = nil
     }
 
     private func newConfig() {
@@ -538,9 +569,11 @@ struct AgentConfigEditorSheet: View {
         draft = .new()
         advancedOpen = false
         modelFilter = ""
+        launchFeedback = nil
     }
 
     private func saveOnly() {
+        launchFeedback = nil
         guard let saved = library.save(draft) else { return }
         draft.sourceId = saved.id
         flashSaved(saved.id)
@@ -548,8 +581,21 @@ struct AgentConfigEditorSheet: View {
 
     private func saveAndLaunch() {
         guard !statsMode, let saved = library.save(draft) else { return }
-        _ = AppDelegate.shared?.launchSavedAgentConfig(saved)
-        onClose(false) // launched — do not return to the popover
+        draft.sourceId = saved.id
+        // Never silently no-op (design MINOR-5): keep the sheet open + explain
+        // when there is nothing to launch into or the recipe has no command.
+        switch AppDelegate.shared?.launchSavedAgentConfig(saved) ?? .noWorkspace {
+        case .launched:
+            onClose(false) // launched — do not return to the popover
+        case .noWorkspace:
+            flashSaved(saved.id)
+            launchFeedback = String(localized: "agentConfigEditor.launch.noWorkspace",
+                                    defaultValue: "Saved. No workspace open to launch into — open one, then launch.")
+        case .emptyCommand:
+            flashSaved(saved.id)
+            launchFeedback = String(localized: "agentConfigEditor.launch.emptyCommand",
+                                    defaultValue: "Saved. This recipe has no command to launch — set one under Advanced.")
+        }
     }
 
     private func backOut() {
@@ -906,7 +952,7 @@ struct AgentConfigRecipeEditor: View {
                         let text = draft.config.systemPrompt?.text ?? ""
                         draft.config.systemPrompt = SystemPromptSetting(mode: m, text: text)
                     } label: {
-                        Text(m.rawValue).font(.system(size: 11))
+                        Text(Self.systemPromptModeLabel(m)).font(.system(size: 11))
                             .foregroundStyle(mode == m ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.65))
                             .padding(.horizontal, 13).padding(.vertical, 4)
                             .background(mode == m ? EditorTheme.goldGhost : BrandColors.surface2SwiftUI)
@@ -1005,6 +1051,15 @@ struct AgentConfigRecipeEditor: View {
 
     // MARK: Shared bits
 
+    /// Localized label for a system-prompt mode; `rawValue` stays logic-only.
+    static func systemPromptModeLabel(_ mode: SystemPromptSetting.Mode) -> String {
+        switch mode {
+        case .inherit: return String(localized: "agentConfigEditor.sysMode.inherit", defaultValue: "inherit")
+        case .append:  return String(localized: "agentConfigEditor.sysMode.append", defaultValue: "append")
+        case .replace: return String(localized: "agentConfigEditor.sysMode.replace", defaultValue: "replace")
+        }
+    }
+
     private func axisOff(_ text: String) -> some View {
         Text(text).font(.system(size: 10.5)).foregroundStyle(Color(white: 0.29)).padding(.vertical, 6)
     }
@@ -1069,7 +1124,9 @@ private struct FlowChips: View {
     }
 }
 
-/// A horizontal, wrapping stack of arbitrary chip content.
+/// A single horizontal row of chip content. Today's chip counts (≤7 effort
+/// tiers, ≤3 suggestions) fit the editor's width inside the 860-pt sheet, so no
+/// wrapping is needed; revisit if a harness ever declares many more.
 private struct FlowChipsRaw<Content: View>: View {
     @ViewBuilder let content: Content
     var body: some View {
@@ -1171,7 +1228,7 @@ struct LaunchStatsView: View {
             AgentLaunchStatsStore.shared?.stats(window: w, by: .model)
         }.value
         guard let result else { bars = []; total = 0; return }
-        bars = AgentLaunchStatsView.statsBars(from: result)
+        bars = LaunchStatsBars.statsBars(from: result)
         total = result.count
     }
 }

--- a/Sources/AgentConfigEditorSheet.swift
+++ b/Sources/AgentConfigEditorSheet.swift
@@ -1,0 +1,1178 @@
+import SwiftUI
+import Combine
+
+// MARK: - Seam types (C11-182 ↔ C11-181)
+//
+// The A-button popover (C11-181, parallel sibling) opens this editor via
+// `AppDelegate.openAgentConfigEditor(focus:origin:)`, which posts the request
+// below. `‹Back`/Esc posts the closed request so the popover can reopen as the
+// single visible surface. Defined here because this file owns the editor.
+
+/// What the editor opens onto.
+enum AgentConfigEditorFocus: Equatable {
+    /// Edit the saved config with this id.
+    case config(String)
+    /// Start a new config.
+    case new
+    /// Open the launch-stats view.
+    case stats
+}
+
+/// Where an open request came from, so close can restore the right surface.
+enum AgentConfigEditorOrigin: String {
+    /// Opened from the Settings Saved Configs subsection (stays put on close).
+    case settings
+    /// Opened from the A-button popover (close orders Settings out + reopens the popover).
+    case popover
+}
+
+/// The NotificationCenter seam that carries open/close requests across windows.
+enum AgentConfigEditorRequest {
+    static let openName = Notification.Name("c11.agentConfigEditor.open")
+    static let closedName = Notification.Name("c11.agentConfigEditor.closed")
+
+    private static let focusKindKey = "focusKind"   // "config" | "new" | "stats"
+    private static let focusIdKey = "focusId"       // config id for .config
+    private static let originKey = "origin"
+    private static let returnToPopoverKey = "returnToPopover"
+
+    static func postOpen(focus: AgentConfigEditorFocus, origin: AgentConfigEditorOrigin) {
+        var info: [String: Any] = [originKey: origin.rawValue]
+        switch focus {
+        case .config(let id): info[focusKindKey] = "config"; info[focusIdKey] = id
+        case .new:            info[focusKindKey] = "new"
+        case .stats:          info[focusKindKey] = "stats"
+        }
+        NotificationCenter.default.post(name: openName, object: nil, userInfo: info)
+    }
+
+    static func focus(from note: Notification) -> AgentConfigEditorFocus {
+        switch note.userInfo?[focusKindKey] as? String {
+        case "config":
+            if let id = note.userInfo?[focusIdKey] as? String { return .config(id) }
+            return .new
+        case "stats": return .stats
+        default:      return .new
+        }
+    }
+
+    static func origin(from note: Notification) -> AgentConfigEditorOrigin {
+        (note.userInfo?[originKey] as? String).flatMap(AgentConfigEditorOrigin.init) ?? .settings
+    }
+
+    /// Post the close request. `returnToPopover` is true only when the operator
+    /// backed out (Back/Esc) from a popover-origin session — never after a launch.
+    static func postClosed(returnToPopover: Bool) {
+        NotificationCenter.default.post(
+            name: closedName, object: nil,
+            userInfo: [returnToPopoverKey: returnToPopover]
+        )
+    }
+
+    static func shouldReturnToPopover(from note: Notification) -> Bool {
+        note.userInfo?[returnToPopoverKey] as? Bool ?? false
+    }
+}
+
+// MARK: - Installed probe (design §5.6)
+
+/// Best-effort "is this harness's binary on PATH" probe. A Finder-launched GUI
+/// app inherits launchd's minimal PATH, so we resolve the operator's real PATH
+/// once per app session via their login shell, cache it, and answer off the
+/// render path. **Degrade-never-block:** any failure (no shell, timeout, empty
+/// capture) resolves to `installed = true`, so the editor never wrongly greys a
+/// working harness (the launch still degrades to the shell's own error, §5.6).
+@MainActor
+final class AgentInstalledProbe: ObservableObject {
+    static let shared = AgentInstalledProbe()
+
+    /// nil = not yet resolved (treat as installed); non-nil = the resolved PATH dirs.
+    @Published private(set) var pathDirs: [String]?
+    private var didStart = false
+
+    /// Kick the async login-shell PATH capture once. Safe to call repeatedly.
+    func startIfNeeded() {
+        guard !didStart else { return }
+        didStart = true
+        Task.detached(priority: .utility) {
+            let dirs = Self.captureLoginShellPath()
+            await MainActor.run { self.pathDirs = dirs }
+        }
+    }
+
+    /// Whether the harness's binary resolves on the captured PATH. Returns
+    /// `true` while the PATH is still resolving or on any failure (degrade-never-block).
+    func isInstalled(harness: String) -> Bool {
+        guard let dirs = pathDirs, !dirs.isEmpty else { return true }
+        let command = AgentRegistry.shared.manifest(forKind: harness)?.factoryCommand ?? ""
+        guard let bin = AgentConfigAxes.firstBinaryToken(command) else { return true }
+        // An absolute path: check it directly.
+        if bin.contains("/") {
+            return FileManager.default.isExecutableFile(atPath: bin)
+        }
+        for dir in dirs {
+            if FileManager.default.isExecutableFile(atPath: dir + "/" + bin) { return true }
+        }
+        return false
+    }
+
+    /// Run the user's login shell once to capture their real PATH. Returns nil on
+    /// any failure so callers degrade to "installed". `nonisolated` so the
+    /// detached capture task can call it off the main actor.
+    private nonisolated static func captureLoginShellPath() -> [String]? {
+        let shell = ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh"
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: shell)
+        process.arguments = ["-l", "-c", "printf %s \"$PATH\""]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard process.terminationStatus == 0,
+              let raw = String(data: data, encoding: .utf8) else { return nil }
+        let dirs = raw.split(separator: ":").map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return dirs.isEmpty ? nil : dirs
+    }
+}
+
+// MARK: - Library view-model
+
+/// Observable wrapper over `AgentConfigLibraryStore` for the SwiftUI surfaces.
+/// Recompute-on-mutation: every mutator writes through the store (the file is
+/// the contract) then reloads the published snapshot. Injectable store for tests.
+@MainActor
+final class AgentConfigLibraryViewModel: ObservableObject {
+    @Published private(set) var configs: [SavedAgentConfig] = []
+    @Published private(set) var defaultState: AgentConfigDefault =
+        AgentConfigLibraryFile.factory.default
+
+    private let store: AgentConfigLibraryStore
+
+    init(store: AgentConfigLibraryStore = .shared) {
+        self.store = store
+        reload()
+    }
+
+    func reload() {
+        let file = store.current
+        configs = file.configs.sorted { $0.order < $1.order }
+        defaultState = file.default
+    }
+
+    func isPinnedDefault(_ config: SavedAgentConfig) -> Bool {
+        defaultState.mode == .pinned && defaultState.configId == config.id
+    }
+
+    var pinnedConfig: SavedAgentConfig? {
+        configs.first { $0.id == defaultState.configId }
+    }
+
+    /// Save the draft (add when `sourceId == nil`, else update in place). Returns
+    /// the stored config (with its resolved id), or nil on a store error.
+    @discardableResult
+    func save(_ draft: EditorDraft) -> SavedAgentConfig? {
+        let name = draft.resolvedName
+        do {
+            if let id = draft.sourceId, let existing = configs.first(where: { $0.id == id }) {
+                let updated = SavedAgentConfig(id: id, name: name, order: existing.order, config: draft.config)
+                var file = store.current
+                if let i = file.configs.firstIndex(where: { $0.id == id }) {
+                    file.configs[i] = updated
+                    try store.write(file)
+                }
+                reload()
+                return updated
+            } else {
+                let stored = try store.add(
+                    SavedAgentConfig(id: "", name: name, order: 0, config: draft.config)
+                )
+                reload()
+                return stored
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    func remove(id: String) {
+        try? store.remove(id: id)
+        reload()
+    }
+
+    func move(fromOffsets source: IndexSet, toOffset destination: Int) {
+        var ordered = configs
+        ordered.move(fromOffsets: source, toOffset: destination)
+        // Persist the new order by reindexing through the store one move at a time.
+        for (index, config) in ordered.enumerated() {
+            try? store.reorder(id: config.id, to: index)
+        }
+        reload()
+    }
+
+    func setDefault(id: String) {
+        try? store.setDefault(configId: id)
+        reload()
+    }
+
+    func setFollowRecent(_ on: Bool) {
+        try? store.setMode(on ? .followRecent : .pinned)
+        reload()
+    }
+}
+
+// MARK: - Editor draft
+
+/// The working copy of the config being edited (a value type SwiftUI can bind
+/// against). `sourceId == nil` means a not-yet-saved new config.
+struct EditorDraft: Equatable {
+    var sourceId: String?
+    var name: String
+    var config: AgentLaunchConfig
+
+    var resolvedName: String {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        return trimmed.isEmpty ? AgentConfigAxes.autoName(for: config) : trimmed
+    }
+
+    static func new() -> EditorDraft {
+        EditorDraft(sourceId: nil, name: "",
+                    config: AgentLaunchConfig(harness: "claude-code",
+                                              systemPrompt: SystemPromptSetting(mode: .inherit)))
+    }
+
+    static func from(_ saved: SavedAgentConfig) -> EditorDraft {
+        EditorDraft(sourceId: saved.id, name: saved.name, config: saved.config)
+    }
+}
+
+// MARK: - Editor sheet chrome tokens
+
+private enum EditorTheme {
+    static var goldGhost: Color { BrandColors.goldSwiftUI.opacity(0.10) }
+    static var goldFaint: Color { BrandColors.goldFaintSwiftUI }
+    static var rowRule: Color { BrandColors.ruleSwiftUI.opacity(0.55) }
+    static let sheetWidth: CGFloat = 860
+}
+
+// MARK: - The editor sheet
+
+/// Tier 2 of the model picker (design §5.4/§5.5): the Saved Configs editor +
+/// launch stats view, reproduced from the binding prototype. Presented as a
+/// `.sheet` from the Settings section.
+struct AgentConfigEditorSheet: View {
+    @ObservedObject var library: AgentConfigLibraryViewModel
+    let initialFocus: AgentConfigEditorFocus
+    /// Called when the operator closes the sheet; `returnToPopover` is true only
+    /// on a Back/Esc backout (not after a launch).
+    var onClose: (_ returnToPopover: Bool) -> Void
+
+    @StateObject private var installed = AgentInstalledProbe.shared
+    @State private var draft: EditorDraft = .new()
+    @State private var statsMode = false
+    @State private var advancedOpen = false
+    @State private var modelFilter = ""
+    @State private var savedFlashId: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider().overlay(BrandColors.ruleSwiftUI)
+            HStack(spacing: 0) {
+                libraryRail
+                Divider().overlay(BrandColors.ruleSwiftUI)
+                Group {
+                    if statsMode {
+                        LaunchStatsView()
+                    } else {
+                        editor
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            }
+            if !statsMode {
+                Divider().overlay(BrandColors.ruleSwiftUI)
+                footer
+            }
+        }
+        .frame(width: EditorTheme.sheetWidth)
+        .frame(maxHeight: 640)
+        .background(BrandColors.surfaceSwiftUI)
+        .environment(\.colorScheme, .dark)
+        .overlay(hiddenKeyboardCatchers)
+        .onAppear { installed.startIfNeeded(); applyFocus(initialFocus) }
+    }
+
+    // Hidden buttons that catch Return (Save & Launch) and Escape (Back).
+    private var hiddenKeyboardCatchers: some View {
+        ZStack {
+            Button("", action: backOut).keyboardShortcut(.cancelAction).hidden()
+            if !statsMode {
+                Button("", action: saveAndLaunch).keyboardShortcut(.defaultAction).hidden()
+            }
+        }
+        .frame(width: 0, height: 0)
+    }
+
+    // MARK: Header
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Button(action: backOut) {
+                HStack(spacing: 5) {
+                    Text("‹").font(.system(size: 13))
+                    Text(String(localized: "agentConfigEditor.back", defaultValue: "Back"))
+                }
+                .font(.system(size: 11))
+                .foregroundStyle(BrandColors.dimSwiftUI)
+                .padding(.horizontal, 9).padding(.vertical, 4)
+                .overlay(RoundedRectangle(cornerRadius: 5).stroke(BrandColors.ruleSwiftUI, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(statsMode
+                     ? String(localized: "agentConfigEditor.stats.title", defaultValue: "Launch Stats")
+                     : String(localized: "agentConfigEditor.title", defaultValue: "Agent Configurations"))
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(BrandColors.whiteSwiftUI)
+                Text(statsMode
+                     ? String(localized: "agentConfigEditor.stats.subtitle",
+                               defaultValue: "Every launch through any path appends to agent-launches.jsonl — these are lifetime numbers.")
+                     : String(localized: "agentConfigEditor.subtitle",
+                               defaultValue: "Every saved recipe layers over its harness's Settings — set a field to override, leave it to inherit."))
+                    .font(.system(size: 11.5, weight: .light))
+                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.6))
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 22).padding(.top, 18).padding(.bottom, 14)
+    }
+
+    // MARK: Library rail
+
+    private var libraryRail: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(String(localized: "agentConfigEditor.savedConfigs", defaultValue: "Saved configs"))
+                    .font(.system(size: 9.5, weight: .medium)).textCase(.uppercase)
+                    .tracking(1.4).foregroundStyle(BrandColors.dimSwiftUI)
+                Spacer()
+                Text(String(localized: "agentConfigEditor.dragToReorder", defaultValue: "drag ⠿ to reorder"))
+                    .font(.system(size: 9)).foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+            }
+            .padding(.horizontal, 14).padding(.top, 11).padding(.bottom, 7)
+
+            List {
+                ForEach(library.configs, id: \.id) { config in
+                    libraryRow(config)
+                        .listRowBackground(rowBackground(config))
+                        .listRowSeparator(.hidden)
+                        .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))
+                }
+                .onMove { library.move(fromOffsets: $0, toOffset: $1) }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+
+            Button(action: newConfig) {
+                HStack(spacing: 8) {
+                    Text("＋").font(.system(size: 13))
+                    Text(String(localized: "agentConfigEditor.newConfig", defaultValue: "New config"))
+                        .font(.system(size: 11.5))
+                    Spacer()
+                }
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.65))
+                .padding(.horizontal, 14).padding(.vertical, 10)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .overlay(Rectangle().frame(height: 1).foregroundStyle(BrandColors.ruleSwiftUI), alignment: .top)
+        }
+        .frame(width: 252)
+        .background(BrandColors.surfaceSwiftUI.opacity(0.5))
+    }
+
+    private func libraryRow(_ config: SavedAgentConfig) -> some View {
+        Button {
+            selectConfig(config)
+        } label: {
+            HStack(spacing: 8) {
+                Text("⠿").font(.system(size: 10)).foregroundStyle(BrandColors.dimSwiftUI)
+                    .frame(width: 14)
+                VStack(alignment: .leading, spacing: 1.5) {
+                    HStack(spacing: 6) {
+                        Text(config.name).font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(BrandColors.whiteSwiftUI)
+                        if library.isPinnedDefault(config) {
+                            Text("●").font(.system(size: 9)).foregroundStyle(BrandColors.goldSwiftUI)
+                        }
+                    }
+                    Text(sublineText(config.config))
+                        .font(.system(size: 9.5)).foregroundStyle(BrandColors.dimSwiftUI)
+                        .lineLimit(1).truncationMode(.tail)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10).padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func rowBackground(_ config: SavedAgentConfig) -> Color {
+        if !statsMode, draft.sourceId == config.id { return EditorTheme.goldFaint }
+        if savedFlashId == config.id { return EditorTheme.goldFaint }
+        return .clear
+    }
+
+    private func sublineText(_ config: AgentLaunchConfig) -> String {
+        var s = AgentConfigAxes.describe(config)
+        if AgentConfigAxes.isBlankSlate(config) { s += " · ·blank·" }
+        return s
+    }
+
+    // MARK: Editor (imported from AgentConfigRecipeEditorContent to keep body small)
+
+    private var editor: some View {
+        AgentConfigRecipeEditor(
+            draft: $draft,
+            advancedOpen: $advancedOpen,
+            modelFilter: $modelFilter,
+            installed: installed
+        )
+    }
+
+    // MARK: Footer
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Text(String(localized: "agentConfigEditor.default", defaultValue: "Default"))
+                .font(.system(size: 9, weight: .medium)).textCase(.uppercase).tracking(1.2)
+                .foregroundStyle(BrandColors.dimSwiftUI)
+            Menu {
+                ForEach(library.configs, id: \.id) { config in
+                    Button(config.name) { library.setDefault(id: config.id) }
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Text("●").foregroundStyle(BrandColors.goldSwiftUI)
+                    Text(library.pinnedConfig?.name
+                         ?? String(localized: "agentConfigEditor.noDefault", defaultValue: "—"))
+                        .foregroundStyle(BrandColors.whiteSwiftUI)
+                    Text("▾").font(.system(size: 9)).foregroundStyle(BrandColors.dimSwiftUI)
+                }
+                .font(.system(size: 11))
+                .padding(.horizontal, 10).padding(.vertical, 4)
+                .background(BrandColors.surface3SwiftUI)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+            }
+            .menuStyle(.borderlessButton).fixedSize()
+
+            Button {
+                library.setFollowRecent(library.defaultState.mode != .followRecent)
+            } label: {
+                HStack(spacing: 6) {
+                    checkbox(on: library.defaultState.mode == .followRecent)
+                    Text(String(localized: "agentConfigEditor.followRecent", defaultValue: "follow most recent"))
+                        .font(.system(size: 10.5)).foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+                }
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Button(String(localized: "agentConfigEditor.save", defaultValue: "Save"), action: saveOnly)
+                .buttonStyle(.bordered)
+            Button(action: saveAndLaunch) {
+                HStack(spacing: 8) {
+                    Text(String(localized: "agentConfigEditor.saveLaunch", defaultValue: "Save & Launch"))
+                    Text("\u{23CE}").opacity(0.55).font(.system(size: 11))
+                }
+            }
+            .buttonStyle(GoldCTAButtonStyle())
+        }
+        .padding(.horizontal, 22).padding(.vertical, 12)
+        .background(BrandColors.surfaceSwiftUI.opacity(0.6))
+    }
+
+    private func checkbox(on: Bool) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(on ? BrandColors.goldSwiftUI : Color.clear)
+                .frame(width: 13, height: 13)
+                .overlay(RoundedRectangle(cornerRadius: 3).stroke(on ? BrandColors.goldSwiftUI : BrandColors.dimSwiftUI, lineWidth: 1))
+            if on { Text("✓").font(.system(size: 9)).foregroundStyle(BrandColors.blackSwiftUI) }
+        }
+    }
+
+    // MARK: Actions
+
+    private func applyFocus(_ focus: AgentConfigEditorFocus) {
+        switch focus {
+        case .config(let id):
+            if let match = library.configs.first(where: { $0.id == id }) { selectConfig(match) }
+            else { newConfig() }
+        case .new:
+            if let first = library.configs.first { selectConfig(first) } else { newConfig() }
+        case .stats:
+            statsMode = true
+        }
+    }
+
+    private func selectConfig(_ config: SavedAgentConfig) {
+        statsMode = false
+        draft = .from(config)
+        advancedOpen = false
+        modelFilter = ""
+    }
+
+    private func newConfig() {
+        statsMode = false
+        draft = .new()
+        advancedOpen = false
+        modelFilter = ""
+    }
+
+    private func saveOnly() {
+        guard let saved = library.save(draft) else { return }
+        draft.sourceId = saved.id
+        flashSaved(saved.id)
+    }
+
+    private func saveAndLaunch() {
+        guard !statsMode, let saved = library.save(draft) else { return }
+        _ = AppDelegate.shared?.launchSavedAgentConfig(saved)
+        onClose(false) // launched — do not return to the popover
+    }
+
+    private func backOut() {
+        onClose(true)
+    }
+
+    private func flashSaved(_ id: String) {
+        savedFlashId = id
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.3) {
+            if savedFlashId == id { savedFlashId = nil }
+        }
+    }
+}
+
+// MARK: - Recipe editor (axis-dependency order, design §5.4)
+
+/// The right-hand recipe editor: harness → model → effort → system prompt →
+/// advanced, each overridable field carrying an inherit/override state chip.
+struct AgentConfigRecipeEditor: View {
+    @Binding var draft: EditorDraft
+    @Binding var advancedOpen: Bool
+    @Binding var modelFilter: String
+    @ObservedObject var installed: AgentInstalledProbe
+
+    private var harness: String { draft.config.harness }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 15) {
+                nameField
+                harnessField
+                modelField
+                effortField
+                systemPromptField
+                advancedField
+            }
+            .padding(.horizontal, 22).padding(.top, 16).padding(.bottom, 18)
+        }
+    }
+
+    // MARK: Field chrome
+
+    private func fieldLabel(_ text: String, trailing: AnyView? = nil) -> some View {
+        HStack(spacing: 8) {
+            Text(text).font(.system(size: 10, weight: .medium)).textCase(.uppercase).tracking(1.2)
+                .foregroundStyle(BrandColors.dimSwiftUI)
+            if let trailing { trailing }
+        }
+    }
+
+    private func overrideChip(_ isOverride: Bool) -> AnyView {
+        AnyView(
+            Text(isOverride
+                 ? String(localized: "agentConfigEditor.override", defaultValue: "● override")
+                 : String(localized: "agentConfigEditor.inherits", defaultValue: "○ inherits harness Settings"))
+                .font(.system(size: 9, weight: isOverride ? .regular : .light))
+                .foregroundStyle(isOverride ? BrandColors.goldSwiftUI : Color(white: 0.29))
+        )
+    }
+
+    private var textFieldFill: some View {
+        RoundedRectangle(cornerRadius: 6).fill(BrandColors.surface2SwiftUI)
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(BrandColors.ruleSwiftUI, lineWidth: 1))
+    }
+
+    // MARK: Name
+
+    private var nameField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(String(localized: "agentConfigEditor.name", defaultValue: "Name"))
+            TextField(AgentConfigAxes.autoName(for: draft.config), text: $draft.name)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(BrandColors.whiteSwiftUI)
+                .padding(.horizontal, 10).padding(.vertical, 7)
+                .background(textFieldFill)
+        }
+    }
+
+    // MARK: Harness grid
+
+    private var harnessField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(String(localized: "agentConfigEditor.harness", defaultValue: "Harness"),
+                       trailing: AnyView(
+                        Text(String(localized: "agentConfigEditor.harness.hint",
+                                    defaultValue: "the root axis — gates everything below"))
+                            .font(.system(size: 9, weight: .light)).foregroundStyle(Color(white: 0.29))))
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 7), count: 3), spacing: 7) {
+                ForEach(AgentType.allCases) { type in
+                    harnessCard(type)
+                }
+            }
+        }
+    }
+
+    private func harnessCard(_ type: AgentType) -> some View {
+        let k = type.rawValue
+        let isSel = harness == k
+        let isInstalled = installed.isInstalled(harness: k)
+        return Button {
+            draft.config = AgentConfigAxes.reconcileHarnessSwitch(draft.config, to: k)
+            modelFilter = ""
+        } label: {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(type.displayName).font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(BrandColors.whiteSwiftUI)
+                    Spacer(minLength: 0)
+                }
+                Text(providerSubline(k))
+                    .font(.system(size: 9))
+                    .foregroundStyle(isSel ? BrandColors.goldSwiftUI.opacity(0.75) : BrandColors.dimSwiftUI)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 10).padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(RoundedRectangle(cornerRadius: 7).fill(isSel ? EditorTheme.goldGhost : BrandColors.surface2SwiftUI))
+            .overlay(RoundedRectangle(cornerRadius: 7).stroke(isSel ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI, lineWidth: isSel ? 1.2 : 1))
+            .overlay(alignment: .topTrailing) {
+                if !isInstalled {
+                    Text(String(localized: "agentConfigEditor.notInstalled", defaultValue: "NOT INSTALLED"))
+                        .font(.system(size: 8)).tracking(0.5).foregroundStyle(BrandColors.dimSwiftUI)
+                        .padding(.top, 7).padding(.trailing, 8)
+                }
+            }
+            .opacity(isInstalled ? 1 : 0.5)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func providerSubline(_ k: String) -> String {
+        switch AgentConfigAxes.providerClass(forHarness: k) {
+        case .router:
+            return String(localized: "agentConfigEditor.provider.router",
+                          defaultValue: "OpenRouter · provider by model prefix")
+        case .fixed(let label):
+            return label
+        case .custom:
+            return String(localized: "agentConfigEditor.provider.custom", defaultValue: "operator-defined")
+        }
+    }
+
+    // MARK: Model
+
+    private var modelField: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(String(localized: "agentConfigEditor.model", defaultValue: "Model"),
+                       trailing: overrideChip(draft.config.model != nil))
+            modelControl
+        }
+    }
+
+    @ViewBuilder private var modelControl: some View {
+        switch AgentConfigAxes.modelAxis(forHarness: harness) {
+        case .families(let families):
+            familiesPanel(families)
+        case .router:
+            routerPanel
+        case .freeform(let providerLabel):
+            freeformModel(providerLabel)
+        case .none:
+            axisOff(String(localized: "agentConfigEditor.model.none",
+                           defaultValue: "no model flag — this harness launches whatever its own config selects"))
+        }
+    }
+
+    private func familiesPanel(_ families: [ClaudeModelFamily]) -> some View {
+        let base = AgentConfigAxes.inheritedModelBase(forHarness: harness,
+                                                      from: DefaultAgentConfigStore.shared.current) ?? "opus"
+        return VStack(alignment: .leading, spacing: 5) {
+            VStack(spacing: 0) {
+                modelRow(value: nil,
+                         label: String(localized: "agentConfigEditor.model.inherit", defaultValue: "Inherit"),
+                         note: String(format: String(localized: "agentConfigEditor.model.inheritNote",
+                                                      defaultValue: "harness Settings → %@"), base))
+                ForEach(families) { family in
+                    modelRow(value: family.rawValue, label: family.displayName, note: nil)
+                }
+            }
+            .background(BrandColors.surface2SwiftUI)
+            .clipShape(RoundedRectangle(cornerRadius: 7))
+            .overlay(RoundedRectangle(cornerRadius: 7).stroke(BrandColors.ruleSwiftUI, lineWidth: 1))
+            Text(String(format: String(localized: "agentConfigEditor.model.familyHint",
+                                        defaultValue: "family alias · claude --model %@ resolves to the latest release; no c11 change on new model drops"),
+                        draft.config.model ?? "opus"))
+                .font(.system(size: 9.5)).foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+        }
+    }
+
+    private var routerPanel: some View {
+        VStack(spacing: 0) {
+            TextField(String(localized: "agentConfigEditor.model.filter",
+                             defaultValue: "filter models… (provider rides the prefix)"),
+                      text: $modelFilter)
+                .textFieldStyle(.plain).font(.system(size: 11.5))
+                .foregroundStyle(BrandColors.whiteSwiftUI)
+                .padding(.horizontal, 12).padding(.vertical, 8)
+                .overlay(Rectangle().frame(height: 1).foregroundStyle(BrandColors.ruleSwiftUI), alignment: .bottom)
+            ScrollView {
+                VStack(spacing: 0) {
+                    if modelFilter.isEmpty {
+                        modelRow(value: nil,
+                                 label: String(localized: "agentConfigEditor.model.inherit", defaultValue: "Inherit"),
+                                 note: String(localized: "agentConfigEditor.model.inheritSettings",
+                                              defaultValue: "harness Settings"))
+                    }
+                    ForEach(AgentConfigAxes.routerModelCatalog, id: \.provider) { group in
+                        let visible = group.models.filter {
+                            modelFilter.isEmpty || $0.lowercased().contains(modelFilter.lowercased())
+                        }
+                        if !visible.isEmpty {
+                            HStack {
+                                Text("\(group.provider)/").font(.system(size: 9, weight: .medium))
+                                    .tracking(1.3).textCase(.uppercase).foregroundStyle(BrandColors.dimSwiftUI)
+                                Spacer()
+                                Text(String(localized: "agentConfigEditor.model.providerTag", defaultValue: "provider"))
+                                    .font(.system(size: 9)).foregroundStyle(BrandColors.dimSwiftUI)
+                            }
+                            .padding(.horizontal, 12).padding(.top, 6).padding(.bottom, 4)
+                            .background(BrandColors.surfaceSwiftUI.opacity(0.5))
+                            ForEach(visible, id: \.self) { model in
+                                let name = model.contains("/") ? String(model.split(separator: "/")[1]) : model
+                                modelRow(value: model, label: name, note: nil)
+                            }
+                        }
+                    }
+                }
+            }
+            .frame(maxHeight: 218)
+        }
+        .background(BrandColors.surface2SwiftUI)
+        .clipShape(RoundedRectangle(cornerRadius: 7))
+        .overlay(RoundedRectangle(cornerRadius: 7).stroke(BrandColors.ruleSwiftUI, lineWidth: 1))
+    }
+
+    private func modelRow(value: String?, label: String, note: String?) -> some View {
+        let isSel = draft.config.model == value
+        return Button {
+            draft.config.model = value
+        } label: {
+            HStack(spacing: 10) {
+                Text(isSel ? "✓" : "").font(.system(size: 10)).foregroundStyle(BrandColors.goldSwiftUI).frame(width: 14)
+                Text(label).font(.system(size: 12))
+                    .foregroundStyle(isSel ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI)
+                if let note {
+                    Text(note).font(.system(size: 9.5)).foregroundStyle(BrandColors.dimSwiftUI)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12).padding(.vertical, 6)
+            .background(isSel ? EditorTheme.goldFaint : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func freeformModel(_ providerLabel: String) -> some View {
+        let suggestions = AgentConfigAxes.freeformSuggestions(forHarness: harness)
+        let modelBinding = Binding<String>(
+            get: { draft.config.model ?? "" },
+            set: { draft.config.model = $0.isEmpty ? nil : $0 }
+        )
+        return VStack(alignment: .leading, spacing: 7) {
+            TextField(String(format: String(localized: "agentConfigEditor.model.freeformPlaceholder",
+                                            defaultValue: "inherit — %@ default"),
+                             AgentRegistry.shared.manifest(forKind: harness)?.displayName ?? harness),
+                      text: modelBinding)
+                .textFieldStyle(.plain).font(.system(size: 12))
+                .foregroundStyle(BrandColors.whiteSwiftUI)
+                .padding(.horizontal, 10).padding(.vertical, 7)
+                .background(textFieldFill)
+            if !suggestions.isEmpty {
+                FlowChips(items: suggestions, selected: draft.config.model) { model in
+                    draft.config.model = model
+                }
+            }
+        }
+    }
+
+    // MARK: Effort
+
+    private var effortField: some View {
+        let chips = AgentConfigAxes.effortChipValues(forHarness: harness)
+        let hasAxis = !(AgentConfigAxes.effortAxis(forHarness: harness) == .none)
+        return VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(String(localized: "agentConfigEditor.effort", defaultValue: "Effort"),
+                       trailing: hasAxis ? overrideChip(draft.config.effort != nil) : nil)
+            if chips.isEmpty {
+                axisOff(String(format: String(localized: "agentConfigEditor.effort.none",
+                                              defaultValue: "no effort axis on %@"),
+                               AgentRegistry.shared.manifest(forKind: harness)?.displayName ?? harness))
+            } else {
+                effortChips(chips)
+                effortHint
+            }
+        }
+    }
+
+    private func effortChips(_ chips: [String]) -> some View {
+        FlowChipsRaw {
+            chip(label: String(localized: "agentConfigEditor.effort.inherit", defaultValue: "inherit"),
+                 selected: draft.config.effort == nil) { draft.config.effort = nil }
+            ForEach(chips, id: \.self) { value in
+                chip(label: value, selected: draft.config.effort == value) { draft.config.effort = value }
+            }
+        }
+    }
+
+    @ViewBuilder private var effortHint: some View {
+        let hint: String? = {
+            switch harness {
+            case "codex":
+                return String(localized: "agentConfigEditor.effort.codexHint",
+                              defaultValue: "rides -c model_reasoning_effort=… — codex enforces values")
+            case "pi", "omp":
+                return String(localized: "agentConfigEditor.effort.thinkingHint", defaultValue: "rides --thinking")
+            default: return nil
+            }
+        }()
+        if let hint {
+            Text(hint).font(.system(size: 9.5)).foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+        }
+    }
+
+    // MARK: System prompt
+
+    private var systemPromptField: some View {
+        let supported = AgentConfigAxes.systemPromptAxis(forHarness: harness) != .none
+        let mode = draft.config.systemPrompt?.mode ?? .inherit
+        return VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(String(localized: "agentConfigEditor.systemPrompt", defaultValue: "System prompt"),
+                       trailing: supported ? overrideChip(mode != .inherit) : nil)
+            if supported {
+                systemPromptControl(mode: mode)
+            } else {
+                axisOff(String(format: String(localized: "agentConfigEditor.systemPrompt.none",
+                                              defaultValue: "no system-prompt flag on %@ — control disabled (same gating as effort)"),
+                               AgentRegistry.shared.manifest(forKind: harness)?.displayName ?? harness))
+            }
+        }
+    }
+
+    @ViewBuilder private func systemPromptControl(mode: SystemPromptSetting.Mode) -> some View {
+        let textBinding = Binding<String>(
+            get: { draft.config.systemPrompt?.text ?? "" },
+            set: { draft.config.systemPrompt = SystemPromptSetting(mode: mode, text: $0) }
+        )
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 0) {
+                ForEach(SystemPromptSetting.Mode.allCases, id: \.self) { m in
+                    Button {
+                        let text = draft.config.systemPrompt?.text ?? ""
+                        draft.config.systemPrompt = SystemPromptSetting(mode: m, text: text)
+                    } label: {
+                        Text(m.rawValue).font(.system(size: 11))
+                            .foregroundStyle(mode == m ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.65))
+                            .padding(.horizontal, 13).padding(.vertical, 4)
+                            .background(mode == m ? EditorTheme.goldGhost : BrandColors.surface2SwiftUI)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .overlay(Rectangle().frame(width: 1).foregroundStyle(BrandColors.ruleSwiftUI),
+                             alignment: .trailing)
+                }
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(BrandColors.ruleSwiftUI, lineWidth: 1))
+
+            if mode != .inherit {
+                TextEditor(text: textBinding)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(BrandColors.whiteSwiftUI)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 54, maxHeight: 90)
+                    .padding(6)
+                    .background(textFieldFill)
+            }
+            if mode == .replace, (draft.config.systemPrompt?.text ?? "").isEmpty {
+                Text(String(localized: "agentConfigEditor.systemPrompt.blank",
+                            defaultValue: "◈ blank slate — launches with --system-prompt '' (the Gregorovich launch)"))
+                    .font(.system(size: 10)).foregroundStyle(BrandColors.goldSwiftUI)
+            }
+        }
+    }
+
+    // MARK: Advanced (full recipe: command · initial prompt · env)
+
+    private var advancedField: some View {
+        let envBinding = Binding<String>(
+            get: { EnvText.toText(draft.config.env) },
+            set: { draft.config.env = EnvText.toDict($0) }
+        )
+        let commandBinding = optionalBinding(\.command)
+        let promptBinding = optionalBinding(\.initialPrompt)
+        return VStack(alignment: .leading, spacing: 10) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.12)) { advancedOpen.toggle() }
+            } label: {
+                HStack(spacing: 7) {
+                    Text("▸").font(.system(size: 8)).rotationEffect(.degrees(advancedOpen ? 90 : 0))
+                    Text(String(localized: "agentConfigEditor.advanced",
+                                defaultValue: "advanced — command · initial prompt · env"))
+                        .font(.system(size: 11))
+                    Text(String(localized: "agentConfigEditor.advanced.allInherit", defaultValue: "all inherit"))
+                        .font(.system(size: 9, weight: .light)).foregroundStyle(Color(white: 0.29))
+                    Spacer()
+                }
+                .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.6))
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if advancedOpen {
+                advancedInput(String(localized: "agentConfigEditor.command", defaultValue: "Command"),
+                              placeholder: AgentRegistry.shared.manifest(forKind: harness)?.factoryCommand ?? "",
+                              binding: commandBinding, isOverride: draft.config.command != nil)
+                advancedInput(String(localized: "agentConfigEditor.initialPrompt", defaultValue: "Initial prompt"),
+                              placeholder: String(localized: "agentConfigEditor.none", defaultValue: "(none)"),
+                              binding: promptBinding, isOverride: draft.config.initialPrompt != nil)
+                VStack(alignment: .leading, spacing: 6) {
+                    fieldLabel(String(localized: "agentConfigEditor.env", defaultValue: "Env overrides"),
+                               trailing: overrideChip(draft.config.env?.isEmpty == false))
+                    TextEditor(text: envBinding)
+                        .font(.system(size: 12, design: .monospaced)).foregroundStyle(BrandColors.whiteSwiftUI)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 44, maxHeight: 90).padding(6).background(textFieldFill)
+                    Text(String(localized: "agentConfigEditor.env.hint",
+                                defaultValue: "KEY=value — one per line, merged over harness env"))
+                        .font(.system(size: 9.5)).foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.45))
+                }
+            }
+        }
+    }
+
+    private func advancedInput(_ label: String, placeholder: String, binding: Binding<String>, isOverride: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            fieldLabel(label, trailing: overrideChip(isOverride))
+            TextField(placeholder, text: binding)
+                .textFieldStyle(.plain).font(.system(size: 12, design: .monospaced))
+                .foregroundStyle(BrandColors.whiteSwiftUI)
+                .padding(.horizontal, 10).padding(.vertical, 7).background(textFieldFill)
+        }
+    }
+
+    private func optionalBinding(_ keyPath: WritableKeyPath<AgentLaunchConfig, String?>) -> Binding<String> {
+        Binding<String>(
+            get: { draft.config[keyPath: keyPath] ?? "" },
+            set: { draft.config[keyPath: keyPath] = $0.isEmpty ? nil : $0 }
+        )
+    }
+
+    // MARK: Shared bits
+
+    private func axisOff(_ text: String) -> some View {
+        Text(text).font(.system(size: 10.5)).foregroundStyle(Color(white: 0.29)).padding(.vertical, 6)
+    }
+
+    private func chip(label: String, selected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label).font(.system(size: 11))
+                .foregroundStyle(selected ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.75))
+                .padding(.horizontal, 11).padding(.vertical, 4)
+                .background(RoundedRectangle(cornerRadius: 5).fill(selected ? EditorTheme.goldGhost : BrandColors.surface2SwiftUI))
+                .overlay(RoundedRectangle(cornerRadius: 5).stroke(selected ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI, lineWidth: 1))
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Env text <-> dict
+
+enum EnvText {
+    static func toText(_ env: [String: String]?) -> String {
+        guard let env, !env.isEmpty else { return "" }
+        return env.keys.sorted().map { "\($0)=\(env[$0] ?? "")" }.joined(separator: "\n")
+    }
+
+    static func toDict(_ text: String) -> [String: String]? {
+        var out: [String: String] = [:]
+        for raw in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = raw.trimmingCharacters(in: .whitespaces)
+            if line.isEmpty || line.hasPrefix("#") { continue }
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let key = line[..<eq].trimmingCharacters(in: .whitespaces)
+            let value = line[line.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            if !key.isEmpty { out[key] = String(value) }
+        }
+        return out.isEmpty ? nil : out
+    }
+}
+
+// MARK: - Chip flow layouts
+
+/// A simple wrapping row of selectable suggestion chips.
+private struct FlowChips: View {
+    let items: [String]
+    let selected: String?
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        FlowChipsRaw {
+            ForEach(items, id: \.self) { item in
+                Button { onSelect(item) } label: {
+                    Text(item).font(.system(size: 11))
+                        .foregroundStyle(selected == item ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.75))
+                        .padding(.horizontal, 11).padding(.vertical, 4)
+                        .background(RoundedRectangle(cornerRadius: 5).fill(selected == item ? BrandColors.goldSwiftUI.opacity(0.10) : BrandColors.surface2SwiftUI))
+                        .overlay(RoundedRectangle(cornerRadius: 5).stroke(selected == item ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI, lineWidth: 1))
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+/// A horizontal, wrapping stack of arbitrary chip content.
+private struct FlowChipsRaw<Content: View>: View {
+    @ViewBuilder let content: Content
+    var body: some View {
+        HStack(spacing: 6) { content }
+    }
+}
+
+// MARK: - Launch stats view (design §5.5)
+
+/// The launch-stats view rendered inside the sheet: window chips (today/30d/all),
+/// gold leader bars, and the agent-launches.jsonl provenance line. Reads the
+/// C11-178 aggregate through `AgentLaunchStatsStore.shared`.
+struct LaunchStatsView: View {
+    @State private var window: StatsWindow = .all
+    @State private var bars: [StatsBarRow] = []
+    @State private var total = 0
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 7) {
+                    windowChip(.today, String(localized: "agentConfigEditor.stats.today", defaultValue: "today"))
+                    windowChip(.days(30), String(localized: "agentConfigEditor.stats.30d", defaultValue: "30d"))
+                    windowChip(.all, String(localized: "agentConfigEditor.stats.all", defaultValue: "all time"))
+                    Spacer()
+                    Text(String(format: String(localized: "agentConfigEditor.stats.query",
+                                               defaultValue: "by model · c11 config stats --window %@"), windowFlag))
+                        .font(.system(size: 10)).foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.35))
+                }
+                .padding(.top, 12).padding(.bottom, 16)
+
+                if bars.isEmpty {
+                    Text(String(localized: "agentConfigEditor.stats.empty",
+                                defaultValue: "no launches recorded yet — launch an agent and it lands here"))
+                        .font(.system(size: 11)).foregroundStyle(BrandColors.dimSwiftUI).padding(.vertical, 20)
+                } else {
+                    ForEach(bars, id: \.label) { row in barRow(row) }
+                }
+
+                Text(String(format: String(localized: "agentConfigEditor.stats.provenance",
+                                           defaultValue: "%d launches · %@ · source: agent-launches.jsonl — every path (A button, CLI, socket, blueprint, fader) records"),
+                            total, windowLabel))
+                    .font(.system(size: 10.5)).foregroundStyle(BrandColors.dimSwiftUI).padding(.top, 14)
+            }
+            .padding(.horizontal, 22).padding(.bottom, 18)
+        }
+        .task(id: windowFlag) { await reload() }
+    }
+
+    private func barRow(_ row: StatsBarRow) -> some View {
+        HStack(spacing: 11) {
+            Text(row.label).font(.system(size: 11.5)).foregroundStyle(BrandColors.whiteSwiftUI)
+                .frame(width: 92, alignment: .trailing)
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3).fill(BrandColors.surface2SwiftUI)
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(row.isLeader
+                              ? LinearGradient(colors: [BrandColors.goldSwiftUI.opacity(0.55), BrandColors.goldSwiftUI],
+                                               startPoint: .leading, endPoint: .trailing)
+                              : LinearGradient(colors: [BrandColors.surface3SwiftUI, BrandColors.surface3SwiftUI],
+                                               startPoint: .leading, endPoint: .trailing))
+                        .frame(width: max(0, geo.size.width * row.widthOfMax))
+                }
+            }
+            .frame(height: 14)
+            Text("\(Int((row.shareOfTotal * 100).rounded()))% (\(row.count))")
+                .font(.system(size: 10.5)).foregroundStyle(BrandColors.dimSwiftUI)
+                .frame(width: 110, alignment: .leading)
+        }
+        .padding(.bottom, 9)
+    }
+
+    private func windowChip(_ w: StatsWindow, _ label: String) -> some View {
+        Button { window = w } label: {
+            Text(label).font(.system(size: 11))
+                .foregroundStyle(window == w ? BrandColors.goldSwiftUI : BrandColors.whiteSwiftUI.opacity(0.75))
+                .padding(.horizontal, 11).padding(.vertical, 4)
+                .background(RoundedRectangle(cornerRadius: 5).fill(window == w ? BrandColors.goldSwiftUI.opacity(0.10) : BrandColors.surface2SwiftUI))
+                .overlay(RoundedRectangle(cornerRadius: 5).stroke(window == w ? BrandColors.goldSwiftUI : BrandColors.ruleSwiftUI, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var windowFlag: String {
+        switch window { case .today: return "today"; case .days: return "30d"; case .all: return "all" }
+    }
+    private var windowLabel: String {
+        switch window {
+        case .today: return String(localized: "agentConfigEditor.stats.label.today", defaultValue: "today")
+        case .days: return String(localized: "agentConfigEditor.stats.label.30d", defaultValue: "last 30d")
+        case .all: return String(localized: "agentConfigEditor.stats.label.all", defaultValue: "all time")
+        }
+    }
+
+    private func reload() async {
+        let w = window
+        let result: LaunchStatsResult? = await Task.detached(priority: .userInitiated) {
+            AgentLaunchStatsStore.shared?.stats(window: w, by: .model)
+        }.value
+        guard let result else { bars = []; total = 0; return }
+        bars = AgentLaunchStatsView.statsBars(from: result)
+        total = result.count
+    }
+}
+

--- a/Sources/AgentConfigEditorSheet.swift
+++ b/Sources/AgentConfigEditorSheet.swift
@@ -93,13 +93,18 @@ final class AgentInstalledProbe: ObservableObject {
     private var didStart = false
 
     /// Kick the async login-shell PATH capture + verdict computation once. Safe
-    /// to call repeatedly.
+    /// to call repeatedly. Snapshots the operator's configured per-harness
+    /// commands on the main actor so the probe reflects a rebound binary, not
+    /// just the factory command.
     func startIfNeeded() {
         guard !didStart else { return }
         didStart = true
+        let base = DefaultAgentConfigStore.shared.current
+        let commands = Dictionary(uniqueKeysWithValues:
+            AgentType.allCases.map { ($0.rawValue, base.config(for: $0).command) })
         Task.detached(priority: .utility) {
             let dirs = Self.captureLoginShellPath()
-            let verdicts = Self.computeVerdicts(pathDirs: dirs)
+            let verdicts = Self.computeVerdicts(pathDirs: dirs, configuredCommands: commands)
             await MainActor.run { self.verdicts = verdicts }
         }
     }
@@ -111,14 +116,19 @@ final class AgentInstalledProbe: ObservableObject {
         verdicts[harness] ?? true
     }
 
-    /// Stat each harness's binary against the captured PATH once, off-main. An
-    /// empty/unresolved PATH yields `[:]` so every harness reads as installed.
-    private nonisolated static func computeVerdicts(pathDirs: [String]?) -> [String: Bool] {
+    /// Stat each harness's binary against the captured PATH once, off-main. Uses
+    /// the operator's configured command where set, falling back to the factory
+    /// command. An empty/unresolved PATH yields `[:]` so every harness reads as
+    /// installed.
+    private nonisolated static func computeVerdicts(pathDirs: [String]?, configuredCommands: [String: String]) -> [String: Bool] {
         guard let dirs = pathDirs, !dirs.isEmpty else { return [:] }
         let fm = FileManager.default
         var out: [String: Bool] = [:]
         for type in AgentType.allCases {
-            let command = AgentRegistry.shared.manifest(forKind: type.rawValue)?.factoryCommand ?? ""
+            let configured = configuredCommands[type.rawValue]?.trimmingCharacters(in: .whitespaces) ?? ""
+            let command = configured.isEmpty
+                ? (AgentRegistry.shared.manifest(forKind: type.rawValue)?.factoryCommand ?? "")
+                : configured
             guard let bin = AgentConfigAxes.firstBinaryToken(command) else { out[type.rawValue] = true; continue }
             if bin.contains("/") {
                 out[type.rawValue] = fm.isExecutableFile(atPath: bin)
@@ -198,23 +208,24 @@ final class AgentConfigLibraryViewModel: ObservableObject {
     @discardableResult
     func save(_ draft: EditorDraft) -> SavedAgentConfig? {
         let name = draft.resolvedName
+        let config = draft.normalizedConfig
         do {
-            if let id = draft.sourceId, let existing = configs.first(where: { $0.id == id }) {
-                let updated = SavedAgentConfig(id: id, name: name, order: existing.order, config: draft.config)
+            // Update path: only when the id still exists in the on-disk file.
+            if let id = draft.sourceId {
                 var file = store.current
                 if let i = file.configs.firstIndex(where: { $0.id == id }) {
+                    let updated = SavedAgentConfig(id: id, name: name, order: file.configs[i].order, config: config)
                     file.configs[i] = updated
                     try store.write(file)
+                    reload()
+                    return updated
                 }
-                reload()
-                return updated
-            } else {
-                let stored = try store.add(
-                    SavedAgentConfig(id: "", name: name, order: 0, config: draft.config)
-                )
-                reload()
-                return stored
+                // The id vanished (deleted out from under us): fall through to add
+                // rather than silently reporting a save that never happened.
             }
+            let stored = try store.add(SavedAgentConfig(id: "", name: name, order: 0, config: config))
+            reload()
+            return stored
         } catch {
             return nil
         }
@@ -264,10 +275,15 @@ struct EditorDraft: Equatable {
         return trimmed.isEmpty ? AgentConfigAxes.autoName(for: config) : trimmed
     }
 
+    /// The config as it should be persisted — an explicit `.inherit` system
+    /// prompt (transient editor state) collapses to `nil` (true inherit).
+    var normalizedConfig: AgentLaunchConfig {
+        AgentConfigAxes.normalizedForPersistence(config)
+    }
+
     static func new() -> EditorDraft {
-        EditorDraft(sourceId: nil, name: "",
-                    config: AgentLaunchConfig(harness: "claude-code",
-                                              systemPrompt: SystemPromptSetting(mode: .inherit)))
+        // systemPrompt nil = inherit; the editor renders `?? .inherit` for display.
+        EditorDraft(sourceId: nil, name: "", config: AgentLaunchConfig(harness: "claude-code"))
     }
 
     static func from(_ saved: SavedAgentConfig) -> EditorDraft {
@@ -574,16 +590,24 @@ struct AgentConfigEditorSheet: View {
 
     private func saveOnly() {
         launchFeedback = nil
-        guard let saved = library.save(draft) else { return }
+        guard let saved = library.save(draft) else {
+            launchFeedback = saveFailedMessage
+            return
+        }
         draft.sourceId = saved.id
         flashSaved(saved.id)
     }
 
     private func saveAndLaunch() {
-        guard !statsMode, let saved = library.save(draft) else { return }
+        guard !statsMode else { return }
+        launchFeedback = nil
+        guard let saved = library.save(draft) else {
+            launchFeedback = saveFailedMessage
+            return
+        }
         draft.sourceId = saved.id
         // Never silently no-op (design MINOR-5): keep the sheet open + explain
-        // when there is nothing to launch into or the recipe has no command.
+        // when there is nothing to launch into or the recipe can't launch.
         switch AppDelegate.shared?.launchSavedAgentConfig(saved) ?? .noWorkspace {
         case .launched:
             onClose(false) // launched — do not return to the popover
@@ -591,11 +615,15 @@ struct AgentConfigEditorSheet: View {
             flashSaved(saved.id)
             launchFeedback = String(localized: "agentConfigEditor.launch.noWorkspace",
                                     defaultValue: "Saved. No workspace open to launch into — open one, then launch.")
-        case .emptyCommand:
+        case .cannotLaunch:
             flashSaved(saved.id)
-            launchFeedback = String(localized: "agentConfigEditor.launch.emptyCommand",
-                                    defaultValue: "Saved. This recipe has no command to launch — set one under Advanced.")
+            launchFeedback = String(localized: "agentConfigEditor.launch.cannotLaunch",
+                                    defaultValue: "Saved. This recipe can't launch — check the harness and its command under Advanced.")
         }
+    }
+
+    private var saveFailedMessage: String {
+        String(localized: "agentConfigEditor.saveFailed", defaultValue: "Couldn't save — please try again.")
     }
 
     private func backOut() {

--- a/Sources/AgentLaunchStats.swift
+++ b/Sources/AgentLaunchStats.swift
@@ -30,6 +30,10 @@ public enum AgentLaunchSource: String, Codable, Sendable, CaseIterable {
     case socket
     case blueprint
     case fader
+    /// A launch fired from the Settings Saved Configs editor's "Save & Launch"
+    /// (design §5.4). Distinct provenance from `.aButton` so the stats rail can
+    /// tell a configured-then-launched recipe from a plain A-button launch.
+    case configEditor = "config-editor"
 }
 
 /// The ingestion rail that produced a most-recent observation. Used only for

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7513,17 +7513,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         openPreferencesWindow(debugSource: "appDelegate")
     }
 
+    /// A pending open request for the agent-config editor, set by
+    /// `openAgentConfigEditor` and drained by the Settings section on appear.
+    /// Covers the cold-first-mount race where the open notification would fire
+    /// before any observer exists.
+    @MainActor private(set) var pendingAgentConfigEditorFocus: (focus: AgentConfigEditorFocus, origin: AgentConfigEditorOrigin)?
+
+    /// Read-and-clear the pending editor focus (nil if none).
+    @MainActor
+    func consumePendingAgentConfigEditorFocus() -> (focus: AgentConfigEditorFocus, origin: AgentConfigEditorOrigin)? {
+        defer { pendingAgentConfigEditorFocus = nil }
+        return pendingAgentConfigEditorFocus
+    }
+
     /// C11-182 seam: open the Settings Saved Configs editor sheet, focused on a
     /// config / a new config / the stats view. Navigates Settings to the Agents
-    /// page, then posts the open-sheet notification the section observes. The
-    /// single call the C11-181 A-button popover's "View all" / "Launch stats"
-    /// makes; `origin: .popover` lets the sheet order the Settings window out on
-    /// close so the popover returns as the one visible surface.
+    /// page, then posts the open-sheet notification the section observes (the
+    /// warm-mount fast path) while also stashing the request for the section to
+    /// drain on appear (the cold-mount path). The single call the C11-181
+    /// A-button popover's "View all" / "Launch stats" makes; `origin: .popover`
+    /// lets the sheet order the Settings window out on close so the popover
+    /// returns as the one visible surface.
     @MainActor
     func openAgentConfigEditor(focus: AgentConfigEditorFocus, origin: AgentConfigEditorOrigin = .popover) {
+        pendingAgentConfigEditorFocus = (focus, origin)
         Self.presentPreferencesWindow(navigationTarget: .agents)
-        // Defer so the Settings view has mounted and switched to the Agents page
-        // before the section's observer receives the open request.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
             AgentConfigEditorRequest.postOpen(focus: focus, origin: origin)
         }
@@ -7534,31 +7548,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     enum SavedConfigLaunchResult {
         case launched
         case noWorkspace
-        case emptyCommand
+        /// The recipe couldn't launch: an empty resolved command, or an
+        /// unresolvable/unknown harness. `launchAgentSurface` declined it.
+        case cannotLaunch
     }
 
     /// C11-182 seam: launch a chosen saved config as a new agent surface in the
     /// current workspace ("Save & Launch"). Never silently no-ops — the caller
     /// keeps the sheet open and shows feedback for `.noWorkspace` (nothing to
-    /// launch into) and `.emptyCommand` (a custom harness whose recipe resolves
-    /// to an empty command, which `launchAgentSurface` would drop).
+    /// launch into) and `.cannotLaunch` (the launch path declined the recipe).
+    /// `launchAgentSurface` resolves with the correct project overlay and reports
+    /// whether it launched, so there is no duplicate resolution here.
     @MainActor
     func launchSavedAgentConfig(_ saved: SavedAgentConfig) -> SavedConfigLaunchResult {
         guard let workspace = tabManager?.selectedWorkspace,
               let pane = workspace.bonsplitController.focusedPaneId else {
             return .noWorkspace
         }
-        // Detect the empty-command case up front (best-effort: no project overlay)
-        // so the operator gets feedback rather than a vanished sheet + no launch.
-        if let overlay = DefaultAgentResolver.resolveOverlay(
-            savedConfig: saved,
-            userDefault: DefaultAgentConfigStore.shared.current,
-            projectConfig: nil
-        ), overlay.launch.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return .emptyCommand
-        }
-        workspace.launchAgentSurface(inPane: pane, explicitConfig: saved, source: .configEditor)
-        return .launched
+        return workspace.launchAgentSurface(inPane: pane, explicitConfig: saved, source: .configEditor)
+            ? .launched : .cannotLaunch
     }
 
     func refreshMenuBarExtraForDebug() {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7529,18 +7529,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+    /// The outcome of a "Save & Launch" attempt, so the editor can give inline
+    /// feedback instead of silently no-op'ing (design C11-182 MINOR-5 resolution).
+    enum SavedConfigLaunchResult {
+        case launched
+        case noWorkspace
+        case emptyCommand
+    }
+
     /// C11-182 seam: launch a chosen saved config as a new agent surface in the
-    /// current workspace ("Save & Launch"). Returns `false` when no workspace is
-    /// open to launch into (the editor then degrades to save-only + a toast).
+    /// current workspace ("Save & Launch"). Never silently no-ops — the caller
+    /// keeps the sheet open and shows feedback for `.noWorkspace` (nothing to
+    /// launch into) and `.emptyCommand` (a custom harness whose recipe resolves
+    /// to an empty command, which `launchAgentSurface` would drop).
     @MainActor
-    @discardableResult
-    func launchSavedAgentConfig(_ saved: SavedAgentConfig) -> Bool {
+    func launchSavedAgentConfig(_ saved: SavedAgentConfig) -> SavedConfigLaunchResult {
         guard let workspace = tabManager?.selectedWorkspace,
               let pane = workspace.bonsplitController.focusedPaneId else {
-            return false
+            return .noWorkspace
+        }
+        // Detect the empty-command case up front (best-effort: no project overlay)
+        // so the operator gets feedback rather than a vanished sheet + no launch.
+        if let overlay = DefaultAgentResolver.resolveOverlay(
+            savedConfig: saved,
+            userDefault: DefaultAgentConfigStore.shared.current,
+            projectConfig: nil
+        ), overlay.launch.command.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return .emptyCommand
         }
         workspace.launchAgentSurface(inPane: pane, explicitConfig: saved, source: .configEditor)
-        return true
+        return .launched
     }
 
     func refreshMenuBarExtraForDebug() {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7513,6 +7513,36 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         openPreferencesWindow(debugSource: "appDelegate")
     }
 
+    /// C11-182 seam: open the Settings Saved Configs editor sheet, focused on a
+    /// config / a new config / the stats view. Navigates Settings to the Agents
+    /// page, then posts the open-sheet notification the section observes. The
+    /// single call the C11-181 A-button popover's "View all" / "Launch stats"
+    /// makes; `origin: .popover` lets the sheet order the Settings window out on
+    /// close so the popover returns as the one visible surface.
+    @MainActor
+    func openAgentConfigEditor(focus: AgentConfigEditorFocus, origin: AgentConfigEditorOrigin = .popover) {
+        Self.presentPreferencesWindow(navigationTarget: .agents)
+        // Defer so the Settings view has mounted and switched to the Agents page
+        // before the section's observer receives the open request.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.12) {
+            AgentConfigEditorRequest.postOpen(focus: focus, origin: origin)
+        }
+    }
+
+    /// C11-182 seam: launch a chosen saved config as a new agent surface in the
+    /// current workspace ("Save & Launch"). Returns `false` when no workspace is
+    /// open to launch into (the editor then degrades to save-only + a toast).
+    @MainActor
+    @discardableResult
+    func launchSavedAgentConfig(_ saved: SavedAgentConfig) -> Bool {
+        guard let workspace = tabManager?.selectedWorkspace,
+              let pane = workspace.bonsplitController.focusedPaneId else {
+            return false
+        }
+        workspace.launchAgentSurface(inPane: pane, explicitConfig: saved, source: .configEditor)
+        return true
+    }
+
     func refreshMenuBarExtraForDebug() {
         menuBarExtraController?.refreshForDebugControls()
     }

--- a/Sources/CreateWorkspaceSheet.swift
+++ b/Sources/CreateWorkspaceSheet.swift
@@ -894,8 +894,9 @@ struct CreateWorkspaceSheet: View {
 // MARK: - Gold CTA button style
 
 /// The standard c11 gold button (solid gold fill, void-black content) sized
-/// up as the sheet's primary call to action.
-private struct GoldCTAButtonStyle: ButtonStyle {
+/// up as a sheet's primary call to action. Module-internal so other sheets
+/// (e.g. the agent-config editor, C11-182) reuse the exact gold-CTA idiom.
+struct GoldCTAButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
 
     func makeBody(configuration: Configuration) -> some View {

--- a/Sources/DefaultAgentSettingsView.swift
+++ b/Sources/DefaultAgentSettingsView.swift
@@ -268,7 +268,11 @@ struct DefaultAgentSettingsSection: View {
                           systemImage: "plus")
                 }
                 Button(String(localized: "settings.savedConfigs.viewAll", defaultValue: "View all models & configs…")) {
-                    openEditor(library.pinnedConfig.map { .config($0.id) } ?? .new)
+                    // Land on the pinned config, else the first — never a blank
+                    // new draft (that is what "New config" is for).
+                    openEditor(library.pinnedConfig.map { .config($0.id) }
+                               ?? library.configs.first.map { .config($0.id) }
+                               ?? .new)
                 }
                 Button(String(localized: "settings.savedConfigs.stats", defaultValue: "Launch stats")) {
                     openEditor(.stats)
@@ -288,8 +292,7 @@ struct DefaultAgentSettingsSection: View {
                 .font(.caption)
             VStack(alignment: .leading, spacing: 1) {
                 Text(config.name).font(.callout)
-                Text(AgentConfigAxes.describe(config.config)
-                     + (AgentConfigAxes.isBlankSlate(config.config) ? " · ·blank·" : ""))
+                Text(AgentConfigAxes.subline(config.config))
                     .font(.caption).foregroundStyle(.secondary).lineLimit(1)
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/DefaultAgentSettingsView.swift
+++ b/Sources/DefaultAgentSettingsView.swift
@@ -202,10 +202,20 @@ struct DefaultAgentSettingsSection: View {
             )
         }
         .onReceive(NotificationCenter.default.publisher(for: AgentConfigEditorRequest.openName)) { note in
+            // Warm-mount fast path. Clear any stashed pending focus so a later
+            // appear can't re-open a stale request.
+            _ = AppDelegate.shared?.consumePendingAgentConfigEditorFocus()
             editorOrigin = AgentConfigEditorRequest.origin(from: note)
             editorPresentation = AgentConfigEditorPresentation(focus: AgentConfigEditorRequest.focus(from: note))
         }
-        .onAppear { library.reload() }
+        .onAppear {
+            library.reload()
+            // Cold-mount path: drain a request that fired before this section existed.
+            if let pending = AppDelegate.shared?.consumePendingAgentConfigEditorFocus() {
+                editorOrigin = pending.origin
+                editorPresentation = AgentConfigEditorPresentation(focus: pending.focus)
+            }
+        }
     }
 
     /// Post the close request from the dismiss handler (fires for Back/Esc/launch

--- a/Sources/DefaultAgentSettingsView.swift
+++ b/Sources/DefaultAgentSettingsView.swift
@@ -96,12 +96,27 @@ final class DefaultAgentSettingsViewModel: ObservableObject {
     }
 }
 
+/// Identifies a presentation of the agent-config editor sheet.
+struct AgentConfigEditorPresentation: Identifiable {
+    let id = UUID()
+    let focus: AgentConfigEditorFocus
+}
+
 struct DefaultAgentSettingsSection: View {
     @StateObject private var vm = DefaultAgentSettingsViewModel()
+    @StateObject private var library = AgentConfigLibraryViewModel()
     @State private var showEnvOverrides = false
+    @State private var editorPresentation: AgentConfigEditorPresentation?
+    @State private var editorOrigin: AgentConfigEditorOrigin = .settings
+    @State private var pendingReturnToPopover = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
+            // Tier 0 — the saved-config library (C11-182), above the per-harness editor.
+            savedConfigsSubsection
+
+            Divider()
+
             // Tier 1 — which agent the A button launches.
             HStack(spacing: 8) {
                 Text(String(localized: "settings.defaultAgent.picker.label",
@@ -176,6 +191,125 @@ struct DefaultAgentSettingsSection: View {
                 .controlSize(.small)
             }
         }
+        .sheet(item: $editorPresentation, onDismiss: handleEditorDismiss) { presentation in
+            AgentConfigEditorSheet(
+                library: library,
+                initialFocus: presentation.focus,
+                onClose: { returnToPopover in
+                    pendingReturnToPopover = returnToPopover && editorOrigin == .popover
+                    editorPresentation = nil
+                }
+            )
+        }
+        .onReceive(NotificationCenter.default.publisher(for: AgentConfigEditorRequest.openName)) { note in
+            editorOrigin = AgentConfigEditorRequest.origin(from: note)
+            editorPresentation = AgentConfigEditorPresentation(focus: AgentConfigEditorRequest.focus(from: note))
+        }
+        .onAppear { library.reload() }
+    }
+
+    /// Post the close request from the dismiss handler (fires for Back/Esc/launch
+    /// and any programmatic dismissal) so the C11-181 popover is never stranded.
+    /// When the operator backed out of a popover-origin session, order the
+    /// Settings window out so the popover returns as the single visible surface.
+    private func handleEditorDismiss() {
+        if pendingReturnToPopover {
+            SettingsWindowController.shared.window?.orderOut(nil)
+        }
+        AgentConfigEditorRequest.postClosed(returnToPopover: pendingReturnToPopover)
+        pendingReturnToPopover = false
+        editorOrigin = .settings
+        library.reload()
+    }
+
+    // MARK: - Saved Configs subsection (design §5.4)
+
+    private var savedConfigsSubsection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "settings.savedConfigs.heading", defaultValue: "Saved configs"))
+                .font(.headline)
+            Text(String(localized: "settings.savedConfigs.note",
+                        defaultValue: "each config is a full launch recipe layered over its harness's Settings. click one to edit; the A button launches the pinned default."))
+                .font(.caption).foregroundStyle(.secondary)
+
+            VStack(spacing: 0) {
+                ForEach(library.configs, id: \.id) { config in
+                    savedConfigRow(config)
+                    Divider().opacity(0.4)
+                }
+            }
+            .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.25), lineWidth: 1))
+
+            HStack(spacing: 12) {
+                Text(String(localized: "settings.savedConfigs.default", defaultValue: "Default:"))
+                    .font(.callout)
+                Menu {
+                    ForEach(library.configs, id: \.id) { config in
+                        Button(config.name) { library.setDefault(id: config.id) }
+                    }
+                } label: {
+                    Text(library.pinnedConfig?.name
+                         ?? String(localized: "settings.savedConfigs.none", defaultValue: "—"))
+                }
+                .fixedSize()
+                Toggle(String(localized: "settings.savedConfigs.followRecent", defaultValue: "follow most recent"),
+                       isOn: Binding(
+                        get: { library.defaultState.mode == .followRecent },
+                        set: { library.setFollowRecent($0) }))
+                    .toggleStyle(.checkbox).controlSize(.small)
+                Spacer()
+            }
+
+            HStack(spacing: 14) {
+                Button {
+                    openEditor(.new)
+                } label: {
+                    Label(String(localized: "settings.savedConfigs.new", defaultValue: "New config"),
+                          systemImage: "plus")
+                }
+                Button(String(localized: "settings.savedConfigs.viewAll", defaultValue: "View all models & configs…")) {
+                    openEditor(library.pinnedConfig.map { .config($0.id) } ?? .new)
+                }
+                Button(String(localized: "settings.savedConfigs.stats", defaultValue: "Launch stats")) {
+                    openEditor(.stats)
+                }
+                Spacer()
+            }
+            .controlSize(.small)
+        }
+    }
+
+    private func savedConfigRow(_ config: SavedAgentConfig) -> some View {
+        // Not a Button wrapping a Button (a macOS SwiftUI footgun): the row is a
+        // tappable HStack; the trash is the only nested Button.
+        HStack(spacing: 8) {
+            Text(library.isPinnedDefault(config) ? "●" : "○")
+                .foregroundStyle(library.isPinnedDefault(config) ? Color.accentColor : Color.secondary)
+                .font(.caption)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(config.name).font(.callout)
+                Text(AgentConfigAxes.describe(config.config)
+                     + (AgentConfigAxes.isBlankSlate(config.config) ? " · ·blank·" : ""))
+                    .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .onTapGesture { openEditor(.config(config.id)) }
+            Image(systemName: "pencil").font(.caption).foregroundStyle(.secondary)
+            Button {
+                library.remove(id: config.id)
+            } label: {
+                Image(systemName: "trash").font(.caption)
+            }
+            .buttonStyle(.borderless)
+            .help(String(localized: "settings.savedConfigs.delete", defaultValue: "Delete this config"))
+        }
+        .padding(.horizontal, 10).padding(.vertical, 7)
+    }
+
+    private func openEditor(_ focus: AgentConfigEditorFocus) {
+        editorOrigin = .settings
+        editorPresentation = AgentConfigEditorPresentation(focus: focus)
     }
 
     /// Model-family picker, shown only for agents c11 pins a `--model` flag

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11956,7 +11956,7 @@ extension Workspace: BonsplitDelegate {
     ///   `.aButton` (the real UI spawn button); the CLI `default-agent launch`
     ///   new-surface path passes `.launchAgent` so button-clicks and CLI launches
     ///   are honestly distinguished in the stats rail.
-    func launchAgentSurface(inPane pane: PaneID, explicitAgent: AgentType? = nil, source: AgentLaunchSource = .aButton) {
+    func launchAgentSurface(inPane pane: PaneID, explicitAgent: AgentType? = nil, explicitConfig: SavedAgentConfig? = nil, source: AgentLaunchSource = .aButton) {
         let userDefault = DefaultAgentConfigStore.shared.current
         let projectConfig = DefaultAgentProjectConfig.find(from: resolverCwdForAgentLaunch())
 
@@ -11972,11 +11972,18 @@ extension Workspace: BonsplitDelegate {
         let resolvedSystemPromptMode: String?
         let savedConfigId: String?
 
-        // Only a plain left-click consults the saved-config library; an explicit
-        // agent keeps `nil` here and takes the raw-harness path below.
-        let overlaySaved: SavedAgentConfig? = explicitAgent == nil
-            ? AgentConfigLibraryStore.shared.effectiveDefault()
-            : nil
+        // A caller-chosen config (Settings "Save & Launch", C11-182) launches
+        // exactly that recipe. Otherwise a plain left-click consults the
+        // saved-config library's `effectiveDefault()`; an explicit agent keeps
+        // `nil` here and takes the raw-harness path below.
+        let overlaySaved: SavedAgentConfig?
+        if let explicitConfig {
+            overlaySaved = explicitConfig
+        } else if explicitAgent == nil {
+            overlaySaved = AgentConfigLibraryStore.shared.effectiveDefault()
+        } else {
+            overlaySaved = nil
+        }
         if let saved = overlaySaved,
            let overlay = DefaultAgentResolver.resolveOverlay(
                savedConfig: saved,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11956,7 +11956,13 @@ extension Workspace: BonsplitDelegate {
     ///   `.aButton` (the real UI spawn button); the CLI `default-agent launch`
     ///   new-surface path passes `.launchAgent` so button-clicks and CLI launches
     ///   are honestly distinguished in the stats rail.
-    func launchAgentSurface(inPane pane: PaneID, explicitAgent: AgentType? = nil, explicitConfig: SavedAgentConfig? = nil, source: AgentLaunchSource = .aButton) {
+    /// Launch an agent surface. Returns `true` when a launch was actually
+    /// performed; `false` when it declined (empty resolved command, surface
+    /// creation failed, or an `explicitConfig` whose recipe couldn't be
+    /// resolved) — the "Save & Launch" caller surfaces that as feedback rather
+    /// than a silent no-op.
+    @discardableResult
+    func launchAgentSurface(inPane pane: PaneID, explicitAgent: AgentType? = nil, explicitConfig: SavedAgentConfig? = nil, source: AgentLaunchSource = .aButton) -> Bool {
         let userDefault = DefaultAgentConfigStore.shared.current
         let projectConfig = DefaultAgentProjectConfig.find(from: resolverCwdForAgentLaunch())
 
@@ -11996,6 +12002,11 @@ extension Workspace: BonsplitDelegate {
             resolvedEffort = overlay.mergedConfig.effort.trimmingCharacters(in: .whitespacesAndNewlines)
             resolvedSystemPromptMode = overlay.mergedConfig.systemPrompt?.mode.rawValue
             savedConfigId = saved.id.isEmpty ? nil : saved.id
+        } else if explicitConfig != nil {
+            // A caller asked to launch a specific recipe that the resolver could
+            // not materialize (unknown harness in a hand-edited agent-configs.json).
+            // Decline rather than silently launching the default agent instead.
+            return false
         } else {
             let resolved = DefaultAgentResolver.resolve(
                 explicitAgent: explicitAgent,
@@ -12011,11 +12022,11 @@ extension Workspace: BonsplitDelegate {
             savedConfigId = nil
         }
 
-        guard !launch.command.isEmpty else { return }
+        guard !launch.command.isEmpty else { return false }
         guard let panel = newTerminalSurface(
             inPane: pane,
             startupEnvironment: launch.envOverrides
-        ) else { return }
+        ) else { return false }
         // By default no orientation prompt is baked (see `c11OrientPrompt`),
         // so the agent boots straight to ready with no dead-time. c11 stamps
         // the identity the sidebar needs itself — no agent round-trip: the
@@ -12051,6 +12062,7 @@ extension Workspace: BonsplitDelegate {
         // this workspace's A-button tooltip. Cheap: `refreshSplitButtonTooltips`
         // diffs and no-ops when unchanged.
         refreshSplitButtonTooltips()
+        return true
     }
 
     /// C11-178/179: emit a rail-1 launch-stats record for an A-button-lineage

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -3112,6 +3112,9 @@ enum SettingsNavigationTarget: String {
     case browserImport
     case textBoxInput
     case keyboardShortcuts
+    /// The Agents & Automation page's default-agent / Saved Configs section
+    /// (C11-182), the anchor the agent-config editor navigates to.
+    case agents
 }
 
 enum SettingsNavigationRequest {
@@ -4364,6 +4367,8 @@ private enum SettingsPage: String, CaseIterable, Identifiable {
             return .input
         case .keyboardShortcuts:
             return .keyboardShortcuts
+        case .agents:
+            return .agents
         }
     }
 }
@@ -6235,6 +6240,7 @@ struct SettingsView: View {
             localized: "settings.section.defaultAgent",
             defaultValue: "default agent"
         ))
+        .id(SettingsNavigationTarget.agents)
         SettingsCardNote(String(
             localized: "settings.defaultAgent.note",
             defaultValue: "the A button on every pane launches this. new terminal still opens bash. drop a `.c11/agents.json` in any repo to override these settings for terminals opened there."

--- a/c11Tests/AgentConfigEditorModelTests.swift
+++ b/c11Tests/AgentConfigEditorModelTests.swift
@@ -1,0 +1,258 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// Pure-logic tests for the Saved Configs editor model (C11-182, design §1.2).
+/// No SwiftUI / `NSApp` construction, so these run in `c11-logic` locally.
+final class AgentConfigEditorModelTests: XCTestCase {
+
+    // MARK: Model axis
+
+    func testModelAxisClaudeIsFamilies() {
+        guard case .families(let fams) = AgentConfigAxes.modelAxis(forHarness: "claude-code") else {
+            return XCTFail("claude-code should be .families")
+        }
+        XCTAssertEqual(fams, ClaudeModelFamily.allCases)
+        XCTAssertEqual(fams.map(\.rawValue), ["opus", "sonnet", "haiku", "fable"])
+    }
+
+    func testModelAxisRouterHarnesses() {
+        for k in ["opencode", "pi", "omp"] {
+            XCTAssertEqual(AgentConfigAxes.modelAxis(forHarness: k), .router, "\(k) should be .router")
+        }
+    }
+
+    func testModelAxisFreeformHarnesses() {
+        let expected: [String: String] = [
+            "codex": "OpenAI", "grok": "xAI", "kimi": "Moonshot", "github-copilot": "GitHub",
+        ]
+        for (k, label) in expected {
+            guard case .freeform(let providerLabel) = AgentConfigAxes.modelAxis(forHarness: k) else {
+                return XCTFail("\(k) should be .freeform")
+            }
+            XCTAssertEqual(providerLabel, label)
+        }
+    }
+
+    func testModelAxisCustomIsNone() {
+        XCTAssertEqual(AgentConfigAxes.modelAxis(forHarness: "custom"), .none)
+        XCTAssertEqual(AgentConfigAxes.modelAxis(forHarness: "unknown-kind"), .none)
+    }
+
+    // MARK: Effort axis
+
+    func testEffortAxisTiers() {
+        XCTAssertEqual(AgentConfigAxes.effortAxis(forHarness: "claude-code"),
+                       .tiers(["low", "medium", "high", "xhigh", "max"]))
+        XCTAssertEqual(AgentConfigAxes.effortAxis(forHarness: "pi"),
+                       .tiers(["off", "minimal", "low", "medium", "high", "xhigh"]))
+        XCTAssertEqual(AgentConfigAxes.effortAxis(forHarness: "omp"),
+                       .tiers(["off", "minimal", "low", "medium", "high", "xhigh"]))
+    }
+
+    func testEffortAxisPassthroughForCodex() {
+        XCTAssertEqual(AgentConfigAxes.effortAxis(forHarness: "codex"), .passthrough)
+    }
+
+    func testEffortAxisNone() {
+        for k in ["grok", "kimi", "opencode", "github-copilot", "custom"] {
+            XCTAssertEqual(AgentConfigAxes.effortAxis(forHarness: k), .none, "\(k) should be .none")
+        }
+    }
+
+    func testEffortChipValues() {
+        XCTAssertEqual(AgentConfigAxes.effortChipValues(forHarness: "claude-code"),
+                       ["low", "medium", "high", "xhigh", "max"])
+        // codex passthrough → the curated suggestion set (matches the prototype).
+        XCTAssertEqual(AgentConfigAxes.effortChipValues(forHarness: "codex"), ["low", "medium", "high"])
+        XCTAssertEqual(AgentConfigAxes.effortChipValues(forHarness: "grok"), [])
+    }
+
+    // MARK: System-prompt axis
+
+    func testSystemPromptAxisClaudeSupported() {
+        guard case .supported(let appendFlag, let replaceFlag) =
+                AgentConfigAxes.systemPromptAxis(forHarness: "claude-code") else {
+            return XCTFail("claude-code should support system prompt")
+        }
+        XCTAssertEqual(appendFlag, "--append-system-prompt")
+        XCTAssertEqual(replaceFlag, "--system-prompt")
+    }
+
+    func testSystemPromptAxisNoneForOthers() {
+        for k in ["codex", "grok", "kimi", "opencode", "github-copilot", "pi", "omp", "custom"] {
+            XCTAssertEqual(AgentConfigAxes.systemPromptAxis(forHarness: k), .none, "\(k) should be .none")
+        }
+    }
+
+    // MARK: Provider identity
+
+    func testProviderClass() {
+        XCTAssertEqual(AgentConfigAxes.providerClass(forHarness: "claude-code"), .fixed(label: "Anthropic"))
+        XCTAssertEqual(AgentConfigAxes.providerClass(forHarness: "codex"), .fixed(label: "OpenAI"))
+        XCTAssertEqual(AgentConfigAxes.providerClass(forHarness: "opencode"), .router)
+        XCTAssertEqual(AgentConfigAxes.providerClass(forHarness: "custom"), .custom)
+    }
+
+    func testProviderDisplayLabel() {
+        XCTAssertEqual(AgentConfigAxes.providerDisplayLabel(forHarness: "grok"), "xAI")
+        XCTAssertEqual(AgentConfigAxes.providerDisplayLabel(forHarness: "pi"), "OpenRouter")
+        XCTAssertEqual(AgentConfigAxes.providerDisplayLabel(forHarness: "custom"), "")
+    }
+
+    // MARK: Harness-switch reconciliation (prototype index.html:1042-1053)
+
+    func testReconcileDropsIncompatibleModelClaudeToRouter() {
+        let c = AgentLaunchConfig(harness: "claude-code", model: "opus")
+        let out = AgentConfigAxes.reconcileHarnessSwitch(c, to: "omp")
+        XCTAssertEqual(out.harness, "omp")
+        XCTAssertNil(out.model, "opus is not a router id → dropped")
+    }
+
+    func testReconcileDropsRouterModelToClaude() {
+        let c = AgentLaunchConfig(harness: "omp", model: "deepseek/deepseek-chat-v3.1")
+        let out = AgentConfigAxes.reconcileHarnessSwitch(c, to: "claude-code")
+        XCTAssertNil(out.model, "slashed router id is not a claude family → dropped")
+    }
+
+    func testReconcileKeepsCompatibleModel() {
+        let c = AgentLaunchConfig(harness: "claude-code", model: "sonnet")
+        let out = AgentConfigAxes.reconcileHarnessSwitch(c, to: "claude-code")
+        XCTAssertEqual(out.model, "sonnet")
+    }
+
+    func testReconcileDropsEffortOutsideTierSet() {
+        let c = AgentLaunchConfig(harness: "claude-code", effort: "max")
+        // grok has no effort axis → dropped.
+        XCTAssertNil(AgentConfigAxes.reconcileHarnessSwitch(c, to: "grok").effort)
+        // pi's tiers do not include "max" → dropped.
+        XCTAssertNil(AgentConfigAxes.reconcileHarnessSwitch(c, to: "pi").effort)
+        // claude keeps "max".
+        XCTAssertEqual(AgentConfigAxes.reconcileHarnessSwitch(c, to: "claude-code").effort, "max")
+    }
+
+    func testReconcileDropsSystemPromptWhenUnsupported() {
+        let c = AgentLaunchConfig(harness: "claude-code",
+                                  systemPrompt: SystemPromptSetting(mode: .replace, text: ""))
+        let out = AgentConfigAxes.reconcileHarnessSwitch(c, to: "codex")
+        XCTAssertNil(out.systemPrompt, "codex has no system-prompt axis → dropped")
+    }
+
+    func testReconcileSeedsInheritSystemPromptWhenSupported() {
+        let c = AgentLaunchConfig(harness: "codex", model: "gpt-5.2")
+        let out = AgentConfigAxes.reconcileHarnessSwitch(c, to: "claude-code")
+        XCTAssertEqual(out.systemPrompt, SystemPromptSetting(mode: .inherit))
+    }
+
+    func testReconcileDropsFreeformModelWithSlashToRouter() {
+        // freeform harness carrying a non-slash id → switching to router drops it.
+        let c = AgentLaunchConfig(harness: "codex", model: "gpt-5.2")
+        XCTAssertNil(AgentConfigAxes.reconcileHarnessSwitch(c, to: "opencode").model)
+    }
+
+    // MARK: Naming + description
+
+    func testModelLabel() {
+        XCTAssertEqual(AgentConfigAxes.modelLabel(AgentLaunchConfig(harness: "claude-code")), "inherit")
+        XCTAssertEqual(AgentConfigAxes.modelLabel(AgentLaunchConfig(harness: "claude-code", model: "opus")), "opus")
+        XCTAssertEqual(AgentConfigAxes.modelLabel(AgentLaunchConfig(harness: "omp", model: "deepseek/deepseek-r1")),
+                       "deepseek-r1")
+    }
+
+    func testAutoName() {
+        XCTAssertEqual(AgentConfigAxes.autoName(for: AgentLaunchConfig(harness: "claude-code", model: "opus")),
+                       "Claude opus")
+        // inherit model → just the first word of the display name.
+        XCTAssertEqual(AgentConfigAxes.autoName(for: AgentLaunchConfig(harness: "codex")), "Codex")
+    }
+
+    func testDescribe() {
+        XCTAssertEqual(AgentConfigAxes.describe(AgentLaunchConfig(harness: "claude-code", model: "opus", effort: "high")),
+                       "claude-code · opus · high")
+        XCTAssertEqual(AgentConfigAxes.describe(AgentLaunchConfig(harness: "omp", model: "deepseek/deepseek-chat-v3.1")),
+                       "oh-my-pi · deepseek-chat-v3.1")
+    }
+
+    func testIsBlankSlate() {
+        XCTAssertTrue(AgentConfigAxes.isBlankSlate(
+            AgentLaunchConfig(harness: "claude-code", systemPrompt: SystemPromptSetting(mode: .replace, text: ""))))
+        XCTAssertFalse(AgentConfigAxes.isBlankSlate(
+            AgentLaunchConfig(harness: "claude-code", systemPrompt: SystemPromptSetting(mode: .replace, text: "hi"))))
+        XCTAssertFalse(AgentConfigAxes.isBlankSlate(
+            AgentLaunchConfig(harness: "claude-code", systemPrompt: SystemPromptSetting(mode: .append, text: ""))))
+        XCTAssertFalse(AgentConfigAxes.isBlankSlate(AgentLaunchConfig(harness: "claude-code")))
+    }
+
+    // MARK: Inherited model base
+
+    func testInheritedModelBaseFactory() {
+        // Factory: claude-code base model is opus.
+        XCTAssertEqual(AgentConfigAxes.inheritedModelBase(forHarness: "claude-code", from: .factory), "opus")
+        // codex has no base model out of the box → nil.
+        XCTAssertNil(AgentConfigAxes.inheritedModelBase(forHarness: "codex", from: .factory))
+        // unknown kind → nil.
+        XCTAssertNil(AgentConfigAxes.inheritedModelBase(forHarness: "unknown-kind", from: .factory))
+    }
+
+    // MARK: Installed-probe core
+
+    func testFirstBinaryToken() {
+        XCTAssertEqual(AgentConfigAxes.firstBinaryToken("claude --dangerously-skip-permissions"), "claude")
+        XCTAssertEqual(AgentConfigAxes.firstBinaryToken("opencode run --dangerously-skip-permissions"), "opencode")
+        XCTAssertEqual(AgentConfigAxes.firstBinaryToken("FOO=bar mytool --x"), "mytool")
+        XCTAssertEqual(AgentConfigAxes.firstBinaryToken("env BAR=baz tool"), "tool")
+        XCTAssertNil(AgentConfigAxes.firstBinaryToken(""))
+        XCTAssertNil(AgentConfigAxes.firstBinaryToken("   "))
+    }
+
+    // MARK: Static seeds
+
+    func testRouterCatalogNonEmpty() {
+        XCTAssertFalse(AgentConfigAxes.routerModelCatalog.isEmpty)
+        let flat = AgentConfigAxes.routerModelCatalog.flatMap { $0.models }
+        XCTAssertTrue(flat.allSatisfy { $0.contains("/") }, "every router id carries a provider prefix")
+        XCTAssertTrue(flat.contains("deepseek/deepseek-chat-v3.1"))
+    }
+
+    func testFreeformSuggestions() {
+        XCTAssertEqual(AgentConfigAxes.freeformSuggestions(forHarness: "codex"),
+                       ["gpt-5.2", "gpt-5.2-codex", "gpt-5.2-mini"])
+        XCTAssertEqual(AgentConfigAxes.freeformSuggestions(forHarness: "kimi"), ["kimi-k2"])
+        XCTAssertTrue(AgentConfigAxes.freeformSuggestions(forHarness: "opencode").isEmpty)
+    }
+
+    // MARK: Stats bars
+
+    func testStatsBarsSortedWithLeader() {
+        let result = LaunchStatsResult(
+            window: .all, axis: .model,
+            tally: ["opus": 412, "fable": 24, "sonnet": 19],
+            count: 455, lastTs: nil
+        )
+        let bars = AgentLaunchStatsView.statsBars(from: result)
+        XCTAssertEqual(bars.map(\.label), ["opus", "fable", "sonnet"])
+        XCTAssertTrue(bars[0].isLeader)
+        XCTAssertFalse(bars[1].isLeader)
+        XCTAssertEqual(bars[0].widthOfMax, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(bars[0].shareOfTotal, 412.0 / 455.0, accuracy: 0.0001)
+        XCTAssertEqual(bars[1].widthOfMax, 24.0 / 412.0, accuracy: 0.0001)
+    }
+
+    func testStatsBarsTieBreakByLabel() {
+        let result = LaunchStatsResult(
+            window: .today, axis: .model,
+            tally: ["zeta": 5, "alpha": 5], count: 10, lastTs: nil
+        )
+        let bars = AgentLaunchStatsView.statsBars(from: result)
+        XCTAssertEqual(bars.map(\.label), ["alpha", "zeta"], "ties break by label ascending")
+    }
+
+    func testStatsBarsEmpty() {
+        let result = LaunchStatsResult(window: .all, axis: .model, tally: [:], count: 0, lastTs: nil)
+        XCTAssertTrue(AgentLaunchStatsView.statsBars(from: result).isEmpty)
+    }
+}

--- a/c11Tests/AgentConfigEditorModelTests.swift
+++ b/c11Tests/AgentConfigEditorModelTests.swift
@@ -177,6 +177,18 @@ final class AgentConfigEditorModelTests: XCTestCase {
                        "oh-my-pi · deepseek-chat-v3.1")
     }
 
+    func testSubline() {
+        // Non-blank recipe → plain describe.
+        XCTAssertEqual(
+            AgentConfigAxes.subline(AgentLaunchConfig(harness: "claude-code", model: "opus", effort: "high")),
+            "claude-code · opus · high")
+        // Blank-slate recipe → describe + the ·blank· suffix.
+        XCTAssertEqual(
+            AgentConfigAxes.subline(AgentLaunchConfig(harness: "claude-code", model: "opus",
+                                                      systemPrompt: SystemPromptSetting(mode: .replace, text: ""))),
+            "claude-code · opus · ·blank·")
+    }
+
     func testIsBlankSlate() {
         XCTAssertTrue(AgentConfigAxes.isBlankSlate(
             AgentLaunchConfig(harness: "claude-code", systemPrompt: SystemPromptSetting(mode: .replace, text: ""))))
@@ -233,7 +245,7 @@ final class AgentConfigEditorModelTests: XCTestCase {
             tally: ["opus": 412, "fable": 24, "sonnet": 19],
             count: 455, lastTs: nil
         )
-        let bars = AgentLaunchStatsView.statsBars(from: result)
+        let bars = LaunchStatsBars.statsBars(from: result)
         XCTAssertEqual(bars.map(\.label), ["opus", "fable", "sonnet"])
         XCTAssertTrue(bars[0].isLeader)
         XCTAssertFalse(bars[1].isLeader)
@@ -247,12 +259,12 @@ final class AgentConfigEditorModelTests: XCTestCase {
             window: .today, axis: .model,
             tally: ["zeta": 5, "alpha": 5], count: 10, lastTs: nil
         )
-        let bars = AgentLaunchStatsView.statsBars(from: result)
+        let bars = LaunchStatsBars.statsBars(from: result)
         XCTAssertEqual(bars.map(\.label), ["alpha", "zeta"], "ties break by label ascending")
     }
 
     func testStatsBarsEmpty() {
         let result = LaunchStatsResult(window: .all, axis: .model, tally: [:], count: 0, lastTs: nil)
-        XCTAssertTrue(AgentLaunchStatsView.statsBars(from: result).isEmpty)
+        XCTAssertTrue(LaunchStatsBars.statsBars(from: result).isEmpty)
     }
 }

--- a/c11Tests/AgentConfigEditorModelTests.swift
+++ b/c11Tests/AgentConfigEditorModelTests.swift
@@ -142,16 +142,31 @@ final class AgentConfigEditorModelTests: XCTestCase {
         XCTAssertNil(out.systemPrompt, "codex has no system-prompt axis → dropped")
     }
 
-    func testReconcileSeedsInheritSystemPromptWhenSupported() {
+    func testReconcileLeavesSystemPromptNilOnSupportedHarness() {
+        // Switching to a supported harness must NOT seed a non-nil `.inherit`
+        // (that would clobber a configured base system prompt via mergeOverlay).
         let c = AgentLaunchConfig(harness: "codex", model: "gpt-5.2")
-        let out = AgentConfigAxes.reconcileHarnessSwitch(c, to: "claude-code")
-        XCTAssertEqual(out.systemPrompt, SystemPromptSetting(mode: .inherit))
+        XCTAssertNil(AgentConfigAxes.reconcileHarnessSwitch(c, to: "claude-code").systemPrompt)
     }
 
-    func testReconcileDropsFreeformModelWithSlashToRouter() {
+    func testReconcileDropsNonSlashFreeformModelToRouter() {
         // freeform harness carrying a non-slash id → switching to router drops it.
         let c = AgentLaunchConfig(harness: "codex", model: "gpt-5.2")
         XCTAssertNil(AgentConfigAxes.reconcileHarnessSwitch(c, to: "opencode").model)
+    }
+
+    func testNormalizedForPersistenceDropsInheritSysPrompt() {
+        // An explicit `.inherit` collapses to nil (true inherit).
+        let inherit = AgentLaunchConfig(harness: "claude-code", model: "opus",
+                                        systemPrompt: SystemPromptSetting(mode: .inherit, text: "x"))
+        XCTAssertNil(AgentConfigAxes.normalizedForPersistence(inherit).systemPrompt)
+        // A real override survives untouched.
+        let replace = AgentLaunchConfig(harness: "claude-code",
+                                        systemPrompt: SystemPromptSetting(mode: .replace, text: ""))
+        XCTAssertEqual(AgentConfigAxes.normalizedForPersistence(replace).systemPrompt,
+                       SystemPromptSetting(mode: .replace, text: ""))
+        // Already-nil stays nil.
+        XCTAssertNil(AgentConfigAxes.normalizedForPersistence(AgentLaunchConfig(harness: "codex")).systemPrompt)
     }
 
     // MARK: Naming + description


### PR DESCRIPTION
Implements **C11-182** — tier 2 of the C11-175 agent-config / model-picker: the **Saved Configs editor** and the **launch-stats view**, reproducing the operator-approved binding prototype (`docs/design-prototypes/model-picker/index.html` routes `#sheet` / `#sheet-router` / `#sheet-greg` / `#stats`) one-to-one.

Design: `docs/agent-config-primitive-design.md` §1.2–1.4, §2.1–2.4, §5.4–5.6.

## What ships
- **Pure axis model** (`AgentConfigEditorModel.swift`) derived from `AgentRegistry` (not a parallel mock table): `ModelAxis`/`EffortAxis`/`SystemPromptAxis` descriptors, provider identity, harness-switch reconciliation, autoName/describe/subline, blank-slate detection, router catalog + freeform suggestions (v1 seeds), the installed-probe core, and the stats-bar model. 33 pure-logic tests in `c11-logic`.
- **Editor sheet** (`AgentConfigEditorSheet.swift`): library rail (drag-reorder, gold ● default, ＋ New config), recipe editor in axis order — harness grid with provider identity (not-installed dim-but-pickable); model per axis (claude families with an Inherit row showing the resolved base; provider-grouped router filter; freeform + suggestion chips; custom axis-off); effort chips in the harness vocabulary; tri-mode system prompt with the gold blank-slate note; folded advanced (command/initialPrompt/env) wired to the real recipe; ○ inherits / ● override per field. Footer: default picker + follow-recent + Save + gold **Save & Launch** (`GoldCTAButtonStyle`). Plus the launch-stats view (today/30d/all chips, gold leader bar, provenance) over the C11-178 aggregate.
- **Settings**: a Saved Configs subsection above the per-harness editor in `DefaultAgentSettingsView`; presents the sheet; observes the open-sheet seam.
- **Launch seam**: `Workspace.launchAgentSurface(explicitConfig:)` (returns whether it launched, declines an unresolvable recipe rather than launching the default); `AppDelegate.launchSavedAgentConfig(_:)` + `openAgentConfigEditor(focus:origin:)` — the single call C11-181's popover will make; `‹Back`/Esc returns toward the popover.
- `AgentLaunchSource.configEditor` for Save & Launch provenance; `SettingsNavigationTarget.agents` anchor; `GoldCTAButtonStyle` made module-internal for reuse.

## Deviations from the prototype (deviate-with-flag — for the visual review)
1. **Cost column omitted** — no token-cost catalog exists yet in-process/CLI/socket (design §5.6 sanctions omission). Largest visual delta.
2. **Codex effort** rendered as chips from a curated suggestion set (the manifest models it as passthrough).
3. **Router catalog + freeform suggestions** are static v1 seeds (mirroring the prototype) pending the real OpenRouter catalog.
4. **Advanced fields wired** to the real recipe (the prototype stubbed them).
5. **Real PATH installed-probe** (login-shell, cached, degrade-to-installed) vs the prototype's hardcoded not-installed.
6. **View-all / return-to-popover seam** defined here for the parallel C11-181 (popover not yet on-branch).
7. **Legacy per-harness default picker retained** (out of scope to remove).
8. **§5.5 command-palette entries deferred** (no board ticket owns them; C11-181 owns 1–9 keys, C11-180 the `c11 config stats` CLI).
9. **Sheet bounded to the Settings window** (~640pt) rather than the prototype's full-viewport height; the recipe editor scrolls on overflow.

## Review
Two headless code-review rounds; every MAJOR resolved (focus routing, Save & Launch never silently no-ops, and the nil=inherit system-prompt contract so a saved "inherit" never clobbers a configured base). The third round timed out; own-reviewer fallback attached to the ticket. All plan-review resolutions honored.

## Tests
`c11-logic`: 33 model + 20 `AgentLaunchStats` (`.configEditor` added) + 24 `AgentLaunchOverlayCompositionTests` (C11-179 contract) green locally. UI validated via a tagged build (screenshots on the ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)