### PR TITLE
C11-191 Persist companion links across workspace artifacts

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -304,6 +304,9 @@ struct SessionBrowserPanelSnapshot: Codable, Sendable {
     var developerToolsVisible: Bool
     var backHistoryURLStrings: [String]?
     var forwardHistoryURLStrings: [String]?
+    /// Durable browser-to-agent association. Optional so pre-companion
+    /// session-v1 snapshots continue to decode unchanged.
+    var linkedAgent: AgentSurfaceLink? = nil
 }
 
 struct SessionMarkdownPanelSnapshot: Codable, Sendable {
@@ -488,6 +491,9 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     /// Operator-authored workspace metadata (e.g. description, icon).
     /// Optional for backward compatibility with pre-metadata snapshots.
     var metadata: [String: String]?
+    /// Session-only active companion context. Blueprints and snapshots do not
+    /// carry this transient focus-derived value.
+    var activeAgentSurfaceId: UUID? = nil
 }
 
 struct SessionTabManagerSnapshot: Codable, Sendable {

--- a/Sources/SocketHandlers/SnapshotHandlers.swift
+++ b/Sources/SocketHandlers/SnapshotHandlers.swift
@@ -188,13 +188,18 @@ extension TerminalController {
         return .ok(payload)
     }
 
-    private nonisolated static func companionDiagnosticPayload(
+    nonisolated static func companionDiagnosticPayload(
         _ diagnostic: CompanionPlanDiagnostic
     ) -> [String: Any] {
         var payload: [String: Any] = [
             "code": diagnostic.code.rawValue,
             "severity": diagnostic.severity.rawValue,
-            "source_plan_id": diagnostic.sourcePlanID
+            "source_plan_id": diagnostic.sourcePlanID,
+            "message": CompanionPlanDiagnosticMessage.localized(
+                code: diagnostic.code,
+                sourcePlanID: diagnostic.sourcePlanID,
+                targetPlanID: diagnostic.targetPlanID
+            )
         ]
         if let target = diagnostic.targetPlanID {
             payload["target_plan_id"] = target

--- a/Sources/SocketHandlers/SnapshotHandlers.swift
+++ b/Sources/SocketHandlers/SnapshotHandlers.swift
@@ -63,16 +63,26 @@ extension TerminalController {
         // so each inner snapshot stays independently restorable.
         let captureAll = (params["all"] as? Bool) == true
         if captureAll {
-            var snapshots: [(envelope: WorkspaceSnapshotFile, ref: String, isSelected: Bool)] = []
+            var snapshots: [(
+                envelope: WorkspaceSnapshotFile,
+                ref: String,
+                isSelected: Bool,
+                warnings: [CompanionPlanDiagnostic]
+            )] = []
             v2MainSync {
                 let source = LiveWorkspaceSnapshotSource(tabManager: tabManager)
                 let selectedId = tabManager.selectedWorkspace?.id
                 for ws in tabManager.tabs {
-                    if let envelope = source.capture(
+                    if let capture = source.captureResult(
                         workspaceId: ws.id, origin: origin, clock: { Date() }
                     ) {
                         let ref = self.v2EnsureHandleRef(kind: .workspace, uuid: ws.id)
-                        snapshots.append((envelope, ref, ws.id == selectedId))
+                        snapshots.append((
+                            capture.snapshot,
+                            ref,
+                            ws.id == selectedId,
+                            capture.warnings
+                        ))
                     }
                 }
             }
@@ -82,14 +92,15 @@ extension TerminalController {
             var selectedIndex: Int?
             var anyWriteFailed = false
             for (offset, item) in snapshots.enumerated() {
-                let (envelope, ref, isSelected) = item
+                let (envelope, ref, isSelected, captureWarnings) = item
                 do {
                     let path = try store.writeToDefaultDirectory(envelope)
                     var row: [String: Any] = [
                         "snapshot_id": envelope.snapshotId,
                         "path": path.path,
                         "surface_count": envelope.plan.surfaces.count,
-                        "workspace_ref": ref
+                        "workspace_ref": ref,
+                        "warnings": captureWarnings.map(Self.companionDiagnosticPayload)
                     ]
                     if isSelected { row["selected"] = true }
                     results.append(row)
@@ -104,7 +115,8 @@ extension TerminalController {
                     results.append([
                         "snapshot_id": envelope.snapshotId,
                         "error": "\(error)",
-                        "workspace_ref": ref
+                        "workspace_ref": ref,
+                        "warnings": captureWarnings.map(Self.companionDiagnosticPayload)
                     ])
                     anyWriteFailed = true
                 }
@@ -141,17 +153,22 @@ extension TerminalController {
             return .ok(payload)
         }
 
-        var snapshot: WorkspaceSnapshotFile?
+        var captureResult: WorkspaceSnapshotCaptureResult?
         var workspaceRef = ""
         v2MainSync {
             guard let workspace = v2ResolveWorkspace(params: params, tabManager: tabManager) else { return }
             let source = LiveWorkspaceSnapshotSource(tabManager: tabManager)
-            snapshot = source.capture(workspaceId: workspace.id, origin: origin, clock: { Date() })
+            captureResult = source.captureResult(
+                workspaceId: workspace.id,
+                origin: origin,
+                clock: { Date() }
+            )
             workspaceRef = self.v2EnsureHandleRef(kind: .workspace, uuid: workspace.id)
         }
-        guard let envelope = snapshot else {
+        guard let captureResult else {
             return .err(code: "not_found", message: "Workspace not found for snapshot.create", data: nil)
         }
+        let envelope = captureResult.snapshot
         let store = WorkspaceSnapshotStore()
         let path: URL
         do {
@@ -165,9 +182,24 @@ extension TerminalController {
             "snapshot_id": envelope.snapshotId,
             "path": path.path,
             "surface_count": envelope.plan.surfaces.count,
-            "workspace_ref": workspaceRef
+            "workspace_ref": workspaceRef,
+            "warnings": captureResult.warnings.map(Self.companionDiagnosticPayload)
         ]
         return .ok(payload)
+    }
+
+    private nonisolated static func companionDiagnosticPayload(
+        _ diagnostic: CompanionPlanDiagnostic
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "code": diagnostic.code.rawValue,
+            "severity": diagnostic.severity.rawValue,
+            "source_plan_id": diagnostic.sourcePlanID
+        ]
+        if let target = diagnostic.targetPlanID {
+            payload["target_plan_id"] = target
+        }
+        return payload
     }
 
     /// `snapshot.restore`: read a snapshot by id, run the embedded plan

--- a/Sources/WorkspaceApplyPlan.swift
+++ b/Sources/WorkspaceApplyPlan.swift
@@ -89,6 +89,11 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
     /// values verbatim. v1 strings-only: non-string values on a `mailbox.*`
     /// key surface as a warning in `ApplyResult` and are dropped.
     var paneMetadata: [String: PersistedJSONValue]?
+    /// Browser-only plan-local link target. Resolved after every surface has
+    /// been materialized so forward references are deterministic.
+    var linkedAgentSurfacePlanId: String?
+    /// Terminal-only declared agent identity used to validate link targets.
+    var declaredAgentKind: String?
 
     init(
         id: String,
@@ -101,6 +106,8 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
         filePath: String? = nil,
         metadata: [String: PersistedJSONValue]? = nil,
         paneMetadata: [String: PersistedJSONValue]? = nil,
+        linkedAgentSurfacePlanId: String? = nil,
+        declaredAgentKind: String? = nil,
         submitCommand: Bool = false
     ) {
         self.id = id
@@ -113,6 +120,8 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
         self.filePath = filePath
         self.metadata = metadata
         self.paneMetadata = paneMetadata
+        self.linkedAgentSurfacePlanId = linkedAgentSurfacePlanId
+        self.declaredAgentKind = declaredAgentKind
         self.submitCommand = submitCommand
     }
 
@@ -126,6 +135,7 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
     private enum CodingKeys: String, CodingKey {
         case id, kind, title, description, workingDirectory, command, url
         case filePath, metadata, paneMetadata, submitCommand
+        case linkedAgentSurfacePlanId, declaredAgentKind
     }
 
     init(from decoder: Decoder) throws {
@@ -140,6 +150,8 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
         filePath = try c.decodeIfPresent(String.self, forKey: .filePath)
         metadata = try c.decodeIfPresent([String: PersistedJSONValue].self, forKey: .metadata)
         paneMetadata = try c.decodeIfPresent([String: PersistedJSONValue].self, forKey: .paneMetadata)
+        linkedAgentSurfacePlanId = try c.decodeIfPresent(String.self, forKey: .linkedAgentSurfacePlanId)
+        declaredAgentKind = try c.decodeIfPresent(String.self, forKey: .declaredAgentKind)
         submitCommand = try c.decodeIfPresent(Bool.self, forKey: .submitCommand) ?? false
     }
 
@@ -155,6 +167,8 @@ struct SurfaceSpec: Codable, Sendable, Equatable {
         try c.encodeIfPresent(filePath, forKey: .filePath)
         try c.encodeIfPresent(metadata, forKey: .metadata)
         try c.encodeIfPresent(paneMetadata, forKey: .paneMetadata)
+        try c.encodeIfPresent(linkedAgentSurfacePlanId, forKey: .linkedAgentSurfacePlanId)
+        try c.encodeIfPresent(declaredAgentKind, forKey: .declaredAgentKind)
         // Omit when false so pre-existing serialized specs stay byte-identical.
         if submitCommand { try c.encode(submitCommand, forKey: .submitCommand) }
     }
@@ -386,6 +400,9 @@ struct ApplyResult: Codable, Sendable, Equatable {
     /// warning has a stable code.
     var warnings: [String]
     var failures: [ApplyFailure]
+    /// Stable structured companion diagnostics. Human-readable mirrors remain
+    /// in `warnings`/`failures` for existing clients.
+    var companionDiagnostics: [CompanionPlanDiagnostic]
 
     init(
         workspaceRef: String = "",
@@ -393,7 +410,8 @@ struct ApplyResult: Codable, Sendable, Equatable {
         paneRefs: [String: String] = [:],
         timings: [StepTiming] = [],
         warnings: [String] = [],
-        failures: [ApplyFailure] = []
+        failures: [ApplyFailure] = [],
+        companionDiagnostics: [CompanionPlanDiagnostic] = []
     ) {
         self.workspaceRef = workspaceRef
         self.surfaceRefs = surfaceRefs
@@ -401,5 +419,38 @@ struct ApplyResult: Codable, Sendable, Equatable {
         self.timings = timings
         self.warnings = warnings
         self.failures = failures
+        self.companionDiagnostics = companionDiagnostics
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case workspaceRef, surfaceRefs, paneRefs, timings, warnings, failures
+        case companionDiagnostics
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        workspaceRef = try c.decode(String.self, forKey: .workspaceRef)
+        surfaceRefs = try c.decode([String: String].self, forKey: .surfaceRefs)
+        paneRefs = try c.decode([String: String].self, forKey: .paneRefs)
+        timings = try c.decode([StepTiming].self, forKey: .timings)
+        warnings = try c.decode([String].self, forKey: .warnings)
+        failures = try c.decode([ApplyFailure].self, forKey: .failures)
+        companionDiagnostics = try c.decodeIfPresent(
+            [CompanionPlanDiagnostic].self,
+            forKey: .companionDiagnostics
+        ) ?? []
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(workspaceRef, forKey: .workspaceRef)
+        try c.encode(surfaceRefs, forKey: .surfaceRefs)
+        try c.encode(paneRefs, forKey: .paneRefs)
+        try c.encode(timings, forKey: .timings)
+        try c.encode(warnings, forKey: .warnings)
+        try c.encode(failures, forKey: .failures)
+        if !companionDiagnostics.isEmpty {
+            try c.encode(companionDiagnostics, forKey: .companionDiagnostics)
+        }
     }
 }

--- a/Sources/WorkspaceApplyPlan.swift
+++ b/Sources/WorkspaceApplyPlan.swift
@@ -385,6 +385,74 @@ struct ApplyFailure: Codable, Sendable, Equatable {
     }
 }
 
+/// Localized human-readable companion diagnostics for user-facing apply and
+/// snapshot response boundaries. The structured diagnostic remains the
+/// stable machine contract; callers add this message when presenting it.
+enum CompanionPlanDiagnosticMessage {
+    static func localized(
+        code: CompanionPlanDiagnosticCode,
+        sourcePlanID: String,
+        targetPlanID: String?,
+        detail: String? = nil
+    ) -> String {
+        let target = targetPlanID ?? ""
+        switch code {
+        case .orphanOmitted:
+            if let targetPlanID {
+                return String(
+                    localized: "workspace.companion.diagnostic.orphanOmittedKnownTarget",
+                    defaultValue: "Companion link from '\(sourcePlanID)' to '\(targetPlanID)' was omitted because the target is not a recognized agent terminal."
+                )
+            }
+            return String(
+                localized: "workspace.companion.diagnostic.orphanOmittedMissingTarget",
+                defaultValue: "Companion link from '\(sourcePlanID)' was omitted because its linked agent is not present in the captured workspace."
+            )
+        case .sourceNotBrowser:
+            return String(
+                localized: "workspace.companion.diagnostic.sourceNotBrowser",
+                defaultValue: "Companion link source '\(sourcePlanID)' is not a browser."
+            )
+        case .targetMissing:
+            return String(
+                localized: "workspace.companion.diagnostic.targetMissing",
+                defaultValue: "Companion link target '\(target)' for browser '\(sourcePlanID)' is missing."
+            )
+        case .targetNotTerminal:
+            return String(
+                localized: "workspace.companion.diagnostic.targetNotTerminal",
+                defaultValue: "Companion link target '\(target)' for browser '\(sourcePlanID)' is not a terminal."
+            )
+        case .targetNotAgent:
+            return String(
+                localized: "workspace.companion.diagnostic.targetNotAgent",
+                defaultValue: "Companion link target '\(target)' for browser '\(sourcePlanID)' is not a declared agent."
+            )
+        case .applyFailed:
+            if let detail, !detail.isEmpty {
+                return String(
+                    localized: "workspace.companion.diagnostic.applyFailedWithDetail",
+                    defaultValue: "Could not apply companion link from '\(sourcePlanID)' to '\(target)': \(detail)"
+                )
+            }
+            return String(
+                localized: "workspace.companion.diagnostic.applyFailed",
+                defaultValue: "Could not apply companion link from '\(sourcePlanID)' to '\(target)'."
+            )
+        case .duplicateSurfaceID:
+            return String(
+                localized: "workspace.companion.diagnostic.duplicateSurfaceID",
+                defaultValue: "Blueprint surface ID '\(sourcePlanID)' is duplicated."
+            )
+        case .invalidAgentKind:
+            return String(
+                localized: "workspace.companion.diagnostic.invalidAgentKind",
+                defaultValue: "Blueprint surface '\(sourcePlanID)' declares an invalid agent kind."
+            )
+        }
+    }
+}
+
 struct ApplyResult: Codable, Sendable, Equatable {
     /// Live workspace ref (`workspace:N`) assigned by the v2 ref helper after
     /// creation. Empty string if the plan failed validation before the

--- a/Sources/WorkspaceBlueprintExporter.swift
+++ b/Sources/WorkspaceBlueprintExporter.swift
@@ -6,6 +6,11 @@ import AppKit
 /// Delegates the walk to `WorkspacePlanCapture.capture(workspace:)` — the
 /// same shared helper used by `LiveWorkspaceSnapshotSource` — so Blueprints
 /// and Snapshots always serialise surface state with identical fidelity.
+struct WorkspaceBlueprintExportResult: Sendable {
+    var file: WorkspaceBlueprintFile
+    var warnings: [CompanionPlanDiagnostic]
+}
+
 @MainActor
 struct WorkspaceBlueprintExporter {
     let tabManager: TabManager
@@ -18,15 +23,34 @@ struct WorkspaceBlueprintExporter {
         name: String,
         description: String? = nil
     ) -> WorkspaceBlueprintFile? {
+        exportWithDiagnostics(
+            workspaceId: workspaceId,
+            name: name,
+            description: description
+        )?.file
+    }
+
+    func exportWithDiagnostics(
+        workspaceId: UUID,
+        name: String,
+        description: String? = nil,
+        companionBridge: WorkspacePlanCompanionCaptureBridge? = nil
+    ) -> WorkspaceBlueprintExportResult? {
         guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
             return nil
         }
-        let plan = WorkspacePlanCapture.capture(workspace: workspace)
-        return WorkspaceBlueprintFile(
-            version: 1,
-            name: name,
-            description: description,
-            plan: plan
+        let capture = WorkspacePlanCapture.capture(
+            workspace: workspace,
+            companionBridge: companionBridge
+        )
+        return WorkspaceBlueprintExportResult(
+            file: WorkspaceBlueprintFile(
+                version: 1,
+                name: name,
+                description: description,
+                plan: capture.plan
+            ),
+            warnings: capture.warnings
         )
     }
 }

--- a/Sources/WorkspaceBlueprintMarkdown.swift
+++ b/Sources/WorkspaceBlueprintMarkdown.swift
@@ -49,6 +49,9 @@ import Foundation
 /// - `frontmatter.description` ↔ `WorkspaceBlueprintFile.description`.
 /// - `frontmatter.custom_color` ↔ `WorkspaceSpec.customColor`.
 /// - The layout tree is encoded under `## Layout` in a fenced YAML block.
+/// - Every surface emits an explicit, plan-local `id:`. IDs must be unique.
+///   Explicit IDs are reserved before generated `sN` fallbacks, so authored
+///   forward links cannot be stolen by an earlier anonymous surface.
 ///   `WorkspaceSpec.workingDirectory` and `WorkspaceSpec.metadata`,
 ///   `SurfaceSpec.description`, `SurfaceSpec.metadata`, and
 ///   `SurfaceSpec.paneMetadata` are silently dropped on serialise; their
@@ -68,6 +71,13 @@ enum WorkspaceBlueprintMarkdown {
         case wrongChildCount(Int)
         case missingType
         case unsupportedSurfaceKind(String)
+        case duplicateSurfaceID(String)
+        case invalidAgentKind(surfaceID: String, kind: String)
+        case invalidCompanionLink(
+            code: CompanionPlanDiagnosticCode,
+            sourceID: String,
+            targetID: String?
+        )
 
         var description: String {
             switch self {
@@ -116,6 +126,22 @@ enum WorkspaceBlueprintMarkdown {
                     localized: "blueprint.markdown.error.unsupportedSurfaceKind",
                     defaultValue: "blueprint markdown: unsupported surface kind '\(raw)' (expected terminal/browser/markdown)"
                 )
+            case .duplicateSurfaceID(let id):
+                return String(
+                    localized: "blueprint.markdown.error.duplicateSurfaceID",
+                    defaultValue: "blueprint markdown: duplicate surface id '\(id)' [\(CompanionPlanDiagnosticCode.duplicateSurfaceID.rawValue)]"
+                )
+            case .invalidAgentKind(let surfaceID, let kind):
+                return String(
+                    localized: "blueprint.markdown.error.invalidAgentKind",
+                    defaultValue: "blueprint markdown: invalid agent_kind '\(kind)' on surface '\(surfaceID)' [\(CompanionPlanDiagnosticCode.invalidAgentKind.rawValue)]"
+                )
+            case .invalidCompanionLink(let code, let sourceID, let targetID):
+                let target = targetID.map { " -> '\($0)'" } ?? ""
+                return String(
+                    localized: "blueprint.markdown.error.invalidCompanionLink",
+                    defaultValue: "blueprint markdown: invalid companion link '\(sourceID)'\(target) [\(code.rawValue)]"
+                )
             }
         }
     }
@@ -134,9 +160,12 @@ enum WorkspaceBlueprintMarkdown {
         guard let rootNode = layoutList.first else {
             throw ParseError.yamlParseFailed("`layout:` is missing or empty")
         }
-        var idGen = SurfaceIDGenerator()
+        var explicitIDs = Set<String>()
+        try reserveExplicitSurfaceIDs(in: rootNode, reserved: &explicitIDs)
+        var idGen = SurfaceIDGenerator(reservedIDs: explicitIDs)
         var surfaces: [SurfaceSpec] = []
         let layout = try buildLayoutTree(from: rootNode, surfaces: &surfaces, idGen: &idGen)
+        try validateCompanionFields(in: surfaces)
 
         let workspaceTitle = frontKV["workspace_title"] ?? frontKV["title"]
         let customColor = frontKV["custom_color"]
@@ -288,10 +317,47 @@ enum WorkspaceBlueprintMarkdown {
 
     private struct SurfaceIDGenerator {
         var counter: Int = 1
+        var reservedIDs: Set<String>
+
         mutating func mint() -> String {
-            defer { counter += 1 }
-            return "s\(counter)"
+            while reservedIDs.contains("s\(counter)") {
+                counter += 1
+            }
+            let id = "s\(counter)"
+            counter += 1
+            reservedIDs.insert(id)
+            return id
         }
+    }
+
+    private static func reserveExplicitSurfaceIDs(
+        in node: YAML.Value,
+        reserved: inout Set<String>
+    ) throws {
+        let keys = Set((node.asMapping ?? []).map { $0.0 })
+        if keys.contains("direction") || keys.contains("children") {
+            for child in node.lookup("children")?.asList ?? [] {
+                try reserveExplicitSurfaceIDs(in: child, reserved: &reserved)
+            }
+            return
+        }
+        if keys.contains("tabs") {
+            for tab in node.lookup("tabs")?.asList ?? [] {
+                try reserveExplicitSurfaceIDs(in: tab, reserved: &reserved)
+            }
+            return
+        }
+        guard let id = nullIfEmpty(node.lookup("id")?.asScalar) else { return }
+        guard reserved.insert(id).inserted else {
+            throw ParseError.duplicateSurfaceID(id)
+        }
+    }
+
+    private static func surfaceID(
+        from node: YAML.Value,
+        generator: inout SurfaceIDGenerator
+    ) -> String {
+        nullIfEmpty(node.lookup("id")?.asScalar) ?? generator.mint()
     }
 
     private static func buildLayoutTree(
@@ -330,7 +396,7 @@ enum WorkspaceBlueprintMarkdown {
             let tabs = node.lookup("tabs")?.asList ?? []
             var ids: [String] = []
             for tab in tabs {
-                let id = idGen.mint()
+                let id = surfaceID(from: tab, generator: &idGen)
                 ids.append(id)
                 surfaces.append(try buildSurfaceSpec(id: id, from: tab))
             }
@@ -342,7 +408,7 @@ enum WorkspaceBlueprintMarkdown {
         }
 
         // Single-tab leaf: has `type:` directly.
-        let id = idGen.mint()
+        let id = surfaceID(from: node, generator: &idGen)
         surfaces.append(try buildSurfaceSpec(id: id, from: node))
         return .pane(LayoutTreeSpec.PaneSpec(surfaceIds: [id], selectedIndex: nil))
     }
@@ -359,6 +425,8 @@ enum WorkspaceBlueprintMarkdown {
         let url = node.lookup("url")?.asScalar
         let file = node.lookup("file")?.asScalar
         let command = node.lookup("command")?.asScalar
+        let declaredAgentKind = nullIfEmpty(node.lookup("agent_kind")?.asScalar)
+        let linkedAgentSurfacePlanId = nullIfEmpty(node.lookup("linked_agent")?.asScalar)
         // Opt-in `submit:` — only the exact scalar `true` (case-insensitive)
         // enables execution; anything else, including absence, stays false.
         let submit = node.lookup("submit")?.asScalar?.lowercased() == "true"
@@ -373,8 +441,49 @@ enum WorkspaceBlueprintMarkdown {
             filePath: nullIfEmpty(file),
             metadata: nil,
             paneMetadata: nil,
+            linkedAgentSurfacePlanId: linkedAgentSurfacePlanId,
+            declaredAgentKind: declaredAgentKind,
             submitCommand: submit
         )
+    }
+
+    private static func validateCompanionFields(in surfaces: [SurfaceSpec]) throws {
+        let byID = Dictionary(uniqueKeysWithValues: surfaces.map { ($0.id, $0) })
+        for surface in surfaces {
+            if let declaredKind = surface.declaredAgentKind,
+               surface.kind != .terminal || !AgentIdentityPolicy.isAgentKind(declaredKind) {
+                throw ParseError.invalidAgentKind(surfaceID: surface.id, kind: declaredKind)
+            }
+            guard let targetID = surface.linkedAgentSurfacePlanId else { continue }
+            guard surface.kind == .browser else {
+                throw ParseError.invalidCompanionLink(
+                    code: .sourceNotBrowser,
+                    sourceID: surface.id,
+                    targetID: targetID
+                )
+            }
+            guard let target = byID[targetID] else {
+                throw ParseError.invalidCompanionLink(
+                    code: .targetMissing,
+                    sourceID: surface.id,
+                    targetID: targetID
+                )
+            }
+            guard target.kind == .terminal else {
+                throw ParseError.invalidCompanionLink(
+                    code: .targetNotTerminal,
+                    sourceID: surface.id,
+                    targetID: targetID
+                )
+            }
+            guard AgentIdentityPolicy.isAgentKind(target.declaredAgentKind) else {
+                throw ParseError.invalidCompanionLink(
+                    code: .targetNotAgent,
+                    sourceID: surface.id,
+                    targetID: targetID
+                )
+            }
+        }
     }
 
     private static func parseSplitRatio(_ raw: String) throws -> Double {
@@ -470,7 +579,14 @@ enum WorkspaceBlueprintMarkdown {
         restPad: String
     ) -> String {
         var out = ""
-        out += "\(firstLinePad)type: \(surface.kind.rawValue)\n"
+        out += "\(firstLinePad)id: \(quoteIfNeeded(surface.id))\n"
+        out += "\(restPad)type: \(surface.kind.rawValue)\n"
+        if let agentKind = surface.declaredAgentKind {
+            out += "\(restPad)agent_kind: \(quoteIfNeeded(agentKind))\n"
+        }
+        if let linkedAgent = surface.linkedAgentSurfacePlanId {
+            out += "\(restPad)linked_agent: \(quoteIfNeeded(linkedAgent))\n"
+        }
         if let title = surface.title {
             out += "\(restPad)title: \(quoteIfNeeded(title))\n"
         }

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -211,8 +211,14 @@ enum WorkspaceLayoutExecutor {
             _ code: CompanionPlanDiagnosticCode,
             source: String,
             target: String?,
-            message: String
+            detail: String? = nil
         ) {
+            let message = CompanionPlanDiagnosticMessage.localized(
+                code: code,
+                sourcePlanID: source,
+                targetPlanID: target,
+                detail: detail
+            )
             companionDiagnostics.append(CompanionPlanDiagnostic(
                 code: code,
                 severity: .error,
@@ -233,8 +239,7 @@ enum WorkspaceLayoutExecutor {
                 recordCompanionDiagnostic(
                     .sourceNotBrowser,
                     source: sourceSpec.id,
-                    target: targetPlanID,
-                    message: "companion link source '\(sourceSpec.id)' is not a browser"
+                    target: targetPlanID
                 )
                 continue
             }
@@ -242,8 +247,7 @@ enum WorkspaceLayoutExecutor {
                 recordCompanionDiagnostic(
                     .targetMissing,
                     source: sourceSpec.id,
-                    target: targetPlanID,
-                    message: "companion link target '\(targetPlanID)' is missing"
+                    target: targetPlanID
                 )
                 continue
             }
@@ -251,8 +255,7 @@ enum WorkspaceLayoutExecutor {
                 recordCompanionDiagnostic(
                     .targetNotTerminal,
                     source: sourceSpec.id,
-                    target: targetPlanID,
-                    message: "companion link target '\(targetPlanID)' is not a terminal"
+                    target: targetPlanID
                 )
                 continue
             }
@@ -260,8 +263,7 @@ enum WorkspaceLayoutExecutor {
                 recordCompanionDiagnostic(
                     .targetNotAgent,
                     source: sourceSpec.id,
-                    target: targetPlanID,
-                    message: "companion link target '\(targetPlanID)' is not a declared agent"
+                    target: targetPlanID
                 )
                 continue
             }
@@ -271,8 +273,7 @@ enum WorkspaceLayoutExecutor {
                 recordCompanionDiagnostic(
                     .applyFailed,
                     source: sourceSpec.id,
-                    target: targetPlanID,
-                    message: "companion link '\(sourceSpec.id)' -> '\(targetPlanID)' could not be applied"
+                    target: targetPlanID
                 )
                 continue
             }
@@ -283,7 +284,7 @@ enum WorkspaceLayoutExecutor {
                     .applyFailed,
                     source: sourceSpec.id,
                     target: targetPlanID,
-                    message: "companion link '\(sourceSpec.id)' -> '\(targetPlanID)' failed: \(error)"
+                    detail: String(describing: error)
                 )
             }
         }

--- a/Sources/WorkspaceLayoutExecutor.swift
+++ b/Sources/WorkspaceLayoutExecutor.swift
@@ -15,17 +15,22 @@ struct WorkspaceLayoutExecutorDependencies {
     var workspaceRefMinter: (UUID) -> String
     var surfaceRefMinter: (UUID) -> String
     var paneRefMinter: (UUID) -> String
+    /// ACB-06 supplies the live Workspace/BrowserPanel mutation. Keeping it
+    /// injected lets this persistence lane compile without hotspot edits.
+    var applyCompanionLink: (@MainActor (Workspace, UUID, UUID) throws -> Void)?
 
     init(
         tabManager: TabManager,
         workspaceRefMinter: @escaping (UUID) -> String,
         surfaceRefMinter: @escaping (UUID) -> String,
-        paneRefMinter: @escaping (UUID) -> String
+        paneRefMinter: @escaping (UUID) -> String,
+        applyCompanionLink: (@MainActor (Workspace, UUID, UUID) throws -> Void)? = nil
     ) {
         self.tabManager = tabManager
         self.workspaceRefMinter = workspaceRefMinter
         self.surfaceRefMinter = surfaceRefMinter
         self.paneRefMinter = paneRefMinter
+        self.applyCompanionLink = applyCompanionLink
     }
 }
 
@@ -67,6 +72,7 @@ enum WorkspaceLayoutExecutor {
         var timings: [StepTiming] = []
         var warnings: [String] = []
         var failures: [ApplyFailure] = []
+        var companionDiagnostics: [CompanionPlanDiagnostic] = []
 
         // Step 1 — validate the plan locally before any AppKit state changes.
         let validateClock = StepClock()
@@ -196,6 +202,90 @@ enum WorkspaceLayoutExecutor {
         for failure in dividerFailures {
             walkState.failures.append(failure)
             walkState.warnings.append(failure.message)
+        }
+
+        // Step 6 — resolve browser companion links only after every surface
+        // has been materialized. This is what makes forward references and a
+        // browser-before-agent plan deterministic.
+        func recordCompanionDiagnostic(
+            _ code: CompanionPlanDiagnosticCode,
+            source: String,
+            target: String?,
+            message: String
+        ) {
+            companionDiagnostics.append(CompanionPlanDiagnostic(
+                code: code,
+                severity: .error,
+                sourcePlanID: source,
+                targetPlanID: target
+            ))
+            walkState.warnings.append(message)
+            walkState.failures.append(ApplyFailure(
+                code: code.rawValue,
+                step: "surface[\(source)].companion_link.apply",
+                message: message
+            ))
+        }
+
+        for sourceSpec in plan.surfaces {
+            guard let targetPlanID = sourceSpec.linkedAgentSurfacePlanId else { continue }
+            guard sourceSpec.kind == .browser else {
+                recordCompanionDiagnostic(
+                    .sourceNotBrowser,
+                    source: sourceSpec.id,
+                    target: targetPlanID,
+                    message: "companion link source '\(sourceSpec.id)' is not a browser"
+                )
+                continue
+            }
+            guard let targetSpec = surfacesById[targetPlanID] else {
+                recordCompanionDiagnostic(
+                    .targetMissing,
+                    source: sourceSpec.id,
+                    target: targetPlanID,
+                    message: "companion link target '\(targetPlanID)' is missing"
+                )
+                continue
+            }
+            guard targetSpec.kind == .terminal else {
+                recordCompanionDiagnostic(
+                    .targetNotTerminal,
+                    source: sourceSpec.id,
+                    target: targetPlanID,
+                    message: "companion link target '\(targetPlanID)' is not a terminal"
+                )
+                continue
+            }
+            guard AgentIdentityPolicy.isAgentKind(targetSpec.declaredAgentKind) else {
+                recordCompanionDiagnostic(
+                    .targetNotAgent,
+                    source: sourceSpec.id,
+                    target: targetPlanID,
+                    message: "companion link target '\(targetPlanID)' is not a declared agent"
+                )
+                continue
+            }
+            guard let sourcePanelID = walkState.planSurfaceIdToPanelId[sourceSpec.id],
+                  let targetPanelID = walkState.planSurfaceIdToPanelId[targetPlanID],
+                  let applyCompanionLink = dependencies.applyCompanionLink else {
+                recordCompanionDiagnostic(
+                    .applyFailed,
+                    source: sourceSpec.id,
+                    target: targetPlanID,
+                    message: "companion link '\(sourceSpec.id)' -> '\(targetPlanID)' could not be applied"
+                )
+                continue
+            }
+            do {
+                try applyCompanionLink(workspace, sourcePanelID, targetPanelID)
+            } catch {
+                recordCompanionDiagnostic(
+                    .applyFailed,
+                    source: sourceSpec.id,
+                    target: targetPlanID,
+                    message: "companion link '\(sourceSpec.id)' -> '\(targetPlanID)' failed: \(error)"
+                )
+            }
         }
 
         // Step 7 — terminal initial commands. TerminalPanel.sendText
@@ -349,7 +439,8 @@ enum WorkspaceLayoutExecutor {
             paneRefs: paneRefs,
             timings: timings,
             warnings: warnings,
-            failures: failures
+            failures: failures,
+            companionDiagnostics: companionDiagnostics
         )
     }
 

--- a/Sources/WorkspacePlanCapture.swift
+++ b/Sources/WorkspacePlanCapture.swift
@@ -2,36 +2,114 @@ import Foundation
 import AppKit
 import Bonsplit
 
+/// A deliberately narrow bridge for the ACB-06 integration lane. Persistence
+/// can compile before Workspace/BrowserPanel expose their companion APIs; the
+/// integrator supplies live link and identity reads without changing capture.
+@MainActor
+struct WorkspacePlanCompanionCaptureBridge {
+    var linkedAgentForBrowser: @MainActor (UUID) -> AgentSurfaceLink?
+    var declaredAgentKindForTerminal: @MainActor (UUID) -> String?
+
+    static let none = WorkspacePlanCompanionCaptureBridge(
+        linkedAgentForBrowser: { _ in nil },
+        declaredAgentKindForTerminal: { _ in nil }
+    )
+
+    static func live(workspace: AgentCompanionWorkspaceAccess) -> Self {
+        WorkspacePlanCompanionCaptureBridge(
+            linkedAgentForBrowser: { browserID in
+                switch workspace.companionPresentation(for: browserID) {
+                case .unlinked:
+                    return nil
+                case .linkedNoContext(let linked),
+                     .aligned(let linked),
+                     .veiled(let linked, _),
+                     .revealed(let linked, _):
+                    return AgentSurfaceLink(
+                        surfaceID: linked.identity.surfaceID,
+                        lastKnownName: linked.identity.displayName
+                    )
+                case .orphaned(let link), .orphanedRevealed(let link):
+                    return link
+                }
+            },
+            declaredAgentKindForTerminal: { terminalID in
+                workspace.liveAgentDescriptors.first {
+                    $0.identity.surfaceID == terminalID
+                }?.terminalKind
+            }
+        )
+    }
+}
+
+struct WorkspacePlanCaptureResult: Equatable, Sendable {
+    var plan: WorkspaceApplyPlan
+    var warnings: [CompanionPlanDiagnostic]
+}
+
 /// Shared plan-capture logic used by both `LiveWorkspaceSnapshotSource` (Snapshots)
 /// and `WorkspaceBlueprintExporter` (Blueprints). Walks AppKit / bonsplit state
-/// on the main actor and returns a `WorkspaceApplyPlan` ready for serialization.
+/// on the main actor and returns a plan plus structured capture warnings.
 @MainActor
 enum WorkspacePlanCapture {
-    static func capture(workspace: Workspace) -> WorkspaceApplyPlan {
-        var walker = Walker(workspace: workspace)
-        let layout = walker.walk(workspace.bonsplitController.treeSnapshot())
+    static func capture(
+        workspace: Workspace,
+        companionBridge: WorkspacePlanCompanionCaptureBridge? = nil
+    ) -> WorkspacePlanCaptureResult {
+        let tree = workspace.bonsplitController.treeSnapshot()
+        let resolvedCompanionBridge = companionBridge ?? .live(workspace: workspace)
+        var walker = Walker(
+            workspace: workspace,
+            companionBridge: resolvedCompanionBridge
+        )
+        // Pass 1 reserves every plan-local id in Bonsplit pane/tab order.
+        // Pass 2 may therefore encode browser-before-agent forward links.
+        walker.reservePlanIDs(in: tree)
+        let layout = walker.walk(tree)
         let spec = WorkspaceSpec(
             title: workspace.customTitle,
             customColor: workspace.customColor,
             workingDirectory: workspace.currentDirectory.isEmpty ? nil : workspace.currentDirectory,
             metadata: workspace.metadata.isEmpty ? nil : workspace.metadata
         )
-        return WorkspaceApplyPlan(
-            version: 1,
-            workspace: spec,
-            layout: layout,
-            surfaces: walker.surfaces
+        return WorkspacePlanCaptureResult(
+            plan: WorkspaceApplyPlan(
+                version: 1,
+                workspace: spec,
+                layout: layout,
+                surfaces: walker.surfaces
+            ),
+            warnings: walker.warnings
         )
     }
 
     @MainActor
     private struct Walker {
         let workspace: Workspace
+        let companionBridge: WorkspacePlanCompanionCaptureBridge
         var surfaces: [SurfaceSpec] = []
+        var warnings: [CompanionPlanDiagnostic] = []
+        private var planIDByPanelID: [UUID: String] = [:]
         private var nextIdCounter: Int = 1
 
-        init(workspace: Workspace) {
+        init(workspace: Workspace, companionBridge: WorkspacePlanCompanionCaptureBridge) {
             self.workspace = workspace
+            self.companionBridge = companionBridge
+        }
+
+        mutating func reservePlanIDs(in node: ExternalTreeNode) {
+            switch node {
+            case .pane(let pane):
+                for tab in pane.tabs {
+                    guard let panelID = panelID(forTabIDString: tab.id),
+                          workspace.panels[panelID] != nil,
+                          planIDByPanelID[panelID] == nil else { continue }
+                    planIDByPanelID[panelID] = mintId()
+                }
+            case .split(let split):
+                reservePlanIDs(in: split.first)
+                reservePlanIDs(in: split.second)
+            }
         }
 
         mutating func walk(_ node: ExternalTreeNode) -> LayoutTreeSpec {
@@ -64,10 +142,10 @@ enum WorkspacePlanCapture {
 
             var ids: [String] = []
             var selectedIndex: Int? = nil
-            for (index, tab) in pane.tabs.enumerated() {
+            for tab in pane.tabs {
                 guard let panelId = panelID(forTabIDString: tab.id),
-                      let panel = workspace.panels[panelId] else { continue }
-                let planId = mintId()
+                      let panel = workspace.panels[panelId],
+                      let planId = planIDByPanelID[panelId] else { continue }
                 ids.append(planId)
 
                 let isFirstInPane = ids.count == 1
@@ -81,6 +159,32 @@ enum WorkspacePlanCapture {
                 let paneMetaForSurface = isFirstInPane && !paneLevelMetadata.isEmpty
                     ? paneLevelMetadata
                     : [String: PersistedJSONValue]()
+                var linkedAgentSurfacePlanId: String?
+                if kind == .browser,
+                   let linkedAgent = companionBridge.linkedAgentForBrowser(panelId) {
+                    if let targetPlanID = planIDByPanelID[linkedAgent.surfaceID],
+                       workspace.panels[linkedAgent.surfaceID] is TerminalPanel,
+                       AgentIdentityPolicy.isAgentKind(
+                           companionBridge.declaredAgentKindForTerminal(linkedAgent.surfaceID)
+                       ) {
+                        linkedAgentSurfacePlanId = targetPlanID
+                    } else {
+                        // Never serialize a stale UUID into a portable plan.
+                        // Omit the link and make the data loss machine-visible.
+                        warnings.append(CompanionPlanDiagnostic(
+                            code: .orphanOmitted,
+                            severity: .warning,
+                            sourcePlanID: planId,
+                            targetPlanID: nil
+                        ))
+                    }
+                }
+                let declaredAgentKind = companionBridge
+                    .declaredAgentKindForTerminal(panelId)
+                    .flatMap { kind == .terminal && AgentIdentityPolicy.isAgentKind($0)
+                        ? AgentIdentityPolicy.normalizedKind($0)
+                        : nil
+                    }
                 let surface = SurfaceSpec(
                     id: planId,
                     kind: kind,
@@ -91,12 +195,14 @@ enum WorkspacePlanCapture {
                     url: url(for: panel),
                     filePath: filePath(for: panel),
                     metadata: metadata.isEmpty ? nil : metadata,
-                    paneMetadata: paneMetaForSurface.isEmpty ? nil : paneMetaForSurface
+                    paneMetadata: paneMetaForSurface.isEmpty ? nil : paneMetaForSurface,
+                    linkedAgentSurfacePlanId: linkedAgentSurfacePlanId,
+                    declaredAgentKind: declaredAgentKind
                 )
                 surfaces.append(surface)
 
                 if let selectedTabId = pane.selectedTabId, selectedTabId == tab.id {
-                    selectedIndex = index
+                    selectedIndex = ids.count - 1
                 }
             }
             return LayoutTreeSpec.PaneSpec(

--- a/Sources/WorkspacePlanCapture.swift
+++ b/Sources/WorkspacePlanCapture.swift
@@ -162,7 +162,8 @@ enum WorkspacePlanCapture {
                 var linkedAgentSurfacePlanId: String?
                 if kind == .browser,
                    let linkedAgent = companionBridge.linkedAgentForBrowser(panelId) {
-                    if let targetPlanID = planIDByPanelID[linkedAgent.surfaceID],
+                    let targetPlanID = planIDByPanelID[linkedAgent.surfaceID]
+                    if let targetPlanID,
                        workspace.panels[linkedAgent.surfaceID] is TerminalPanel,
                        AgentIdentityPolicy.isAgentKind(
                            companionBridge.declaredAgentKindForTerminal(linkedAgent.surfaceID)
@@ -175,7 +176,7 @@ enum WorkspacePlanCapture {
                             code: .orphanOmitted,
                             severity: .warning,
                             sourcePlanID: planId,
-                            targetPlanID: nil
+                            targetPlanID: targetPlanID
                         ))
                     }
                 }

--- a/Sources/WorkspaceSnapshotCapture.swift
+++ b/Sources/WorkspaceSnapshotCapture.swift
@@ -22,6 +22,11 @@ protocol WorkspaceSnapshotSource {
     ) -> WorkspaceSnapshotFile?
 }
 
+struct WorkspaceSnapshotCaptureResult: Sendable {
+    var snapshot: WorkspaceSnapshotFile
+    var warnings: [CompanionPlanDiagnostic]
+}
+
 /// Production capture. Runs on the main actor because AppKit / bonsplit /
 /// the metadata stores expect it. The walk is O(surfaces) + O(panes²) (the
 /// second term from an `allPaneIds` linear scan per tree node, which is
@@ -54,21 +59,36 @@ struct LiveWorkspaceSnapshotSource: WorkspaceSnapshotSource {
         origin: WorkspaceSnapshotFile.Origin,
         clock: () -> Date = { Date() }
     ) -> WorkspaceSnapshotFile? {
+        captureResult(workspaceId: workspaceId, origin: origin, clock: clock)?.snapshot
+    }
+
+    func captureResult(
+        workspaceId: UUID,
+        origin: WorkspaceSnapshotFile.Origin,
+        clock: () -> Date = { Date() },
+        companionBridge: WorkspacePlanCompanionCaptureBridge? = nil
+    ) -> WorkspaceSnapshotCaptureResult? {
         guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
             return nil
         }
-        let plan = WorkspacePlanCapture.capture(workspace: workspace)
+        let capture = WorkspacePlanCapture.capture(
+            workspace: workspace,
+            companionBridge: companionBridge
+        )
         // Single clock read so the ULID time prefix in `snapshotId` and the
         // envelope's `createdAt` can never diverge by a tick.
         let now = clock()
-        return WorkspaceSnapshotFile(
-            version: 1,
-            snapshotId: WorkspaceSnapshotID.generate(now: now),
-            createdAt: now,
-            c11Version: c11Version,
-            origin: origin,
-            surfaceCount: plan.surfaces.count,
-            plan: plan
+        return WorkspaceSnapshotCaptureResult(
+            snapshot: WorkspaceSnapshotFile(
+                version: 1,
+                snapshotId: WorkspaceSnapshotID.generate(now: now),
+                createdAt: now,
+                c11Version: c11Version,
+                origin: origin,
+                surfaceCount: capture.plan.surfaces.count,
+                plan: capture.plan
+            ),
+            warnings: capture.warnings
         )
     }
 

--- a/c11Tests/Fixtures/agent-companion/prefeature-session-v1.json
+++ b/c11Tests/Fixtures/agent-companion/prefeature-session-v1.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "createdAt": 0,
+  "windows": [
+    {
+      "tabManager": {
+        "selectedWorkspaceIndex": 0,
+        "workspaces": [
+          {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "processTitle": "Browser",
+            "isPinned": false,
+            "currentDirectory": "/tmp",
+            "layout": {
+              "type": "pane",
+              "pane": {
+                "panelIds": ["22222222-2222-2222-2222-222222222222"]
+              }
+            },
+            "panels": [
+              {
+                "id": "22222222-2222-2222-2222-222222222222",
+                "type": "browser",
+                "isPinned": false,
+                "isManuallyUnread": false,
+                "listeningPorts": [],
+                "browser": {
+                  "urlString": "https://example.com",
+                  "shouldRenderWebView": true,
+                  "pageZoom": 1,
+                  "developerToolsVisible": false
+                }
+              }
+            ],
+            "statusEntries": [],
+            "logEntries": []
+          }
+        ]
+      },
+      "sidebar": {
+        "isVisible": true,
+        "selection": "tabs"
+      }
+    }
+  ]
+}

--- a/c11Tests/Fixtures/workspace-blueprints/browser-before-agent.md
+++ b/c11Tests/Fixtures/workspace-blueprints/browser-before-agent.md
@@ -1,0 +1,19 @@
+---
+title: Browser Before Agent
+---
+
+## Layout
+
+```yaml
+layout:
+  - direction: horizontal
+    split: 50/50
+    children:
+      - type: browser
+        title: Research
+        linked_agent: s1
+      - id: s1
+        type: terminal
+        title: Agent
+        agent_kind: codex
+```

--- a/c11Tests/Fixtures/workspace-blueprints/duplicate-surface-id.md
+++ b/c11Tests/Fixtures/workspace-blueprints/duplicate-surface-id.md
@@ -1,0 +1,15 @@
+---
+title: Duplicate IDs
+---
+
+## Layout
+
+```yaml
+layout:
+  - tabs:
+      - id: agent
+        type: terminal
+        agent_kind: codex
+      - id: agent
+        type: browser
+```

--- a/c11Tests/Fixtures/workspace-blueprints/invalid-agent-kind.md
+++ b/c11Tests/Fixtures/workspace-blueprints/invalid-agent-kind.md
@@ -1,0 +1,12 @@
+---
+title: Invalid Agent Kind
+---
+
+## Layout
+
+```yaml
+layout:
+  - id: terminal
+    type: terminal
+    agent_kind: shell
+```

--- a/c11Tests/SessionPersistenceTests.swift
+++ b/c11Tests/SessionPersistenceTests.swift
@@ -426,6 +426,30 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertEqual(decoded.forwardHistoryURLStrings, source.forwardHistoryURLStrings)
     }
 
+    func testSessionBrowserCompanionLinkRoundTripsWithoutChangingSchemaVersion() throws {
+        let linkedID = try XCTUnwrap(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        var source = SessionBrowserPanelSnapshot(
+            urlString: "https://example.com/current",
+            profileID: nil,
+            shouldRenderWebView: true,
+            pageZoom: 1,
+            developerToolsVisible: false,
+            backHistoryURLStrings: nil,
+            forwardHistoryURLStrings: nil
+        )
+        source.linkedAgent = AgentSurfaceLink(
+            surfaceID: linkedID,
+            lastKnownName: "Build agent"
+        )
+
+        let decoded = try JSONDecoder().decode(
+            SessionBrowserPanelSnapshot.self,
+            from: JSONEncoder().encode(source)
+        )
+        XCTAssertEqual(decoded.linkedAgent, source.linkedAgent)
+        XCTAssertEqual(SessionSnapshotSchema.currentVersion, 1)
+    }
+
     func testSessionBrowserPanelSnapshotHistoryDecodesWhenKeysAreMissing() throws {
         let json = """
         {
@@ -441,6 +465,37 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNil(decoded.profileID)
         XCTAssertNil(decoded.backHistoryURLStrings)
         XCTAssertNil(decoded.forwardHistoryURLStrings)
+        XCTAssertNil(decoded.linkedAgent)
+    }
+
+    func testPrefeatureSessionV1FixtureDecodesWithNoCompanionState() throws {
+        let fixture = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/agent-companion/prefeature-session-v1.json")
+        let decoded = try JSONDecoder().decode(
+            AppSessionSnapshot.self,
+            from: Data(contentsOf: fixture)
+        )
+        let workspace = try XCTUnwrap(decoded.windows.first?.tabManager.workspaces.first)
+        let browser = try XCTUnwrap(workspace.panels.first?.browser)
+        XCTAssertEqual(decoded.version, 1)
+        XCTAssertNil(workspace.activeAgentSurfaceId)
+        XCTAssertNil(browser.linkedAgent)
+    }
+
+    func testSessionActiveAgentContextRoundTripsButIsOptional() throws {
+        let activeID = try XCTUnwrap(UUID(uuidString: "AAAAAAAA-1111-2222-3333-BBBBBBBBBBBB"))
+        var snapshot = makeSnapshot(version: 1)
+        snapshot.windows[0].tabManager.workspaces[0].activeAgentSurfaceId = activeID
+
+        let decoded = try JSONDecoder().decode(
+            AppSessionSnapshot.self,
+            from: JSONEncoder().encode(snapshot)
+        )
+        XCTAssertEqual(
+            decoded.windows[0].tabManager.workspaces[0].activeAgentSurfaceId,
+            activeID
+        )
     }
 
     func testScrollbackReplayEnvironmentWritesReplayFile() {

--- a/c11Tests/WorkspaceApplyPlanCodableTests.swift
+++ b/c11Tests/WorkspaceApplyPlanCodableTests.swift
@@ -80,6 +80,29 @@ final class WorkspaceApplyPlanCodableTests: XCTestCase {
         try roundTrip(spec)
     }
 
+    func testSurfaceSpecCompanionFieldsRoundTrip() throws {
+        let browser = SurfaceSpec(
+            id: "browser",
+            kind: .browser,
+            linkedAgentSurfacePlanId: "agent"
+        )
+        let agent = SurfaceSpec(
+            id: "agent",
+            kind: .terminal,
+            declaredAgentKind: "codex"
+        )
+        try roundTrip(browser)
+        try roundTrip(agent)
+    }
+
+    func testSurfaceSpecDecodesPrefeatureShapeWithoutCompanionFields() throws {
+        let legacyJSON = #"{"id":"t","kind":"terminal"}"#
+        let decoded = try decode(SurfaceSpec.self, from: Data(legacyJSON.utf8))
+        XCTAssertNil(decoded.linkedAgentSurfacePlanId)
+        XCTAssertNil(decoded.declaredAgentKind)
+        XCTAssertFalse(decoded.submitCommand)
+    }
+
     func testSurfaceSpecMarkdownRoundTrips() throws {
         let spec = SurfaceSpec(
             id: "notes",
@@ -283,9 +306,23 @@ final class WorkspaceApplyPlanCodableTests: XCTestCase {
                     step: "metadata.pane[main].write",
                     message: "mailbox.retention_days must be a string in v1"
                 )
+            ],
+            companionDiagnostics: [
+                CompanionPlanDiagnostic(
+                    code: .targetMissing,
+                    severity: .error,
+                    sourcePlanID: "browser",
+                    targetPlanID: "agent"
+                )
             ]
         )
         try roundTrip(result)
+    }
+
+    func testApplyResultDecodesLegacyShapeWithEmptyCompanionDiagnostics() throws {
+        let legacyJSON = #"{"workspaceRef":"workspace:1","surfaceRefs":{},"paneRefs":{},"timings":[],"warnings":[],"failures":[]}"#
+        let decoded = try decode(ApplyResult.self, from: Data(legacyJSON.utf8))
+        XCTAssertTrue(decoded.companionDiagnostics.isEmpty)
     }
 
     // MARK: - Validation (review cycle 1 R6: I4a/I4b/I4d)

--- a/c11Tests/WorkspaceBlueprintMarkdownTests.swift
+++ b/c11Tests/WorkspaceBlueprintMarkdownTests.swift
@@ -20,6 +20,13 @@ final class WorkspaceBlueprintMarkdownTests: XCTestCase {
         return try WorkspaceBlueprintMarkdown.parse(data)
     }
 
+    private func fixture(_ name: String) throws -> Data {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("Fixtures/workspace-blueprints/\(name).md")
+        return try Data(contentsOf: url)
+    }
+
     // MARK: - Round-trips at the value level
 
     func testRoundTripSingleTerminalLeaf() throws {
@@ -60,6 +67,141 @@ final class WorkspaceBlueprintMarkdownTests: XCTestCase {
         )
         let r = try roundTrip(file)
         XCTAssertEqual(r, file)
+    }
+
+    func testExplicitIDsReserveFallbackNamespaceAndAllowBrowserBeforeAgent() throws {
+        let parsed = try WorkspaceBlueprintMarkdown.parse(fixture("browser-before-agent"))
+        XCTAssertEqual(parsed.version, 1)
+        XCTAssertEqual(parsed.plan.version, 1)
+        XCTAssertEqual(parsed.plan.surfaces.map(\.id), ["s2", "s1"])
+
+        let browser = parsed.plan.surfaces[0]
+        let agent = parsed.plan.surfaces[1]
+        XCTAssertEqual(browser.kind, .browser)
+        XCTAssertEqual(browser.linkedAgentSurfacePlanId, "s1")
+        XCTAssertEqual(agent.kind, .terminal)
+        XCTAssertEqual(agent.declaredAgentKind, "codex")
+
+        let emitted = String(
+            data: try WorkspaceBlueprintMarkdown.serialize(parsed),
+            encoding: .utf8
+        ) ?? ""
+        XCTAssertTrue(emitted.contains("id: s2"))
+        XCTAssertTrue(emitted.contains("id: s1"))
+        XCTAssertTrue(emitted.contains("linked_agent: s1"))
+        XCTAssertTrue(emitted.contains("agent_kind: codex"))
+        XCTAssertEqual(try WorkspaceBlueprintMarkdown.parse(Data(emitted.utf8)), parsed)
+    }
+
+    func testParseRejectsDuplicateExplicitSurfaceIDWithStableCode() throws {
+        XCTAssertThrowsError(
+            try WorkspaceBlueprintMarkdown.parse(fixture("duplicate-surface-id"))
+        ) { error in
+            guard case WorkspaceBlueprintMarkdown.ParseError.duplicateSurfaceID(let id) = error else {
+                return XCTFail("expected duplicateSurfaceID, got \(error)")
+            }
+            XCTAssertEqual(id, "agent")
+            XCTAssertTrue(String(describing: error).contains("blueprint_duplicate_surface_id"))
+        }
+    }
+
+    func testParseRejectsInvalidAgentKindWithStableCode() throws {
+        XCTAssertThrowsError(
+            try WorkspaceBlueprintMarkdown.parse(fixture("invalid-agent-kind"))
+        ) { error in
+            guard case WorkspaceBlueprintMarkdown.ParseError.invalidAgentKind(
+                let surfaceID,
+                let kind
+            ) = error else {
+                return XCTFail("expected invalidAgentKind, got \(error)")
+            }
+            XCTAssertEqual(surfaceID, "terminal")
+            XCTAssertEqual(kind, "shell")
+            XCTAssertTrue(String(describing: error).contains("blueprint_invalid_agent_kind"))
+        }
+    }
+
+    func testParseRejectsMissingAndNonAgentLinkTargets() {
+        let missing = """
+        ## Layout
+
+        ```yaml
+        layout:
+          - id: browser
+            type: browser
+            linked_agent: absent
+        ```
+        """
+        XCTAssertThrowsError(try WorkspaceBlueprintMarkdown.parse(Data(missing.utf8))) { error in
+            guard case WorkspaceBlueprintMarkdown.ParseError.invalidCompanionLink(
+                let code,
+                let source,
+                let target
+            ) = error else {
+                return XCTFail("expected invalidCompanionLink, got \(error)")
+            }
+            XCTAssertEqual(code, .targetMissing)
+            XCTAssertEqual(source, "browser")
+            XCTAssertEqual(target, "absent")
+        }
+
+        let ordinaryTerminal = """
+        ## Layout
+
+        ```yaml
+        layout:
+          - tabs:
+              - id: browser
+                type: browser
+                linked_agent: shell
+              - id: shell
+                type: terminal
+        ```
+        """
+        XCTAssertThrowsError(
+            try WorkspaceBlueprintMarkdown.parse(Data(ordinaryTerminal.utf8))
+        ) { error in
+            guard case WorkspaceBlueprintMarkdown.ParseError.invalidCompanionLink(
+                let code,
+                _,
+                _
+            ) = error else {
+                return XCTFail("expected invalidCompanionLink, got \(error)")
+            }
+            XCTAssertEqual(code, .targetNotAgent)
+        }
+    }
+
+    func testBlueprintOmitsSessionContextRevealAndGenerationState() throws {
+        let file = WorkspaceBlueprintFile(
+            name: "Portable link",
+            plan: WorkspaceApplyPlan(
+                version: 1,
+                workspace: WorkspaceSpec(title: "Portable link"),
+                layout: .pane(.init(surfaceIds: ["browser", "agent"])),
+                surfaces: [
+                    SurfaceSpec(
+                        id: "browser",
+                        kind: .browser,
+                        linkedAgentSurfacePlanId: "agent"
+                    ),
+                    SurfaceSpec(
+                        id: "agent",
+                        kind: .terminal,
+                        declaredAgentKind: "codex"
+                    )
+                ]
+            )
+        )
+        let markdown = String(
+            data: try WorkspaceBlueprintMarkdown.serialize(file),
+            encoding: .utf8
+        ) ?? ""
+        let json = String(data: try JSONEncoder().encode(file.plan), encoding: .utf8) ?? ""
+        for forbidden in ["activeAgent", "reveal", "generation"] {
+            XCTAssertFalse(markdown.contains(forbidden))
+            XCTAssertFalse(json.contains(forbidden))
+        }
     }
 
     func testRoundTripNestedSplitMatchesSchemaExample() throws {

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -80,6 +80,177 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
         )
     }
 
+    // MARK: - Agent companion persistence/remapping
+
+    func testBrowserBeforeAgentLinkResolvesAfterAllSurfacesMaterialize() throws {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(title: "browser before agent"),
+            layout: .pane(.init(surfaceIds: ["browser", "agent"])),
+            surfaces: [
+                SurfaceSpec(
+                    id: "browser",
+                    kind: .browser,
+                    url: "https://example.com",
+                    linkedAgentSurfacePlanId: "agent"
+                ),
+                SurfaceSpec(
+                    id: "agent",
+                    kind: .terminal,
+                    declaredAgentKind: "codex"
+                )
+            ]
+        )
+        var applied: [(browser: UUID, agent: UUID)] = []
+        let deps = WorkspaceLayoutExecutorDependencies(
+            tabManager: tabManager,
+            workspaceRefMinter: { "workspace:\($0.uuidString)" },
+            surfaceRefMinter: { "surface:\($0.uuidString)" },
+            paneRefMinter: { "pane:\($0.uuidString)" },
+            applyCompanionLink: { _, browserID, agentID in
+                applied.append((browserID, agentID))
+            }
+        )
+
+        let result = WorkspaceLayoutExecutor.apply(
+            plan,
+            options: ApplyOptions(select: false),
+            dependencies: deps
+        )
+        XCTAssertTrue(result.companionDiagnostics.isEmpty)
+        XCTAssertEqual(applied.count, 1)
+        XCTAssertEqual(applied.first?.browser, parseUUIDSuffix(result.surfaceRefs["browser"]))
+        XCTAssertEqual(applied.first?.agent, parseUUIDSuffix(result.surfaceRefs["agent"]))
+    }
+
+    func testCompanionApplyRejectsUndeclaredAgentWithStructuredDiagnostic() {
+        let plan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(title: "invalid target"),
+            layout: .pane(.init(surfaceIds: ["browser", "terminal"])),
+            surfaces: [
+                SurfaceSpec(
+                    id: "browser",
+                    kind: .browser,
+                    linkedAgentSurfacePlanId: "terminal"
+                ),
+                SurfaceSpec(id: "terminal", kind: .terminal)
+            ]
+        )
+        var mutationCount = 0
+        let deps = WorkspaceLayoutExecutorDependencies(
+            tabManager: tabManager,
+            workspaceRefMinter: { "workspace:\($0.uuidString)" },
+            surfaceRefMinter: { "surface:\($0.uuidString)" },
+            paneRefMinter: { "pane:\($0.uuidString)" },
+            applyCompanionLink: { _, _, _ in mutationCount += 1 }
+        )
+
+        let result = WorkspaceLayoutExecutor.apply(
+            plan,
+            options: ApplyOptions(select: false),
+            dependencies: deps
+        )
+        XCTAssertEqual(mutationCount, 0)
+        XCTAssertEqual(result.companionDiagnostics, [
+            CompanionPlanDiagnostic(
+                code: .targetNotAgent,
+                severity: .error,
+                sourcePlanID: "browser",
+                targetPlanID: "terminal"
+            )
+        ])
+        XCTAssertTrue(result.failures.contains { $0.code == "companion_link_target_not_agent" })
+    }
+
+    func testTwoPassCaptureRemapsLinkAndOmitsOrphanWithWarning() throws {
+        let seedPlan = WorkspaceApplyPlan(
+            version: 1,
+            workspace: WorkspaceSpec(title: "capture remap"),
+            layout: .pane(.init(surfaceIds: ["browser", "agent"])),
+            surfaces: [
+                SurfaceSpec(id: "browser", kind: .browser, url: "https://example.com"),
+                SurfaceSpec(id: "agent", kind: .terminal)
+            ]
+        )
+        let seed = WorkspaceLayoutExecutor.apply(
+            seedPlan,
+            options: ApplyOptions(select: false),
+            dependencies: WorkspaceLayoutExecutorDependencies(
+                tabManager: tabManager,
+                workspaceRefMinter: { "workspace:\($0.uuidString)" },
+                surfaceRefMinter: { "surface:\($0.uuidString)" },
+                paneRefMinter: { "pane:\($0.uuidString)" }
+            )
+        )
+        let workspace = try XCTUnwrap(resolveWorkspace(from: seed.workspaceRef))
+        let browserID = try XCTUnwrap(parseUUIDSuffix(seed.surfaceRefs["browser"]))
+        let agentID = try XCTUnwrap(parseUUIDSuffix(seed.surfaceRefs["agent"]))
+
+        let captured = WorkspacePlanCapture.capture(
+            workspace: workspace,
+            companionBridge: WorkspacePlanCompanionCaptureBridge(
+                linkedAgentForBrowser: { id in
+                    id == browserID ? AgentSurfaceLink(
+                        surfaceID: agentID,
+                        lastKnownName: "Agent"
+                    ) : nil
+                },
+                declaredAgentKindForTerminal: { id in id == agentID ? "codex" : nil }
+            )
+        )
+        XCTAssertEqual(captured.plan.surfaces.map(\.id), ["s1", "s2"])
+        XCTAssertEqual(captured.plan.surfaces[0].linkedAgentSurfacePlanId, "s2")
+        XCTAssertEqual(captured.plan.surfaces[1].declaredAgentKind, "codex")
+        XCTAssertTrue(captured.warnings.isEmpty)
+
+        let missingAgentID = UUID()
+        let orphanBridge = WorkspacePlanCompanionCaptureBridge(
+            linkedAgentForBrowser: { id in
+                id == browserID ? AgentSurfaceLink(
+                    surfaceID: missingAgentID,
+                    lastKnownName: "Gone"
+                ) : nil
+            },
+            declaredAgentKindForTerminal: { id in id == agentID ? "codex" : nil }
+        )
+        let orphaned = WorkspacePlanCapture.capture(
+            workspace: workspace,
+            companionBridge: orphanBridge
+        )
+        XCTAssertNil(orphaned.plan.surfaces[0].linkedAgentSurfacePlanId)
+        XCTAssertEqual(orphaned.warnings, [
+            CompanionPlanDiagnostic(
+                code: .orphanOmitted,
+                severity: .warning,
+                sourcePlanID: "s1",
+                targetPlanID: nil
+            )
+        ])
+
+        let snapshot = try XCTUnwrap(LiveWorkspaceSnapshotSource(
+            tabManager: tabManager,
+            c11Version: "companion-test+0"
+        ).captureResult(
+            workspaceId: workspace.id,
+            origin: .manual,
+            clock: { Date(timeIntervalSince1970: 1_745_000_000) },
+            companionBridge: orphanBridge
+        ))
+        XCTAssertEqual(snapshot.warnings, orphaned.warnings)
+        XCTAssertNil(snapshot.snapshot.plan.surfaces[0].linkedAgentSurfacePlanId)
+
+        let blueprint = try XCTUnwrap(WorkspaceBlueprintExporter(
+            tabManager: tabManager
+        ).exportWithDiagnostics(
+            workspaceId: workspace.id,
+            name: "Orphan capture",
+            companionBridge: orphanBridge
+        ))
+        XCTAssertEqual(blueprint.warnings, orphaned.warnings)
+        XCTAssertNil(blueprint.file.plan.surfaces[0].linkedAgentSurfacePlanId)
+    }
+
     // MARK: - Phase 0 parity: whitespace-only command (B4)
 
     /// Phase 0 sent `SurfaceSpec.command` to the terminal verbatim as long

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 import Bonsplit
 
@@ -20,8 +21,7 @@ import Bonsplit
 /// 3. Every `SurfaceSpec.metadata` / `SurfaceSpec.paneMetadata` entry in the
 ///    fixture round-trips through `SurfaceMetadataStore` / `PaneMetadataStore`.
 ///
-/// Per `CLAUDE.md`, tests are never run locally by the impl agent; this file
-/// is committed and exercised only in CI.
+/// Runs in the no-host `c11LogicTests` process both locally and in CI.
 @MainActor
 final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
 
@@ -41,6 +41,10 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        // The logic-test runner has no host application, but constructing a
+        // TabManager reaches Ghostty setup that reads NSApp. Create AppKit's
+        // process singleton without launching or hosting the c11 application.
+        _ = NSApplication.shared
         tabManager = TabManager()
     }
 

--- a/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
+++ b/c11Tests/WorkspaceLayoutExecutorAcceptanceTests.swift
@@ -160,7 +160,18 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
                 targetPlanID: "terminal"
             )
         ])
-        XCTAssertTrue(result.failures.contains { $0.code == "companion_link_target_not_agent" })
+        let expectedMessage = CompanionPlanDiagnosticMessage.localized(
+            code: .targetNotAgent,
+            sourcePlanID: "browser",
+            targetPlanID: "terminal"
+        )
+        XCTAssertTrue(expectedMessage.contains("browser"))
+        XCTAssertTrue(expectedMessage.contains("terminal"))
+        XCTAssertTrue(result.warnings.contains(expectedMessage))
+        XCTAssertTrue(result.failures.contains {
+            $0.code == "companion_link_target_not_agent"
+                && $0.message == expectedMessage
+        })
     }
 
     func testTwoPassCaptureRemapsLinkAndOmitsOrphanWithWarning() throws {
@@ -225,6 +236,29 @@ final class WorkspaceLayoutExecutorAcceptanceTests: XCTestCase {
                 severity: .warning,
                 sourcePlanID: "s1",
                 targetPlanID: nil
+            )
+        ])
+
+        let declassifiedBridge = WorkspacePlanCompanionCaptureBridge(
+            linkedAgentForBrowser: { id in
+                id == browserID ? AgentSurfaceLink(
+                    surfaceID: agentID,
+                    lastKnownName: "Former Agent"
+                ) : nil
+            },
+            declaredAgentKindForTerminal: { _ in nil }
+        )
+        let declassified = WorkspacePlanCapture.capture(
+            workspace: workspace,
+            companionBridge: declassifiedBridge
+        )
+        XCTAssertNil(declassified.plan.surfaces[0].linkedAgentSurfacePlanId)
+        XCTAssertEqual(declassified.warnings, [
+            CompanionPlanDiagnostic(
+                code: .orphanOmitted,
+                severity: .warning,
+                sourcePlanID: "s1",
+                targetPlanID: "s2"
             )
         ])
 

--- a/c11Tests/WorkspaceSnapshotCaptureTests.swift
+++ b/c11Tests/WorkspaceSnapshotCaptureTests.swift
@@ -361,6 +361,32 @@ final class WorkspaceSnapshotCaptureTests: XCTestCase {
         ))
     }
 
+    func testCompanionWarningPayloadIncludesLocalizedActionableMessage() throws {
+        let diagnostic = CompanionPlanDiagnostic(
+            code: .orphanOmitted,
+            severity: .warning,
+            sourcePlanID: "browser",
+            targetPlanID: "agent"
+        )
+        let payload = TerminalController.companionDiagnosticPayload(diagnostic)
+
+        XCTAssertEqual(payload["code"] as? String, "companion_link_orphan_omitted")
+        XCTAssertEqual(payload["severity"] as? String, "warning")
+        XCTAssertEqual(payload["source_plan_id"] as? String, "browser")
+        XCTAssertEqual(payload["target_plan_id"] as? String, "agent")
+        let message = try XCTUnwrap(payload["message"] as? String)
+        XCTAssertEqual(
+            message,
+            CompanionPlanDiagnosticMessage.localized(
+                code: .orphanOmitted,
+                sourcePlanID: "browser",
+                targetPlanID: "agent"
+            )
+        )
+        XCTAssertTrue(message.contains("browser"))
+        XCTAssertTrue(message.contains("agent"))
+    }
+
     // MARK: - Capture → Write → Read → Convert loop
 
     func testCaptureWriteReadConvertRoundTrip() throws {


### PR DESCRIPTION
## Summary

- Extend session v1 and workspace-plan v1 with backward-compatible optional companion link and active-agent fields.
- Capture and apply links in two passes so browser-before-agent forward references remap deterministically.
- Preserve only participating links in snapshots and blueprints, surface structured actionable warnings for omissions, and never persist reveal state.
- Add explicit Markdown surface IDs, agent kinds, linked-agent references, uniqueness/forward-reference validation, and localized apply/snapshot diagnostic messages.
- Cover pre-feature decode, plan Codable behavior, Markdown fixtures, snapshot warning payloads, and executor remapping.

## Why

C11-191 owns the persistence/compiler layer for agent-linked companion browsers. Links must survive the intended persistence families without serializing live surface refs, active context outside sessions, or ephemeral reveal grants. Missing and invalid targets must be honest and actionable rather than silently dropped.

## Validation

- Fresh context-clean review: PASS at exact HEAD a9f56c634dd3a6f2d530ddeec4d542062128f27a (Critical 0, Major 0, Minor 0), Lattice artifact art_01KY5RFZ8Y33V6XK24HPYRYYSR.
- git diff --check: PASS.
- xcrun swiftc -parse across the six review-fix files: PASS.
- The corrected explicit-test command did execute WorkspaceLayoutExecutorAcceptanceTests, but the local result is TEST FAILED: 15 total, 0 passed, 15 runner-exit failures at the documented bare-runner NSApp nil crash in GhosttyTerminalView.swift:1200; no assertion result was reached.
- Local validation artifact: art_01KY5RVX3A41FBNA140K39XKKQ.
- No local PASS is claimed; repository CI is the host-dependent execution gate.

## Scope

This PR changes only the C11-191 persistence/compiler, owned snapshot warning handler, existing tests, and fixtures. It does not change Workspace, TabManager, BrowserPanel, AppDelegate, portal/UI, CLI, project configuration, submodules, or tenant configuration.
