### PR TITLE
Show agent state on surface tabs

### DIFF
--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -131,13 +131,24 @@ final class AgentDetector: @unchecked Sendable {
                 continue
             }
             let classification = Self.classify(comm: info.comm, args: info.args)
-            SurfaceMetadataStore.shared.setInternal(
+            let changed = SurfaceMetadataStore.shared.setInternal(
                 workspaceId: key.workspaceId,
                 surfaceId: key.panelId,
                 key: "terminal_type",
                 value: classification,
                 source: .heuristic
             )
+            if changed {
+                DispatchQueue.main.async {
+                    MainActor.assumeIsolated {
+                        guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: key.workspaceId),
+                              let workspace = tabManager.tabs.first(where: { $0.id == key.workspaceId }) else {
+                            return
+                        }
+                        workspace.syncSurfaceTabActivityStateForPanel(key.panelId)
+                    }
+                }
+            }
         }
     }
 

--- a/Sources/PersistedMetadata.swift
+++ b/Sources/PersistedMetadata.swift
@@ -130,10 +130,12 @@ enum PersistedMetadataBridge {
     /// log; the rest of the blob survives. Never throws — snapshot writes
     /// must be side-effect-free with respect to persistence failures.
     ///
-    /// C11-104 — derived keys are excluded by checking the parallel
+    /// C11-104 — recomputable derived keys are excluded by checking the parallel
     /// `sources` sidecar (when provided): a value whose recorded source
     /// is `.derived` is dropped from the persisted blob because it will
-    /// be recomputed on session resume.
+    /// be recomputed on session resume. Surface activity is the exception:
+    /// shell state may not transition after restore, so its last durable truth
+    /// must survive long enough to seed the live projection.
     static func encodeValues(
         _ values: [String: Any],
         surfaceIdForLog: UUID? = nil,
@@ -154,14 +156,14 @@ enum PersistedMetadataBridge {
     /// Convert sidecar entries as returned by
     /// `SurfaceMetadataStore.getMetadata().sources` (`[String: [String: Any]]`
     /// via `SourceRecord.toJSON()`) into persisted form. Derived sources
-    /// are dropped to match the value-side filter.
+    /// are dropped to match the value-side filter, except for activity.
     static func encodeSources(
         _ sources: [String: [String: Any]]
     ) -> [String: PersistedMetadataSource] {
         var result: [String: PersistedMetadataSource] = [:]
         for (key, record) in sources {
             guard let source = record["source"] as? String else { continue }
-            if source == MetadataSource.derived.rawValue { continue }
+            if source == MetadataSource.derived.rawValue, key != MetadataKey.activity { continue }
             let ts = (record["ts"] as? Double) ?? 0.0
             result[key] = PersistedMetadataSource(source: source, ts: ts)
         }
@@ -171,7 +173,7 @@ enum PersistedMetadataBridge {
     private static func isDerivedKey(key: String, sources: [String: [String: Any]]?) -> Bool {
         guard let sources, let record = sources[key],
               let raw = record["source"] as? String else { return false }
-        return raw == MetadataSource.derived.rawValue
+        return raw == MetadataSource.derived.rawValue && key != MetadataKey.activity
     }
 
     // MARK: - Restore-direction bridge (persisted → [String: Any])

--- a/Sources/SocketHandlers/SurfaceHandlers.swift
+++ b/Sources/SocketHandlers/SurfaceHandlers.swift
@@ -1420,6 +1420,7 @@ extension TerminalController {
                 surfaceId: resolved.surfaceId,
                 tabManager: resolved.tabManager,
                 applied: result.applied,
+                removedKeys: result.removedKeys,
                 autoExpand: (params["auto_expand"] as? Bool) ?? true
             )
             return .ok(buildMetadataOkPayload(
@@ -1534,6 +1535,7 @@ extension TerminalController {
                 surfaceId: resolved.surfaceId,
                 tabManager: resolved.tabManager,
                 applied: result.applied,
+                removedKeys: result.removedKeys,
                 autoExpand: false
             )
             return .ok(buildMetadataOkPayload(

--- a/Sources/SurfaceLivenessDeriver.swift
+++ b/Sources/SurfaceLivenessDeriver.swift
@@ -1,7 +1,28 @@
 import Foundation
-#if DEBUG
 import Bonsplit
-#endif
+
+enum SurfaceTabActivityResolver {
+    static func resolve(
+        hasExactSurfaceNotification: Bool,
+        derivedActivity: SidebarActivityState?,
+        terminalType: String?
+    ) -> BonsplitTabActivityState? {
+        if hasExactSurfaceNotification {
+            return .waiting
+        }
+        guard PaneSizePolicy.isAgentKind(terminalType) else {
+            return nil
+        }
+        switch derivedActivity {
+        case .working:
+            return .running
+        case .idle:
+            return .idle
+        case nil:
+            return .cold
+        }
+    }
+}
 
 /// C11-162 (Telemetry truth) — TEL-3/4.
 ///

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -390,6 +390,9 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         /// convention (CMUX-11 Phase 2) so callers get the prior value back
         /// in-hand without a separate round trip.
         var priorValues: [String: Any] = [:]
+        /// Keys removed by clear-all, keyed clear, or replace semantics.
+        /// Consumers use this to invalidate projections whose inputs disappeared.
+        var removedKeys: Set<String> = []
     }
 
     /// Merge or replace a partial metadata object on a surface.
@@ -463,6 +466,7 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 }
                 let existing = metadata[workspaceId]?[surfaceId] ?? [:]
                 let existingSrc = sources[workspaceId]?[surfaceId] ?? [:]
+                result.removedKeys = Set(existing.keys).union(existingSrc.keys)
                 metadata[workspaceId]?[surfaceId] = [:]
                 sources[workspaceId]?[surfaceId] = [:]
                 result.metadata = [:]
@@ -489,7 +493,10 @@ final class SurfaceMetadataStore: @unchecked Sendable {
                 }
                 let hadValue = blob.removeValue(forKey: key) != nil
                 let hadSource = sblob.removeValue(forKey: key) != nil
-                if hadValue || hadSource { removedAny = true }
+                if hadValue || hadSource {
+                    removedAny = true
+                    result.removedKeys.insert(key)
+                }
                 result.applied[key] = true
             }
 
@@ -665,6 +672,9 @@ final class SurfaceMetadataStore: @unchecked Sendable {
             // the new partial is a subset; flag accordingly.
             let priorBlob = metadata[workspaceId]?[surfaceId] ?? [:]
             let priorSrc = sources[workspaceId]?[surfaceId] ?? [:]
+            result.removedKeys = Set(priorBlob.keys)
+                .union(priorSrc.keys)
+                .subtracting(partial.keys)
             if !priorBlob.isEmpty || !priorSrc.isEmpty { mutated = true }
         }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3386,7 +3386,7 @@ class TerminalController {
 
 
 
-    /// Sync render state when title, description, or terminal type changes
+    /// Sync render state when title, description, terminal type, or activity changes
     /// through M2's metadata API.
     func applyTitleDescriptionSideEffects(
         workspaceId: UUID,
@@ -3399,7 +3399,15 @@ class TerminalController {
         let titleApplied = applied[MetadataKey.title] == true || removedKeys.contains(MetadataKey.title)
         let descriptionApplied = applied[MetadataKey.description] == true || removedKeys.contains(MetadataKey.description)
         let terminalTypeApplied = applied[MetadataKey.terminalType] == true || removedKeys.contains(MetadataKey.terminalType)
-        guard titleApplied || descriptionApplied || terminalTypeApplied else { return }
+        let activityApplied = applied[MetadataKey.activity] == true || removedKeys.contains(MetadataKey.activity)
+        guard titleApplied || descriptionApplied || terminalTypeApplied || activityApplied else { return }
+        let resolvedActivity: SidebarActivityState? = if activityApplied {
+            (SurfaceMetadataStore.shared.getMetadata(workspaceId: workspaceId, surfaceId: surfaceId)
+                .metadata[MetadataKey.activity] as? String)
+                .flatMap(SidebarActivityState.init(rawValue:))
+        } else {
+            nil
+        }
         v2MainSync {
             guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
             if titleApplied {
@@ -3407,6 +3415,9 @@ class TerminalController {
             }
             if descriptionApplied && autoExpand {
                 ws.maybeAutoExpandTitleBar(panelId: surfaceId)
+            }
+            if activityApplied {
+                ws.setDerivedActivity(resolvedActivity, forSurface: surfaceId)
             }
             if terminalTypeApplied {
                 ws.syncSurfaceTabActivityStateForPanel(surfaceId)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3386,8 +3386,8 @@ class TerminalController {
 
 
 
-    /// M7 side effect: sync render cache + auto-expand title bar when
-    /// `title` / `description` is written through M2's metadata API.
+    /// Sync render state when title, description, or terminal type changes
+    /// through M2's metadata API.
     func applyTitleDescriptionSideEffects(
         workspaceId: UUID,
         surfaceId: UUID,
@@ -3397,7 +3397,8 @@ class TerminalController {
     ) {
         let titleApplied = applied[MetadataKey.title] == true
         let descriptionApplied = applied[MetadataKey.description] == true
-        guard titleApplied || descriptionApplied else { return }
+        let terminalTypeApplied = applied[MetadataKey.terminalType] == true
+        guard titleApplied || descriptionApplied || terminalTypeApplied else { return }
         v2MainSync {
             guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
             if titleApplied {
@@ -3405,6 +3406,9 @@ class TerminalController {
             }
             if descriptionApplied && autoExpand {
                 ws.maybeAutoExpandTitleBar(panelId: surfaceId)
+            }
+            if terminalTypeApplied {
+                ws.syncSurfaceTabActivityStateForPanel(surfaceId)
             }
         }
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3393,11 +3393,12 @@ class TerminalController {
         surfaceId: UUID,
         tabManager: TabManager,
         applied: [String: Bool],
+        removedKeys: Set<String> = [],
         autoExpand: Bool
     ) {
-        let titleApplied = applied[MetadataKey.title] == true
-        let descriptionApplied = applied[MetadataKey.description] == true
-        let terminalTypeApplied = applied[MetadataKey.terminalType] == true
+        let titleApplied = applied[MetadataKey.title] == true || removedKeys.contains(MetadataKey.title)
+        let descriptionApplied = applied[MetadataKey.description] == true || removedKeys.contains(MetadataKey.description)
+        let terminalTypeApplied = applied[MetadataKey.terminalType] == true || removedKeys.contains(MetadataKey.terminalType)
         guard titleApplied || descriptionApplied || terminalTypeApplied else { return }
         v2MainSync {
             guard let ws = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6635,7 +6635,6 @@ final class Workspace: Identifiable, ObservableObject {
             hasExactSurfaceNotification: hasExact
         )
         let shouldShowLegacyUnread = manualUnreadPanelIds.contains(panelId)
-            || (hasExact && activityState != .waiting)
         guard existing.activityState != activityState
             || existing.showsNotificationBadge != shouldShowLegacyUnread else { return }
         bonsplitController.updateTab(
@@ -6645,12 +6644,9 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
-    func syncSurfaceTabActivityStates(exactUnreadSurfaceIds: Set<UUID>? = nil) {
+    func syncSurfaceTabActivityStates() {
         for panelId in surfaceIdToPanelId.values {
-            syncSurfaceTabActivityStateForPanel(
-                panelId,
-                hasExactSurfaceNotification: exactUnreadSurfaceIds.map { $0.contains(panelId) }
-            )
+            syncSurfaceTabActivityStateForPanel(panelId)
         }
     }
 
@@ -9320,6 +9316,7 @@ final class Workspace: Identifiable, ObservableObject {
             _ = bonsplitController.reorderTab(newTabId, toIndex: index)
         }
         syncPinnedStateForTab(newTabId, panelId: detached.panelId)
+        syncSurfaceTabActivityStateForPanel(detached.panelId)
         normalizePinnedTabs(in: paneId)
 
         if focus {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7496,6 +7496,12 @@ final class Workspace: Identifiable, ObservableObject {
                 values: values,
                 sources: sources
             )
+            if let rawActivity = values[MetadataKey.activity] as? String,
+               let activity = SidebarActivityState(rawValue: rawActivity) {
+                derivedActivityBySurface[panelId] = activity
+            } else {
+                derivedActivityBySurface.removeValue(forKey: panelId)
+            }
         }
     }
 
@@ -11431,6 +11437,12 @@ extension Workspace: BonsplitDelegate {
             let tabs = controller.tabs(inPane: pane)
             guard let idx = tabs.firstIndex(where: { $0.id == tab.id }) else {
                 postCloseSelectTabId.removeValue(forKey: tab.id)
+                return
+            }
+
+            if let selectedTabId = controller.selectedTab(inPane: pane)?.id,
+               selectedTabId != tab.id {
+                postCloseSelectTabId[tab.id] = selectedTabId
                 return
             }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -284,6 +284,7 @@ extension Workspace {
         }
 
         restoreSurfaceMetadataFromSnapshot(panels: snapshot.panels)
+        syncSurfaceTabActivityStates()
 
         // CMUX-11 Phase 3: rehydrate PaneMetadataStore entries from each
         // restored leaf and prune any pane metadata not in the live set.
@@ -5554,6 +5555,27 @@ final class Workspace: Identifiable, ObservableObject {
         .init(backgroundHex: backgroundColor.hexString())
     }
 
+    nonisolated static func resolvedSurfaceTabActivityColors(
+        from backgroundColor: NSColor
+    ) -> BonsplitConfiguration.Appearance.TabActivityColors {
+        if backgroundColor.isLightColor {
+            return .init(
+                runningHex: "#326D9E",
+                idleHex: "#357B61",
+                coldHex: "#7F8289",
+                waitingHex: "#9B7415",
+                waitingInkHex: "#FFFDF8"
+            )
+        }
+        return .init(
+            runningHex: "#79AEE8",
+            idleHex: "#78B59E",
+            coldHex: "#707681",
+            waitingHex: "#D0AA45",
+            waitingInkHex: "#08090B"
+        )
+    }
+
     /// Resolved theme-aware divider presentation for bonsplit. `borderHex` encodes
     /// RGBA so the alpha from `$workspaceColor.mix(...)` survives into bonsplit.
     private struct BonsplitDividerResolution {
@@ -5606,6 +5628,7 @@ final class Workspace: Identifiable, ObservableObject {
                 borderHex: divider.borderHex,
                 activeIndicatorHex: activeIndicatorHex
             ),
+            tabActivityColors: Self.resolvedSurfaceTabActivityColors(from: backgroundColor),
             dividerStyle: .init(thicknessPt: divider.thicknessPt)
         )
         Self.applyChromeScale(tokens, to: &appearance)
@@ -5747,6 +5770,10 @@ final class Workspace: Identifiable, ObservableObject {
 
         let currentAppearance = bonsplitController.configuration.appearance
         let currentChromeColors = currentAppearance.chromeColors
+        let currentActivityColors = currentAppearance.tabActivityColors
+        let nextActivityColors = Self.resolvedSurfaceTabActivityColors(
+            from: NSColor(hex: nextHex) ?? backgroundColor
+        )
         let currentThickness = currentAppearance.dividerStyle.thicknessPt
 
         // No-op guard spans background, divider color, divider thickness, and
@@ -5758,7 +5785,13 @@ final class Workspace: Identifiable, ObservableObject {
         let borderMatches = currentChromeColors.borderHex == nextBorderHex
         let thicknessMatches = currentThickness == nextThicknessPt
         let activeIndicatorMatches = currentChromeColors.activeIndicatorHex == nextActiveIndicatorHex
-        let isNoOp = backgroundMatches && borderMatches && thicknessMatches && activeIndicatorMatches
+        let activityColorsMatch =
+            currentActivityColors.runningHex == nextActivityColors.runningHex &&
+            currentActivityColors.idleHex == nextActivityColors.idleHex &&
+            currentActivityColors.coldHex == nextActivityColors.coldHex &&
+            currentActivityColors.waitingHex == nextActivityColors.waitingHex &&
+            currentActivityColors.waitingInkHex == nextActivityColors.waitingInkHex
+        let isNoOp = backgroundMatches && borderMatches && thicknessMatches && activeIndicatorMatches && activityColorsMatch
 
         if GhosttyApp.shared.backgroundLogEnabled {
             let currentBackgroundHex = currentChromeColors.backgroundHex ?? "nil"
@@ -5779,6 +5812,7 @@ final class Workspace: Identifiable, ObservableObject {
         nextAppearance.chromeColors.backgroundHex = nextHex
         nextAppearance.chromeColors.borderHex = nextBorderHex
         nextAppearance.chromeColors.activeIndicatorHex = nextActiveIndicatorHex
+        nextAppearance.tabActivityColors = nextActivityColors
         nextAppearance.dividerStyle.thicknessPt = nextThicknessPt
 
         var nextConfiguration = bonsplitController.configuration
@@ -5851,10 +5885,8 @@ final class Workspace: Identifiable, ObservableObject {
             autoCloseEmptyPanes: true,
             contentViewLifecycle: .keepAllAlive,
             newTabPosition: .current,
-            // C11-26: left-anchored always-visible close X + two-item
-            // right-click menu (Close Tab, Close Pane). Sidesteps the
-            // right-edge hit-collision bug and matches native macOS
-            // Cocoa tab convention (Finder, Terminal.app, Notes).
+            // C11-184: leading activity state, trailing always-visible close X,
+            // and the two-item right-click menu (Close Tab, Close Pane).
             simplifiedTabContextMenu: true,
             // Hide the Browser / Markdown spawn buttons when the operator has
             // disabled those surface types. `applySurfaceAvailability()` keeps
@@ -6266,6 +6298,7 @@ final class Workspace: Identifiable, ObservableObject {
         let customTitle: String?
         let customColor: String?
         let manuallyUnread: Bool
+        let activityState: BonsplitTabActivityState?
     }
 
     private var detachingTabIds: Set<TabID> = []
@@ -6579,16 +6612,50 @@ final class Workspace: Identifiable, ObservableObject {
         AppDelegate.shared?.notificationStore?.hasUnreadNotification(forTabId: id, surfaceId: panelId) ?? false
     }
 
-    private func syncUnreadBadgeStateForPanel(_ panelId: UUID) {
-        guard let tabId = surfaceIdFromPanelId(panelId) else { return }
-        let shouldShowUnread = Self.shouldShowUnreadIndicator(
-            hasUnreadNotification: hasUnreadNotification(panelId: panelId),
-            isManuallyUnread: manualUnreadPanelIds.contains(panelId)
+    func resolvedSurfaceTabActivityState(
+        panelId: UUID,
+        hasExactSurfaceNotification: Bool? = nil
+    ) -> BonsplitTabActivityState? {
+        SurfaceTabActivityResolver.resolve(
+            hasExactSurfaceNotification: hasExactSurfaceNotification ?? hasUnreadNotification(panelId: panelId),
+            derivedActivity: derivedActivityBySurface[panelId],
+            terminalType: surfaceTerminalKind(panelId: panelId)
         )
-        if let existing = bonsplitController.tab(tabId), existing.showsNotificationBadge == shouldShowUnread {
-            return
+    }
+
+    func syncSurfaceTabActivityStateForPanel(
+        _ panelId: UUID,
+        hasExactSurfaceNotification: Bool? = nil
+    ) {
+        guard let tabId = surfaceIdFromPanelId(panelId),
+              let existing = bonsplitController.tab(tabId) else { return }
+        let hasExact = hasExactSurfaceNotification ?? hasUnreadNotification(panelId: panelId)
+        let activityState = resolvedSurfaceTabActivityState(
+            panelId: panelId,
+            hasExactSurfaceNotification: hasExact
+        )
+        let shouldShowLegacyUnread = manualUnreadPanelIds.contains(panelId)
+            || (hasExact && activityState != .waiting)
+        guard existing.activityState != activityState
+            || existing.showsNotificationBadge != shouldShowLegacyUnread else { return }
+        bonsplitController.updateTab(
+            tabId,
+            showsNotificationBadge: shouldShowLegacyUnread,
+            activityState: .some(activityState)
+        )
+    }
+
+    func syncSurfaceTabActivityStates(exactUnreadSurfaceIds: Set<UUID>? = nil) {
+        for panelId in surfaceIdToPanelId.values {
+            syncSurfaceTabActivityStateForPanel(
+                panelId,
+                hasExactSurfaceNotification: exactUnreadSurfaceIds.map { $0.contains(panelId) }
+            )
         }
-        bonsplitController.updateTab(tabId, showsNotificationBadge: shouldShowUnread)
+    }
+
+    private func syncUnreadBadgeStateForPanel(_ panelId: UUID) {
+        syncSurfaceTabActivityStateForPanel(panelId)
     }
 
     private func normalizePinnedTabs(in paneId: PaneID) {
@@ -6911,12 +6978,22 @@ final class Workspace: Identifiable, ObservableObject {
     /// overwrites it. The enclosing type is `@MainActor`, so this publishes on
     /// the main actor. Cheap and I/O-free.
     func setDerivedActivity(_ state: SidebarActivityState?, forSurface surfaceId: UUID) {
+        let changed: Bool
         if let state {
             if derivedActivityBySurface[surfaceId] != state {
                 derivedActivityBySurface[surfaceId] = state
+                changed = true
+            } else {
+                changed = false
             }
         } else if derivedActivityBySurface[surfaceId] != nil {
             derivedActivityBySurface.removeValue(forKey: surfaceId)
+            changed = true
+        } else {
+            changed = false
+        }
+        if changed {
+            syncSurfaceTabActivityStateForPanel(surfaceId)
         }
     }
 
@@ -9212,10 +9289,12 @@ final class Workspace: Identifiable, ObservableObject {
             iconImageData: detached.iconImageData,
             kind: detached.kind,
             isDirty: detached.panel.isDirty,
+            showsNotificationBadge: detached.manuallyUnread,
             isLoading: detached.isLoading,
             isPinned: detached.isPinned,
             customColorHex: detached.customColor,
             displayOrdinal: TerminalController.shared.surfaceOrdinal(forSurfaceUUID: detached.panelId),
+            activityState: detached.activityState,
             inPane: paneId
         ) else {
             panels.removeValue(forKey: detached.panelId)
@@ -9241,7 +9320,6 @@ final class Workspace: Identifiable, ObservableObject {
             _ = bonsplitController.reorderTab(newTabId, toIndex: index)
         }
         syncPinnedStateForTab(newTabId, panelId: detached.panelId)
-        syncUnreadBadgeStateForPanel(detached.panelId)
         normalizePinnedTabs(in: paneId)
 
         if focus {
@@ -11460,7 +11538,11 @@ extension Workspace: BonsplitDelegate {
                 cachedTitle: cachedTitle,
                 customTitle: panelCustomTitles[panelId],
                 customColor: panelCustomColors[panelId],
-                manuallyUnread: manualUnreadPanelIds.contains(panelId)
+                manuallyUnread: manualUnreadPanelIds.contains(panelId),
+                activityState: resolvedSurfaceTabActivityState(
+                    panelId: panelId,
+                    hasExactSurfaceNotification: false
+                )
             )
         } else {
             if let closedBrowserRestoreSnapshot {
@@ -12146,6 +12228,7 @@ extension Workspace: BonsplitDelegate {
             source: .declare
         )
         syncPanelTitleFromMetadata(panelId: surfaceId)
+        syncSurfaceTabActivityStateForPanel(surfaceId)
     }
 
     /// Identity-at-birth stamp for `agent.launch` (`c11 launch-agent`). Unlike
@@ -12192,6 +12275,7 @@ extension Workspace: BonsplitDelegate {
             source: .declare
         )
         syncPanelTitleFromMetadata(panelId: surfaceId)
+        syncSurfaceTabActivityStateForPanel(surfaceId)
     }
 
     func splitTabBar(_ controller: BonsplitController, menuItemsForNewTabKind kind: String, inPane pane: PaneID) -> [BonsplitNewTabMenuItem] {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6298,6 +6298,10 @@ final class Workspace: Identifiable, ObservableObject {
         let customTitle: String?
         let customColor: String?
         let manuallyUnread: Bool
+        let terminalType: String?
+        let terminalTypeSource: MetadataSource?
+        let derivedActivity: SidebarActivityState?
+        let derivedActivitySource: MetadataSource?
         let activityState: BonsplitTabActivityState?
     }
 
@@ -9277,6 +9281,27 @@ final class Workspace: Identifiable, ObservableObject {
             manualUnreadPanelIds.remove(detached.panelId)
             manualUnreadMarkedAt.removeValue(forKey: detached.panelId)
         }
+        if let terminalType = detached.terminalType {
+            _ = SurfaceMetadataStore.shared.setInternal(
+                workspaceId: id,
+                surfaceId: detached.panelId,
+                key: MetadataKey.terminalType,
+                value: terminalType,
+                source: detached.terminalTypeSource ?? .heuristic
+            )
+        }
+        if let derivedActivity = detached.derivedActivity {
+            derivedActivityBySurface[detached.panelId] = derivedActivity
+            _ = SurfaceMetadataStore.shared.setInternal(
+                workspaceId: id,
+                surfaceId: detached.panelId,
+                key: MetadataKey.activity,
+                value: derivedActivity.rawValue,
+                source: detached.derivedActivitySource ?? .derived
+            )
+        } else {
+            derivedActivityBySurface.removeValue(forKey: detached.panelId)
+        }
 
         guard let newTabId = bonsplitController.createTab(
             title: TitleFormatting.sidebarLabel(from: detached.title),
@@ -9301,6 +9326,8 @@ final class Workspace: Identifiable, ObservableObject {
             pinnedPanelIds.remove(detached.panelId)
             manualUnreadPanelIds.remove(detached.panelId)
             manualUnreadMarkedAt.removeValue(forKey: detached.panelId)
+            derivedActivityBySurface.removeValue(forKey: detached.panelId)
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: id, surfaceId: detached.panelId)
             panelSubscriptions.removeValue(forKey: detached.panelId)
 #if DEBUG
             dlog(
@@ -11536,6 +11563,18 @@ extension Workspace: BonsplitDelegate {
                 customTitle: panelCustomTitles[panelId],
                 customColor: panelCustomColors[panelId],
                 manuallyUnread: manualUnreadPanelIds.contains(panelId),
+                terminalType: surfaceTerminalKind(panelId: panelId),
+                terminalTypeSource: SurfaceMetadataStore.shared.getSource(
+                    workspaceId: id,
+                    surfaceId: panelId,
+                    key: MetadataKey.terminalType
+                ),
+                derivedActivity: derivedActivityBySurface[panelId],
+                derivedActivitySource: SurfaceMetadataStore.shared.getSource(
+                    workspaceId: id,
+                    surfaceId: panelId,
+                    key: MetadataKey.activity
+                ),
                 activityState: resolvedSurfaceTabActivityState(
                     panelId: panelId,
                     hasExactSurfaceNotification: false
@@ -11573,6 +11612,7 @@ extension Workspace: BonsplitDelegate {
         manualUnreadMarkedAt.removeValue(forKey: panelId)
         panelSubscriptions.removeValue(forKey: panelId)
         panelShellActivityStates.removeValue(forKey: panelId)
+        derivedActivityBySurface.removeValue(forKey: panelId)
         mailboxStdinBuffer.removeSurface(panelId)
         surfaceTTYNames.removeValue(forKey: panelId)
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
@@ -11755,6 +11795,7 @@ extension Workspace: BonsplitDelegate {
                 manualUnreadPanelIds.remove(panelId)
                 panelSubscriptions.removeValue(forKey: panelId)
                 panelShellActivityStates.removeValue(forKey: panelId)
+                derivedActivityBySurface.removeValue(forKey: panelId)
                 mailboxStdinBuffer.removeSurface(panelId)
                 surfaceTTYNames.removeValue(forKey: panelId)
                 surfaceListeningPorts.removeValue(forKey: panelId)

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -252,10 +252,7 @@ struct WorkspaceContentView: View {
                         hasExactSurfaceNotification: unreadFromNotifications.contains($0)
                     )
                 }
-                let shouldShow = panelId.map {
-                    manualUnread.contains($0)
-                        || (unreadFromNotifications.contains($0) && expectedActivity != .waiting)
-                } ?? false
+                let shouldShow = panelId.map { manualUnread.contains($0) } ?? false
                 let kindUpdate: String?? = expectedKind.map { .some($0) }
 
                 if tab.showsNotificationBadge != shouldShow ||

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -169,6 +169,9 @@ struct WorkspaceContentView: View {
         .onChange(of: workspace.manualUnreadPanelIds) { _, _ in
             syncBonsplitNotificationBadges()
         }
+        .onChange(of: workspace.derivedActivityBySurface) { _, _ in
+            syncBonsplitNotificationBadges()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
             GhosttyConfig.invalidateLoadCache()
             refreshGhosttyAppearanceConfig(reason: "ghosttyConfigDidReload")
@@ -243,17 +246,28 @@ struct WorkspaceContentView: View {
                 let panelId = workspace.panelIdFromSurfaceId(tab.id)
                 let expectedKind = panelId.flatMap { workspace.panelKind(panelId: $0) }
                 let expectedPinned = panelId.map { workspace.isPanelPinned($0) } ?? false
-                let shouldShow = panelId.map { unreadFromNotifications.contains($0) || manualUnread.contains($0) } ?? false
+                let expectedActivity = panelId.flatMap {
+                    workspace.resolvedSurfaceTabActivityState(
+                        panelId: $0,
+                        hasExactSurfaceNotification: unreadFromNotifications.contains($0)
+                    )
+                }
+                let shouldShow = panelId.map {
+                    manualUnread.contains($0)
+                        || (unreadFromNotifications.contains($0) && expectedActivity != .waiting)
+                } ?? false
                 let kindUpdate: String?? = expectedKind.map { .some($0) }
 
                 if tab.showsNotificationBadge != shouldShow ||
+                    tab.activityState != expectedActivity ||
                     tab.isPinned != expectedPinned ||
                     (expectedKind != nil && tab.kind != expectedKind) {
                     workspace.bonsplitController.updateTab(
                         tab.id,
                         kind: kindUpdate,
                         showsNotificationBadge: shouldShow,
-                        isPinned: expectedPinned
+                        isPinned: expectedPinned,
+                        activityState: .some(expectedActivity)
                     )
                 }
             }

--- a/c11Tests/MetadataDerivedPrecedenceTests.swift
+++ b/c11Tests/MetadataDerivedPrecedenceTests.swift
@@ -137,11 +137,13 @@ final class MetadataDerivedPrecedenceTests: XCTestCase {
             "task": "lat-412",
             "worktree": "c11-104-sidebar-chips",
             "branch": "feat/c11-104-sidebar-chips",
+            "activity": "working",
         ]
         let sources: [String: [String: Any]] = [
             "task":     ["source": "declare",  "ts": 1.0],
             "worktree": ["source": "derived",  "ts": 2.0],
             "branch":   ["source": "derived",  "ts": 3.0],
+            "activity": ["source": "derived",  "ts": 4.0],
         ]
         let bridged = PersistedMetadataBridge.encodeValues(
             metadata,
@@ -151,11 +153,13 @@ final class MetadataDerivedPrecedenceTests: XCTestCase {
         XCTAssertNotNil(bridged["task"], "non-derived keys must persist")
         XCTAssertNil(bridged["worktree"], "derived `worktree` must NOT persist")
         XCTAssertNil(bridged["branch"], "derived `branch` must NOT persist")
+        XCTAssertNotNil(bridged["activity"], "derived `activity` must persist for restore-time projection")
 
         let bridgedSources = PersistedMetadataBridge.encodeSources(sources)
         XCTAssertNotNil(bridgedSources["task"])
         XCTAssertNil(bridgedSources["worktree"])
         XCTAssertNil(bridgedSources["branch"])
+        XCTAssertNotNil(bridgedSources["activity"])
     }
 
     func testEncodeValuesWithoutSourcesPreservesEverything() {

--- a/c11Tests/SurfaceLivenessDeriverTests.swift
+++ b/c11Tests/SurfaceLivenessDeriverTests.swift
@@ -1,4 +1,6 @@
 import XCTest
+import AppKit
+import Bonsplit
 
 #if canImport(c11_DEV)
 @testable import c11_DEV
@@ -52,6 +54,107 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
         XCTAssertEqual(SurfaceLivenessDeriver.activityState(for: .commandRunning), .working)
         XCTAssertEqual(SurfaceLivenessDeriver.activityState(for: .promptIdle), .idle)
         XCTAssertNil(SurfaceLivenessDeriver.activityState(for: .unknown))
+    }
+
+    func testSurfaceTabResolverMapsRecognizedAgentStates() {
+        XCTAssertEqual(
+            SurfaceTabActivityResolver.resolve(
+                hasExactSurfaceNotification: false,
+                derivedActivity: .working,
+                terminalType: "codex"
+            ),
+            .running
+        )
+        XCTAssertEqual(
+            SurfaceTabActivityResolver.resolve(
+                hasExactSurfaceNotification: false,
+                derivedActivity: .idle,
+                terminalType: "claude-code"
+            ),
+            .idle
+        )
+        XCTAssertEqual(
+            SurfaceTabActivityResolver.resolve(
+                hasExactSurfaceNotification: false,
+                derivedActivity: nil,
+                terminalType: "opencode-run"
+            ),
+            .cold
+        )
+    }
+
+    func testSurfaceTabResolverGivesExactDemandPrecedence() {
+        for activity in [SidebarActivityState.working, .idle, nil] {
+            XCTAssertEqual(
+                SurfaceTabActivityResolver.resolve(
+                    hasExactSurfaceNotification: true,
+                    derivedActivity: activity,
+                    terminalType: "codex"
+                ),
+                .waiting
+            )
+        }
+    }
+
+    func testSurfaceTabResolverDoesNotManufactureWaitingFromWorkspaceOrManualUnread() {
+        XCTAssertEqual(
+            SurfaceTabActivityResolver.resolve(
+                hasExactSurfaceNotification: false,
+                derivedActivity: .idle,
+                terminalType: "codex"
+            ),
+            .idle
+        )
+        XCTAssertEqual(
+            SurfaceTabActivityResolver.resolve(
+                hasExactSurfaceNotification: false,
+                derivedActivity: nil,
+                terminalType: "codex"
+            ),
+            .cold
+        )
+    }
+
+    func testSurfaceTabResolverOmitsNonAgentActivity() {
+        XCTAssertNil(SurfaceTabActivityResolver.resolve(
+            hasExactSurfaceNotification: false,
+            derivedActivity: .working,
+            terminalType: "terminal"
+        ))
+        XCTAssertNil(SurfaceTabActivityResolver.resolve(
+            hasExactSurfaceNotification: false,
+            derivedActivity: .idle,
+            terminalType: nil
+        ))
+    }
+
+    func testHarnessIdentityDoesNotChangeResolvedState() {
+        for terminalType in ["codex", "claude-code", "opencode", "omp", "pi"] {
+            XCTAssertEqual(
+                SurfaceTabActivityResolver.resolve(
+                    hasExactSurfaceNotification: false,
+                    derivedActivity: .working,
+                    terminalType: terminalType
+                ),
+                .running
+            )
+        }
+    }
+
+    func testSurfaceTabActivityColorsMatchDarkAndLightContract() {
+        let dark = Workspace.resolvedSurfaceTabActivityColors(from: NSColor(hex: "#101114")!)
+        XCTAssertEqual(dark.runningHex, "#79AEE8")
+        XCTAssertEqual(dark.idleHex, "#78B59E")
+        XCTAssertEqual(dark.coldHex, "#707681")
+        XCTAssertEqual(dark.waitingHex, "#D0AA45")
+        XCTAssertEqual(dark.waitingInkHex, "#08090B")
+
+        let light = Workspace.resolvedSurfaceTabActivityColors(from: NSColor(hex: "#F5F3EF")!)
+        XCTAssertEqual(light.runningHex, "#326D9E")
+        XCTAssertEqual(light.idleHex, "#357B61")
+        XCTAssertEqual(light.coldHex, "#7F8289")
+        XCTAssertEqual(light.waitingHex, "#9B7415")
+        XCTAssertEqual(light.waitingInkHex, "#FFFDF8")
     }
 
     // MARK: - Realtime transitions write the derived truth

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -1624,6 +1624,87 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertEqual(restored.bonsplitController.tab(restoredTabId)?.activityState, .running)
     }
 
+    func testActivityMetadataMutationsRehydrateLiveTabProjection() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let tabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(panelId))
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: workspace.id, surfaceId: panelId)
+        }
+
+        func apply(_ result: SurfaceMetadataStore.WriteResult) {
+            TerminalController.shared.applyTitleDescriptionSideEffects(
+                workspaceId: workspace.id,
+                surfaceId: panelId,
+                tabManager: manager,
+                applied: result.applied,
+                removedKeys: result.removedKeys,
+                autoExpand: false
+            )
+        }
+
+        let runningResult = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            partial: [
+                MetadataKey.terminalType: "codex",
+                MetadataKey.activity: SidebarActivityState.working.rawValue,
+            ],
+            mode: .merge,
+            source: .explicit
+        )
+        apply(runningResult)
+        XCTAssertEqual(workspace.derivedActivityBySurface[panelId], .working)
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .running)
+
+        let keyedClearResult = try SurfaceMetadataStore.shared.clearMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            keys: [MetadataKey.activity],
+            source: .explicit
+        )
+        apply(keyedClearResult)
+        XCTAssertNil(workspace.derivedActivityBySurface[panelId])
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .cold)
+
+        let clearAllResult = try SurfaceMetadataStore.shared.clearMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            keys: nil,
+            source: .explicit
+        )
+        apply(clearAllResult)
+        XCTAssertNil(workspace.derivedActivityBySurface[panelId])
+        XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
+
+        let idleResult = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            partial: [
+                MetadataKey.terminalType: "codex",
+                MetadataKey.activity: SidebarActivityState.idle.rawValue,
+            ],
+            mode: .merge,
+            source: .explicit
+        )
+        apply(idleResult)
+        XCTAssertEqual(workspace.derivedActivityBySurface[panelId], .idle)
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .idle)
+
+        let replaceResult = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            partial: [MetadataKey.terminalType: "codex"],
+            mode: .replace,
+            source: .explicit
+        )
+        apply(replaceResult)
+        XCTAssertTrue(replaceResult.removedKeys.contains(MetadataKey.activity))
+        XCTAssertNil(workspace.derivedActivityBySurface[panelId])
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .cold)
+    }
+
     func testClosingBackgroundTabPreservesSelectedSurfaceAndFocus() throws {
         let workspace = Workspace()
         let selectedPanelId = try XCTUnwrap(workspace.focusedPanelId)

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -1480,6 +1480,22 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertEqual(destination.surfaceTerminalKind(panelId: panelId), "codex")
         XCTAssertEqual(destination.derivedActivityBySurface[panelId], .working)
         XCTAssertEqual(destination.bonsplitController.tab(destinationTabId)?.activityState, .running)
+        XCTAssertEqual(
+            SurfaceMetadataStore.shared.getSource(
+                workspaceId: destination.id,
+                surfaceId: panelId,
+                key: MetadataKey.terminalType
+            ),
+            .explicit
+        )
+        XCTAssertEqual(
+            SurfaceMetadataStore.shared.getSource(
+                workspaceId: destination.id,
+                surfaceId: panelId,
+                key: MetadataKey.activity
+            ),
+            .derived
+        )
 
         destination.setDerivedActivity(nil, forSurface: panelId)
         XCTAssertEqual(destination.bonsplitController.tab(destinationTabId)?.activityState, .cold)
@@ -1536,6 +1552,24 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
 
         try seedColdAgentState()
+        let keyedClearResult = try SurfaceMetadataStore.shared.clearMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            keys: [MetadataKey.terminalType],
+            source: .explicit
+        )
+        TerminalController.shared.applyTitleDescriptionSideEffects(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            tabManager: manager,
+            applied: keyedClearResult.applied,
+            removedKeys: keyedClearResult.removedKeys,
+            autoExpand: false
+        )
+        XCTAssertEqual(keyedClearResult.removedKeys, [MetadataKey.terminalType])
+        XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
+
+        try seedColdAgentState()
         let replaceResult = try SurfaceMetadataStore.shared.setMetadata(
             workspaceId: workspace.id,
             surfaceId: panelId,
@@ -1553,6 +1587,61 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
         XCTAssertTrue(replaceResult.removedKeys.contains(MetadataKey.terminalType))
         XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
+    }
+
+    func testSessionRestoreRehydratesPersistedDerivedActivityBeforeTabSync() throws {
+        let source = Workspace()
+        let panelId = try XCTUnwrap(source.focusedPanelId)
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: source.id, surfaceId: panelId)
+        }
+
+        _ = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: source.id,
+            surfaceId: panelId,
+            partial: [MetadataKey.terminalType: "codex"],
+            mode: .merge,
+            source: .explicit
+        )
+        _ = SurfaceMetadataStore.shared.setInternal(
+            workspaceId: source.id,
+            surfaceId: panelId,
+            key: MetadataKey.activity,
+            value: SidebarActivityState.working.rawValue,
+            source: .derived
+        )
+        source.setDerivedActivity(.working, forSurface: panelId)
+
+        let snapshot = source.sessionSnapshot(includeScrollback: false)
+        let restored = Workspace()
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: restored.id, surfaceId: panelId)
+        }
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredTabId = try XCTUnwrap(restored.surfaceIdFromPanelId(panelId))
+        XCTAssertEqual(restored.derivedActivityBySurface[panelId], .working)
+        XCTAssertEqual(restored.bonsplitController.tab(restoredTabId)?.activityState, .running)
+    }
+
+    func testClosingBackgroundTabPreservesSelectedSurfaceAndFocus() throws {
+        let workspace = Workspace()
+        let selectedPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let paneId = try XCTUnwrap(workspace.paneId(forPanelId: selectedPanelId))
+        let selectedTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(selectedPanelId))
+        let backgroundPanel = try XCTUnwrap(
+            workspace.newBrowserSurface(
+                inPane: paneId,
+                url: URL(string: "https://example.com"),
+                focus: false
+            )
+        )
+        let backgroundTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(backgroundPanel.id))
+
+        XCTAssertEqual(workspace.bonsplitController.selectedTab(inPane: paneId)?.id, selectedTabId)
+        XCTAssertTrue(workspace.bonsplitController.closeTab(backgroundTabId, inPane: paneId))
+        XCTAssertEqual(workspace.bonsplitController.selectedTab(inPane: paneId)?.id, selectedTabId)
+        XCTAssertEqual(workspace.focusedPanelId, selectedPanelId)
     }
 
     func testBrowserSplitWithFocusFalseRecoversFromDelayedStaleSelection() {

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -1434,6 +1434,127 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertFalse(attachedTab.hasCustomTitle)
     }
 
+    func testDetachAttachAndRollbackPreserveSurfaceActivityResolverInputs() throws {
+        let source = Workspace()
+        guard let panelId = source.focusedPanelId,
+              let sourcePane = source.paneId(forPanelId: panelId),
+              let sourceTabId = source.surfaceIdFromPanelId(panelId) else {
+            XCTFail("Expected source panel, pane, and tab")
+            return
+        }
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: source.id, surfaceId: panelId)
+        }
+
+        _ = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: source.id,
+            surfaceId: panelId,
+            partial: [MetadataKey.terminalType: "codex"],
+            mode: .merge,
+            source: .explicit
+        )
+        _ = SurfaceMetadataStore.shared.setInternal(
+            workspaceId: source.id,
+            surfaceId: panelId,
+            key: MetadataKey.activity,
+            value: SidebarActivityState.working.rawValue,
+            source: .derived
+        )
+        source.setDerivedActivity(.working, forSurface: panelId)
+        XCTAssertEqual(source.bonsplitController.tab(sourceTabId)?.activityState, .running)
+
+        let detached = try XCTUnwrap(source.detachSurface(panelId: panelId))
+        XCTAssertNil(source.derivedActivityBySurface[panelId])
+
+        let destination = Workspace()
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: destination.id, surfaceId: panelId)
+        }
+        let destinationPane = try XCTUnwrap(destination.bonsplitController.allPaneIds.first)
+        XCTAssertEqual(
+            destination.attachDetachedSurface(detached, inPane: destinationPane, focus: false),
+            panelId
+        )
+
+        let destinationTabId = try XCTUnwrap(destination.surfaceIdFromPanelId(panelId))
+        XCTAssertEqual(destination.surfaceTerminalKind(panelId: panelId), "codex")
+        XCTAssertEqual(destination.derivedActivityBySurface[panelId], .working)
+        XCTAssertEqual(destination.bonsplitController.tab(destinationTabId)?.activityState, .running)
+
+        destination.setDerivedActivity(nil, forSurface: panelId)
+        XCTAssertEqual(destination.bonsplitController.tab(destinationTabId)?.activityState, .cold)
+
+        let rollbackTransfer = try XCTUnwrap(destination.detachSurface(panelId: panelId))
+        XCTAssertEqual(
+            source.attachDetachedSurface(rollbackTransfer, inPane: sourcePane, focus: false),
+            panelId
+        )
+
+        let rollbackTabId = try XCTUnwrap(source.surfaceIdFromPanelId(panelId))
+        XCTAssertEqual(source.surfaceTerminalKind(panelId: panelId), "codex")
+        XCTAssertNil(source.derivedActivityBySurface[panelId])
+        XCTAssertEqual(source.bonsplitController.tab(rollbackTabId)?.activityState, .cold)
+    }
+
+    func testRemovingTerminalTypeMetadataClearsColdSurfaceActivityState() throws {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let tabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(panelId))
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: workspace.id, surfaceId: panelId)
+        }
+
+        func seedColdAgentState() throws {
+            _ = try SurfaceMetadataStore.shared.setMetadata(
+                workspaceId: workspace.id,
+                surfaceId: panelId,
+                partial: [MetadataKey.terminalType: "codex"],
+                mode: .merge,
+                source: .explicit
+            )
+            workspace.syncSurfaceTabActivityStateForPanel(panelId)
+            XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .cold)
+        }
+
+        try seedColdAgentState()
+        let clearResult = try SurfaceMetadataStore.shared.clearMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            keys: nil,
+            source: .explicit
+        )
+        TerminalController.shared.applyTitleDescriptionSideEffects(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            tabManager: manager,
+            applied: clearResult.applied,
+            removedKeys: clearResult.removedKeys,
+            autoExpand: false
+        )
+        XCTAssertTrue(clearResult.removedKeys.contains(MetadataKey.terminalType))
+        XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
+
+        try seedColdAgentState()
+        let replaceResult = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            partial: [MetadataKey.description: "replacement metadata"],
+            mode: .replace,
+            source: .explicit
+        )
+        TerminalController.shared.applyTitleDescriptionSideEffects(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            tabManager: manager,
+            applied: replaceResult.applied,
+            removedKeys: replaceResult.removedKeys,
+            autoExpand: false
+        )
+        XCTAssertTrue(replaceResult.removedKeys.contains(MetadataKey.terminalType))
+        XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
+    }
+
     func testBrowserSplitWithFocusFalseRecoversFromDelayedStaleSelection() {
         let workspace = Workspace()
         guard let originalFocusedPanelId = workspace.focusedPanelId else {

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -22,10 +22,6 @@
       --running: #79aee8;
       --idle: #78b59e;
       --cold: #707681;
-      --harness-claude: #d88968;
-      --harness-codex: #69b5a8;
-      --harness-other: #6f9ed6;
-      --harness-shell: #818791;
       --badge-ink: #08090b;
       --shadow: rgba(0, 0, 0, .72);
       --terminal-line: #b8bcc4;
@@ -50,10 +46,6 @@
       --running: #326d9e;
       --idle: #357b61;
       --cold: #7f8289;
-      --harness-claude: #a84f32;
-      --harness-codex: #28776d;
-      --harness-other: #386fa8;
-      --harness-shell: #6d7178;
       --badge-ink: #fffdf8;
       --shadow: rgba(35, 34, 30, .25);
       --terminal-line: #4b4e55;
@@ -199,7 +191,6 @@
     .tab-scroll::-webkit-scrollbar { display: none; }
     .surface-tab {
       --state: var(--cold);
-      --harness: var(--harness-shell);
       position: relative;
       height: 30px;
       min-width: 112px;
@@ -225,11 +216,6 @@
     .surface-tab.state-running { --state: var(--running); }
     .surface-tab.state-idle { --state: var(--idle); }
     .surface-tab.state-cold { --state: var(--cold); color: color-mix(in srgb, var(--dim) 74%, transparent); }
-    .surface-tab.harness-claude { --harness: var(--harness-claude); }
-    .surface-tab.harness-codex { --harness: var(--harness-codex); }
-    .surface-tab.harness-other { --harness: var(--harness-other); }
-    .surface-tab.harness-shell { --harness: var(--harness-shell); }
-    body.neutral-harness .surface-tab { --harness: var(--text-soft); }
     .surface-tab.state-waiting {
       --state: var(--gold);
     }
@@ -270,51 +256,63 @@
       flex: 0 0 13px;
       display: grid;
       place-items: center;
+      position: relative;
       color: var(--state);
-      border: 1px solid color-mix(in srgb, var(--state) 76%, transparent);
-      border-radius: 50%;
-      font: 8px/1 var(--mono);
-      font-weight: 700;
     }
+    .state-mark::before {
+      content: "";
+      display: block;
+      width: 8px;
+      height: 8px;
+      background: currentColor;
+      border-radius: 2px;
+    }
+    .state-mark > span { display: none; }
     .surface-tab > .state-mark {
-      width: 22px;
-      height: 22px;
-      flex: 0 0 22px;
+      width: 18px;
+      height: 18px;
+      flex: 0 0 18px;
+      place-items: center start;
       margin-right: 5px;
-      color: var(--harness);
-      border-color: color-mix(in srgb, var(--harness) 76%, transparent);
-      font-size: 10px;
+      color: var(--state);
     }
-    .surface-tab.state-running > .state-mark {
-      color: var(--harness);
+    .state-mark.state-running::before {
+      width: 10px;
+      height: 10px;
       background: transparent;
-      border-color: color-mix(in srgb, var(--harness) 44%, transparent);
-      border-top-color: var(--harness);
-      animation: turn 1.8s linear infinite;
+      border: 1px solid color-mix(in srgb, currentColor 38%, transparent);
+      border-top-color: currentColor;
+      border-radius: 50%;
+      animation: turn 2.4s linear infinite;
     }
-    .surface-tab.state-running > .state-mark span { animation: counter-turn 1.8s linear infinite; }
-    .surface-tab.state-idle > .state-mark {
-      color: var(--harness);
-      background: transparent;
-      border-color: color-mix(in srgb, var(--harness) 78%, transparent);
-      border-radius: 4px;
+    .state-mark.state-idle::before {
+      width: 8px;
+      height: 8px;
+      opacity: .82;
     }
-    .surface-tab.state-cold > .state-mark {
-      color: var(--harness);
-      background: transparent;
-      border-color: color-mix(in srgb, var(--harness) 68%, transparent);
-      border-style: dotted;
-      opacity: .8;
+    .state-mark.state-cold::before {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      opacity: .48;
     }
-    .surface-tab.state-waiting > .state-mark {
+    .state-mark.state-waiting {
       color: var(--badge-ink);
+    }
+    .state-mark.state-waiting::before {
+      width: 17px;
+      height: 17px;
       background: var(--gold);
-      border-color: var(--gold);
       border-radius: 4px;
       box-shadow: 0 0 8px color-mix(in srgb, var(--gold) 30%, transparent);
     }
+    .state-mark.state-waiting > span {
+      display: block;
+      position: absolute;
+      font: 8px/1 var(--mono);
+      font-weight: 750;
+    }
     @keyframes turn { to { transform: rotate(360deg); } }
-    @keyframes counter-turn { to { transform: rotate(-360deg); } }
     .tab-title {
       min-width: 0;
       overflow: hidden;
@@ -390,7 +388,7 @@
       text-transform: uppercase;
       white-space: nowrap;
     }
-    .surface-state-readout .state-mark { --state: var(--selected-state, var(--running)); }
+    .surface-state-readout .state-mark { width: 18px; height: 18px; --state: var(--selected-state, var(--running)); }
 
     .content {
       min-height: 0;
@@ -452,38 +450,28 @@
     .state-button[data-state="idle"] { --state-button-color: var(--idle); }
     .state-button[data-state="cold"] { --state-button-color: var(--cold); }
     .state-button[data-state="waiting"] { --state-button-color: var(--gold); }
+    .control-mark {
+      width: 7px;
+      height: 7px;
+      flex: 0 0 7px;
+      background: var(--state-button-color);
+      border-radius: 2px;
+      opacity: .8;
+    }
+    .state-button[data-state="running"] .control-mark { background: transparent; border: 1px solid var(--running); border-radius: 50%; }
+    .state-button[data-state="cold"] .control-mark { width: 5px; height: 5px; flex-basis: 5px; border-radius: 50%; opacity: .48; }
+    .state-button[data-state="waiting"] .control-mark { display: none; }
     .section-rule { height: 1px; margin: 17px 0; background: var(--rule); }
     .legend { display: grid; gap: 9px; margin-top: 11px; }
     .legend-row { display: grid; grid-template-columns: 18px 62px 1fr; align-items: center; gap: 6px; }
     .legend-row .state-mark { --state: var(--legend-state); }
-    .legend-row.running { --legend-state: var(--text-soft); }
-    .legend-row.idle { --legend-state: var(--text-soft); }
-    .legend-row.cold { --legend-state: var(--text-soft); }
+    .legend-row.running { --legend-state: var(--running); }
+    .legend-row.idle { --legend-state: var(--idle); }
+    .legend-row.cold { --legend-state: var(--cold); }
     .legend-row.waiting { --legend-state: var(--gold); }
     .legend-row strong { color: var(--text-soft); font: 9px var(--mono); font-weight: 650; text-transform: uppercase; }
     .legend-row span:last-child { color: var(--dim); font: 9px/1.3 var(--mono); }
-    .legend-row.running .state-mark { border-color: color-mix(in srgb, var(--text-soft) 44%, transparent); border-top-color: var(--text-soft); }
-    .legend-row.idle .state-mark { border-radius: 3px; }
-    .legend-row.cold .state-mark { border-style: dotted; }
-    .legend-row.waiting .state-mark { color: var(--badge-ink); background: var(--gold); border-color: var(--gold); border-radius: 3px; }
-    .harness-key {
-      display: flex;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 10px;
-      margin-top: 12px;
-      color: var(--dim);
-      font: 8px var(--mono);
-      text-transform: uppercase;
-    }
-    .harness-key span { display: inline-flex; align-items: center; gap: 4px; }
-    body.neutral-harness .harness-key { opacity: .35; }
-    .harness-swatch { width: 7px; height: 7px; border-radius: 50%; background: var(--swatch); }
-    .harness-swatch.claude { --swatch: var(--harness-claude); }
-    .harness-swatch.codex { --swatch: var(--harness-codex); }
-    .harness-swatch.other { --swatch: var(--harness-other); }
-    .harness-swatch.shell { --swatch: var(--harness-shell); }
-    .option-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+    .option-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }
     .option-button[aria-pressed="true"] { color: var(--gold); border-color: color-mix(in srgb, var(--gold) 55%, var(--rule)); }
     .collision-note {
       margin-top: 14px;
@@ -568,7 +556,7 @@
             <div class="surface-description" id="surfaceDescription"></div>
           </div>
           <div class="surface-state-readout" id="surfaceStateReadout">
-            <span class="state-mark"><span id="readoutGlyph"></span></span>
+            <span class="state-mark" id="readoutMark"><span id="readoutGlyph"></span></span>
             <span id="readoutLabel"></span>
           </div>
         </div>
@@ -582,38 +570,31 @@
             <p>Click any tab, then force a state. Selection and state should remain readable in every combination.</p>
 
             <div class="state-controls" aria-label="Change selected surface state">
-              <button class="state-button" data-state="running">R Running</button>
-              <button class="state-button" data-state="idle">I Idle</button>
-              <button class="state-button" data-state="cold">C Cold</button>
+              <button class="state-button" data-state="running"><span class="control-mark"></span>Running</button>
+              <button class="state-button" data-state="idle"><span class="control-mark"></span>Idle</button>
+              <button class="state-button" data-state="cold"><span class="control-mark"></span>Cold</button>
               <button class="state-button" data-state="waiting">W Your turn</button>
             </div>
 
             <div class="section-rule"></div>
             <div class="eyebrow">Grammar</div>
             <div class="legend">
-              <div class="legend-row running"><span class="state-mark"><span>R</span></span><strong>Running</strong><span>R + slow rim; work is moving</span></div>
-              <div class="legend-row idle"><span class="state-mark"><span>I</span></span><strong>Idle</strong><span>I; prompt is ready</span></div>
-              <div class="legend-row cold"><span class="state-mark"><span>C</span></span><strong>Cold</strong><span>C + dotted shell; no live session</span></div>
-              <div class="legend-row waiting"><span class="state-mark"><span>W</span></span><strong>Your turn</strong><span>prominent gold W; no second signal</span></div>
-            </div>
-            <div class="harness-key" aria-label="Harness color key">
-              <span><i class="harness-swatch claude"></i> Claude</span>
-              <span><i class="harness-swatch codex"></i> Codex</span>
-              <span><i class="harness-swatch other"></i> Other agent</span>
-              <span><i class="harness-swatch shell"></i> Shell</span>
+              <div class="legend-row running"><span class="state-mark state-running"></span><strong>Running</strong><span>blue + slow rim; work is moving</span></div>
+              <div class="legend-row idle"><span class="state-mark state-idle"></span><strong>Idle</strong><span>static green mark; prompt is ready</span></div>
+              <div class="legend-row cold"><span class="state-mark state-cold"></span><strong>Cold</strong><span>quiet gray dot; no live session</span></div>
+              <div class="legend-row waiting"><span class="state-mark state-waiting"><span>W</span></span><strong>Your turn</strong><span>compact gold W; explicit demand</span></div>
             </div>
 
             <div class="section-rule"></div>
             <div class="eyebrow">Stress the strip</div>
             <div class="option-grid">
               <button class="option-button" id="toggleIds" aria-pressed="false">Surface IDs</button>
-              <button class="option-button" id="toggleHarness" aria-pressed="true">Harness color</button>
               <button class="option-button" id="toggleTheme" aria-pressed="false">Light theme</button>
               <button class="option-button" id="toggleMotion" aria-pressed="false">Reduce motion</button>
             </div>
 
             <div class="collision-note">
-              <b>One badge, two reads.</b> R/I/C/W names state; quiet outline hue names the harness. Other agent harnesses share blue. Waiting overrides hue with gold alone. Close remains hard-right.
+              <b>State first.</b> Color carries routine state; only running moves. Waiting is the deliberate exception: a compact gold W makes the operator demand explicit. Close remains hard-right.
             </div>
           </aside>
         </div>
@@ -639,17 +620,10 @@
     ];
 
     const stateCopy = {
-      running: { glyph: 'R', label: 'Running · work in motion', color: 'var(--running)', line: 'Command in flight. Output and prompt-state observation say this agent is moving.' },
-      idle: { glyph: 'I', label: 'Idle · at the prompt', color: 'var(--idle)', line: 'Live session, quiet prompt. Available for another task without a resume step.' },
-      cold: { glyph: 'C', label: 'Cold · no live agent', color: 'var(--cold)', line: 'The surface remains, but no agent session is currently live. It may be resumable.' },
+      running: { glyph: '', label: 'Running · work in motion', color: 'var(--running)', line: 'Command in flight. Output and prompt-state observation say this agent is moving.' },
+      idle: { glyph: '', label: 'Idle · at the prompt', color: 'var(--idle)', line: 'Live session, quiet prompt. Available for another task without a resume step.' },
+      cold: { glyph: '', label: 'Cold · no live agent', color: 'var(--cold)', line: 'The surface remains, but no agent session is currently live. It may be resumable.' },
       waiting: { glyph: 'W', label: 'Your turn · response needed', color: 'var(--gold)', line: 'The agent has yielded with a question or decision. This is the operator’s turn.' }
-    };
-
-    const harnessColors = {
-      claude: 'var(--harness-claude)',
-      codex: 'var(--harness-codex)',
-      other: 'var(--harness-other)',
-      shell: 'var(--harness-shell)'
     };
 
     let selectedId = 62;
@@ -663,19 +637,15 @@
       return Math.max(112, Math.min(190, 52 + idCost + surface.title.length * 4));
     }
 
-    function harnessFamily(harness) {
-      return ['claude', 'codex', 'shell'].includes(harness) ? harness : 'other';
-    }
-
     function tabMarkup(surface) {
       const copy = stateCopy[surface.state];
       return `
-        <div class="surface-tab state-${surface.state} harness-${harnessFamily(surface.harness)}${surface.id === selectedId ? ' selected' : ''}"
+        <div class="surface-tab state-${surface.state}${surface.id === selectedId ? ' selected' : ''}"
              style="--tab-width:${widthFor(surface)}px"
              data-id="${surface.id}" role="tab" tabindex="0"
              aria-selected="${surface.id === selectedId}" aria-label="${surface.title}, ${copy.label}, ${surface.harness} harness"
              title="surface:${surface.id} · ${surface.title} · ${copy.label} · ${surface.harness}">
-          <span class="state-mark" aria-hidden="true"><span>${copy.glyph}</span></span>
+          <span class="state-mark state-${surface.state}" aria-hidden="true"><span>${copy.glyph}</span></span>
           <span class="tab-title"><span class="surface-id">${surface.id}: </span>${surface.title}</span>
           <button class="close-tab" aria-label="Close ${surface.title}" title="Close tab">×</button>
         </div>`;
@@ -720,16 +690,14 @@
     function updateSelection() {
       const surface = surfaces.find(item => item.id === selectedId);
       const copy = stateCopy[surface.state];
-      const harnessColor = document.body.classList.contains('neutral-harness')
-        ? 'var(--text-soft)'
-        : harnessColors[harnessFamily(surface.harness)];
-      const badgeColor = surface.state === 'waiting' ? copy.color : harnessColor;
+      const badgeColor = copy.color;
       const waitingCount = surfaces.filter(item => item.state === 'waiting').length;
       document.getElementById('surfaceTitle').textContent = `surface:${surface.id} · ${surface.title}`;
       document.getElementById('surfaceDescription').textContent = surface.description;
       document.getElementById('inspectorTitle').textContent = surface.title;
       document.getElementById('readoutGlyph').textContent = copy.glyph;
       document.getElementById('readoutLabel').textContent = copy.label;
+      document.getElementById('readoutMark').className = `state-mark state-${surface.state}`;
       document.getElementById('surfaceStateReadout').style.setProperty('--selected-state', badgeColor);
       document.querySelectorAll('.state-button').forEach(button => {
         button.classList.toggle('active', button.dataset.state === surface.state);
@@ -737,15 +705,15 @@
       document.getElementById('terminalCopy').innerHTML = `
         <div><span class="dim">$</span> c11 inspect surface:${surface.id}</div>
         <br>
-        <div><span style="color:${badgeColor}">${copy.glyph}</span> <strong>${copy.label}</strong> <span class="dim">· ${surface.harness}</span></div>
+        <div><span style="color:${badgeColor}">${surface.state === 'waiting' ? 'W' : '●'}</span> <strong>${copy.label}</strong> <span class="dim">· ${surface.harness}</span></div>
         <div class="dim">${copy.line}</div>
         <div class="rule">────────────────────────────────────────────────────────</div>
         <div><span class="gold">${waitingCount}</span> of ${surfaces.length} surfaces currently need the operator.</div>
         <div class="dim">The tab strip keeps that answer visible through selection, truncation, and overflow.</div>
         <br>
         <div><span class="blue">selection</span> → neutral top rail + raised fill</div>
-        <div><span class="gold">operator turn</span> → prominent gold W alone</div>
-        <div><span class="green">harness</span> → quiet outline hue; other agents share blue</div>`;
+        <div><span class="gold">operator turn</span> → compact gold W alone</div>
+        <div><span class="green">state</span> → color first; motion only while running</div>`;
     }
 
     function setSelectedState(state) {
@@ -771,12 +739,6 @@
       const shown = !document.body.classList.contains('hide-ids');
       event.currentTarget.setAttribute('aria-pressed', shown);
       renderTabs();
-    });
-    document.getElementById('toggleHarness').addEventListener('click', event => {
-      document.body.classList.toggle('neutral-harness');
-      const shown = !document.body.classList.contains('neutral-harness');
-      event.currentTarget.setAttribute('aria-pressed', shown);
-      updateSelection();
     });
     document.getElementById('toggleTheme').addEventListener('click', event => {
       const light = document.body.dataset.theme !== 'light';

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -24,6 +24,7 @@
       --cold: #707681;
       --harness-claude: #d88968;
       --harness-codex: #69b5a8;
+      --harness-other: #6f9ed6;
       --harness-shell: #818791;
       --badge-ink: #08090b;
       --shadow: rgba(0, 0, 0, .72);
@@ -51,6 +52,7 @@
       --cold: #7f8289;
       --harness-claude: #a84f32;
       --harness-codex: #28776d;
+      --harness-other: #386fa8;
       --harness-shell: #6d7178;
       --badge-ink: #fffdf8;
       --shadow: rgba(35, 34, 30, .25);
@@ -225,6 +227,7 @@
     .surface-tab.state-cold { --state: var(--cold); color: color-mix(in srgb, var(--dim) 74%, transparent); }
     .surface-tab.harness-claude { --harness: var(--harness-claude); }
     .surface-tab.harness-codex { --harness: var(--harness-codex); }
+    .surface-tab.harness-other { --harness: var(--harness-other); }
     .surface-tab.harness-shell { --harness: var(--harness-shell); }
     body.neutral-harness .surface-tab { --harness: var(--text-soft); }
     .surface-tab.state-waiting {
@@ -283,27 +286,25 @@
       font-size: 10px;
     }
     .surface-tab.state-running > .state-mark {
-      color: var(--badge-ink);
-      background: var(--harness);
-      border-color: var(--harness);
-      border-top-color: color-mix(in srgb, var(--badge-ink) 74%, transparent);
-      box-shadow: 0 0 7px color-mix(in srgb, var(--harness) 24%, transparent);
+      color: var(--harness);
+      background: transparent;
+      border-color: color-mix(in srgb, var(--harness) 44%, transparent);
+      border-top-color: var(--harness);
       animation: turn 1.8s linear infinite;
     }
     .surface-tab.state-running > .state-mark span { animation: counter-turn 1.8s linear infinite; }
     .surface-tab.state-idle > .state-mark {
-      color: var(--badge-ink);
-      background: var(--harness);
-      border-color: var(--harness);
+      color: var(--harness);
+      background: transparent;
+      border-color: color-mix(in srgb, var(--harness) 78%, transparent);
       border-radius: 4px;
-      box-shadow: 0 0 7px color-mix(in srgb, var(--harness) 24%, transparent);
     }
     .surface-tab.state-cold > .state-mark {
       color: var(--harness);
-      background: color-mix(in srgb, var(--harness) 12%, transparent);
-      border-color: var(--harness);
+      background: transparent;
+      border-color: color-mix(in srgb, var(--harness) 68%, transparent);
       border-style: dotted;
-      opacity: .9;
+      opacity: .8;
     }
     .surface-tab.state-waiting > .state-mark {
       color: var(--badge-ink);
@@ -461,19 +462,14 @@
     .legend-row.waiting { --legend-state: var(--gold); }
     .legend-row strong { color: var(--text-soft); font: 9px var(--mono); font-weight: 650; text-transform: uppercase; }
     .legend-row span:last-child { color: var(--dim); font: 9px/1.3 var(--mono); }
-    .legend-row.running .state-mark,
-    .legend-row.idle .state-mark {
-      color: var(--badge-ink);
-      background: var(--text-soft);
-      border-color: var(--text-soft);
-    }
-    .legend-row.running .state-mark { border-top-color: color-mix(in srgb, var(--badge-ink) 74%, transparent); }
+    .legend-row.running .state-mark { border-color: color-mix(in srgb, var(--text-soft) 44%, transparent); border-top-color: var(--text-soft); }
     .legend-row.idle .state-mark { border-radius: 3px; }
     .legend-row.cold .state-mark { border-style: dotted; }
     .legend-row.waiting .state-mark { color: var(--badge-ink); background: var(--gold); border-color: var(--gold); border-radius: 3px; }
     .harness-key {
       display: flex;
       align-items: center;
+      flex-wrap: wrap;
       gap: 10px;
       margin-top: 12px;
       color: var(--dim);
@@ -485,6 +481,7 @@
     .harness-swatch { width: 7px; height: 7px; border-radius: 50%; background: var(--swatch); }
     .harness-swatch.claude { --swatch: var(--harness-claude); }
     .harness-swatch.codex { --swatch: var(--harness-codex); }
+    .harness-swatch.other { --swatch: var(--harness-other); }
     .harness-swatch.shell { --swatch: var(--harness-shell); }
     .option-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
     .option-button[aria-pressed="true"] { color: var(--gold); border-color: color-mix(in srgb, var(--gold) 55%, var(--rule)); }
@@ -602,6 +599,7 @@
             <div class="harness-key" aria-label="Harness color key">
               <span><i class="harness-swatch claude"></i> Claude</span>
               <span><i class="harness-swatch codex"></i> Codex</span>
+              <span><i class="harness-swatch other"></i> Other agent</span>
               <span><i class="harness-swatch shell"></i> Shell</span>
             </div>
 
@@ -615,7 +613,7 @@
             </div>
 
             <div class="collision-note">
-              <b>One badge, two reads.</b> R/I/C/W names state; solid badge hue names the harness. Waiting overrides hue with gold alone. Close remains hard-right.
+              <b>One badge, two reads.</b> R/I/C/W names state; quiet outline hue names the harness. Other agent harnesses share blue. Waiting overrides hue with gold alone. Close remains hard-right.
             </div>
           </aside>
         </div>
@@ -632,11 +630,11 @@
       { id: 72, title: 'Release staging', state: 'running', harness: 'claude', description: 'Building and validating the signed release candidate.' },
       { id: 77, title: 'Mailbox attribution', state: 'idle', harness: 'codex', description: 'At the prompt after completing the attribution copy pass.' },
       { id: 91, title: 'Socket watchdog', state: 'cold', harness: 'shell', description: 'Resumable terminal; no agent process is currently live.' },
-      { id: 105, title: 'Browser regression sweep', state: 'running', harness: 'claude', description: 'Exercising browser navigation, snapshots, and auth-state restore.' },
-      { id: 118, title: 'Theme conformance', state: 'idle', harness: 'codex', description: 'Dark and light c11 theme slot review is complete.' },
+      { id: 105, title: 'Browser regression sweep', state: 'running', harness: 'opencode', description: 'Exercising browser navigation, snapshots, and auth-state restore.' },
+      { id: 118, title: 'Theme conformance', state: 'idle', harness: 'oh-my-pi', description: 'Dark and light c11 theme slot review is complete.' },
       { id: 126, title: 'Japanese localization', state: 'cold', harness: 'claude', description: 'Session ended after committing the locale update.' },
       { id: 144, title: 'Workspace snapshot recovery validation and persistence audit', state: 'waiting', harness: 'codex', description: 'Needs approval to replace the corrupted fixture with a captured snapshot.' },
-      { id: 158, title: 'Docs pruning', state: 'idle', harness: 'claude', description: 'At the prompt with a clean documentation diff.' },
+      { id: 158, title: 'Docs pruning', state: 'idle', harness: 'pi', description: 'At the prompt with a clean documentation diff.' },
       { id: 203, title: 'Flaky focus test diagnosis', state: 'running', harness: 'codex', description: 'Repeating the focused-pane event test under contention.' }
     ];
 
@@ -650,6 +648,7 @@
     const harnessColors = {
       claude: 'var(--harness-claude)',
       codex: 'var(--harness-codex)',
+      other: 'var(--harness-other)',
       shell: 'var(--harness-shell)'
     };
 
@@ -664,10 +663,14 @@
       return Math.max(112, Math.min(190, 52 + idCost + surface.title.length * 4));
     }
 
+    function harnessFamily(harness) {
+      return ['claude', 'codex', 'shell'].includes(harness) ? harness : 'other';
+    }
+
     function tabMarkup(surface) {
       const copy = stateCopy[surface.state];
       return `
-        <div class="surface-tab state-${surface.state} harness-${surface.harness}${surface.id === selectedId ? ' selected' : ''}"
+        <div class="surface-tab state-${surface.state} harness-${harnessFamily(surface.harness)}${surface.id === selectedId ? ' selected' : ''}"
              style="--tab-width:${widthFor(surface)}px"
              data-id="${surface.id}" role="tab" tabindex="0"
              aria-selected="${surface.id === selectedId}" aria-label="${surface.title}, ${copy.label}, ${surface.harness} harness"
@@ -719,7 +722,7 @@
       const copy = stateCopy[surface.state];
       const harnessColor = document.body.classList.contains('neutral-harness')
         ? 'var(--text-soft)'
-        : harnessColors[surface.harness];
+        : harnessColors[harnessFamily(surface.harness)];
       const badgeColor = surface.state === 'waiting' ? copy.color : harnessColor;
       const waitingCount = surfaces.filter(item => item.state === 'waiting').length;
       document.getElementById('surfaceTitle').textContent = `surface:${surface.id} · ${surface.title}`;
@@ -742,7 +745,7 @@
         <br>
         <div><span class="blue">selection</span> → neutral top rail + raised fill</div>
         <div><span class="gold">operator turn</span> → prominent gold W alone</div>
-        <div><span class="green">harness</span> → badge hue; no second glyph</div>`;
+        <div><span class="green">harness</span> → quiet outline hue; other agents share blue</div>`;
     }
 
     function setSelectedState(state) {

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -199,7 +199,7 @@
       display: flex;
       align-items: center;
       gap: 0;
-      padding: 0 2px 1px;
+      padding: 0 2px 1px 4px;
       overflow: hidden;
       color: var(--dim);
       background: transparent;
@@ -270,12 +270,16 @@
     }
     .state-mark > span { display: none; }
     .surface-tab > .state-mark {
-      width: 18px;
+      width: 10px;
       height: 18px;
-      flex: 0 0 18px;
-      place-items: center start;
-      margin-right: 5px;
+      flex: 0 0 10px;
+      place-items: center;
+      margin-right: 4px;
       color: var(--state);
+    }
+    .surface-tab > .state-mark.state-waiting {
+      width: 17px;
+      flex-basis: 17px;
     }
     .state-mark.state-running::before {
       width: 10px;

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -233,9 +233,9 @@
     }
 
     .close-tab {
-      width: 24px;
-      height: 27px;
-      flex: 0 0 24px;
+      width: 28px;
+      height: 29px;
+      flex: 0 0 28px;
       display: grid;
       place-items: center;
       margin-left: auto;

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -262,6 +262,7 @@
     .state-mark::before {
       content: "";
       display: block;
+      grid-area: 1 / 1;
       width: 8px;
       height: 8px;
       background: currentColor;
@@ -307,10 +308,15 @@
       box-shadow: 0 0 8px color-mix(in srgb, var(--gold) 30%, transparent);
     }
     .state-mark.state-waiting > span {
-      display: block;
-      position: absolute;
+      grid-area: 1 / 1;
+      display: grid;
+      place-items: center;
+      width: 17px;
+      height: 17px;
+      z-index: 1;
       font: 8px/1 var(--mono);
-      font-weight: 750;
+      font-weight: 700;
+      text-align: center;
     }
     @keyframes turn { to { transform: rotate(360deg); } }
     .tab-title {


### PR DESCRIPTION
## Summary
- add running, idle, cold, and waiting activity grammar to surface tabs without coupling state to selection
- preserve activity across transfer, rollback, restore, and metadata mutation lifecycles
- keep the trailing close target usable in dense/overflow layouts, including successful and vetoed background-close focus behavior
- localize activity accessibility across all seven shipped locales and expose state in full, overflow-row, and collapsed-header presentations

## Validation
- exact-HEAD tagged build `c11-184-surface-pulse`: passed
- focused parent lifecycle/metadata tests: passed
- rendered Bonsplit collapsed close/accessibility tests: passed
- final context-clean review: PASS
- full Bonsplit suite retains only the documented six pre-existing assertions in two baseline interaction tests; all C11-184 tests pass

Lattice: C11-184