### PR TITLE
Add opt-in `submit: true` to blueprint terminal leaves

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2665,6 +2665,18 @@ final class TerminalSurface: Identifiable, ObservableObject {
         for chunk in pendingTextQueue { bytes.append(chunk) }
         return String(data: bytes, encoding: .utf8) ?? ""
     }
+
+    /// Test-only accessor mirroring `pendingInitialInputForTests`: reports
+    /// whether a submit (synthetic Return) is armed to fire when the pending
+    /// text flushes on surface attach. The layout-executor harness uses it to
+    /// distinguish a blueprint's `submit: true` leaf (routed through
+    /// `sendSubmitFormText`, which sets this on a not-yet-attached surface)
+    /// from the default type-but-don't-submit path (`sendText`, which does
+    /// not). Same `@MainActor` rationale as the accessor above.
+    @MainActor
+    var pendingSubmitOnFlushForTests: Bool {
+        pendingSubmitOnFlush
+    }
 #endif
     private enum PortalLifecycleState: String {
         case live

--- a/Sources/WorkspaceApplyPlan.swift
+++ b/Sources/WorkspaceApplyPlan.swift
@@ -69,6 +69,13 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
     /// Terminal: sent via `TerminalPanel.sendText` once the surface is created.
     /// Pre-surface-ready sends auto-queue and flush when the surface comes up.
     var command: String?
+    /// Terminal: opt-in. When `true`, an explicit `command` is *executed* — the
+    /// executor routes it through `sendSubmitFormText`, which types the bytes
+    /// and dispatches a synthetic Return outside the bracketed-paste sequence
+    /// so the shell/TUI actually submits. Default `false` preserves Phase 0
+    /// parity: the command is pre-typed at the prompt but never submitted,
+    /// which also keeps whitespace-only "kick" commands working verbatim.
+    var submitCommand: Bool = false
     /// Browser: passed to `newBrowserSplit(url:)` / `newBrowserSurface(url:)`.
     var url: String?
     /// Markdown: passed to `newMarkdownSplit(filePath:)` / `newMarkdownSurface(filePath:)`.
@@ -93,7 +100,8 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
         url: String? = nil,
         filePath: String? = nil,
         metadata: [String: PersistedJSONValue]? = nil,
-        paneMetadata: [String: PersistedJSONValue]? = nil
+        paneMetadata: [String: PersistedJSONValue]? = nil,
+        submitCommand: Bool = false
     ) {
         self.id = id
         self.kind = kind
@@ -105,6 +113,50 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
         self.filePath = filePath
         self.metadata = metadata
         self.paneMetadata = paneMetadata
+        self.submitCommand = submitCommand
+    }
+
+    // Custom Codable: `submitCommand` is a defaulted non-optional Bool. Swift's
+    // synthesized decoder throws `keyNotFound` for a missing non-optional key
+    // rather than falling back to the property default, so an older snapshot or
+    // plan (pickled by `SessionPersistence` before this field existed) would
+    // fail to decode. Decode it with `decodeIfPresent(...) ?? false`, and on
+    // encode omit it when `false` so existing serialized output is unchanged
+    // for the common case.
+    private enum CodingKeys: String, CodingKey {
+        case id, kind, title, description, workingDirectory, command, url
+        case filePath, metadata, paneMetadata, submitCommand
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        kind = try c.decode(SurfaceSpecKind.self, forKey: .kind)
+        title = try c.decodeIfPresent(String.self, forKey: .title)
+        description = try c.decodeIfPresent(String.self, forKey: .description)
+        workingDirectory = try c.decodeIfPresent(String.self, forKey: .workingDirectory)
+        command = try c.decodeIfPresent(String.self, forKey: .command)
+        url = try c.decodeIfPresent(String.self, forKey: .url)
+        filePath = try c.decodeIfPresent(String.self, forKey: .filePath)
+        metadata = try c.decodeIfPresent([String: PersistedJSONValue].self, forKey: .metadata)
+        paneMetadata = try c.decodeIfPresent([String: PersistedJSONValue].self, forKey: .paneMetadata)
+        submitCommand = try c.decodeIfPresent(Bool.self, forKey: .submitCommand) ?? false
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(kind, forKey: .kind)
+        try c.encodeIfPresent(title, forKey: .title)
+        try c.encodeIfPresent(description, forKey: .description)
+        try c.encodeIfPresent(workingDirectory, forKey: .workingDirectory)
+        try c.encodeIfPresent(command, forKey: .command)
+        try c.encodeIfPresent(url, forKey: .url)
+        try c.encodeIfPresent(filePath, forKey: .filePath)
+        try c.encodeIfPresent(metadata, forKey: .metadata)
+        try c.encodeIfPresent(paneMetadata, forKey: .paneMetadata)
+        // Omit when false so pre-existing serialized specs stay byte-identical.
+        if submitCommand { try c.encode(submitCommand, forKey: .submitCommand) }
     }
 }
 

--- a/Sources/WorkspaceBlueprintMarkdown.swift
+++ b/Sources/WorkspaceBlueprintMarkdown.swift
@@ -359,6 +359,9 @@ enum WorkspaceBlueprintMarkdown {
         let url = node.lookup("url")?.asScalar
         let file = node.lookup("file")?.asScalar
         let command = node.lookup("command")?.asScalar
+        // Opt-in `submit:` — only the exact scalar `true` (case-insensitive)
+        // enables execution; anything else, including absence, stays false.
+        let submit = node.lookup("submit")?.asScalar?.lowercased() == "true"
         return SurfaceSpec(
             id: id,
             kind: kind,
@@ -369,7 +372,8 @@ enum WorkspaceBlueprintMarkdown {
             url: nullIfEmpty(url),
             filePath: nullIfEmpty(file),
             metadata: nil,
-            paneMetadata: nil
+            paneMetadata: nil,
+            submitCommand: submit
         )
     }
 
@@ -481,6 +485,11 @@ enum WorkspaceBlueprintMarkdown {
         }
         if let command = surface.command {
             out += "\(restPad)command: \(quoteIfNeeded(command))\n"
+        }
+        // Opt-in flag: emit only when set so default blueprints round-trip
+        // unchanged and stay free of noise.
+        if surface.submitCommand {
+            out += "\(restPad)submit: true\n"
         }
         return out
     }

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -272,6 +272,13 @@ enum WorkspaceLayoutExecutor {
                 // dispatches a synthetic Return outside the bracketed-paste
                 // sequence so the receiving shell or TUI actually submits.
                 terminalPanel.surface.sendSubmitFormText(cmd)
+            } else if surfaceSpec.submitCommand {
+                // Opt-in execute: the blueprint asked for this command to run,
+                // not sit at the prompt. `sendSubmitFormText` types the bytes
+                // (queueing if the surface isn't yet attached) and dispatches a
+                // synthetic Return outside the bracketed-paste sequence so the
+                // shell/TUI actually submits.
+                terminalPanel.surface.sendSubmitFormText(cmd)
             } else {
                 // Explicit `SurfaceSpec.command` — Phase 0 parity. Deliver
                 // raw bytes verbatim, including whitespace-only "kick"

--- a/c11Tests/WorkspaceApplyPlanCodableTests.swift
+++ b/c11Tests/WorkspaceApplyPlanCodableTests.swift
@@ -114,6 +114,38 @@ final class WorkspaceApplyPlanCodableTests: XCTestCase {
         XCTAssertEqual(decoded.paneMetadata?["mailbox.retention_days"], .number(14))
     }
 
+    // MARK: - SurfaceSpec.submitCommand (opt-in, back-compat)
+
+    func testSurfaceSpecSubmitCommandRoundTrips() throws {
+        let spec = SurfaceSpec(
+            id: "launcher",
+            kind: .terminal,
+            command: "python3 /path/position.py --watch",
+            submitCommand: true
+        )
+        let decoded = try decode(SurfaceSpec.self, from: try encode(spec))
+        XCTAssertTrue(decoded.submitCommand)
+        XCTAssertEqual(decoded, spec)
+    }
+
+    /// An older plan/snapshot serialized before `submitCommand` existed has no
+    /// such key. Swift's *synthesized* decoder would throw `keyNotFound`; the
+    /// custom `init(from:)` must instead default it to `false`.
+    func testSurfaceSpecDecodesMissingSubmitCommandAsFalse() throws {
+        let legacyJSON = #"{"id":"t","kind":"terminal","command":"ls"}"#
+        let decoded = try decode(SurfaceSpec.self, from: Data(legacyJSON.utf8))
+        XCTAssertFalse(decoded.submitCommand)
+        XCTAssertEqual(decoded.command, "ls")
+    }
+
+    /// When `submitCommand` is `false` the encoder omits the key entirely, so
+    /// serialized output for every pre-existing spec stays byte-identical.
+    func testSurfaceSpecOmitsSubmitCommandWhenFalse() throws {
+        let spec = SurfaceSpec(id: "t", kind: .terminal, command: "ls")
+        let json = String(data: try encode(spec), encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("submitCommand"), "false must not serialize; got \(json)")
+    }
+
     // MARK: - LayoutTreeSpec
 
     func testLayoutTreeSpecSinglePaneRoundTrips() throws {

--- a/c11Tests/WorkspaceBlueprintMarkdownTests.swift
+++ b/c11Tests/WorkspaceBlueprintMarkdownTests.swift
@@ -191,6 +191,92 @@ final class WorkspaceBlueprintMarkdownTests: XCTestCase {
         XCTAssertEqual(markdown?.filePath,         "~/notes/today.md")
     }
 
+    // MARK: - Opt-in submit flag (`submit: true`)
+
+    private func parseSingleTerminal(submitLine: String) throws -> SurfaceSpec {
+        let source = """
+        ---
+        title: Launcher
+        ---
+
+        ## Layout
+
+        ```yaml
+        layout:
+          - type: terminal
+            title: Dashboard
+            cwd: ~/work
+            command: python3 /path/position.py --watch
+        \(submitLine)
+        ```
+        """
+        let parsed = try WorkspaceBlueprintMarkdown.parse(Data(source.utf8))
+        return try XCTUnwrap(parsed.plan.surfaces.first)
+    }
+
+    func testParseSubmitTrueSetsFlag() throws {
+        let spec = try parseSingleTerminal(submitLine: "    submit: true")
+        XCTAssertTrue(spec.submitCommand)
+        XCTAssertEqual(spec.command, "python3 /path/position.py --watch")
+    }
+
+    func testParseSubmitAbsentDefaultsToFalse() throws {
+        let spec = try parseSingleTerminal(submitLine: "")
+        XCTAssertFalse(spec.submitCommand)
+    }
+
+    func testParseSubmitNonTrueScalarIsFalse() throws {
+        let spec = try parseSingleTerminal(submitLine: "    submit: yes")
+        XCTAssertFalse(spec.submitCommand, "only the literal `true` opts in")
+    }
+
+    /// `submitCommand == true` must survive serialize → parse and the emitted
+    /// markdown must carry `submit: true` so `export-blueprint` round-trips.
+    func testRoundTripPreservesSubmitFlag() throws {
+        let file = WorkspaceBlueprintFile(
+            name: "Launcher",
+            description: nil,
+            plan: WorkspaceApplyPlan(
+                version: 1,
+                workspace: WorkspaceSpec(title: "Launcher"),
+                layout: .pane(.init(surfaceIds: ["s1"])),
+                surfaces: [
+                    SurfaceSpec(
+                        id: "s1",
+                        kind: .terminal,
+                        title: "Dashboard",
+                        command: "python3 /path/position.py --watch",
+                        submitCommand: true
+                    )
+                ]
+            )
+        )
+        let data = try WorkspaceBlueprintMarkdown.serialize(file)
+        let text = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("submit: true"), "emitter must write submit: true; got:\n\(text)")
+        let reparsed = try WorkspaceBlueprintMarkdown.parse(data)
+        XCTAssertEqual(reparsed, file)
+        XCTAssertTrue(try XCTUnwrap(reparsed.plan.surfaces.first).submitCommand)
+    }
+
+    /// The default (no submit) blueprint must not gain a `submit:` line.
+    func testDefaultBlueprintOmitsSubmitLine() throws {
+        let file = WorkspaceBlueprintFile(
+            name: "Plain",
+            description: nil,
+            plan: WorkspaceApplyPlan(
+                version: 1,
+                workspace: WorkspaceSpec(title: "Plain"),
+                layout: .pane(.init(surfaceIds: ["s1"])),
+                surfaces: [
+                    SurfaceSpec(id: "s1", kind: .terminal, command: "ls")
+                ]
+            )
+        )
+        let text = String(data: try WorkspaceBlueprintMarkdown.serialize(file), encoding: .utf8) ?? ""
+        XCTAssertFalse(text.contains("submit:"), "default blueprint must stay submit-free")
+    }
+
     // MARK: - Errors surface readable strings
 
     func testParseRejectsMissingLayoutSection() {

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -142,6 +142,88 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
         #endif
     }
 
+    // MARK: - Opt-in submit (blueprint `submit: true`)
+
+    /// Shared driver: apply a single-terminal plan carrying `command` and the
+    /// given `submitCommand`, then return the freshly created (not-yet-attached)
+    /// terminal surface so the caller can inspect what was queued.
+    private func applySingleTerminal(
+        command: String,
+        submitCommand: Bool
+    ) throws -> TerminalSurface {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(title: "submit opt-in"),
+            layout: .pane(LayoutTreeSpec.PaneSpec(surfaceIds: ["t"])),
+            surfaces: [
+                SurfaceSpec(
+                    id: "t",
+                    kind: .terminal,
+                    title: "launcher",
+                    command: command,
+                    submitCommand: submitCommand
+                )
+            ]
+        )
+        let deps = WorkspaceLayoutExecutorDependencies(
+            tabManager: tabManager,
+            workspaceRefMinter: { "workspace:\($0.uuidString)" },
+            surfaceRefMinter: { "surface:\($0.uuidString)" },
+            paneRefMinter: { "pane:\($0.uuidString)" }
+        )
+        let result = WorkspaceLayoutExecutor.apply(
+            plan,
+            options: ApplyOptions(select: false),
+            dependencies: deps
+        )
+        let workspace = try XCTUnwrap(resolveWorkspace(from: result.workspaceRef))
+        let panelId = try XCTUnwrap(parseUUIDSuffix(result.surfaceRefs["t"]))
+        let terminal = try XCTUnwrap(workspace.panels[panelId] as? TerminalPanel)
+        return terminal.surface
+    }
+
+    /// `submit: true` routes an explicit command through `sendSubmitFormText`,
+    /// which on a not-yet-attached surface queues the bytes AND arms a Return
+    /// to fire on flush. Both the command text and the armed submit are
+    /// observable.
+    func testSubmitTrueArmsReturnOnFlush() throws {
+        let surface = try applySingleTerminal(
+            command: "python3 /path/position.py --watch",
+            submitCommand: true
+        )
+        #if DEBUG
+        XCTAssertEqual(
+            surface.pendingInitialInputForTests,
+            "python3 /path/position.py --watch",
+            "submit:true still delivers the command bytes"
+        )
+        XCTAssertTrue(
+            surface.pendingSubmitOnFlushForTests,
+            "submit:true must arm a synthetic Return via sendSubmitFormText"
+        )
+        #endif
+    }
+
+    /// Default (`submit` absent / false) preserves Phase 0 parity: the command
+    /// is typed via `sendText` but no Return is armed, so it sits at the prompt.
+    func testSubmitFalseDoesNotArmReturn() throws {
+        let surface = try applySingleTerminal(
+            command: "python3 /path/position.py --watch",
+            submitCommand: false
+        )
+        #if DEBUG
+        XCTAssertEqual(
+            surface.pendingInitialInputForTests,
+            "python3 /path/position.py --watch",
+            "default path still delivers the command bytes"
+        )
+        XCTAssertFalse(
+            surface.pendingSubmitOnFlushForTests,
+            "default must not submit — sendText leaves the line at the prompt"
+        )
+        #endif
+    }
+
     // MARK: - In-place restore (I2)
 
     /// BL-1 regression: with a single workspace in the window, in-place

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -23,6 +23,9 @@
       --running: #79aee8;
       --idle: #78b59e;
       --cold: #707681;
+      --harness-claude: #d88968;
+      --harness-codex: #69b5a8;
+      --harness-shell: #818791;
       --shadow: rgba(0, 0, 0, .72);
       --terminal-line: #b8bcc4;
       --mono: "SFMono-Regular", "JetBrains Mono", Menlo, monospace;
@@ -47,6 +50,9 @@
       --running: #326d9e;
       --idle: #357b61;
       --cold: #7f8289;
+      --harness-claude: #a84f32;
+      --harness-codex: #28776d;
+      --harness-shell: #6d7178;
       --shadow: rgba(35, 34, 30, .25);
       --terminal-line: #4b4e55;
     }
@@ -191,6 +197,7 @@
     .tab-scroll::-webkit-scrollbar { display: none; }
     .surface-tab {
       --state: var(--cold);
+      --harness: var(--harness-shell);
       position: relative;
       height: 30px;
       min-width: 112px;
@@ -216,6 +223,10 @@
     .surface-tab.state-running { --state: var(--running); }
     .surface-tab.state-idle { --state: var(--idle); }
     .surface-tab.state-cold { --state: var(--cold); color: color-mix(in srgb, var(--dim) 74%, transparent); }
+    .surface-tab.harness-claude { --harness: var(--harness-claude); }
+    .surface-tab.harness-codex { --harness: var(--harness-codex); }
+    .surface-tab.harness-shell { --harness: var(--harness-shell); }
+    body.neutral-harness .surface-tab { --harness: var(--text-soft); }
     .surface-tab.state-waiting {
       --state: var(--gold);
       color: color-mix(in srgb, var(--text) 92%, var(--gold));
@@ -266,15 +277,6 @@
       line-height: 1;
     }
     .close-tab:hover { color: var(--text); background: var(--rule); opacity: 1; }
-    .agent-mark {
-      width: 11px;
-      flex: 0 0 11px;
-      margin: 0 4px 0 3px;
-      color: color-mix(in srgb, var(--text-soft) 72%, transparent);
-      font: 9px var(--mono);
-      text-align: center;
-    }
-    body.hide-agents .agent-mark { display: none; }
     .state-mark {
       width: 13px;
       height: 13px;
@@ -292,17 +294,19 @@
       height: 20px;
       flex: 0 0 20px;
       margin-right: 4px;
+      color: var(--harness);
+      border-color: color-mix(in srgb, var(--harness) 76%, transparent);
       font-size: 10px;
     }
-    .state-running .state-mark {
-      border-color: color-mix(in srgb, var(--running) 28%, transparent);
-      border-top-color: var(--running);
+    .surface-tab.state-running > .state-mark {
+      border-color: color-mix(in srgb, var(--harness) 28%, transparent);
+      border-top-color: var(--harness);
       animation: turn 1.8s linear infinite;
     }
-    .state-running .state-mark span { animation: counter-turn 1.8s linear infinite; }
-    .state-idle .state-mark { border-radius: 3px; }
-    .state-cold .state-mark { border-style: dotted; opacity: .72; }
-    .state-waiting .state-mark {
+    .surface-tab.state-running > .state-mark span { animation: counter-turn 1.8s linear infinite; }
+    .surface-tab.state-idle > .state-mark { border-radius: 3px; }
+    .surface-tab.state-cold > .state-mark { border-style: dotted; opacity: .72; }
+    .surface-tab.state-waiting > .state-mark {
       color: var(--void);
       background: var(--gold);
       border-color: var(--gold);
@@ -452,16 +456,31 @@
     .legend { display: grid; gap: 9px; margin-top: 11px; }
     .legend-row { display: grid; grid-template-columns: 18px 62px 1fr; align-items: center; gap: 6px; }
     .legend-row .state-mark { --state: var(--legend-state); }
-    .legend-row.running { --legend-state: var(--running); }
-    .legend-row.idle { --legend-state: var(--idle); }
-    .legend-row.cold { --legend-state: var(--cold); }
+    .legend-row.running { --legend-state: var(--text-soft); }
+    .legend-row.idle { --legend-state: var(--text-soft); }
+    .legend-row.cold { --legend-state: var(--text-soft); }
     .legend-row.waiting { --legend-state: var(--gold); }
     .legend-row strong { color: var(--text-soft); font: 9px var(--mono); font-weight: 650; text-transform: uppercase; }
     .legend-row span:last-child { color: var(--dim); font: 9px/1.3 var(--mono); }
-    .legend-row.running .state-mark { border-top-color: var(--running); }
+    .legend-row.running .state-mark { border-top-color: var(--text-soft); }
     .legend-row.idle .state-mark { border-radius: 3px; }
     .legend-row.cold .state-mark { border-style: dotted; }
     .legend-row.waiting .state-mark { color: var(--void); background: var(--gold); border-color: var(--gold); border-radius: 3px; }
+    .harness-key {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-top: 12px;
+      color: var(--dim);
+      font: 8px var(--mono);
+      text-transform: uppercase;
+    }
+    .harness-key span { display: inline-flex; align-items: center; gap: 4px; }
+    body.neutral-harness .harness-key { opacity: .35; }
+    .harness-swatch { width: 7px; height: 7px; border-radius: 50%; background: var(--swatch); }
+    .harness-swatch.claude { --swatch: var(--harness-claude); }
+    .harness-swatch.codex { --swatch: var(--harness-codex); }
+    .harness-swatch.shell { --swatch: var(--harness-shell); }
     .option-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
     .option-button[aria-pressed="true"] { color: var(--gold); border-color: color-mix(in srgb, var(--gold) 55%, var(--rule)); }
     .collision-note {
@@ -503,7 +522,6 @@
     @media (max-width: 970px) {
       .sidebar { width: 160px; }
       .content { grid-template-columns: minmax(0, 1fr) 275px; }
-      .agent-mark { display: none; }
     }
   </style>
 </head>
@@ -562,32 +580,37 @@
             <p>Click any tab, then force a state. Selection and state should remain readable in every combination.</p>
 
             <div class="state-controls" aria-label="Change selected surface state">
-              <button class="state-button" data-state="running">↻ Running</button>
-              <button class="state-button" data-state="idle">Ⅱ Idle</button>
-              <button class="state-button" data-state="cold">– Cold</button>
-              <button class="state-button" data-state="waiting">! Your turn</button>
+              <button class="state-button" data-state="running">R Running</button>
+              <button class="state-button" data-state="idle">I Idle</button>
+              <button class="state-button" data-state="cold">C Cold</button>
+              <button class="state-button" data-state="waiting">W Your turn</button>
             </div>
 
             <div class="section-rule"></div>
             <div class="eyebrow">Grammar</div>
             <div class="legend">
-              <div class="legend-row running"><span class="state-mark"><span>↻</span></span><strong>Running</strong><span>slow rotor; work is moving</span></div>
-              <div class="legend-row idle"><span class="state-mark"><span>Ⅱ</span></span><strong>Idle</strong><span>quiet pause; prompt is ready</span></div>
-              <div class="legend-row cold"><span class="state-mark"><span>–</span></span><strong>Cold</strong><span>dotted shell; no live session</span></div>
-              <div class="legend-row waiting"><span class="state-mark"><span>!</span></span><strong>Your turn</strong><span>boxed bang + striped demand rail</span></div>
+              <div class="legend-row running"><span class="state-mark"><span>R</span></span><strong>Running</strong><span>R + slow rim; work is moving</span></div>
+              <div class="legend-row idle"><span class="state-mark"><span>I</span></span><strong>Idle</strong><span>I; prompt is ready</span></div>
+              <div class="legend-row cold"><span class="state-mark"><span>C</span></span><strong>Cold</strong><span>C + dotted shell; no live session</span></div>
+              <div class="legend-row waiting"><span class="state-mark"><span>W</span></span><strong>Your turn</strong><span>W + striped demand rail</span></div>
+            </div>
+            <div class="harness-key" aria-label="Harness color key">
+              <span><i class="harness-swatch claude"></i> Claude</span>
+              <span><i class="harness-swatch codex"></i> Codex</span>
+              <span><i class="harness-swatch shell"></i> Shell</span>
             </div>
 
             <div class="section-rule"></div>
             <div class="eyebrow">Stress the strip</div>
             <div class="option-grid">
               <button class="option-button" id="toggleIds" aria-pressed="false">Surface IDs</button>
-              <button class="option-button" id="toggleAgents" aria-pressed="true">Agent glyphs</button>
+              <button class="option-button" id="toggleHarness" aria-pressed="true">Harness color</button>
               <button class="option-button" id="toggleTheme" aria-pressed="false">Light theme</button>
               <button class="option-button" id="toggleMotion" aria-pressed="false">Reduce motion</button>
             </div>
 
             <div class="collision-note">
-              <b>Read the edges first.</b> State owns the hard-left edge; close owns the hard-right. The white top rail and raised fill say “you are here.” Only <b>your turn</b> earns the lower gold demand rail.
+              <b>One badge, two reads.</b> R/I/C/W names state; badge hue names the harness. Waiting overrides hue with gold and the demand rail. Close remains hard-right.
             </div>
           </aside>
         </div>
@@ -599,24 +622,30 @@
 
   <script>
     const surfaces = [
-      { id: 54, title: 'Agent Pulse', state: 'waiting', agent: 'C', description: 'Waiting for the operator to choose the workspace-level direction.' },
-      { id: 62, title: 'Surface Pulse', state: 'running', agent: '◇', description: 'Prototyping agent presence on dense horizontal surface tabs.' },
-      { id: 72, title: 'Release staging', state: 'running', agent: 'C', description: 'Building and validating the signed release candidate.' },
-      { id: 77, title: 'Mailbox attribution', state: 'idle', agent: '◇', description: 'At the prompt after completing the attribution copy pass.' },
-      { id: 91, title: 'Socket watchdog', state: 'cold', agent: '·', description: 'Resumable terminal; no agent process is currently live.' },
-      { id: 105, title: 'Browser regression sweep', state: 'running', agent: 'C', description: 'Exercising browser navigation, snapshots, and auth-state restore.' },
-      { id: 118, title: 'Theme conformance', state: 'idle', agent: '◇', description: 'Dark and light c11 theme slot review is complete.' },
-      { id: 126, title: 'Japanese localization', state: 'cold', agent: 'C', description: 'Session ended after committing the locale update.' },
-      { id: 144, title: 'Workspace snapshot recovery validation and persistence audit', state: 'waiting', agent: '◇', description: 'Needs approval to replace the corrupted fixture with a captured snapshot.' },
-      { id: 158, title: 'Docs pruning', state: 'idle', agent: 'C', description: 'At the prompt with a clean documentation diff.' },
-      { id: 203, title: 'Flaky focus test diagnosis', state: 'running', agent: '◇', description: 'Repeating the focused-pane event test under contention.' }
+      { id: 54, title: 'Agent Pulse', state: 'waiting', harness: 'claude', description: 'Waiting for the operator to choose the workspace-level direction.' },
+      { id: 62, title: 'Surface Pulse', state: 'running', harness: 'codex', description: 'Prototyping agent presence on dense horizontal surface tabs.' },
+      { id: 72, title: 'Release staging', state: 'running', harness: 'claude', description: 'Building and validating the signed release candidate.' },
+      { id: 77, title: 'Mailbox attribution', state: 'idle', harness: 'codex', description: 'At the prompt after completing the attribution copy pass.' },
+      { id: 91, title: 'Socket watchdog', state: 'cold', harness: 'shell', description: 'Resumable terminal; no agent process is currently live.' },
+      { id: 105, title: 'Browser regression sweep', state: 'running', harness: 'claude', description: 'Exercising browser navigation, snapshots, and auth-state restore.' },
+      { id: 118, title: 'Theme conformance', state: 'idle', harness: 'codex', description: 'Dark and light c11 theme slot review is complete.' },
+      { id: 126, title: 'Japanese localization', state: 'cold', harness: 'claude', description: 'Session ended after committing the locale update.' },
+      { id: 144, title: 'Workspace snapshot recovery validation and persistence audit', state: 'waiting', harness: 'codex', description: 'Needs approval to replace the corrupted fixture with a captured snapshot.' },
+      { id: 158, title: 'Docs pruning', state: 'idle', harness: 'claude', description: 'At the prompt with a clean documentation diff.' },
+      { id: 203, title: 'Flaky focus test diagnosis', state: 'running', harness: 'codex', description: 'Repeating the focused-pane event test under contention.' }
     ];
 
     const stateCopy = {
-      running: { glyph: '↻', label: 'Running · work in motion', color: 'var(--running)', line: 'Command in flight. Output and prompt-state observation say this agent is moving.' },
-      idle: { glyph: 'Ⅱ', label: 'Idle · at the prompt', color: 'var(--idle)', line: 'Live session, quiet prompt. Available for another task without a resume step.' },
-      cold: { glyph: '–', label: 'Cold · no live agent', color: 'var(--cold)', line: 'The surface remains, but no agent session is currently live. It may be resumable.' },
-      waiting: { glyph: '!', label: 'Your turn · response needed', color: 'var(--gold)', line: 'The agent has yielded with a question or decision. This is the operator’s turn.' }
+      running: { glyph: 'R', label: 'Running · work in motion', color: 'var(--running)', line: 'Command in flight. Output and prompt-state observation say this agent is moving.' },
+      idle: { glyph: 'I', label: 'Idle · at the prompt', color: 'var(--idle)', line: 'Live session, quiet prompt. Available for another task without a resume step.' },
+      cold: { glyph: 'C', label: 'Cold · no live agent', color: 'var(--cold)', line: 'The surface remains, but no agent session is currently live. It may be resumable.' },
+      waiting: { glyph: 'W', label: 'Your turn · response needed', color: 'var(--gold)', line: 'The agent has yielded with a question or decision. This is the operator’s turn.' }
+    };
+
+    const harnessColors = {
+      claude: 'var(--harness-claude)',
+      codex: 'var(--harness-codex)',
+      shell: 'var(--harness-shell)'
     };
 
     let selectedId = 62;
@@ -624,23 +653,21 @@
 
     function widthFor(surface) {
       const idCost = document.body.classList.contains('hide-ids') ? 0 : 23;
-      const agentCost = document.body.classList.contains('hide-agents') ? 0 : 15;
       // Deliberately exercise Bonsplit's dense end of the real 112–220pt range:
       // eight tabs remain scannable by default, while IDs and long titles still
       // push the strip into its native horizontal-overflow behavior.
-      return Math.max(112, Math.min(190, 52 + idCost + agentCost + surface.title.length * 4));
+      return Math.max(112, Math.min(190, 52 + idCost + surface.title.length * 4));
     }
 
     function tabMarkup(surface) {
       const copy = stateCopy[surface.state];
       return `
-        <div class="surface-tab state-${surface.state}${surface.id === selectedId ? ' selected' : ''}"
+        <div class="surface-tab state-${surface.state} harness-${surface.harness}${surface.id === selectedId ? ' selected' : ''}"
              style="--tab-width:${widthFor(surface)}px"
              data-id="${surface.id}" role="tab" tabindex="0"
-             aria-selected="${surface.id === selectedId}" aria-label="${surface.title}, ${copy.label}"
-             title="surface:${surface.id} · ${surface.title} · ${copy.label}">
+             aria-selected="${surface.id === selectedId}" aria-label="${surface.title}, ${copy.label}, ${surface.harness} harness"
+             title="surface:${surface.id} · ${surface.title} · ${copy.label} · ${surface.harness}">
           <span class="state-mark" aria-hidden="true"><span>${copy.glyph}</span></span>
-          <span class="agent-mark" aria-hidden="true">${surface.agent}</span>
           <span class="tab-title"><span class="surface-id">${surface.id}: </span>${surface.title}</span>
           <button class="close-tab" aria-label="Close ${surface.title}" title="Close tab">×</button>
         </div>`;
@@ -685,28 +712,32 @@
     function updateSelection() {
       const surface = surfaces.find(item => item.id === selectedId);
       const copy = stateCopy[surface.state];
+      const harnessColor = document.body.classList.contains('neutral-harness')
+        ? 'var(--text-soft)'
+        : harnessColors[surface.harness];
+      const badgeColor = surface.state === 'waiting' ? copy.color : harnessColor;
       const waitingCount = surfaces.filter(item => item.state === 'waiting').length;
       document.getElementById('surfaceTitle').textContent = `surface:${surface.id} · ${surface.title}`;
       document.getElementById('surfaceDescription').textContent = surface.description;
       document.getElementById('inspectorTitle').textContent = surface.title;
       document.getElementById('readoutGlyph').textContent = copy.glyph;
       document.getElementById('readoutLabel').textContent = copy.label;
-      document.getElementById('surfaceStateReadout').style.setProperty('--selected-state', copy.color);
+      document.getElementById('surfaceStateReadout').style.setProperty('--selected-state', badgeColor);
       document.querySelectorAll('.state-button').forEach(button => {
         button.classList.toggle('active', button.dataset.state === surface.state);
       });
       document.getElementById('terminalCopy').innerHTML = `
         <div><span class="dim">$</span> c11 inspect surface:${surface.id}</div>
         <br>
-        <div><span style="color:${copy.color}">${copy.glyph}</span> <strong>${copy.label}</strong></div>
+        <div><span style="color:${badgeColor}">${copy.glyph}</span> <strong>${copy.label}</strong> <span class="dim">· ${surface.harness}</span></div>
         <div class="dim">${copy.line}</div>
         <div class="rule">────────────────────────────────────────────────────────</div>
         <div><span class="gold">${waitingCount}</span> of ${surfaces.length} surfaces currently need the operator.</div>
         <div class="dim">The tab strip keeps that answer visible through selection, truncation, and overflow.</div>
         <br>
         <div><span class="blue">selection</span> → neutral top rail + raised fill</div>
-        <div><span class="gold">operator turn</span> → ! glyph + patterned lower rail</div>
-        <div><span class="green">availability</span> → quiet geometric glyph</div>`;
+        <div><span class="gold">operator turn</span> → W + patterned lower rail</div>
+        <div><span class="green">harness</span> → badge hue; no second glyph</div>`;
     }
 
     function setSelectedState(state) {
@@ -733,11 +764,11 @@
       event.currentTarget.setAttribute('aria-pressed', shown);
       renderTabs();
     });
-    document.getElementById('toggleAgents').addEventListener('click', event => {
-      document.body.classList.toggle('hide-agents');
-      const shown = !document.body.classList.contains('hide-agents');
+    document.getElementById('toggleHarness').addEventListener('click', event => {
+      document.body.classList.toggle('neutral-harness');
+      const shown = !document.body.classList.contains('neutral-harness');
       event.currentTarget.setAttribute('aria-pressed', shown);
-      renderTabs();
+      updateSelection();
     });
     document.getElementById('toggleTheme').addEventListener('click', event => {
       const light = document.body.dataset.theme !== 'light';

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -1,0 +1,750 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>c11 — Surface pulse prototype</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --void: #08090b;
+      --chrome: #0d0f12;
+      --chrome-raised: #15181d;
+      --panel: #101216;
+      --panel-raised: #171a20;
+      --rule: #2b2e34;
+      --rule-strong: #3a3e46;
+      --text: #ececef;
+      --text-soft: #b4b7be;
+      --dim: #777b84;
+      --selection: #f0f0ed;
+      --gold: #d0aa45;
+      --gold-soft: rgba(208, 170, 69, .15);
+      --running: #79aee8;
+      --idle: #78b59e;
+      --cold: #707681;
+      --shadow: rgba(0, 0, 0, .72);
+      --terminal-line: #b8bcc4;
+      --mono: "SFMono-Regular", "JetBrains Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    }
+
+    body[data-theme="light"] {
+      color-scheme: light;
+      --void: #f4f3ef;
+      --chrome: #e8e7e2;
+      --chrome-raised: #dcdad4;
+      --panel: #efeee9;
+      --panel-raised: #ffffff;
+      --rule: #c9c7c0;
+      --rule-strong: #aaa79f;
+      --text: #202126;
+      --text-soft: #4d5058;
+      --dim: #777a81;
+      --selection: #24252a;
+      --gold: #9b7415;
+      --gold-soft: rgba(155, 116, 21, .12);
+      --running: #326d9e;
+      --idle: #357b61;
+      --cold: #7f8289;
+      --shadow: rgba(35, 34, 30, .25);
+      --terminal-line: #4b4e55;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      color: var(--text);
+      background: #030405;
+      font-family: var(--sans);
+      -webkit-font-smoothing: antialiased;
+    }
+    body[data-theme="light"] { background: #d7d5ce; }
+    button { color: inherit; font: inherit; }
+
+    .prototype-stamp {
+      position: fixed;
+      top: 12px;
+      left: 50%;
+      z-index: 20;
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      transform: translateX(-50%);
+      color: #8c9099;
+      font: 10px var(--mono);
+      letter-spacing: .035em;
+      white-space: nowrap;
+    }
+    .prototype-badge {
+      padding: 3px 7px;
+      color: var(--gold);
+      border: 1px solid color-mix(in srgb, var(--gold) 54%, transparent);
+      border-radius: 4px;
+      letter-spacing: .14em;
+    }
+
+    .window {
+      width: min(1480px, calc(100vw - 34px));
+      height: min(850px, calc(100vh - 66px));
+      min-height: 610px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      background: var(--void);
+      border: 1px solid var(--rule-strong);
+      border-radius: 12px;
+      box-shadow: 0 28px 90px var(--shadow);
+    }
+
+    .mac-titlebar {
+      height: 38px;
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      padding: 0 14px;
+      background: var(--chrome);
+      border-bottom: 1px solid var(--rule);
+    }
+    .traffic { display: flex; gap: 7px; }
+    .traffic i { width: 11px; height: 11px; border-radius: 50%; }
+    .traffic i:nth-child(1) { background: #ff5f57; }
+    .traffic i:nth-child(2) { background: #febc2e; }
+    .traffic i:nth-child(3) { background: #28c840; }
+    .window-title {
+      margin: 0 auto;
+      color: var(--dim);
+      font: 11px var(--mono);
+      letter-spacing: .04em;
+    }
+    .body { min-height: 0; flex: 1; display: flex; }
+
+    /* Shell context only. Agent-state treatment intentionally does not appear here. */
+    .sidebar {
+      position: relative;
+      width: 205px;
+      flex: 0 0 auto;
+      padding: 12px 8px;
+      background: var(--chrome);
+      border-right: 1px solid var(--rule);
+    }
+    .sidebar-label {
+      padding: 2px 8px 10px;
+      color: var(--dim);
+      font: 9px var(--mono);
+      letter-spacing: .14em;
+      text-transform: uppercase;
+    }
+    .workspace-row {
+      display: flex;
+      align-items: center;
+      gap: 9px;
+      height: 37px;
+      margin-bottom: 3px;
+      padding: 0 9px;
+      color: var(--text-soft);
+      border: 1px solid transparent;
+      border-radius: 6px;
+      font-size: 12px;
+    }
+    .workspace-row.selected {
+      color: var(--text);
+      background: var(--panel-raised);
+      border-color: var(--rule);
+    }
+    .folder {
+      width: 14px;
+      color: var(--dim);
+      font: 11px var(--mono);
+      text-align: center;
+    }
+    .sidebar-foot {
+      position: absolute;
+      bottom: 17px;
+      padding: 0 9px;
+      color: var(--dim);
+      font: 9px/1.5 var(--mono);
+    }
+
+    .pane { min-width: 0; flex: 1; display: flex; flex-direction: column; background: var(--void); }
+    .tabbar-shell {
+      position: relative;
+      height: 30px;
+      flex: 0 0 30px;
+      overflow: hidden;
+      background: var(--chrome);
+      border-bottom: 1px solid var(--rule);
+    }
+    .tab-scroll {
+      height: 30px;
+      display: flex;
+      align-items: stretch;
+      overflow-x: auto;
+      overflow-y: hidden;
+      padding-right: 178px;
+      scrollbar-width: none;
+      scroll-behavior: smooth;
+    }
+    .tab-scroll::-webkit-scrollbar { display: none; }
+    .surface-tab {
+      --state: var(--cold);
+      position: relative;
+      height: 30px;
+      min-width: 112px;
+      max-width: 220px;
+      flex: 0 0 var(--tab-width, 146px);
+      display: flex;
+      align-items: center;
+      gap: 5px;
+      padding: 0 6px 1px;
+      overflow: hidden;
+      color: var(--dim);
+      background: transparent;
+      border-right: 1px solid var(--rule);
+      cursor: default;
+      user-select: none;
+    }
+    .surface-tab:hover { color: var(--text-soft); background: color-mix(in srgb, var(--panel-raised) 72%, transparent); }
+    .surface-tab.selected {
+      color: var(--text);
+      background: var(--panel-raised);
+      box-shadow: inset 0 3px 0 var(--selection);
+    }
+    .surface-tab.state-running { --state: var(--running); }
+    .surface-tab.state-idle { --state: var(--idle); }
+    .surface-tab.state-cold { --state: var(--cold); color: color-mix(in srgb, var(--dim) 74%, transparent); }
+    .surface-tab.state-waiting {
+      --state: var(--gold);
+      color: color-mix(in srgb, var(--text) 92%, var(--gold));
+      background: linear-gradient(90deg, var(--gold-soft), transparent 76%);
+    }
+    .surface-tab.state-waiting::after {
+      content: "";
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      height: 3px;
+      background: repeating-linear-gradient(90deg, var(--gold) 0 7px, transparent 7px 10px);
+    }
+    .surface-tab.selected.state-waiting {
+      background:
+        linear-gradient(90deg, var(--gold-soft), transparent 80%),
+        var(--panel-raised);
+    }
+    .surface-tab.state-changed { animation: state-arrival .9s ease-out 1; }
+    @keyframes state-arrival {
+      0% { box-shadow: inset 0 0 0 1px var(--state), 0 0 0 0 color-mix(in srgb, var(--state) 60%, transparent); }
+      50% { box-shadow: inset 0 0 0 1px var(--state), 0 0 0 4px transparent; }
+      100% { box-shadow: none; }
+    }
+    .surface-tab.selected.state-changed { animation-name: selected-state-arrival; }
+    @keyframes selected-state-arrival {
+      0% { box-shadow: inset 0 3px 0 var(--selection), inset 0 0 0 1px var(--state), 0 0 0 0 color-mix(in srgb, var(--state) 60%, transparent); }
+      50% { box-shadow: inset 0 3px 0 var(--selection), inset 0 0 0 1px var(--state), 0 0 0 4px transparent; }
+      100% { box-shadow: inset 0 3px 0 var(--selection); }
+    }
+
+    .close-tab {
+      width: 19px;
+      height: 19px;
+      flex: 0 0 19px;
+      display: grid;
+      place-items: center;
+      padding: 0;
+      color: currentColor;
+      background: transparent;
+      border: 0;
+      border-radius: 50%;
+      opacity: .54;
+      cursor: default;
+      font-size: 12px;
+      line-height: 1;
+    }
+    .close-tab:hover { color: var(--text); background: var(--rule); opacity: 1; }
+    .agent-mark {
+      width: 11px;
+      flex: 0 0 11px;
+      color: color-mix(in srgb, var(--text-soft) 72%, transparent);
+      font: 9px var(--mono);
+      text-align: center;
+    }
+    body.hide-agents .agent-mark { display: none; }
+    .state-mark {
+      width: 13px;
+      height: 13px;
+      flex: 0 0 13px;
+      display: grid;
+      place-items: center;
+      color: var(--state);
+      border: 1px solid color-mix(in srgb, var(--state) 76%, transparent);
+      border-radius: 50%;
+      font: 8px/1 var(--mono);
+      font-weight: 700;
+    }
+    .state-running .state-mark {
+      border-color: color-mix(in srgb, var(--running) 28%, transparent);
+      border-top-color: var(--running);
+      animation: turn 1.8s linear infinite;
+    }
+    .state-running .state-mark span { animation: counter-turn 1.8s linear infinite; }
+    .state-idle .state-mark { border-radius: 3px; }
+    .state-cold .state-mark { border-style: dotted; opacity: .72; }
+    .state-waiting .state-mark {
+      color: var(--void);
+      background: var(--gold);
+      border-color: var(--gold);
+      border-radius: 3px;
+      box-shadow: 0 0 8px color-mix(in srgb, var(--gold) 30%, transparent);
+    }
+    @keyframes turn { to { transform: rotate(360deg); } }
+    @keyframes counter-turn { to { transform: rotate(-360deg); } }
+    .tab-title {
+      min-width: 0;
+      overflow: hidden;
+      font-size: 11px;
+      line-height: 1;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .surface-tab.selected .tab-title { font-weight: 650; }
+    .surface-id { color: var(--dim); font: 9px var(--mono); }
+    body.hide-ids .surface-id { display: none; }
+
+    .tab-toolbar {
+      position: absolute;
+      top: 0;
+      right: 0;
+      z-index: 4;
+      height: 29px;
+      display: flex;
+      align-items: center;
+      padding-left: 22px;
+      background: linear-gradient(90deg, transparent, var(--chrome) 20px);
+    }
+    .tool-button {
+      width: 25px;
+      height: 25px;
+      display: grid;
+      place-items: center;
+      padding: 0;
+      color: var(--dim);
+      background: transparent;
+      border: 0;
+      border-radius: 4px;
+      cursor: default;
+      font: 13px var(--mono);
+    }
+    .tool-button:hover { color: var(--text); background: var(--panel-raised); }
+    .tool-divider { width: 1px; height: 18px; margin: 0 3px; background: var(--rule); }
+
+    .surface-titlebar {
+      min-height: 60px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      background: var(--panel);
+      border-bottom: 1px solid var(--rule);
+    }
+    .surface-title-copy { min-width: 0; }
+    .surface-title {
+      overflow: hidden;
+      font-size: 12px;
+      font-weight: 650;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .surface-description {
+      margin-top: 4px;
+      overflow: hidden;
+      color: var(--dim);
+      font: 10px var(--mono);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .surface-state-readout {
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      color: var(--selected-state, var(--running));
+      font: 9px var(--mono);
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .surface-state-readout .state-mark { --state: var(--selected-state, var(--running)); }
+
+    .content {
+      min-height: 0;
+      flex: 1;
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 312px;
+    }
+    .terminal {
+      min-width: 0;
+      padding: 22px;
+      overflow: hidden;
+      color: var(--terminal-line);
+      background:
+        radial-gradient(circle at 26% 20%, color-mix(in srgb, var(--running) 5%, transparent), transparent 30%),
+        var(--void);
+      font: 12px/1.72 var(--mono);
+    }
+    .terminal .dim { color: var(--dim); }
+    .terminal .gold { color: var(--gold); }
+    .terminal .blue { color: var(--running); }
+    .terminal .green { color: var(--idle); }
+    .terminal .rule { margin: 18px 0; color: var(--rule-strong); }
+
+    .inspector {
+      min-width: 0;
+      padding: 18px;
+      background: var(--panel);
+      border-left: 1px solid var(--rule);
+      overflow-y: auto;
+    }
+    .eyebrow {
+      color: var(--dim);
+      font: 9px var(--mono);
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    .inspector h1 { margin: 7px 0 8px; font-size: 16px; line-height: 1.2; }
+    .inspector p { margin: 0 0 15px; color: var(--dim); font: 10px/1.5 var(--mono); }
+    .state-controls { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+    .state-button, .option-button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      min-height: 31px;
+      padding: 6px 8px;
+      color: var(--text-soft);
+      background: transparent;
+      border: 1px solid var(--rule-strong);
+      border-radius: 5px;
+      cursor: default;
+      font: 9px var(--mono);
+      letter-spacing: .05em;
+      text-transform: uppercase;
+    }
+    .state-button:hover, .option-button:hover { color: var(--text); background: var(--panel-raised); }
+    .state-button.active { color: var(--state-button-color); border-color: var(--state-button-color); background: color-mix(in srgb, var(--state-button-color) 10%, transparent); }
+    .state-button[data-state="running"] { --state-button-color: var(--running); }
+    .state-button[data-state="idle"] { --state-button-color: var(--idle); }
+    .state-button[data-state="cold"] { --state-button-color: var(--cold); }
+    .state-button[data-state="waiting"] { --state-button-color: var(--gold); }
+    .section-rule { height: 1px; margin: 17px 0; background: var(--rule); }
+    .legend { display: grid; gap: 9px; margin-top: 11px; }
+    .legend-row { display: grid; grid-template-columns: 18px 62px 1fr; align-items: center; gap: 6px; }
+    .legend-row .state-mark { --state: var(--legend-state); }
+    .legend-row.running { --legend-state: var(--running); }
+    .legend-row.idle { --legend-state: var(--idle); }
+    .legend-row.cold { --legend-state: var(--cold); }
+    .legend-row.waiting { --legend-state: var(--gold); }
+    .legend-row strong { color: var(--text-soft); font: 9px var(--mono); font-weight: 650; text-transform: uppercase; }
+    .legend-row span:last-child { color: var(--dim); font: 9px/1.3 var(--mono); }
+    .legend-row.running .state-mark { border-top-color: var(--running); }
+    .legend-row.idle .state-mark { border-radius: 3px; }
+    .legend-row.cold .state-mark { border-style: dotted; }
+    .legend-row.waiting .state-mark { color: var(--void); background: var(--gold); border-color: var(--gold); border-radius: 3px; }
+    .option-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+    .option-button[aria-pressed="true"] { color: var(--gold); border-color: color-mix(in srgb, var(--gold) 55%, var(--rule)); }
+    .collision-note {
+      margin-top: 14px;
+      padding: 10px;
+      color: var(--text-soft);
+      background: var(--void);
+      border-left: 2px solid var(--selection);
+      font: 9px/1.5 var(--mono);
+    }
+    .collision-note b { color: var(--gold); font-weight: 650; }
+    .toast {
+      position: fixed;
+      bottom: 17px;
+      left: 50%;
+      z-index: 30;
+      padding: 7px 10px;
+      color: var(--text);
+      background: var(--panel-raised);
+      border: 1px solid var(--rule-strong);
+      border-radius: 5px;
+      box-shadow: 0 8px 30px var(--shadow);
+      opacity: 0;
+      transform: translate(-50%, 6px);
+      transition: opacity .16s, transform .16s;
+      pointer-events: none;
+      font: 9px var(--mono);
+    }
+    .toast.show { opacity: 1; transform: translate(-50%, 0); }
+
+    body.reduce-motion *, body.reduce-motion *::before, body.reduce-motion *::after {
+      scroll-behavior: auto !important;
+      animation: none !important;
+      transition-duration: 0s !important;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; animation: none !important; transition-duration: 0s !important; }
+    }
+    @media (max-width: 970px) {
+      .sidebar { width: 160px; }
+      .content { grid-template-columns: minmax(0, 1fr) 275px; }
+      .agent-mark { display: none; }
+    }
+  </style>
+</head>
+<body class="hide-ids">
+  <div class="prototype-stamp">
+    <span class="prototype-badge">PROTOTYPE</span>
+    <span>surface-tab state study · not wired to real data</span>
+  </div>
+
+  <main class="window">
+    <header class="mac-titlebar">
+      <div class="traffic"><i></i><i></i><i></i></div>
+      <div class="window-title">c11 — Stage 11</div>
+    </header>
+
+    <div class="body">
+      <aside class="sidebar" aria-label="Workspace shell context">
+        <div class="sidebar-label">Workspaces</div>
+        <div class="workspace-row"><span class="folder">◇</span><span>Acetate</span></div>
+        <div class="workspace-row selected"><span class="folder">◇</span><span>c11</span></div>
+        <div class="workspace-row"><span class="folder">◇</span><span>Lattice</span></div>
+        <div class="workspace-row"><span class="folder">◇</span><span>Overwatch</span></div>
+        <div class="sidebar-foot">Workspace rows are shell context only.<br>No state treatment is proposed here.</div>
+      </aside>
+
+      <section class="pane">
+        <div class="tabbar-shell" aria-label="Surface tab state experiment">
+          <div class="tab-scroll" id="tabScroll" role="tablist"></div>
+          <div class="tab-toolbar" aria-label="Pane controls">
+            <button class="tool-button" id="scrollLeft" aria-label="Scroll tabs left">‹</button>
+            <button class="tool-button" id="scrollRight" aria-label="Scroll tabs right">›</button>
+            <div class="tool-divider"></div>
+            <button class="tool-button" aria-label="New surface">＋</button>
+            <button class="tool-button" aria-label="Split pane">⊞</button>
+            <button class="tool-button" aria-label="More pane actions">•••</button>
+          </div>
+        </div>
+
+        <div class="surface-titlebar">
+          <div class="surface-title-copy">
+            <div class="surface-title" id="surfaceTitle"></div>
+            <div class="surface-description" id="surfaceDescription"></div>
+          </div>
+          <div class="surface-state-readout" id="surfaceStateReadout">
+            <span class="state-mark"><span id="readoutGlyph"></span></span>
+            <span id="readoutLabel"></span>
+          </div>
+        </div>
+
+        <div class="content">
+          <div class="terminal" id="terminalCopy"></div>
+
+          <aside class="inspector">
+            <div class="eyebrow">Selected surface</div>
+            <h1 id="inspectorTitle"></h1>
+            <p>Click any tab, then force a state. Selection and state should remain readable in every combination.</p>
+
+            <div class="state-controls" aria-label="Change selected surface state">
+              <button class="state-button" data-state="running">↻ Running</button>
+              <button class="state-button" data-state="idle">Ⅱ Idle</button>
+              <button class="state-button" data-state="cold">– Cold</button>
+              <button class="state-button" data-state="waiting">! Your turn</button>
+            </div>
+
+            <div class="section-rule"></div>
+            <div class="eyebrow">Grammar</div>
+            <div class="legend">
+              <div class="legend-row running"><span class="state-mark"><span>↻</span></span><strong>Running</strong><span>slow rotor; work is moving</span></div>
+              <div class="legend-row idle"><span class="state-mark"><span>Ⅱ</span></span><strong>Idle</strong><span>quiet pause; prompt is ready</span></div>
+              <div class="legend-row cold"><span class="state-mark"><span>–</span></span><strong>Cold</strong><span>dotted shell; no live session</span></div>
+              <div class="legend-row waiting"><span class="state-mark"><span>!</span></span><strong>Your turn</strong><span>boxed bang + striped demand rail</span></div>
+            </div>
+
+            <div class="section-rule"></div>
+            <div class="eyebrow">Stress the strip</div>
+            <div class="option-grid">
+              <button class="option-button" id="toggleIds" aria-pressed="false">Surface IDs</button>
+              <button class="option-button" id="toggleAgents" aria-pressed="true">Agent glyphs</button>
+              <button class="option-button" id="toggleTheme" aria-pressed="false">Light theme</button>
+              <button class="option-button" id="toggleMotion" aria-pressed="false">Reduce motion</button>
+            </div>
+
+            <div class="collision-note">
+              <b>State is not selection.</b> The white top rail and raised fill say “you are here.” The state glyph says what the agent is doing. Only <b>your turn</b> earns the lower gold demand rail.
+            </div>
+          </aside>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <div class="toast" id="toast">Close hover is live; prototype tabs stay in place.</div>
+
+  <script>
+    const surfaces = [
+      { id: 54, title: 'Agent Pulse', state: 'waiting', agent: 'C', description: 'Waiting for the operator to choose the workspace-level direction.' },
+      { id: 62, title: 'Surface Pulse', state: 'running', agent: '◇', description: 'Prototyping agent presence on dense horizontal surface tabs.' },
+      { id: 72, title: 'Release staging', state: 'running', agent: 'C', description: 'Building and validating the signed release candidate.' },
+      { id: 77, title: 'Mailbox attribution', state: 'idle', agent: '◇', description: 'At the prompt after completing the attribution copy pass.' },
+      { id: 91, title: 'Socket watchdog', state: 'cold', agent: '·', description: 'Resumable terminal; no agent process is currently live.' },
+      { id: 105, title: 'Browser regression sweep', state: 'running', agent: 'C', description: 'Exercising browser navigation, snapshots, and auth-state restore.' },
+      { id: 118, title: 'Theme conformance', state: 'idle', agent: '◇', description: 'Dark and light c11 theme slot review is complete.' },
+      { id: 126, title: 'Japanese localization', state: 'cold', agent: 'C', description: 'Session ended after committing the locale update.' },
+      { id: 144, title: 'Workspace snapshot recovery validation and persistence audit', state: 'waiting', agent: '◇', description: 'Needs approval to replace the corrupted fixture with a captured snapshot.' },
+      { id: 158, title: 'Docs pruning', state: 'idle', agent: 'C', description: 'At the prompt with a clean documentation diff.' },
+      { id: 203, title: 'Flaky focus test diagnosis', state: 'running', agent: '◇', description: 'Repeating the focused-pane event test under contention.' }
+    ];
+
+    const stateCopy = {
+      running: { glyph: '↻', label: 'Running · work in motion', color: 'var(--running)', line: 'Command in flight. Output and prompt-state observation say this agent is moving.' },
+      idle: { glyph: 'Ⅱ', label: 'Idle · at the prompt', color: 'var(--idle)', line: 'Live session, quiet prompt. Available for another task without a resume step.' },
+      cold: { glyph: '–', label: 'Cold · no live agent', color: 'var(--cold)', line: 'The surface remains, but no agent session is currently live. It may be resumable.' },
+      waiting: { glyph: '!', label: 'Your turn · response needed', color: 'var(--gold)', line: 'The agent has yielded with a question or decision. This is the operator’s turn.' }
+    };
+
+    let selectedId = 62;
+    const tabScroll = document.getElementById('tabScroll');
+
+    function widthFor(surface) {
+      const idCost = document.body.classList.contains('hide-ids') ? 0 : 23;
+      const agentCost = document.body.classList.contains('hide-agents') ? 0 : 15;
+      // Deliberately exercise Bonsplit's dense end of the real 112–220pt range:
+      // eight tabs remain scannable by default, while IDs and long titles still
+      // push the strip into its native horizontal-overflow behavior.
+      return Math.max(112, Math.min(190, 52 + idCost + agentCost + surface.title.length * 4));
+    }
+
+    function tabMarkup(surface) {
+      const copy = stateCopy[surface.state];
+      return `
+        <div class="surface-tab state-${surface.state}${surface.id === selectedId ? ' selected' : ''}"
+             style="--tab-width:${widthFor(surface)}px"
+             data-id="${surface.id}" role="tab" tabindex="0"
+             aria-selected="${surface.id === selectedId}" aria-label="${surface.title}, ${copy.label}"
+             title="surface:${surface.id} · ${surface.title} · ${copy.label}">
+          <button class="close-tab" aria-label="Close ${surface.title}" title="Close tab">×</button>
+          <span class="agent-mark" aria-hidden="true">${surface.agent}</span>
+          <span class="state-mark" aria-hidden="true"><span>${copy.glyph}</span></span>
+          <span class="tab-title"><span class="surface-id">${surface.id}: </span>${surface.title}</span>
+        </div>`;
+    }
+
+    function renderTabs({ changedId = null } = {}) {
+      tabScroll.innerHTML = surfaces.map(tabMarkup).join('');
+      tabScroll.querySelectorAll('.surface-tab').forEach(tab => {
+        const id = Number(tab.dataset.id);
+        tab.addEventListener('click', event => {
+          if (event.target.closest('.close-tab')) return;
+          selectSurface(id);
+        });
+        tab.addEventListener('keydown', event => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            selectSurface(id);
+          }
+        });
+        tab.querySelector('.close-tab').addEventListener('click', event => {
+          event.stopPropagation();
+          showToast();
+        });
+      });
+      if (changedId !== null) {
+        const changed = tabScroll.querySelector(`[data-id="${changedId}"]`);
+        if (changed) {
+          changed.classList.add('state-changed');
+          setTimeout(() => changed.classList.remove('state-changed'), 950);
+        }
+      }
+    }
+
+    function selectSurface(id) {
+      selectedId = id;
+      renderTabs();
+      updateSelection();
+      const tab = tabScroll.querySelector(`[data-id="${id}"]`);
+      if (tab) tab.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' });
+    }
+
+    function updateSelection() {
+      const surface = surfaces.find(item => item.id === selectedId);
+      const copy = stateCopy[surface.state];
+      const waitingCount = surfaces.filter(item => item.state === 'waiting').length;
+      document.getElementById('surfaceTitle').textContent = `surface:${surface.id} · ${surface.title}`;
+      document.getElementById('surfaceDescription').textContent = surface.description;
+      document.getElementById('inspectorTitle').textContent = surface.title;
+      document.getElementById('readoutGlyph').textContent = copy.glyph;
+      document.getElementById('readoutLabel').textContent = copy.label;
+      document.getElementById('surfaceStateReadout').style.setProperty('--selected-state', copy.color);
+      document.querySelectorAll('.state-button').forEach(button => {
+        button.classList.toggle('active', button.dataset.state === surface.state);
+      });
+      document.getElementById('terminalCopy').innerHTML = `
+        <div><span class="dim">$</span> c11 inspect surface:${surface.id}</div>
+        <br>
+        <div><span style="color:${copy.color}">${copy.glyph}</span> <strong>${copy.label}</strong></div>
+        <div class="dim">${copy.line}</div>
+        <div class="rule">────────────────────────────────────────────────────────</div>
+        <div><span class="gold">${waitingCount}</span> of ${surfaces.length} surfaces currently need the operator.</div>
+        <div class="dim">The tab strip keeps that answer visible through selection, truncation, and overflow.</div>
+        <br>
+        <div><span class="blue">selection</span> → neutral top rail + raised fill</div>
+        <div><span class="gold">operator turn</span> → ! glyph + patterned lower rail</div>
+        <div><span class="green">availability</span> → quiet geometric glyph</div>`;
+    }
+
+    function setSelectedState(state) {
+      const surface = surfaces.find(item => item.id === selectedId);
+      surface.state = state;
+      renderTabs({ changedId: selectedId });
+      updateSelection();
+    }
+
+    function showToast() {
+      const toast = document.getElementById('toast');
+      toast.classList.add('show');
+      clearTimeout(window.prototypeToastTimer);
+      window.prototypeToastTimer = setTimeout(() => toast.classList.remove('show'), 1600);
+    }
+
+    document.querySelectorAll('.state-button').forEach(button => {
+      button.addEventListener('click', () => setSelectedState(button.dataset.state));
+    });
+
+    document.getElementById('toggleIds').addEventListener('click', event => {
+      document.body.classList.toggle('hide-ids');
+      const shown = !document.body.classList.contains('hide-ids');
+      event.currentTarget.setAttribute('aria-pressed', shown);
+      renderTabs();
+    });
+    document.getElementById('toggleAgents').addEventListener('click', event => {
+      document.body.classList.toggle('hide-agents');
+      const shown = !document.body.classList.contains('hide-agents');
+      event.currentTarget.setAttribute('aria-pressed', shown);
+      renderTabs();
+    });
+    document.getElementById('toggleTheme').addEventListener('click', event => {
+      const light = document.body.dataset.theme !== 'light';
+      document.body.dataset.theme = light ? 'light' : 'dark';
+      event.currentTarget.setAttribute('aria-pressed', light);
+      event.currentTarget.textContent = light ? 'Dark theme' : 'Light theme';
+    });
+    document.getElementById('toggleMotion').addEventListener('click', event => {
+      const reduced = document.body.classList.toggle('reduce-motion');
+      event.currentTarget.setAttribute('aria-pressed', reduced);
+    });
+    document.getElementById('scrollLeft').addEventListener('click', () => tabScroll.scrollBy({ left: -360, behavior: 'smooth' }));
+    document.getElementById('scrollRight').addEventListener('click', () => tabScroll.scrollBy({ left: 360, behavior: 'smooth' }));
+
+    renderTabs();
+    updateSelection();
+  </script>
+</body>
+</html>

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -198,8 +198,8 @@
       flex: 0 0 var(--tab-width, 146px);
       display: flex;
       align-items: center;
-      gap: 5px;
-      padding: 0 6px 1px;
+      gap: 0;
+      padding: 0 2px 1px;
       overflow: hidden;
       color: var(--dim);
       background: transparent;
@@ -249,16 +249,17 @@
     }
 
     .close-tab {
-      width: 19px;
-      height: 19px;
-      flex: 0 0 19px;
+      width: 24px;
+      height: 27px;
+      flex: 0 0 24px;
       display: grid;
       place-items: center;
+      margin-left: auto;
       padding: 0;
       color: currentColor;
       background: transparent;
       border: 0;
-      border-radius: 50%;
+      border-radius: 4px;
       opacity: .54;
       cursor: default;
       font-size: 12px;
@@ -268,6 +269,7 @@
     .agent-mark {
       width: 11px;
       flex: 0 0 11px;
+      margin: 0 4px 0 3px;
       color: color-mix(in srgb, var(--text-soft) 72%, transparent);
       font: 9px var(--mono);
       text-align: center;
@@ -284,6 +286,13 @@
       border-radius: 50%;
       font: 8px/1 var(--mono);
       font-weight: 700;
+    }
+    .surface-tab > .state-mark {
+      width: 20px;
+      height: 20px;
+      flex: 0 0 20px;
+      margin-right: 4px;
+      font-size: 10px;
     }
     .state-running .state-mark {
       border-color: color-mix(in srgb, var(--running) 28%, transparent);
@@ -578,7 +587,7 @@
             </div>
 
             <div class="collision-note">
-              <b>State is not selection.</b> The white top rail and raised fill say “you are here.” The state glyph says what the agent is doing. Only <b>your turn</b> earns the lower gold demand rail.
+              <b>Read the edges first.</b> State owns the hard-left edge; close owns the hard-right. The white top rail and raised fill say “you are here.” Only <b>your turn</b> earns the lower gold demand rail.
             </div>
           </aside>
         </div>
@@ -630,10 +639,10 @@
              data-id="${surface.id}" role="tab" tabindex="0"
              aria-selected="${surface.id === selectedId}" aria-label="${surface.title}, ${copy.label}"
              title="surface:${surface.id} · ${surface.title} · ${copy.label}">
-          <button class="close-tab" aria-label="Close ${surface.title}" title="Close tab">×</button>
-          <span class="agent-mark" aria-hidden="true">${surface.agent}</span>
           <span class="state-mark" aria-hidden="true"><span>${copy.glyph}</span></span>
+          <span class="agent-mark" aria-hidden="true">${surface.agent}</span>
           <span class="tab-title"><span class="surface-id">${surface.id}: </span>${surface.title}</span>
+          <button class="close-tab" aria-label="Close ${surface.title}" title="Close tab">×</button>
         </div>`;
     }
 

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -19,13 +19,13 @@
       --dim: #777b84;
       --selection: #f0f0ed;
       --gold: #d0aa45;
-      --gold-soft: rgba(208, 170, 69, .15);
       --running: #79aee8;
       --idle: #78b59e;
       --cold: #707681;
       --harness-claude: #d88968;
       --harness-codex: #69b5a8;
       --harness-shell: #818791;
+      --badge-ink: #08090b;
       --shadow: rgba(0, 0, 0, .72);
       --terminal-line: #b8bcc4;
       --mono: "SFMono-Regular", "JetBrains Mono", Menlo, monospace;
@@ -46,13 +46,13 @@
       --dim: #777a81;
       --selection: #24252a;
       --gold: #9b7415;
-      --gold-soft: rgba(155, 116, 21, .12);
       --running: #326d9e;
       --idle: #357b61;
       --cold: #7f8289;
       --harness-claude: #a84f32;
       --harness-codex: #28776d;
       --harness-shell: #6d7178;
+      --badge-ink: #fffdf8;
       --shadow: rgba(35, 34, 30, .25);
       --terminal-line: #4b4e55;
     }
@@ -229,22 +229,6 @@
     body.neutral-harness .surface-tab { --harness: var(--text-soft); }
     .surface-tab.state-waiting {
       --state: var(--gold);
-      color: color-mix(in srgb, var(--text) 92%, var(--gold));
-      background: linear-gradient(90deg, var(--gold-soft), transparent 76%);
-    }
-    .surface-tab.state-waiting::after {
-      content: "";
-      position: absolute;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      height: 3px;
-      background: repeating-linear-gradient(90deg, var(--gold) 0 7px, transparent 7px 10px);
-    }
-    .surface-tab.selected.state-waiting {
-      background:
-        linear-gradient(90deg, var(--gold-soft), transparent 80%),
-        var(--panel-raised);
     }
     .surface-tab.state-changed { animation: state-arrival .9s ease-out 1; }
     @keyframes state-arrival {
@@ -290,27 +274,42 @@
       font-weight: 700;
     }
     .surface-tab > .state-mark {
-      width: 20px;
-      height: 20px;
-      flex: 0 0 20px;
-      margin-right: 4px;
+      width: 22px;
+      height: 22px;
+      flex: 0 0 22px;
+      margin-right: 5px;
       color: var(--harness);
       border-color: color-mix(in srgb, var(--harness) 76%, transparent);
       font-size: 10px;
     }
     .surface-tab.state-running > .state-mark {
-      border-color: color-mix(in srgb, var(--harness) 28%, transparent);
-      border-top-color: var(--harness);
+      color: var(--badge-ink);
+      background: var(--harness);
+      border-color: var(--harness);
+      border-top-color: color-mix(in srgb, var(--badge-ink) 74%, transparent);
+      box-shadow: 0 0 7px color-mix(in srgb, var(--harness) 24%, transparent);
       animation: turn 1.8s linear infinite;
     }
     .surface-tab.state-running > .state-mark span { animation: counter-turn 1.8s linear infinite; }
-    .surface-tab.state-idle > .state-mark { border-radius: 3px; }
-    .surface-tab.state-cold > .state-mark { border-style: dotted; opacity: .72; }
+    .surface-tab.state-idle > .state-mark {
+      color: var(--badge-ink);
+      background: var(--harness);
+      border-color: var(--harness);
+      border-radius: 4px;
+      box-shadow: 0 0 7px color-mix(in srgb, var(--harness) 24%, transparent);
+    }
+    .surface-tab.state-cold > .state-mark {
+      color: var(--harness);
+      background: color-mix(in srgb, var(--harness) 12%, transparent);
+      border-color: var(--harness);
+      border-style: dotted;
+      opacity: .9;
+    }
     .surface-tab.state-waiting > .state-mark {
-      color: var(--void);
+      color: var(--badge-ink);
       background: var(--gold);
       border-color: var(--gold);
-      border-radius: 3px;
+      border-radius: 4px;
       box-shadow: 0 0 8px color-mix(in srgb, var(--gold) 30%, transparent);
     }
     @keyframes turn { to { transform: rotate(360deg); } }
@@ -462,10 +461,16 @@
     .legend-row.waiting { --legend-state: var(--gold); }
     .legend-row strong { color: var(--text-soft); font: 9px var(--mono); font-weight: 650; text-transform: uppercase; }
     .legend-row span:last-child { color: var(--dim); font: 9px/1.3 var(--mono); }
-    .legend-row.running .state-mark { border-top-color: var(--text-soft); }
+    .legend-row.running .state-mark,
+    .legend-row.idle .state-mark {
+      color: var(--badge-ink);
+      background: var(--text-soft);
+      border-color: var(--text-soft);
+    }
+    .legend-row.running .state-mark { border-top-color: color-mix(in srgb, var(--badge-ink) 74%, transparent); }
     .legend-row.idle .state-mark { border-radius: 3px; }
     .legend-row.cold .state-mark { border-style: dotted; }
-    .legend-row.waiting .state-mark { color: var(--void); background: var(--gold); border-color: var(--gold); border-radius: 3px; }
+    .legend-row.waiting .state-mark { color: var(--badge-ink); background: var(--gold); border-color: var(--gold); border-radius: 3px; }
     .harness-key {
       display: flex;
       align-items: center;
@@ -592,7 +597,7 @@
               <div class="legend-row running"><span class="state-mark"><span>R</span></span><strong>Running</strong><span>R + slow rim; work is moving</span></div>
               <div class="legend-row idle"><span class="state-mark"><span>I</span></span><strong>Idle</strong><span>I; prompt is ready</span></div>
               <div class="legend-row cold"><span class="state-mark"><span>C</span></span><strong>Cold</strong><span>C + dotted shell; no live session</span></div>
-              <div class="legend-row waiting"><span class="state-mark"><span>W</span></span><strong>Your turn</strong><span>W + striped demand rail</span></div>
+              <div class="legend-row waiting"><span class="state-mark"><span>W</span></span><strong>Your turn</strong><span>prominent gold W; no second signal</span></div>
             </div>
             <div class="harness-key" aria-label="Harness color key">
               <span><i class="harness-swatch claude"></i> Claude</span>
@@ -610,7 +615,7 @@
             </div>
 
             <div class="collision-note">
-              <b>One badge, two reads.</b> R/I/C/W names state; badge hue names the harness. Waiting overrides hue with gold and the demand rail. Close remains hard-right.
+              <b>One badge, two reads.</b> R/I/C/W names state; solid badge hue names the harness. Waiting overrides hue with gold alone. Close remains hard-right.
             </div>
           </aside>
         </div>
@@ -736,7 +741,7 @@
         <div class="dim">The tab strip keeps that answer visible through selection, truncation, and overflow.</div>
         <br>
         <div><span class="blue">selection</span> → neutral top rail + raised fill</div>
-        <div><span class="gold">operator turn</span> → W + patterned lower rail</div>
+        <div><span class="gold">operator turn</span> → prominent gold W alone</div>
         <div><span class="green">harness</span> → badge hue; no second glyph</div>`;
     }
 

--- a/docs/design-prototypes/agent-pulse/index.html
+++ b/docs/design-prototypes/agent-pulse/index.html
@@ -3,22 +3,46 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>c11 — Agent Pulse prototype</title>
+  <title>c11 — Workspace pulse prototype</title>
   <style>
     :root {
       color-scheme: dark;
       --void: #08090b;
-      --surface: #101216;
-      --surface-2: #171a20;
+      --chrome: #0d0f12;
+      --panel: #101216;
+      --raised: #171a20;
       --rule: #2b2e34;
+      --rule-strong: #3a3e46;
       --text: #ececef;
-      --dim: #8a8e97;
-      --gold: #c9a84c;
-      --running: #62a8ff;
-      --idle: #7fc7aa;
-      --cold: #68707c;
+      --text-soft: #b7bac1;
+      --dim: #777b84;
+      --selection: #f0f0ed;
+      --gold: #d0aa45;
+      --running: #79aee8;
+      --idle: #78b59e;
+      --cold: #707681;
+      --shadow: rgba(0, 0, 0, .72);
       --mono: "SFMono-Regular", "JetBrains Mono", Menlo, monospace;
       --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    }
+
+    body[data-theme="light"] {
+      color-scheme: light;
+      --void: #f4f3ef;
+      --chrome: #e8e7e2;
+      --panel: #efeee9;
+      --raised: #ffffff;
+      --rule: #c9c7c0;
+      --rule-strong: #aaa79f;
+      --text: #202126;
+      --text-soft: #4d5058;
+      --dim: #777a81;
+      --selection: #24252a;
+      --gold: #9b7415;
+      --running: #326d9e;
+      --idle: #357b61;
+      --cold: #7f8289;
+      --shadow: rgba(35, 34, 30, .25);
     }
 
     * { box-sizing: border-box; }
@@ -27,325 +51,363 @@
       display: grid;
       place-items: center;
       overflow: hidden;
-      background: #000;
       color: var(--text);
+      background: #030405;
       font-family: var(--sans);
       -webkit-font-smoothing: antialiased;
     }
-
+    body[data-theme="light"] { background: #d7d5ce; }
     button { font: inherit; }
 
-    .prototype-note {
+    .prototype-stamp {
       position: fixed;
-      top: 14px;
+      top: 13px;
       left: 50%;
-      z-index: 5;
-      transform: translateX(-50%);
+      z-index: 20;
       display: flex;
       align-items: center;
       gap: 10px;
-      font: 10px var(--mono);
+      transform: translateX(-50%);
       color: #81858d;
+      font: 10px var(--mono);
       letter-spacing: .04em;
     }
-
     .prototype-badge {
-      color: var(--gold);
-      border: 1px solid rgba(201, 168, 76, .45);
-      border-radius: 4px;
       padding: 3px 7px;
+      color: var(--gold);
+      border: 1px solid color-mix(in srgb, var(--gold) 48%, transparent);
+      border-radius: 4px;
       letter-spacing: .14em;
     }
 
     .window {
-      width: min(1160px, calc(100vw - 44px));
-      height: min(720px, calc(100vh - 72px));
+      width: min(1210px, calc(100vw - 42px));
+      height: min(750px, calc(100vh - 68px));
       display: flex;
       flex-direction: column;
       overflow: hidden;
       background: var(--void);
-      border: 1px solid #303238;
+      border: 1px solid var(--rule-strong);
       border-radius: 12px;
-      box-shadow: 0 28px 90px rgba(0, 0, 0, .72);
+      box-shadow: 0 28px 90px var(--shadow);
     }
-
     .titlebar {
       height: 38px;
       flex: 0 0 auto;
       display: flex;
       align-items: center;
       padding: 0 14px;
+      background: var(--chrome);
       border-bottom: 1px solid var(--rule);
-      background: #0d0f12;
     }
-
     .traffic { display: flex; gap: 7px; }
     .traffic i { width: 11px; height: 11px; border-radius: 50%; }
     .traffic i:nth-child(1) { background: #ff5f57; }
     .traffic i:nth-child(2) { background: #febc2e; }
     .traffic i:nth-child(3) { background: #28c840; }
-    .window-title {
-      margin: 0 auto;
-      color: #6d7078;
-      font: 11px var(--mono);
-      letter-spacing: .05em;
-    }
+    .window-title { margin: 0 auto; color: var(--dim); font: 11px var(--mono); letter-spacing: .05em; }
 
     .body { min-height: 0; flex: 1; display: flex; }
-
     .sidebar {
-      width: 270px;
+      width: 310px;
       flex: 0 0 auto;
       display: flex;
       flex-direction: column;
+      background: var(--chrome);
       border-right: 1px solid var(--rule);
-      background: #0c0e11;
     }
-
     .sidebar-head {
       display: flex;
-      align-items: baseline;
-      padding: 15px 13px 10px;
-      color: #6e727a;
+      align-items: center;
+      padding: 12px 12px 9px;
+      color: var(--dim);
       font: 9px var(--mono);
       letter-spacing: .15em;
       text-transform: uppercase;
     }
-    .sidebar-head span:last-child {
+    .attention-total {
       margin-left: auto;
-      color: var(--gold);
-      letter-spacing: .05em;
+      padding: 3px 6px;
+      color: var(--void);
+      background: var(--gold);
+      border-radius: 4px;
+      font-weight: 750;
+      letter-spacing: .04em;
       text-transform: none;
     }
-
-    .workspaces { padding: 0 8px; display: grid; gap: 7px; }
+    .workspace-list { display: grid; gap: 6px; padding: 0 8px 8px; }
 
     .workspace {
-      --state: var(--cold);
+      --identity: #737983;
+      --dominant: var(--cold);
       position: relative;
       width: 100%;
-      min-height: 93px;
-      display: grid;
-      grid-template-columns: 22px 1fr;
-      gap: 9px;
-      padding: 11px 10px;
+      min-height: 88px;
+      padding: 9px 10px 9px 13px;
       overflow: hidden;
       color: var(--text);
       text-align: left;
-      background: #101216;
+      background: var(--panel);
       border: 1px solid var(--rule);
       border-radius: 8px;
       cursor: pointer;
       transition: background .14s, border-color .14s, opacity .14s;
     }
-    .workspace:hover { background: #15181d; }
-    .workspace.active { border: 2px solid rgba(255,255,255,.88); padding: 10px 9px; }
-    .workspace[data-state="running"] { --state: var(--running); }
-    .workspace[data-state="waiting"] { --state: var(--gold); }
-    .workspace[data-state="idle"] { --state: var(--idle); }
-    .workspace[data-state="cold"] { --state: var(--cold); opacity: .72; }
-    .workspace[data-state="cold"]:hover,
-    .workspace[data-state="cold"].active { opacity: 1; }
-    .workspace[data-state="waiting"] {
-      background: linear-gradient(90deg, rgba(201,168,76,.15), #111316 72%);
-      border-color: rgba(201,168,76,.58);
-    }
-
-    .beacon {
-      position: relative;
-      width: 20px;
-      height: 20px;
-      display: grid;
-      place-items: center;
-      margin-top: 1px;
-      border: 1px solid color-mix(in srgb, var(--state) 75%, transparent);
-      border-radius: 50%;
-      color: var(--state);
-      font: 10px var(--mono);
-    }
-    [data-state="running"] .beacon::after {
+    .workspace::before {
       content: "";
       position: absolute;
-      inset: -1px;
-      border: 1px solid var(--running);
-      border-radius: 50%;
-      animation: breathe 1.8s ease-out infinite;
+      top: 7px;
+      bottom: 7px;
+      left: 4px;
+      width: 3px;
+      background: var(--identity);
+      border-radius: 2px;
     }
-    @keyframes breathe {
-      0%, 35% { transform: scale(.75); opacity: .7; }
-      100% { transform: scale(1.65); opacity: 0; }
+    .workspace::after {
+      content: "";
+      position: absolute;
+      right: 8px;
+      bottom: 0;
+      left: 8px;
+      height: 0;
+      background: var(--gold);
+      border-radius: 2px 2px 0 0;
     }
-    @media (prefers-reduced-motion: reduce) {
-      [data-state="running"] .beacon::after { animation: none; }
+    .workspace:hover { background: color-mix(in srgb, var(--raised) 78%, var(--panel)); }
+    .workspace.selected {
+      padding: 8px 9px 8px 12px;
+      border: 2px solid var(--selection);
     }
+    .workspace.dominant-waiting {
+      background: linear-gradient(90deg, color-mix(in srgb, var(--gold) 11%, var(--panel)), var(--panel) 66%);
+    }
+    .workspace.dominant-waiting::after { height: 3px; }
+    .workspace.dominant-cold:not(.selected) { opacity: .72; }
+    .workspace.dominant-cold:hover { opacity: 1; }
 
-    .workspace-copy { min-width: 0; }
+    .workspace-top { display: flex; align-items: center; min-width: 0; }
     .workspace-title {
-      display: flex;
-      align-items: center;
-      gap: 7px;
-      margin-bottom: 5px;
-      font-size: 13px;
-      font-weight: 650;
-      white-space: nowrap;
-    }
-    .agent-chip {
-      padding: 2px 5px;
-      color: #aaadb4;
-      border: 1px solid #35383f;
-      border-radius: 4px;
-      font: 8px var(--mono);
-      font-weight: 500;
-    }
-    .description {
+      min-width: 0;
       overflow: hidden;
-      color: var(--dim);
-      font: 10px/1.4 var(--mono);
+      color: var(--text);
+      font-size: 12.5px;
+      font-weight: 650;
       text-overflow: ellipsis;
       white-space: nowrap;
     }
-    .state-line {
-      display: flex;
+    .workspace-actions { margin-left: auto; display: flex; align-items: center; gap: 7px; color: var(--dim); font: 10px var(--mono); }
+    .close { width: 14px; opacity: 0; text-align: center; }
+    .workspace:hover .close { opacity: 1; }
+
+    .workspace-signal {
+      display: grid;
+      grid-template-columns: 20px minmax(0, 1fr) auto;
       align-items: center;
-      gap: 6px;
-      margin-top: 9px;
-      color: var(--state);
-      font: 9px var(--mono);
-      letter-spacing: .09em;
-      text-transform: uppercase;
-    }
-    .state-line::before {
-      content: "";
-      width: 18px;
-      height: 2px;
-      border-radius: 2px;
-      background: var(--state);
-    }
-    [data-state="waiting"] .state-line {
-      width: fit-content;
+      gap: 7px;
       margin-top: 7px;
-      padding: 4px 7px;
-      color: #0b0c0e;
-      background: var(--gold);
-      border-radius: 4px;
+    }
+    .state-mark {
+      --state: var(--dominant);
+      position: relative;
+      width: 18px;
+      height: 18px;
+      display: grid;
+      place-items: center;
+      color: var(--state);
+      border: 1px solid color-mix(in srgb, var(--state) 76%, transparent);
+      border-radius: 50%;
+      font: 9px var(--mono);
       font-weight: 750;
     }
-    [data-state="waiting"] .state-line::before { display: none; }
+    .dominant-running .state-mark { border-top-color: transparent; }
+    .dominant-running .state-mark span { animation: turn 1.8s linear infinite; }
+    .dominant-idle .state-mark { border-radius: 4px; }
+    .dominant-cold .state-mark { border-style: dotted; }
+    .dominant-waiting .state-mark {
+      color: var(--void);
+      background: var(--gold);
+      border-color: var(--gold);
+      border-radius: 4px;
+    }
+    @keyframes turn { to { transform: rotate(360deg); } }
+
+    .signal-copy { min-width: 0; }
+    .signal-label {
+      display: block;
+      overflow: hidden;
+      color: var(--dominant);
+      font: 9px var(--mono);
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-overflow: ellipsis;
+      text-transform: uppercase;
+      white-space: nowrap;
+    }
+    .signal-detail {
+      display: block;
+      margin-top: 2px;
+      overflow: hidden;
+      color: var(--dim);
+      font: 9px var(--mono);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .mix {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .mix-chip {
+      --chip: var(--cold);
+      min-width: 25px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 3px;
+      padding: 3px 4px;
+      color: var(--chip);
+      border: 1px solid color-mix(in srgb, var(--chip) 38%, var(--rule));
+      border-radius: 4px;
+      font: 8px var(--mono);
+    }
+    .mix-chip.waiting { --chip: var(--gold); }
+    .mix-chip.running { --chip: var(--running); }
+    .mix-chip.idle { --chip: var(--idle); }
+    .mix-chip.cold { --chip: var(--cold); }
+    body.dominant-only .mix { display: none; }
 
     .sidebar-foot {
       margin-top: auto;
-      padding: 11px 12px 13px;
+      padding: 10px 12px 12px;
+      color: var(--dim);
       border-top: 1px solid var(--rule);
-      color: #666a72;
       font: 9px/1.45 var(--mono);
     }
-    .sidebar-foot strong { color: var(--gold); font-weight: 500; }
+    .sidebar-foot b { color: var(--gold); font-weight: 600; }
 
     .main { min-width: 0; flex: 1; display: flex; flex-direction: column; }
-    .tabstrip {
-      height: 37px;
+    .surface-tabs {
+      height: 36px;
       display: flex;
       align-items: stretch;
+      background: var(--chrome);
       border-bottom: 1px solid var(--rule);
-      background: #0c0e11;
     }
     .surface-tab {
+      min-width: 158px;
       display: flex;
       align-items: center;
-      gap: 7px;
-      min-width: 170px;
-      padding: 0 13px;
-      color: #8b8e95;
+      padding: 0 12px;
+      color: var(--dim);
       border-right: 1px solid var(--rule);
-      font-size: 11px;
+      font-size: 10px;
     }
-    .surface-tab.active { color: var(--text); background: var(--surface-2); }
-    .surface-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--running); }
-    .tools { margin-left: auto; display: flex; align-items: center; gap: 13px; padding: 0 14px; color: #72767e; font: 12px var(--mono); }
+    .surface-tab.active { color: var(--text); background: var(--raised); box-shadow: inset 0 2px var(--selection); }
+    .surface-note { margin-left: auto; align-self: center; padding-right: 13px; color: var(--dim); font: 8px var(--mono); }
 
-    .surface-bar {
-      min-height: 72px;
+    .workspace-bar {
       display: flex;
       align-items: center;
-      gap: 13px;
-      padding: 12px 17px;
+      gap: 10px;
+      min-height: 68px;
+      padding: 11px 16px;
+      background: var(--panel);
       border-bottom: 1px solid var(--rule);
-      background: #111318;
     }
-    .large-beacon {
-      width: 34px;
-      height: 34px;
-      display: grid;
-      place-items: center;
-      color: var(--running);
-      border: 1px solid currentColor;
-      border-radius: 50%;
-      font: 13px var(--mono);
-    }
-    .surface-copy { min-width: 0; }
-    .surface-name { font-size: 13px; font-weight: 650; }
-    .surface-desc { margin-top: 5px; color: var(--dim); font: 10px var(--mono); }
-    .surface-state {
+    .identity-block { width: 7px; height: 35px; background: var(--identity, #787d85); border-radius: 3px; }
+    .workspace-name { font-size: 13px; font-weight: 650; }
+    .workspace-desc { margin-top: 4px; color: var(--dim); font: 10px var(--mono); }
+    .workspace-rollup {
       margin-left: auto;
       padding: 5px 8px;
-      color: var(--running);
+      color: var(--dominant, var(--running));
       border: 1px solid currentColor;
       border-radius: 5px;
       font: 9px var(--mono);
-      letter-spacing: .12em;
+      font-weight: 650;
+      letter-spacing: .08em;
       text-transform: uppercase;
     }
 
+    .content { min-height: 0; flex: 1; display: grid; grid-template-columns: minmax(0, 1fr) 300px; }
     .terminal {
-      flex: 1;
-      min-height: 0;
-      padding: 20px;
+      min-width: 0;
+      padding: 18px;
       overflow: hidden;
-      color: #b9bdc4;
+      color: var(--text-soft);
       background: var(--void);
-      font: 12px/1.68 var(--mono);
+      border-right: 1px solid var(--rule);
+      font: 11px/1.65 var(--mono);
     }
-    .terminal .dim { color: #686c74; }
-    .terminal .blue { color: var(--running); }
+    .terminal .dim { color: var(--dim); }
     .terminal .gold { color: var(--gold); }
+    .terminal .blue { color: var(--running); }
     .terminal .green { color: var(--idle); }
-    .cursor { display: inline-block; width: 7px; height: 14px; vertical-align: -2px; background: var(--gold); }
+    .terminal .cold { color: var(--cold); }
+    .agent-row {
+      display: grid;
+      grid-template-columns: 16px 76px 1fr;
+      gap: 8px;
+      margin: 5px 0;
+      color: var(--text-soft);
+    }
+    .agent-row .state { text-transform: uppercase; font-size: 9px; font-weight: 650; }
 
-    .state-lab {
-      display: flex;
-      align-items: center;
-      gap: 7px;
-      min-height: 53px;
-      padding: 9px 14px;
-      border-top: 1px solid var(--rule);
-      background: #0e1013;
+    .inspector { min-width: 0; padding: 13px; overflow: auto; background: var(--panel); }
+    .eyebrow { color: var(--dim); font: 8px var(--mono); letter-spacing: .14em; text-transform: uppercase; }
+    .inspector h2 { margin: 5px 0 7px; font-size: 14px; }
+    .inspector p { margin: 0; color: var(--dim); font: 9px/1.5 var(--mono); }
+    .rule-card {
+      margin-top: 12px;
+      padding: 9px;
+      background: var(--void);
+      border: 1px solid var(--rule);
+      border-radius: 6px;
+      font: 9px/1.55 var(--mono);
     }
-    .lab-label {
-      margin-right: auto;
-      color: #676b73;
-      font: 9px var(--mono);
-      letter-spacing: .1em;
-      text-transform: uppercase;
-    }
-    .state-button {
-      padding: 6px 9px;
-      color: #8c9098;
+    .rule-card b { color: var(--gold); font-weight: 650; }
+    .preset-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; margin-top: 12px; }
+    .preset, .option {
+      padding: 7px;
+      color: var(--text-soft);
       background: transparent;
-      border: 1px solid #34373d;
+      border: 1px solid var(--rule-strong);
       border-radius: 5px;
       cursor: pointer;
-      font: 9px var(--mono);
-      letter-spacing: .06em;
-      text-transform: uppercase;
+      font: 8px var(--mono);
+      text-align: left;
     }
-    .state-button:hover { color: var(--text); background: #191c21; }
-    .state-button[data-set="waiting"] { color: var(--gold); border-color: rgba(201,168,76,.5); }
+    .preset:hover, .option:hover { color: var(--text); background: var(--raised); }
+    .option-grid { display: grid; gap: 6px; margin-top: 12px; }
+    .option[aria-pressed="true"] { color: var(--gold); border-color: var(--gold); }
+    .collision-note {
+      margin-top: 12px;
+      padding: 9px;
+      color: var(--text-soft);
+      background: var(--void);
+      border-left: 2px solid var(--selection);
+      font: 9px/1.5 var(--mono);
+    }
+    .collision-note b { color: var(--gold); font-weight: 650; }
+
+    body.reduce-motion *, body.reduce-motion *::before, body.reduce-motion *::after {
+      animation: none !important;
+      transition-duration: 0s !important;
+    }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { animation: none !important; transition-duration: 0s !important; }
+    }
+    @media (max-width: 1000px) {
+      .sidebar { width: 275px; }
+      .content { grid-template-columns: minmax(0, 1fr) 270px; }
+      .mix-chip { min-width: 20px; padding-inline: 3px; }
+    }
   </style>
 </head>
 <body>
-  <div class="prototype-note">
+  <div class="prototype-stamp">
     <span class="prototype-badge">PROTOTYPE</span>
-    <span>not wired to real agent data · click a tab, then change its state</span>
+    <span>workspace-tab rollup study · not wired to real data</span>
   </div>
 
   <main class="window">
@@ -355,129 +417,207 @@
     </header>
 
     <div class="body">
-      <aside class="sidebar">
-        <div class="sidebar-head"><span>Workspaces</span><span>1 needs you</span></div>
-        <div class="workspaces">
-          <button class="workspace active" data-state="running" data-title="Release captain" data-desc="Building and validating the release candidate.">
-            <span class="beacon">▶</span>
-            <span class="workspace-copy">
-              <span class="workspace-title">Release captain <span class="agent-chip">CODEX</span></span>
-              <span class="description">Running the tagged build and smoke tests</span>
-              <span class="state-line">Working</span>
-            </span>
-          </button>
-
-          <button class="workspace" data-state="waiting" data-title="Mailbox review" data-desc="Waiting for your decision on the attribution copy.">
-            <span class="beacon">!</span>
-            <span class="workspace-copy">
-              <span class="workspace-title">Mailbox review <span class="agent-chip">CLAUDE</span></span>
-              <span class="description">Choose between the two attribution labels</span>
-              <span class="state-line">Your turn</span>
-            </span>
-          </button>
-
-          <button class="workspace" data-state="idle" data-title="Agent pulse" data-desc="At the prompt and ready for another task.">
-            <span class="beacon">Ⅱ</span>
-            <span class="workspace-copy">
-              <span class="workspace-title">Agent pulse <span class="agent-chip">CODEX</span></span>
-              <span class="description">Prototype pass complete</span>
-              <span class="state-line">Idle</span>
-            </span>
-          </button>
-
-          <button class="workspace" data-state="cold" data-title="Docs sweep" data-desc="No live agent session; reopen to resume.">
-            <span class="beacon">❄</span>
-            <span class="workspace-copy">
-              <span class="workspace-title">Docs sweep <span class="agent-chip">CODEX</span></span>
-              <span class="description">Last active 2h ago</span>
-              <span class="state-line">Cold</span>
-            </span>
-          </button>
-        </div>
-        <div class="sidebar-foot"><strong>State beats decoration.</strong> Color, glyph, and text always agree; selection remains a separate white outline.</div>
+      <aside class="sidebar" aria-label="Workspace state rollup experiment">
+        <div class="sidebar-head"><span>Workspaces</span><span class="attention-total" id="attentionTotal"></span></div>
+        <div class="workspace-list" id="workspaceList"></div>
+        <div class="sidebar-foot"><b>Identity ≠ selection ≠ state.</b><br>Color rail names the workspace. White outline selects it. The pulse summarizes its agents.</div>
       </aside>
 
       <section class="main">
-        <div class="tabstrip">
-          <div class="surface-tab active"><span class="surface-dot"></span><span>Release captain</span></div>
+        <div class="surface-tabs">
+          <div class="surface-tab active">Agent Pulse</div>
           <div class="surface-tab">Preview</div>
-          <div class="tools">＋ &nbsp; ⋯</div>
+          <div class="surface-note">surface-tab state is a separate design</div>
         </div>
 
-        <div class="surface-bar">
-          <div class="large-beacon">▶</div>
-          <div class="surface-copy">
-            <div class="surface-name">Release captain</div>
-            <div class="surface-desc">Building and validating the release candidate.</div>
-          </div>
-          <div class="surface-state">Working</div>
+        <div class="workspace-bar" id="workspaceBar">
+          <span class="identity-block"></span>
+          <span><div class="workspace-name" id="workspaceName"></div><div class="workspace-desc" id="workspaceDesc"></div></span>
+          <span class="workspace-rollup" id="workspaceRollup"></span>
         </div>
 
-        <div class="terminal">
-          <div><span class="dim">$</span> ./scripts/reload.sh --tag agent-pulse</div>
-          <br>
-          <div><span class="blue">●</span> Building c11 DEV (agent-pulse)…</div>
-          <div><span class="green">✓</span> Swift package dependencies resolved</div>
-          <div><span class="green">✓</span> c11-logic tests passed</div>
-          <div><span class="gold">→</span> Launching tagged build for validation</div>
-          <br>
-          <div class="dim">The sidebar answers one question before you open a pane:</div>
-          <div>“Which agents are moving, and which one needs me?” <span class="cursor"></span></div>
-        </div>
+        <div class="content">
+          <div class="terminal" id="terminal"></div>
+          <aside class="inspector">
+            <div class="eyebrow">Workspace rollup lab</div>
+            <h2>Change the fleet, not the tab</h2>
+            <p>Select a workspace, then apply a fleet mix. The row recomputes one dominant signal while retaining the smaller state counts.</p>
 
-        <div class="state-lab">
-          <span class="lab-label">Set selected tab</span>
-          <button class="state-button" data-set="running">▶ Running</button>
-          <button class="state-button" data-set="waiting">! Waiting</button>
-          <button class="state-button" data-set="idle">Ⅱ Idle</button>
-          <button class="state-button" data-set="cold">❄ Cold</button>
+            <div class="preset-grid">
+              <button class="preset" data-preset="mixed">Mixed + waiting</button>
+              <button class="preset" data-preset="working">Actively working</button>
+              <button class="preset" data-preset="idle">All live agents idle</button>
+              <button class="preset" data-preset="cold">No live agents</button>
+            </div>
+
+            <div class="rule-card"><b>Precedence</b><br>your turn → working → idle → cold<br><br>Waiting wins because it changes what the operator should do next. Smaller chips preserve the rest of the fleet truth.</div>
+
+            <div class="option-grid">
+              <button class="option" id="toggleMix" aria-pressed="true">Show all state counts</button>
+              <button class="option" id="toggleTheme" aria-pressed="false">Light theme</button>
+              <button class="option" id="toggleMotion" aria-pressed="false">Reduce motion</button>
+            </div>
+
+            <div class="collision-note"><b>Three independent signals.</b> A selected workspace waiting for you has a white outline, its own color rail, and a gold demand rail. None steals another’s job.</div>
+          </aside>
         </div>
       </section>
     </div>
   </main>
 
   <script>
-    const rows = [...document.querySelectorAll('.workspace')];
     const stateCopy = {
-      running: { glyph: '▶', label: 'Working', color: 'var(--running)', terminal: 'Command in flight; output is still moving.' },
-      waiting: { glyph: '!', label: 'Your turn', color: 'var(--gold)', terminal: 'The agent asked a question and is blocked on your response.' },
-      idle: { glyph: 'Ⅱ', label: 'Idle', color: 'var(--idle)', terminal: 'The agent is at its prompt and ready for another task.' },
-      cold: { glyph: '❄', label: 'Cold', color: 'var(--cold)', terminal: 'No live agent session; reopen this workspace to resume.' }
+      waiting: { glyph: '!', noun: 'need you', color: 'var(--gold)', className: 'waiting' },
+      running: { glyph: '↻', noun: 'working', color: 'var(--running)', className: 'running' },
+      idle: { glyph: 'Ⅱ', noun: 'idle', color: 'var(--idle)', className: 'idle' },
+      cold: { glyph: '–', noun: 'cold', color: 'var(--cold)', className: 'cold' }
     };
 
-    function select(row) {
-      rows.forEach(item => item.classList.toggle('active', item === row));
-      const state = row.dataset.state;
-      const copy = stateCopy[state];
-      document.querySelector('.surface-tab span:last-child').textContent = row.dataset.title;
-      document.querySelector('.surface-dot').style.background = copy.color;
-      document.querySelector('.surface-name').textContent = row.dataset.title;
-      document.querySelector('.surface-desc').textContent = row.dataset.desc;
-      document.querySelector('.surface-state').textContent = copy.label;
-      document.querySelector('.surface-state').style.color = copy.color;
-      document.querySelector('.large-beacon').textContent = copy.glyph;
-      document.querySelector('.large-beacon').style.color = copy.color;
-      document.querySelector('.terminal').innerHTML = `<div><span class="dim">agent.state</span> → <span style="color:${copy.color}">${copy.label}</span></div><br><div>${copy.terminal}</div><br><div class="dim">Color + glyph + text carry the same meaning.</div>`;
+    const workspaces = [
+      { id: 1, title: 'c11', identity: '#c97956', description: 'Agent presence prototype and release work', counts: { waiting: 1, running: 3, idle: 2, cold: 2 }, latest: 'Agent Pulse needs a workspace-rollup decision' },
+      { id: 2, title: 'Acetate', identity: '#8c73d1', description: 'Library health and Engine DJ sync', counts: { waiting: 0, running: 2, idle: 1, cold: 1 }, latest: 'Two agents are reconciling duplicate track paths' },
+      { id: 3, title: 'Lattice', identity: '#4d9b82', description: 'Orchestrator runtime and ticket fleet', counts: { waiting: 0, running: 6, idle: 1, cold: 3 }, latest: 'Six delegators are actively moving tickets' },
+      { id: 4, title: 'Overwatch', identity: '#b18445', description: 'Cross-workspace fleet monitor', counts: { waiting: 2, running: 4, idle: 0, cold: 1 }, latest: 'Two workspaces need an operator decision' },
+      { id: 5, title: 'Stage 11 website refresh and distribution experiments', identity: '#537fb4', description: 'Campaign pages and instrumented funnels', counts: { waiting: 0, running: 0, idle: 3, cold: 2 }, latest: 'Three agents are at the prompt' },
+      { id: 6, title: 'Crabbox research', identity: '#747981', description: 'Archived research workspace', counts: { waiting: 0, running: 0, idle: 0, cold: 4 }, latest: 'No live agents · last active yesterday' }
+    ];
+
+    let selectedId = 1;
+
+    function dominantFor(counts) {
+      return ['waiting', 'running', 'idle', 'cold'].find(state => counts[state] > 0) || 'cold';
     }
 
-    function updateNeedsYouCount() {
-      const count = rows.filter(row => row.dataset.state === 'waiting').length;
-      document.querySelector('.sidebar-head span:last-child').textContent = `${count} need${count === 1 ? 's' : ''} you`;
+    function totalAgents(counts) {
+      return Object.values(counts).reduce((sum, count) => sum + count, 0);
     }
 
-    rows.forEach(row => row.addEventListener('click', () => select(row)));
-    document.querySelectorAll('.state-button').forEach(button => {
-      button.addEventListener('click', () => {
-        const row = document.querySelector('.workspace.active');
-        const state = button.dataset.set;
+    function dominantLabel(workspace) {
+      const state = dominantFor(workspace.counts);
+      const count = workspace.counts[state];
+      if (state === 'cold') return `${count || totalAgents(workspace.counts)} cold`;
+      return `${count} ${stateCopy[state].noun}`;
+    }
+
+    function mixMarkup(counts) {
+      return ['waiting', 'running', 'idle', 'cold']
+        .filter(state => counts[state] > 0)
+        .map(state => `<span class="mix-chip ${state}" title="${counts[state]} ${stateCopy[state].noun}"><span>${stateCopy[state].glyph}</span><b>${counts[state]}</b></span>`)
+        .join('');
+    }
+
+    function renderWorkspaces() {
+      const list = document.getElementById('workspaceList');
+      list.innerHTML = workspaces.map(workspace => {
+        const state = dominantFor(workspace.counts);
         const copy = stateCopy[state];
-        row.dataset.state = state;
-        row.querySelector('.beacon').textContent = copy.glyph;
-        row.querySelector('.state-line').textContent = copy.label;
-        updateNeedsYouCount();
-        select(row);
+        return `<button class="workspace dominant-${state}${workspace.id === selectedId ? ' selected' : ''}"
+          data-id="${workspace.id}" style="--identity:${workspace.identity};--dominant:${copy.color}">
+          <span class="workspace-top">
+            <span class="workspace-title">${workspace.title}</span>
+            <span class="workspace-actions"><span>${totalAgents(workspace.counts)}</span><span class="close">×</span></span>
+          </span>
+          <span class="workspace-signal">
+            <span class="state-mark"><span>${copy.glyph}</span></span>
+            <span class="signal-copy"><span class="signal-label">${dominantLabel(workspace)}</span><span class="signal-detail">${workspace.latest}</span></span>
+            <span class="mix">${mixMarkup(workspace.counts)}</span>
+          </span>
+        </button>`;
+      }).join('');
+
+      list.querySelectorAll('.workspace').forEach(row => {
+        row.addEventListener('click', () => {
+          selectedId = Number(row.dataset.id);
+          render();
+        });
+      });
+
+      const waiting = workspaces.reduce((sum, workspace) => sum + workspace.counts.waiting, 0);
+      document.getElementById('attentionTotal').textContent = `${waiting} need you`;
+    }
+
+    function agentRows(workspace) {
+      const rows = [];
+      const names = {
+        waiting: ['Agent Pulse', 'Release approval'],
+        running: ['Surface Pulse', 'Build captain', 'Test runner', 'Translation pass', 'CI watcher', 'Review agent'],
+        idle: ['Docs editor', 'Research pass', 'Spec reader'],
+        cold: ['Archived shell', 'Old browser', 'Finished review', 'Prior session']
+      };
+      ['waiting', 'running', 'idle', 'cold'].forEach(state => {
+        for (let index = 0; index < workspace.counts[state]; index += 1) {
+          const copy = stateCopy[state];
+          rows.push(`<div class="agent-row"><span style="color:${copy.color}">${copy.glyph}</span><span class="state" style="color:${copy.color}">${copy.noun}</span><span>${names[state][index % names[state].length]}</span></div>`);
+        }
+      });
+      return rows.join('');
+    }
+
+    function renderDetail() {
+      const workspace = workspaces.find(item => item.id === selectedId);
+      const state = dominantFor(workspace.counts);
+      const copy = stateCopy[state];
+      const bar = document.getElementById('workspaceBar');
+      bar.style.setProperty('--identity', workspace.identity);
+      bar.style.setProperty('--dominant', copy.color);
+      document.getElementById('workspaceName').textContent = workspace.title;
+      document.getElementById('workspaceDesc').textContent = workspace.description;
+      document.getElementById('workspaceRollup').textContent = dominantLabel(workspace);
+      document.getElementById('terminal').innerHTML = `
+        <div><span class="dim">workspace.rollup</span> → <span style="color:${copy.color}">${dominantLabel(workspace)}</span></div>
+        <div class="dim">${totalAgents(workspace.counts)} agent surfaces contribute to this workspace signal.</div><br>
+        ${agentRows(workspace)}
+        <br><div class="dim">The workspace row is an attention router, not a replacement for per-surface truth.</div>`;
+    }
+
+    function render() {
+      renderWorkspaces();
+      renderDetail();
+    }
+
+    const presets = {
+      mixed: { waiting: 1, running: 3, idle: 2, cold: 2 },
+      working: { waiting: 0, running: 4, idle: 1, cold: 2 },
+      idle: { waiting: 0, running: 0, idle: 3, cold: 2 },
+      cold: { waiting: 0, running: 0, idle: 0, cold: 5 }
+    };
+
+    document.querySelectorAll('.preset').forEach(button => {
+      button.addEventListener('click', () => {
+        const workspace = workspaces.find(item => item.id === selectedId);
+        workspace.counts = { ...presets[button.dataset.preset] };
+        workspace.latest = {
+          mixed: 'Agent Pulse needs a workspace-rollup decision',
+          working: 'Four agents are actively moving',
+          idle: 'All live agents are at their prompts',
+          cold: 'No live agents · reopen a surface to resume'
+        }[button.dataset.preset];
+        render();
       });
     });
+
+    document.getElementById('toggleMix').addEventListener('click', event => {
+      document.body.classList.toggle('dominant-only');
+      const shown = !document.body.classList.contains('dominant-only');
+      event.currentTarget.setAttribute('aria-pressed', String(shown));
+      event.currentTarget.textContent = shown ? 'Show all state counts' : 'Dominant signal only';
+    });
+
+    document.getElementById('toggleTheme').addEventListener('click', event => {
+      const light = document.body.dataset.theme !== 'light';
+      document.body.dataset.theme = light ? 'light' : 'dark';
+      event.currentTarget.setAttribute('aria-pressed', String(light));
+      event.currentTarget.textContent = light ? 'Dark theme' : 'Light theme';
+    });
+
+    document.getElementById('toggleMotion').addEventListener('click', event => {
+      document.body.classList.toggle('reduce-motion');
+      const reduced = document.body.classList.contains('reduce-motion');
+      event.currentTarget.setAttribute('aria-pressed', String(reduced));
+      event.currentTarget.textContent = reduced ? 'Restore motion' : 'Reduce motion';
+    });
+
+    render();
   </script>
 </body>
 </html>

--- a/docs/design-prototypes/agent-pulse/index.html
+++ b/docs/design-prototypes/agent-pulse/index.html
@@ -1,0 +1,483 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>c11 — Agent Pulse prototype</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --void: #08090b;
+      --surface: #101216;
+      --surface-2: #171a20;
+      --rule: #2b2e34;
+      --text: #ececef;
+      --dim: #8a8e97;
+      --gold: #c9a84c;
+      --running: #62a8ff;
+      --idle: #7fc7aa;
+      --cold: #68707c;
+      --mono: "SFMono-Regular", "JetBrains Mono", Menlo, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { height: 100%; margin: 0; }
+    body {
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      background: #000;
+      color: var(--text);
+      font-family: var(--sans);
+      -webkit-font-smoothing: antialiased;
+    }
+
+    button { font: inherit; }
+
+    .prototype-note {
+      position: fixed;
+      top: 14px;
+      left: 50%;
+      z-index: 5;
+      transform: translateX(-50%);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      font: 10px var(--mono);
+      color: #81858d;
+      letter-spacing: .04em;
+    }
+
+    .prototype-badge {
+      color: var(--gold);
+      border: 1px solid rgba(201, 168, 76, .45);
+      border-radius: 4px;
+      padding: 3px 7px;
+      letter-spacing: .14em;
+    }
+
+    .window {
+      width: min(1160px, calc(100vw - 44px));
+      height: min(720px, calc(100vh - 72px));
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      background: var(--void);
+      border: 1px solid #303238;
+      border-radius: 12px;
+      box-shadow: 0 28px 90px rgba(0, 0, 0, .72);
+    }
+
+    .titlebar {
+      height: 38px;
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      padding: 0 14px;
+      border-bottom: 1px solid var(--rule);
+      background: #0d0f12;
+    }
+
+    .traffic { display: flex; gap: 7px; }
+    .traffic i { width: 11px; height: 11px; border-radius: 50%; }
+    .traffic i:nth-child(1) { background: #ff5f57; }
+    .traffic i:nth-child(2) { background: #febc2e; }
+    .traffic i:nth-child(3) { background: #28c840; }
+    .window-title {
+      margin: 0 auto;
+      color: #6d7078;
+      font: 11px var(--mono);
+      letter-spacing: .05em;
+    }
+
+    .body { min-height: 0; flex: 1; display: flex; }
+
+    .sidebar {
+      width: 270px;
+      flex: 0 0 auto;
+      display: flex;
+      flex-direction: column;
+      border-right: 1px solid var(--rule);
+      background: #0c0e11;
+    }
+
+    .sidebar-head {
+      display: flex;
+      align-items: baseline;
+      padding: 15px 13px 10px;
+      color: #6e727a;
+      font: 9px var(--mono);
+      letter-spacing: .15em;
+      text-transform: uppercase;
+    }
+    .sidebar-head span:last-child {
+      margin-left: auto;
+      color: var(--gold);
+      letter-spacing: .05em;
+      text-transform: none;
+    }
+
+    .workspaces { padding: 0 8px; display: grid; gap: 7px; }
+
+    .workspace {
+      --state: var(--cold);
+      position: relative;
+      width: 100%;
+      min-height: 93px;
+      display: grid;
+      grid-template-columns: 22px 1fr;
+      gap: 9px;
+      padding: 11px 10px;
+      overflow: hidden;
+      color: var(--text);
+      text-align: left;
+      background: #101216;
+      border: 1px solid var(--rule);
+      border-radius: 8px;
+      cursor: pointer;
+      transition: background .14s, border-color .14s, opacity .14s;
+    }
+    .workspace:hover { background: #15181d; }
+    .workspace.active { border: 2px solid rgba(255,255,255,.88); padding: 10px 9px; }
+    .workspace[data-state="running"] { --state: var(--running); }
+    .workspace[data-state="waiting"] { --state: var(--gold); }
+    .workspace[data-state="idle"] { --state: var(--idle); }
+    .workspace[data-state="cold"] { --state: var(--cold); opacity: .72; }
+    .workspace[data-state="cold"]:hover,
+    .workspace[data-state="cold"].active { opacity: 1; }
+    .workspace[data-state="waiting"] {
+      background: linear-gradient(90deg, rgba(201,168,76,.15), #111316 72%);
+      border-color: rgba(201,168,76,.58);
+    }
+
+    .beacon {
+      position: relative;
+      width: 20px;
+      height: 20px;
+      display: grid;
+      place-items: center;
+      margin-top: 1px;
+      border: 1px solid color-mix(in srgb, var(--state) 75%, transparent);
+      border-radius: 50%;
+      color: var(--state);
+      font: 10px var(--mono);
+    }
+    [data-state="running"] .beacon::after {
+      content: "";
+      position: absolute;
+      inset: -1px;
+      border: 1px solid var(--running);
+      border-radius: 50%;
+      animation: breathe 1.8s ease-out infinite;
+    }
+    @keyframes breathe {
+      0%, 35% { transform: scale(.75); opacity: .7; }
+      100% { transform: scale(1.65); opacity: 0; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      [data-state="running"] .beacon::after { animation: none; }
+    }
+
+    .workspace-copy { min-width: 0; }
+    .workspace-title {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      margin-bottom: 5px;
+      font-size: 13px;
+      font-weight: 650;
+      white-space: nowrap;
+    }
+    .agent-chip {
+      padding: 2px 5px;
+      color: #aaadb4;
+      border: 1px solid #35383f;
+      border-radius: 4px;
+      font: 8px var(--mono);
+      font-weight: 500;
+    }
+    .description {
+      overflow: hidden;
+      color: var(--dim);
+      font: 10px/1.4 var(--mono);
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .state-line {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 9px;
+      color: var(--state);
+      font: 9px var(--mono);
+      letter-spacing: .09em;
+      text-transform: uppercase;
+    }
+    .state-line::before {
+      content: "";
+      width: 18px;
+      height: 2px;
+      border-radius: 2px;
+      background: var(--state);
+    }
+    [data-state="waiting"] .state-line {
+      width: fit-content;
+      margin-top: 7px;
+      padding: 4px 7px;
+      color: #0b0c0e;
+      background: var(--gold);
+      border-radius: 4px;
+      font-weight: 750;
+    }
+    [data-state="waiting"] .state-line::before { display: none; }
+
+    .sidebar-foot {
+      margin-top: auto;
+      padding: 11px 12px 13px;
+      border-top: 1px solid var(--rule);
+      color: #666a72;
+      font: 9px/1.45 var(--mono);
+    }
+    .sidebar-foot strong { color: var(--gold); font-weight: 500; }
+
+    .main { min-width: 0; flex: 1; display: flex; flex-direction: column; }
+    .tabstrip {
+      height: 37px;
+      display: flex;
+      align-items: stretch;
+      border-bottom: 1px solid var(--rule);
+      background: #0c0e11;
+    }
+    .surface-tab {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      min-width: 170px;
+      padding: 0 13px;
+      color: #8b8e95;
+      border-right: 1px solid var(--rule);
+      font-size: 11px;
+    }
+    .surface-tab.active { color: var(--text); background: var(--surface-2); }
+    .surface-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--running); }
+    .tools { margin-left: auto; display: flex; align-items: center; gap: 13px; padding: 0 14px; color: #72767e; font: 12px var(--mono); }
+
+    .surface-bar {
+      min-height: 72px;
+      display: flex;
+      align-items: center;
+      gap: 13px;
+      padding: 12px 17px;
+      border-bottom: 1px solid var(--rule);
+      background: #111318;
+    }
+    .large-beacon {
+      width: 34px;
+      height: 34px;
+      display: grid;
+      place-items: center;
+      color: var(--running);
+      border: 1px solid currentColor;
+      border-radius: 50%;
+      font: 13px var(--mono);
+    }
+    .surface-copy { min-width: 0; }
+    .surface-name { font-size: 13px; font-weight: 650; }
+    .surface-desc { margin-top: 5px; color: var(--dim); font: 10px var(--mono); }
+    .surface-state {
+      margin-left: auto;
+      padding: 5px 8px;
+      color: var(--running);
+      border: 1px solid currentColor;
+      border-radius: 5px;
+      font: 9px var(--mono);
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+
+    .terminal {
+      flex: 1;
+      min-height: 0;
+      padding: 20px;
+      overflow: hidden;
+      color: #b9bdc4;
+      background: var(--void);
+      font: 12px/1.68 var(--mono);
+    }
+    .terminal .dim { color: #686c74; }
+    .terminal .blue { color: var(--running); }
+    .terminal .gold { color: var(--gold); }
+    .terminal .green { color: var(--idle); }
+    .cursor { display: inline-block; width: 7px; height: 14px; vertical-align: -2px; background: var(--gold); }
+
+    .state-lab {
+      display: flex;
+      align-items: center;
+      gap: 7px;
+      min-height: 53px;
+      padding: 9px 14px;
+      border-top: 1px solid var(--rule);
+      background: #0e1013;
+    }
+    .lab-label {
+      margin-right: auto;
+      color: #676b73;
+      font: 9px var(--mono);
+      letter-spacing: .1em;
+      text-transform: uppercase;
+    }
+    .state-button {
+      padding: 6px 9px;
+      color: #8c9098;
+      background: transparent;
+      border: 1px solid #34373d;
+      border-radius: 5px;
+      cursor: pointer;
+      font: 9px var(--mono);
+      letter-spacing: .06em;
+      text-transform: uppercase;
+    }
+    .state-button:hover { color: var(--text); background: #191c21; }
+    .state-button[data-set="waiting"] { color: var(--gold); border-color: rgba(201,168,76,.5); }
+  </style>
+</head>
+<body>
+  <div class="prototype-note">
+    <span class="prototype-badge">PROTOTYPE</span>
+    <span>not wired to real agent data · click a tab, then change its state</span>
+  </div>
+
+  <main class="window">
+    <header class="titlebar">
+      <div class="traffic"><i></i><i></i><i></i></div>
+      <div class="window-title">c11 — Stage 11</div>
+    </header>
+
+    <div class="body">
+      <aside class="sidebar">
+        <div class="sidebar-head"><span>Workspaces</span><span>1 needs you</span></div>
+        <div class="workspaces">
+          <button class="workspace active" data-state="running" data-title="Release captain" data-desc="Building and validating the release candidate.">
+            <span class="beacon">▶</span>
+            <span class="workspace-copy">
+              <span class="workspace-title">Release captain <span class="agent-chip">CODEX</span></span>
+              <span class="description">Running the tagged build and smoke tests</span>
+              <span class="state-line">Working</span>
+            </span>
+          </button>
+
+          <button class="workspace" data-state="waiting" data-title="Mailbox review" data-desc="Waiting for your decision on the attribution copy.">
+            <span class="beacon">!</span>
+            <span class="workspace-copy">
+              <span class="workspace-title">Mailbox review <span class="agent-chip">CLAUDE</span></span>
+              <span class="description">Choose between the two attribution labels</span>
+              <span class="state-line">Your turn</span>
+            </span>
+          </button>
+
+          <button class="workspace" data-state="idle" data-title="Agent pulse" data-desc="At the prompt and ready for another task.">
+            <span class="beacon">Ⅱ</span>
+            <span class="workspace-copy">
+              <span class="workspace-title">Agent pulse <span class="agent-chip">CODEX</span></span>
+              <span class="description">Prototype pass complete</span>
+              <span class="state-line">Idle</span>
+            </span>
+          </button>
+
+          <button class="workspace" data-state="cold" data-title="Docs sweep" data-desc="No live agent session; reopen to resume.">
+            <span class="beacon">❄</span>
+            <span class="workspace-copy">
+              <span class="workspace-title">Docs sweep <span class="agent-chip">CODEX</span></span>
+              <span class="description">Last active 2h ago</span>
+              <span class="state-line">Cold</span>
+            </span>
+          </button>
+        </div>
+        <div class="sidebar-foot"><strong>State beats decoration.</strong> Color, glyph, and text always agree; selection remains a separate white outline.</div>
+      </aside>
+
+      <section class="main">
+        <div class="tabstrip">
+          <div class="surface-tab active"><span class="surface-dot"></span><span>Release captain</span></div>
+          <div class="surface-tab">Preview</div>
+          <div class="tools">＋ &nbsp; ⋯</div>
+        </div>
+
+        <div class="surface-bar">
+          <div class="large-beacon">▶</div>
+          <div class="surface-copy">
+            <div class="surface-name">Release captain</div>
+            <div class="surface-desc">Building and validating the release candidate.</div>
+          </div>
+          <div class="surface-state">Working</div>
+        </div>
+
+        <div class="terminal">
+          <div><span class="dim">$</span> ./scripts/reload.sh --tag agent-pulse</div>
+          <br>
+          <div><span class="blue">●</span> Building c11 DEV (agent-pulse)…</div>
+          <div><span class="green">✓</span> Swift package dependencies resolved</div>
+          <div><span class="green">✓</span> c11-logic tests passed</div>
+          <div><span class="gold">→</span> Launching tagged build for validation</div>
+          <br>
+          <div class="dim">The sidebar answers one question before you open a pane:</div>
+          <div>“Which agents are moving, and which one needs me?” <span class="cursor"></span></div>
+        </div>
+
+        <div class="state-lab">
+          <span class="lab-label">Set selected tab</span>
+          <button class="state-button" data-set="running">▶ Running</button>
+          <button class="state-button" data-set="waiting">! Waiting</button>
+          <button class="state-button" data-set="idle">Ⅱ Idle</button>
+          <button class="state-button" data-set="cold">❄ Cold</button>
+        </div>
+      </section>
+    </div>
+  </main>
+
+  <script>
+    const rows = [...document.querySelectorAll('.workspace')];
+    const stateCopy = {
+      running: { glyph: '▶', label: 'Working', color: 'var(--running)', terminal: 'Command in flight; output is still moving.' },
+      waiting: { glyph: '!', label: 'Your turn', color: 'var(--gold)', terminal: 'The agent asked a question and is blocked on your response.' },
+      idle: { glyph: 'Ⅱ', label: 'Idle', color: 'var(--idle)', terminal: 'The agent is at its prompt and ready for another task.' },
+      cold: { glyph: '❄', label: 'Cold', color: 'var(--cold)', terminal: 'No live agent session; reopen this workspace to resume.' }
+    };
+
+    function select(row) {
+      rows.forEach(item => item.classList.toggle('active', item === row));
+      const state = row.dataset.state;
+      const copy = stateCopy[state];
+      document.querySelector('.surface-tab span:last-child').textContent = row.dataset.title;
+      document.querySelector('.surface-dot').style.background = copy.color;
+      document.querySelector('.surface-name').textContent = row.dataset.title;
+      document.querySelector('.surface-desc').textContent = row.dataset.desc;
+      document.querySelector('.surface-state').textContent = copy.label;
+      document.querySelector('.surface-state').style.color = copy.color;
+      document.querySelector('.large-beacon').textContent = copy.glyph;
+      document.querySelector('.large-beacon').style.color = copy.color;
+      document.querySelector('.terminal').innerHTML = `<div><span class="dim">agent.state</span> → <span style="color:${copy.color}">${copy.label}</span></div><br><div>${copy.terminal}</div><br><div class="dim">Color + glyph + text carry the same meaning.</div>`;
+    }
+
+    function updateNeedsYouCount() {
+      const count = rows.filter(row => row.dataset.state === 'waiting').length;
+      document.querySelector('.sidebar-head span:last-child').textContent = `${count} need${count === 1 ? 's' : ''} you`;
+    }
+
+    rows.forEach(row => row.addEventListener('click', () => select(row)));
+    document.querySelectorAll('.state-button').forEach(button => {
+      button.addEventListener('click', () => {
+        const row = document.querySelector('.workspace.active');
+        const state = button.dataset.set;
+        const copy = stateCopy[state];
+        row.dataset.state = state;
+        row.querySelector('.beacon').textContent = copy.glyph;
+        row.querySelector('.state-line').textContent = copy.label;
+        updateNeedsYouCount();
+        select(row);
+      });
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds an **opt-in** `submit: true` field to a blueprint terminal leaf so its `command:` is **executed** (a real Return is dispatched) instead of only being pre-typed at the prompt.

```yaml
layout:
  - type: terminal
    cwd: ~/work
    command: python3 /path/position.py --watch
    submit: true        # NEW — default false = today's type-but-don't-submit
```

## Why

Blueprint terminal commands are delivered via `TerminalPanel.sendText`, which wraps bytes in bracketed-paste markers — deliberate Phase 0 parity so an embedded `\n` does NOT auto-execute and whitespace "kick" commands work verbatim. A blueprint meant to launch an always-on program (e.g. a live dashboard) therefore opens with the command sitting at the prompt, needing a manual Enter. This lets a blueprint launch with zero touch, reusing the battle-tested `TerminalSurface.sendSubmitFormText` (types bytes + dispatches Return outside the paste sequence; arms a deferred Return via `pendingSubmitOnFlush` when the surface isn't yet attached — the blueprint case).

Default `false` → every existing blueprint and every persisted plan is unchanged.

## Changes

- **`SurfaceSpec`**: new `submitCommand: Bool = false` with **custom `Codable`** — synthesized decoding throws `keyNotFound` on a defaulted non-optional key, so a pre-existing snapshot (pickled by `SessionPersistence`) would fail to decode; `decodeIfPresent(...) ?? false` fixes it, and encode omits the key when `false` to keep serialized output byte-identical.
- **Blueprint parser**: reads `submit:`; only the literal `true` (case-insensitive) opts in.
- **Executor Step 7**: explicit-command branch routes to `sendSubmitFormText` when the flag is set; registry + empty/whitespace guards untouched.
- **Blueprint emitter**: writes `submit: true` when set so `export-blueprint` round-trips.
- **DEBUG-only test seam** `pendingSubmitOnFlushForTests`, mirroring existing `pendingInitialInputForTests`, giving the executor test a real behavioral observable.

## Tests

Parse (true / absent / non-true scalar → false), serialize round-trip (+ default stays submit-free), executor behavior (submit arms Return, default does not — both still deliver the command bytes), Codable back-compat (missing key → false, false omitted on encode). Logic-target tests, no host app.

## Notes

- **Draft — do not merge.** Left for operator review + rebuild. Validation gate is CI (repo convention: these XCTest targets are CI-only; no local `xcodebuild`).
- Motivating use case: `~/.config/c11/blueprints/Glideslope.md` can add `submit: true` and drop its "press Enter" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)