### PR TITLE
Fix session-autosave main-thread stall at high surface count (C11-183)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4048,7 +4048,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         didDisableSuddenTermination = false
     }
 
-    private func sessionAutosaveFingerprint(includeScrollback: Bool) -> Int? {
+    private func sessionAutosaveFingerprint(
+        includeScrollback: Bool,
+        conversationsByPanelId injectedConversations: [String: SurfaceConversations]? = nil
+    ) -> Int? {
         guard !includeScrollback else { return nil }
 
         var hasher = Hasher()
@@ -4087,24 +4090,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // snapshot is the one written at clean shutdown — losing every
         // ref captured in a session that ended any other way.
         if !ConversationStorePolicy.isDisabled {
-            let conversations = Workspace.readConversationsByPanelIdSync(timeout: 0.5)
-            // Order-independent: sort surface ids before hashing.
-            for surfaceId in conversations.keys.sorted() {
-                guard let surface = conversations[surfaceId],
-                      let active = surface.active else { continue }
-                hasher.combine(surfaceId)
-                hasher.combine(active.kind)
-                hasher.combine(active.id)
-                hasher.combine(active.state.rawValue)
-                hasher.combine(active.capturedVia.rawValue)
-            }
+            // C11-183: the autosave tick injects the conversation map it
+            // already read off-main via `await`, so this hot path no longer
+            // blocks main on `readConversationsByPanelIdSync`'s semaphore.
+            // Synchronous callers pass nil and fall back to the sync bridge.
+            let conversations = injectedConversations
+                ?? Workspace.readConversationsByPanelIdSync(timeout: 0.5)
+            Self.hashConversationState(conversations, into: &hasher)
         }
 
         return hasher.finalize()
     }
 
+    /// C11-183: pure, order-independent hash of the conversation store's
+    /// active refs, extracted so the autosave fingerprint's conversation
+    /// contribution is unit-testable off-main. Only `active` refs move the
+    /// hash; a change to any surface's active id/kind/state/capture source
+    /// flips the fingerprint so the next tick persists (the C11-24 invariant
+    /// that conversation activity — wrapper-claim / hook-push / tombstone —
+    /// forces an autosave write).
+    nonisolated static func hashConversationState(
+        _ conversations: [String: SurfaceConversations],
+        into hasher: inout Hasher
+    ) {
+        for surfaceId in conversations.keys.sorted() {
+            guard let surface = conversations[surfaceId],
+                  let active = surface.active else { continue }
+            hasher.combine(surfaceId)
+            hasher.combine(active.kind)
+            hasher.combine(active.id)
+            hasher.combine(active.state.rawValue)
+            hasher.combine(active.capturedVia.rawValue)
+        }
+    }
+
     @discardableResult
-    private func saveSessionSnapshot(includeScrollback: Bool, removeWhenEmpty: Bool = false) -> Bool {
+    private func saveSessionSnapshot(
+        includeScrollback: Bool,
+        removeWhenEmpty: Bool = false,
+        conversationsByPanelId: [String: SurfaceConversations]? = nil
+    ) -> Bool {
         if Self.shouldSkipSessionSaveDuringStartupRestore(
             isApplyingStartupSessionRestore: isApplyingStartupSessionRestore,
             includeScrollback: includeScrollback
@@ -4130,7 +4155,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 #endif
 
-        guard let snapshot = buildSessionSnapshot(includeScrollback: includeScrollback) else {
+        guard let snapshot = buildSessionSnapshot(
+            includeScrollback: includeScrollback,
+            conversationsByPanelId: conversationsByPanelId
+        ) else {
             persistSessionSnapshot(
                 nil,
                 removeWhenEmpty: removeWhenEmpty,
@@ -4216,14 +4244,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
 
+        // C11-183: claim the in-flight slot synchronously (so the next timer
+        // tick coalesces), then run the actual save on the main actor via an
+        // async hop. The conversation-store read happens with a non-blocking
+        // `await` instead of a main-thread `DispatchSemaphore.wait`, so the
+        // 8 s tick no longer stalls the UI at high surface count. The
+        // in-flight flag is released in `performSessionAutosaveTick`'s defer,
+        // which spans the await.
         sessionAutosaveTickInFlight = true
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performSessionAutosaveTick(source: source)
+        }
+    }
+
+    private func performSessionAutosaveTick(source: String) async {
+        defer { sessionAutosaveTickInFlight = false }
+
+        // Non-blocking read of the *global* conversation store off the main
+        // thread. Unlike the old `readConversationsByPanelIdSync` semaphore
+        // wait, this never blocks main and never times out to a partial map
+        // (the C11-170 "drops under load" class), so the injected snapshot
+        // still carries full `surface_conversations` (C11-24).
+        let conversations: [String: SurfaceConversations]
+        if ConversationStorePolicy.isDisabled {
+            conversations = [:]
+        } else {
+            conversations = await ConversationStore.shared.snapshot()
+        }
+
+        // State may have changed across the await (app started terminating,
+        // or a synchronous save already ran).
+        guard Self.shouldRunSessionAutosaveTick(isTerminatingApp: isTerminatingApp) else { return }
+
 #if DEBUG
+        // Time only the synchronous main-thread work after the await — that
+        // is the "main-thread stall" the acceptance criterion targets
+        // (< 100 ms at ≥150 surfaces); the await itself never blocks main.
         let timingStart = CmuxTypingTiming.start()
         let phaseStart = ProcessInfo.processInfo.systemUptime
         var fingerprintMs: Double = 0
         var saveMs: Double = 0
         defer {
-            sessionAutosaveTickInFlight = false
             let totalMs = (ProcessInfo.processInfo.systemUptime - phaseStart) * 1000.0
             CmuxTypingTiming.logBreakdown(
                 path: "session.autosaveTick.phase",
@@ -4241,15 +4303,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 extra: "source=\(source)"
             )
         }
-#else
-        defer { sessionAutosaveTickInFlight = false }
 #endif
 
         let now = Date()
 #if DEBUG
         let fingerprintStart = ProcessInfo.processInfo.systemUptime
 #endif
-        let autosaveFingerprint = sessionAutosaveFingerprint(includeScrollback: false)
+        let autosaveFingerprint = sessionAutosaveFingerprint(
+            includeScrollback: false,
+            conversationsByPanelId: conversations
+        )
 #if DEBUG
         fingerprintMs = (ProcessInfo.processInfo.systemUptime - fingerprintStart) * 1000.0
 #endif
@@ -4272,7 +4335,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
         let saveStart = ProcessInfo.processInfo.systemUptime
 #endif
-        _ = saveSessionSnapshot(includeScrollback: false)
+        _ = saveSessionSnapshot(includeScrollback: false, conversationsByPanelId: conversations)
 #if DEBUG
         saveMs = (ProcessInfo.processInfo.systemUptime - saveStart) * 1000.0
 #endif
@@ -4364,7 +4427,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private func buildSessionSnapshot(includeScrollback: Bool) -> AppSessionSnapshot? {
+    private func buildSessionSnapshot(
+        includeScrollback: Bool,
+        conversationsByPanelId injectedConversations: [String: SurfaceConversations]? = nil
+    ) -> AppSessionSnapshot? {
         let contexts = mainWindowContexts.values.sorted { lhs, rhs in
             let lhsWindow = lhs.window ?? windowForMainWindowId(lhs.windowId)
             let rhsWindow = rhs.window ?? windowForMainWindowId(rhs.windowId)
@@ -4388,7 +4454,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // one and cuts main-thread blocking on save from up-to-N×2s to ≤2s.
         // (`readConversationsByPanelIdSync` already short-circuits to `[:]`
         // when the store is disabled, before spawning the detached read.)
-        let conversationsByPanelId = Workspace.readConversationsByPanelIdSync()
+        //
+        // C11-183: the recurring autosave tick now reads the store off-main
+        // via `await` and injects the map here, so the hot path never blocks
+        // main on the semaphore. Synchronous callers (termination, power-off,
+        // window unregister) pass nil and keep the sync bridge — blocking is
+        // acceptable there (rare, one-shot, correct when the app is dying).
+        let conversationsByPanelId = injectedConversations
+            ?? Workspace.readConversationsByPanelIdSync()
 
         let windows: [SessionWindowSnapshot] = contexts
             .prefix(SessionPersistencePolicy.maxWindowsPerSnapshot)

--- a/c11Tests/WorkspaceConversationResumeTests.swift
+++ b/c11Tests/WorkspaceConversationResumeTests.swift
@@ -218,4 +218,108 @@ final class WorkspaceConversationResumeTests: XCTestCase {
         XCTAssertTrue(captured.isEmpty,
                       "expected empty dict from empty store; got \(captured.count) entries")
     }
+
+    // MARK: - C11-183: autosave stalls at high surface count
+
+    /// The autosave fingerprint must flip when any surface's active
+    /// conversation ref changes (so wrapper-claim / hook-push / tombstone
+    /// activity forces a save — the C11-24 invariant) and must be
+    /// order-independent (dictionary iteration order must not spuriously
+    /// change the fingerprint and cause churn). `hashConversationState` is
+    /// the pure, off-main seam extracted from `sessionAutosaveFingerprint`
+    /// so the async autosave tick can feed it the map it read via `await`
+    /// instead of blocking main on a semaphore. Pure (no `Workspace`), so
+    /// this one runs in the bare local xctest runner too.
+    func testAutosaveConversationHashChangeSensitiveAndOrderIndependent() {
+        func hash(_ map: [String: SurfaceConversations]) -> Int {
+            var hasher = Hasher()
+            AppDelegate.hashConversationState(map, into: &hasher)
+            return hasher.finalize()
+        }
+        func ref(
+            id: String,
+            state: ConversationState = .alive,
+            via: CaptureSource = .hook,
+            kind: String = "claude-code"
+        ) -> SurfaceConversations {
+            SurfaceConversations(active: ConversationRef(
+                kind: kind, id: id, capturedVia: via, state: state))
+        }
+
+        let base: [String: SurfaceConversations] = [
+            "surface-a": ref(id: "sess-1"),
+            "surface-b": ref(id: "sess-2"),
+        ]
+        // Same entries, rebuilt dict → identical hash (order-independent).
+        let reordered: [String: SurfaceConversations] = [
+            "surface-b": ref(id: "sess-2"),
+            "surface-a": ref(id: "sess-1"),
+        ]
+        XCTAssertEqual(hash(base), hash(reordered),
+                       "fingerprint must not depend on dictionary iteration order")
+
+        // A changed active id / lifecycle state / capture source each flips it.
+        XCTAssertNotEqual(hash(base), hash([
+            "surface-a": ref(id: "sess-1-CHANGED"),
+            "surface-b": ref(id: "sess-2"),
+        ]), "a changed active id must change the fingerprint")
+        XCTAssertNotEqual(hash(base), hash([
+            "surface-a": ref(id: "sess-1", state: .tombstoned),
+            "surface-b": ref(id: "sess-2"),
+        ]), "a changed lifecycle state must change the fingerprint")
+        XCTAssertNotEqual(hash(base), hash([
+            "surface-a": ref(id: "sess-1", via: .scrape),
+            "surface-b": ref(id: "sess-2"),
+        ]), "a changed capture source must change the fingerprint")
+
+        // A surface with no active ref must not contribute (empty == none),
+        // so idle terminals don't force perpetual autosaves.
+        let withEmpty = base.merging(["surface-c": .empty]) { existing, _ in existing }
+        XCTAssertEqual(hash(base), hash(withEmpty),
+                       "a surface with no active ref must not change the fingerprint")
+    }
+
+    /// C11-183: the async autosave tick reads the conversation store off-main
+    /// via `await` and injects the resulting map into `sessionSnapshot`, so
+    /// the 8 s tick no longer blocks main on a `DispatchSemaphore.wait`.
+    /// Injection must be honored verbatim (the map the tick read is exactly
+    /// what gets persisted), while synchronous callers that pass no map still
+    /// fall back to the in-process store read. Both keep `surface_conversations`
+    /// populated (C11-24 — guards against the C11-170 "drops under load" class).
+    ///
+    /// Constructs a live terminal surface → CI-only (the bare local xctest
+    /// runner crashes on `Workspace` construction; see CLAUDE.md).
+    func testSessionSnapshotHonorsInjectedConversationMapOverStore() async throws {
+        let workspace = Workspace()
+        let paneId = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let panel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneId, focus: false))
+        let surfaceId = panel.id.uuidString
+
+        // Store holds ref X (claude) for the surface.
+        await ConversationStore.shared.push(
+            surfaceId: surfaceId,
+            kind: "claude-code",
+            id: claudeSessionId,
+            source: .hook,
+            state: .alive
+        )
+
+        // Inject a DIFFERENT map (ref Y, codex). Injection wins over the store.
+        let injectedY = SurfaceConversations(active: ConversationRef(
+            kind: "codex", id: codexSessionId, capturedVia: .scrape, state: .suspended))
+        let injectedSnapshot = workspace.sessionSnapshot(
+            includeScrollback: false,
+            conversationsByPanelId: [surfaceId: injectedY]
+        )
+        let injectedPanel = try XCTUnwrap(injectedSnapshot.panels.first { $0.id == panel.id })
+        XCTAssertEqual(injectedPanel.surfaceConversations?.active?.id, codexSessionId,
+                       "injected conversation map must be honored verbatim")
+        XCTAssertEqual(injectedPanel.surfaceConversations?.active?.kind, "codex")
+
+        // No injection → synchronous in-process store read (ref X) still populates.
+        let fallbackSnapshot = workspace.sessionSnapshot(includeScrollback: false)
+        let fallbackPanel = try XCTUnwrap(fallbackSnapshot.panels.first { $0.id == panel.id })
+        XCTAssertEqual(fallbackPanel.surfaceConversations?.active?.id, claudeSessionId,
+                       "sync fallback must still read the live store (C11-24)")
+    }
 }


### PR DESCRIPTION
## Summary
The 8 s session-autosave timer did O(surface-count) work **on the main queue** and blocked the main thread on two `DispatchSemaphore.wait` calls reading the `ConversationStore` actor. At 169 live surfaces this stalled the UI for tens of seconds every tick. This makes the recurring tick read the conversation store off-main via a non-blocking `await` and inject the map into the existing snapshot build, removing both semaphore waits from the main thread — while keeping the `@MainActor` state capture on main so `surface_conversations` stays populated (the C11-24 constraint).

## Root cause
`AppDelegate.runSessionAutosaveTick` (fires every 8 s on `queue: .main`) blocked main twice per tick:
1. `sessionAutosaveFingerprint` → `Workspace.readConversationsByPanelIdSync(timeout: 0.5)` — a semaphore wait up to **0.5 s**, on *every* tick (even when nothing changed, since the fingerprint decides whether to skip).
2. `buildSessionSnapshot` → `Workspace.readConversationsByPanelIdSync()` — a second semaphore wait up to **2.0 s**, plus the O(surface) main-actor value capture.

Under `ConversationStore`-actor contention (the C11-170 telemetry-load class) these waits burned their full timeout, compounding across ticks. `hang.log` recorded **2154** hang episodes since Jun 15; worst single main-thread stall ~30 min. (Scrollback serialization is *not* on this path — the timer tick passes `includeScrollback: false`; the JSON encode + disk write were already off-main.)

## The fix
`Sources/AppDelegate.swift`:
- Split `runSessionAutosaveTick` into a synchronous guard/coalesce wrapper + a new `performSessionAutosaveTick(_:) async`. The tick claims the in-flight slot synchronously, then hops to `Task { @MainActor }` and reads the store with `await ConversationStore.shared.snapshot()` — a proper actor hop that **suspends without blocking main** (and never times out → strictly more correct than the 2 s wait; eliminates the C11-170 partial-map risk).
- Thread the read map through `sessionAutosaveFingerprint`, `saveSessionSnapshot`, and `buildSessionSnapshot` via an optional `conversationsByPanelId` parameter (default `nil`). The `@MainActor` value capture still runs on main with the map in hand, so `surface_conversations` is populated exactly as before.
- Synchronous callers (app termination / power-off with `includeScrollback: true`, window unregister, session-resign) pass `nil` and keep the sync bridge — blocking is fine there (rare, one-shot, correct when the app is dying).
- Extract a pure `nonisolated static hashConversationState(_:into:)` seam for the fingerprint's conversation contribution.
- DEBUG timing now measures only the synchronous post-await work — i.e., the actual main-thread stall the acceptance criterion targets.

## Why C11-24 is preserved
`surface_conversations` is still built on the main actor from the same map via the same `sessionPanelSnapshot` merge; the async read replaces a timeout-prone semaphore with a read that always returns the full, current store contents.

## Test evidence
`c11Tests/WorkspaceConversationResumeTests.swift` (members of `c11LogicTests`):
- `testAutosaveConversationHashChangeSensitiveAndOrderIndependent` — pure test of `hashConversationState`: order-independent, and flips on any change to a surface's active id / lifecycle state / capture source (the C11-24 "conversation activity forces a save" invariant). **Runs in the local xctest runner.**
- `testSessionSnapshotHonorsInjectedConversationMapOverStore` — constructs a Workspace + terminal surface, seeds the store with ref X, and asserts an injected map (ref Y) is honored verbatim while the nil-injection path still reads the live store (ref X). CI-covered (Workspace construction crashes the bare local runner per repo convention).

Local run of `c11-logic` (full c11 target + both new tests compiled; pure test executed):
```
** TEST SUCCEEDED **
```

## Acceptance / validation status
- **< 100 ms main-thread stall at ≥150 surfaces** — the up-to-2.5 s/tick semaphore waits are removed from main; the remaining work is the fast O(surface) main-actor capture.
- **Zero autosave-rooted hangs over a soak** — no blocking wait remains on the tick.
- **High-surface (~170) soak is a POST-MERGE operator smoke item** (machine under heavy load; balanced-profile HOLD). Steps recorded on the ticket: launch a tagged build, drive to ≥150 surfaces, confirm `session.autosaveTick.phase` DEBUG timing stays < 100 ms and `hang.log` shows zero autosave-rooted `hang.begin` over ≥10 min.

Ref: **C11-183**. Root-cause note + acceptance criteria in `.lattice/notes/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)