### PR TITLE
Add companion browser portal veil

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1677,6 +1677,9 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
     }
 
     private func deactivate(restoreResponder: Bool) {
+        let currentWindow = window
+        let overlayOwnedFirstResponderBeforeHide =
+            currentWindow?.firstResponder === self || currentWindow?.firstResponder === revealButton
         for snapshot in accessibilitySnapshots.values {
             snapshot.view?.setAccessibilityHidden(snapshot.wasHidden)
         }
@@ -1688,19 +1691,18 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
         shouldAcquireKeyboardFocus = false
         isHidden = true
 
-        guard let window else {
+        guard let window = currentWindow else {
             priorFirstResponder = nil
             return
         }
-        let overlayOwnsFirstResponder =
-            window.firstResponder === self || window.firstResponder === revealButton
         if restoreResponder,
-           overlayOwnsFirstResponder || window.firstResponder == nil,
+           overlayOwnedFirstResponderBeforeHide || window.firstResponder == nil,
            let priorFirstResponder,
            priorFirstResponder.acceptsFirstResponder,
            priorFirstResponder.browserPortalOwningView?.window === window {
             _ = window.makeFirstResponder(priorFirstResponder)
-        } else if overlayOwnsFirstResponder {
+        } else if overlayOwnedFirstResponderBeforeHide,
+                  window.firstResponder === self || window.firstResponder === revealButton {
             _ = window.makeFirstResponder(nil)
         }
         priorFirstResponder = nil

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Bonsplit
+import Combine
 import ObjectiveC
 import SwiftUI
 import WebKit
@@ -1322,6 +1323,330 @@ struct BrowserPortalPaneInteractionConfiguration {
     let runtime: PaneInteractionRuntime
 }
 
+private final class BrowserCompanionAccessibilitySnapshot {
+    weak var view: NSView?
+    let wasHidden: Bool
+
+    init(view: NSView, wasHidden: Bool) {
+        self.view = view
+        self.wasHidden = wasHidden
+    }
+}
+
+private final class BrowserCompanionRevealButton: NSButton {
+    weak var companionHost: BrowserCompanionOverlayHost?
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        companionHost?.beginPointerSequence()
+        defer { companionHost?.endPointerSequence() }
+        super.mouseDown(with: event)
+    }
+}
+
+/// AppKit-owned inertness boundary for companion-linked browser content.
+///
+/// The host remains a real hit target while blocked, owns keyboard focus, and
+/// accessibility-hides the page plus any attached WebKit inspector roots. A
+/// reveal requested by mouse-down keeps the host installed through the matching
+/// mouse-up so that release cannot fall through to the newly revealed page.
+final class BrowserCompanionOverlayHost: NSVisualEffectView {
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let detailLabel = NSTextField(wrappingLabelWithString: "")
+    private let revealButton = BrowserCompanionRevealButton(
+        title: String(
+            localized: "agentCompanion.portal.viewAnyway",
+            defaultValue: "View anyway"
+        ),
+        target: nil,
+        action: nil
+    )
+
+    private var configuration: BrowserPortalCompanionConfiguration?
+    private var accessibilitySnapshots: [ObjectIdentifier: BrowserCompanionAccessibilitySnapshot] = [:]
+    private weak var priorFirstResponder: NSResponder?
+    private var isPointerSequenceActive = false
+    private var hasPendingConfiguration = false
+    private var pendingConfiguration: BrowserPortalCompanionConfiguration?
+
+    override var acceptsFirstResponder: Bool { isBlocking }
+
+    var isBlocking: Bool {
+        configuration?.state.blocksWebContent == true && !isHidden
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        material = .hudWindow
+        blendingMode = .withinWindow
+        state = .active
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.windowBackgroundColor.withAlphaComponent(0.72).cgColor
+        autoresizingMask = [.width, .height]
+        isHidden = true
+
+        titleLabel.alignment = .center
+        titleLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+        titleLabel.maximumNumberOfLines = 2
+        titleLabel.lineBreakMode = .byWordWrapping
+        detailLabel.alignment = .center
+        detailLabel.font = .systemFont(ofSize: 13)
+        detailLabel.textColor = .secondaryLabelColor
+        detailLabel.maximumNumberOfLines = 3
+        detailLabel.lineBreakMode = .byWordWrapping
+        revealButton.bezelStyle = .rounded
+        revealButton.controlSize = .large
+        revealButton.target = self
+        revealButton.action = #selector(revealButtonPressed(_:))
+        revealButton.companionHost = self
+
+        let stack = NSStackView(views: [titleLabel, detailLabel, revealButton])
+        stack.orientation = .vertical
+        stack.alignment = .centerX
+        stack.spacing = 10
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            stack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -24),
+            detailLabel.widthAnchor.constraint(lessThanOrEqualToConstant: 440),
+        ])
+
+        setAccessibilityRole(.group)
+        setAccessibilityLabel(
+            String(
+                localized: "agentCompanion.portal.accessibilityLabel",
+                defaultValue: "Agent companion browser privacy veil"
+            )
+        )
+        revealButton.setAccessibilityLabel(
+            String(
+                localized: "agentCompanion.portal.viewAnyway",
+                defaultValue: "View anyway"
+            )
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard isBlocking else { return nil }
+        return super.hitTest(point) ?? self
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if newWindow == nil {
+            deactivate(restoreResponder: false)
+        }
+        super.viewWillMove(toWindow: newWindow)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil, configuration?.state.blocksWebContent == true else { return }
+        isHidden = false
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard isBlocking else { return }
+        beginPointerSequence()
+        requestReveal()
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard isPointerSequenceActive || isBlocking else { return }
+        endPointerSequence()
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        // The veil is an inertness boundary. Context clicks never reach WebKit.
+    }
+
+    override func otherMouseDown(with event: NSEvent) {
+        // Auxiliary-button navigation must not reach the covered page.
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        // Scrolling is consumed while the page is veiled.
+    }
+
+    override func keyDown(with event: NSEvent) {
+        guard isBlocking else { return }
+        switch event.keyCode {
+        case 36, 49, 76: // Return, Space, keypad Enter
+            requestReveal()
+        case 48: // Tab: keep traversal inside the AppKit overlay layer.
+            if event.modifierFlags.contains(.shift) {
+                window?.selectPreviousKeyView(nil)
+            } else {
+                window?.selectNextKeyView(nil)
+            }
+        default:
+            // Deliberately consume all other keys; forwarding to super can route
+            // them back into a WKContentView through the responder chain.
+            break
+        }
+    }
+
+    func apply(
+        configuration: BrowserPortalCompanionConfiguration?,
+        coveredViews: [NSView],
+        restoreResponder: Bool
+    ) {
+        if isPointerSequenceActive,
+           configuration?.state.blocksWebContent != true {
+            pendingConfiguration = configuration
+            hasPendingConfiguration = true
+            return
+        }
+
+        self.configuration = configuration
+        guard configuration?.state.blocksWebContent == true else {
+            deactivate(restoreResponder: restoreResponder)
+            return
+        }
+
+        configureContent(for: configuration!.state.presentation)
+        isHidden = false
+        cacheAndHideAccessibility(for: coveredViews)
+        if let window {
+            capturePriorFirstResponderIfNeeded(in: window, coveredViews: coveredViews)
+        }
+    }
+
+    func updateCoveredViews(_ coveredViews: [NSView]) {
+        guard isBlocking else { return }
+        cacheAndHideAccessibility(for: coveredViews)
+    }
+
+    func restoreAccessibility(for view: NSView) {
+        let viewId = ObjectIdentifier(view)
+        guard let snapshot = accessibilitySnapshots.removeValue(forKey: viewId) else { return }
+        snapshot.view?.setAccessibilityHidden(snapshot.wasHidden)
+    }
+
+    @discardableResult
+    func requestKeyboardFocus(reason: String) -> Bool {
+        guard isBlocking, let window else { return false }
+        if window.firstResponder === revealButton || window.firstResponder === self {
+            return true
+        }
+        if window.makeFirstResponder(revealButton) { return true }
+        window.makeFirstResponder(nil)
+        return window.makeFirstResponder(revealButton) || window.makeFirstResponder(self)
+    }
+
+    fileprivate func beginPointerSequence() {
+        guard isBlocking else { return }
+        isPointerSequenceActive = true
+    }
+
+    fileprivate func endPointerSequence() {
+        isPointerSequenceActive = false
+        guard hasPendingConfiguration else { return }
+        let pending = pendingConfiguration
+        pendingConfiguration = nil
+        hasPendingConfiguration = false
+        apply(configuration: pending, coveredViews: [], restoreResponder: true)
+    }
+
+    @objc private func revealButtonPressed(_ sender: Any?) {
+        requestReveal()
+    }
+
+    private func requestReveal() {
+        guard let configuration, configuration.state.blocksWebContent else { return }
+        configuration.onReveal()
+    }
+
+    private func configureContent(for presentation: BrowserCompanionPresentation) {
+        switch presentation {
+        case .veiled(let linked, let active):
+            titleLabel.stringValue = String(
+                localized: "agentCompanion.portal.linkedTitle",
+                defaultValue: "This page belongs to \(linked.identity.displayName)"
+            )
+            detailLabel.stringValue = String(
+                localized: "agentCompanion.portal.activeDetail",
+                defaultValue: "\(active.identity.displayName) is active. Reveal this page only if you intend to cross agent contexts."
+            )
+        case .orphaned(let link):
+            let name = link.lastKnownName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            titleLabel.stringValue = String(
+                localized: "agentCompanion.portal.orphanedTitle",
+                defaultValue: "This page belongs to an unavailable agent"
+            )
+            detailLabel.stringValue = name.flatMap { $0.isEmpty ? nil : $0 }.map {
+                String(
+                    localized: "agentCompanion.portal.orphanedDetail",
+                    defaultValue: "The linked agent \($0) is no longer available."
+                )
+            } ?? String(
+                localized: "agentCompanion.portal.orphanedDetailUnknown",
+                defaultValue: "The linked agent is no longer available."
+            )
+        default:
+            titleLabel.stringValue = String(
+                localized: "agentCompanion.portal.genericTitle",
+                defaultValue: "This companion page is private"
+            )
+            detailLabel.stringValue = ""
+        }
+    }
+
+    private func cacheAndHideAccessibility(for views: [NSView]) {
+        for view in views {
+            let viewId = ObjectIdentifier(view)
+            if accessibilitySnapshots[viewId] == nil {
+                accessibilitySnapshots[viewId] = BrowserCompanionAccessibilitySnapshot(
+                    view: view,
+                    wasHidden: view.isAccessibilityHidden()
+                )
+            }
+            view.setAccessibilityHidden(true)
+        }
+    }
+
+    private func capturePriorFirstResponderIfNeeded(in window: NSWindow, coveredViews: [NSView]) {
+        guard priorFirstResponder == nil,
+              let responder = window.firstResponder,
+              responder !== self,
+              responder !== revealButton,
+              let owningView = responder.browserPortalOwningView,
+              coveredViews.contains(where: { owningView === $0 || owningView.isDescendant(of: $0) })
+        else { return }
+        priorFirstResponder = responder
+    }
+
+    private func deactivate(restoreResponder: Bool) {
+        for snapshot in accessibilitySnapshots.values {
+            snapshot.view?.setAccessibilityHidden(snapshot.wasHidden)
+        }
+        accessibilitySnapshots.removeAll()
+        isHidden = true
+
+        guard let window else {
+            priorFirstResponder = nil
+            return
+        }
+        if restoreResponder,
+           let priorFirstResponder,
+           priorFirstResponder.acceptsFirstResponder,
+           priorFirstResponder.browserPortalOwningView?.window === window {
+            _ = window.makeFirstResponder(priorFirstResponder)
+        } else if window.firstResponder === self || window.firstResponder === revealButton {
+            _ = window.makeFirstResponder(nil)
+        }
+        priorFirstResponder = nil
+    }
+}
+
 struct BrowserPaneDropContext: Equatable {
     let workspaceId: UUID
     let panelId: UUID
@@ -1695,7 +2020,11 @@ final class WindowBrowserSlotView: NSView {
     private let paneDropTargetView = BrowserPaneDropTargetView(frame: .zero)
     private let dropZoneOverlayView = BrowserDropZoneOverlayView(frame: .zero)
     private var searchOverlayHostingView: NSHostingView<BrowserSearchOverlay>?
+    private var searchOverlayConfiguration: BrowserPortalSearchOverlayConfiguration?
+    private var companionOverlayHost: BrowserCompanionOverlayHost?
+    private var companionConfiguration: BrowserPortalCompanionConfiguration?
     private var paneInteractionOverlay: PaneInteractionOverlayHost?
+    private var paneInteractionActivityCancellable: AnyCancellable?
     private weak var hostedWebView: WKWebView?
     private var hostedWebViewConstraints: [NSLayoutConstraint] = []
     private var forwardedDropZone: DropZone?
@@ -1716,6 +2045,7 @@ final class WindowBrowserSlotView: NSView {
     private var lastHostedInspectorLayoutBoundsSize: NSSize?
 
     override func willRemoveSubview(_ subview: NSView) {
+        companionOverlayHost?.restoreAccessibility(for: subview)
         super.willRemoveSubview(subview)
         onHierarchyChanged?(self)
     }
@@ -1767,6 +2097,19 @@ final class WindowBrowserSlotView: NSView {
         super.viewDidMoveToSuperview()
         attachDropZoneOverlayIfNeeded()
         applyResolvedDropZoneOverlay()
+        companionOverlayHost?.updateCoveredViews(companionCoveredViews())
+        refreshInteractionLayersAndFocus(reason: "slotMovedToSuperview")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        guard window != nil, let companionConfiguration else { return }
+        companionOverlayHost?.apply(
+            configuration: companionConfiguration,
+            coveredViews: companionCoveredViews(),
+            restoreResponder: paneInteractionOverlay?.isHidden != false
+        )
+        refreshInteractionLayersAndFocus(reason: "slotMovedToWindow")
     }
 
     func recordPreferredHostedInspectorWidth(_ width: CGFloat, containerBounds: NSRect) {
@@ -1832,6 +2175,12 @@ final class WindowBrowserSlotView: NSView {
     }
 
     func setSearchOverlay(_ configuration: BrowserPortalSearchOverlayConfiguration?) {
+        if let configuration, companionConfiguration?.state.blocksWebContent == true {
+            closeSearchOverlayBeforeVeil(configuration)
+            return
+        }
+
+        searchOverlayConfiguration = configuration
         guard let configuration else {
             logSearchOverlayEvent("remove", panelId: nil)
             if let overlay = searchOverlayHostingView {
@@ -1844,6 +2193,7 @@ final class WindowBrowserSlotView: NSView {
             }
             searchOverlayHostingView?.removeFromSuperview()
             searchOverlayHostingView = nil
+            refreshInteractionLayersAndFocus(reason: "searchRemoved")
             return
         }
 
@@ -1878,6 +2228,7 @@ final class WindowBrowserSlotView: NSView {
                     overlay.trailingAnchor.constraint(equalTo: trailingAnchor),
                 ])
             }
+            refreshInteractionLayersAndFocus(reason: "searchUpdated")
             return
         }
 
@@ -1898,6 +2249,55 @@ final class WindowBrowserSlotView: NSView {
         ])
         searchOverlayHostingView = overlay
         logSearchOverlayEvent("create", panelId: configuration.panelId)
+        refreshInteractionLayersAndFocus(reason: "searchCreated")
+    }
+
+    /// Apply the companion privacy state to either a window-portal slot or the
+    /// same slot class used by local-inline browser hosting.
+    func setCompanion(_ configuration: BrowserPortalCompanionConfiguration?) {
+        let beginsBlocking = configuration?.state.blocksWebContent == true
+        if beginsBlocking, let searchOverlayConfiguration {
+            closeSearchOverlayBeforeVeil(searchOverlayConfiguration)
+        }
+
+        companionConfiguration = configuration
+        guard beginsBlocking || companionOverlayHost != nil else { return }
+        let overlay: BrowserCompanionOverlayHost
+        if let existing = companionOverlayHost {
+            overlay = existing
+        } else {
+            let created = BrowserCompanionOverlayHost(frame: bounds)
+            created.autoresizingMask = [.width, .height]
+            addSubview(created, positioned: .above, relativeTo: nil)
+            companionOverlayHost = created
+            overlay = created
+        }
+
+        overlay.frame = bounds
+        overlay.apply(
+            configuration: configuration,
+            coveredViews: companionCoveredViews(),
+            restoreResponder: paneInteractionOverlay?.isHidden != false
+        )
+        refreshInteractionLayersAndFocus(reason: "companionUpdated")
+    }
+
+    private func closeSearchOverlayBeforeVeil(_ configuration: BrowserPortalSearchOverlayConfiguration) {
+        if let window {
+            _ = yieldSearchOverlayFocusIfOwned(by: configuration.panelId, in: window)
+        }
+        searchOverlayConfiguration = nil
+        if let overlay = searchOverlayHostingView {
+            objc_setAssociatedObject(
+                overlay,
+                &cmuxBrowserSearchOverlayPanelIdAssociationKey,
+                nil,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+            overlay.removeFromSuperview()
+        }
+        searchOverlayHostingView = nil
+        configuration.onClose()
     }
 
     func searchOverlayPanelId(for responder: NSResponder) -> UUID? {
@@ -1916,8 +2316,10 @@ final class WindowBrowserSlotView: NSView {
     /// the webView above the modal card.
     func setPaneInteraction(_ configuration: BrowserPortalPaneInteractionConfiguration?) {
         guard let configuration else {
+            paneInteractionActivityCancellable = nil
             paneInteractionOverlay?.removeFromSuperview()
             paneInteractionOverlay = nil
+            refreshInteractionLayersAndFocus(reason: "paneInteractionRemoved")
             return
         }
 
@@ -1930,7 +2332,7 @@ final class WindowBrowserSlotView: NSView {
                 // would otherwise cover the modal card.
                 addSubview(existing, positioned: .above, relativeTo: nil)
                 existing.frame = bounds
-                _ = existing.requestKeyboardFocus(reason: "browserPortal.reraise")
+                refreshInteractionLayersAndFocus(reason: "paneInteractionReraise")
                 return
             }
             existing.removeFromSuperview()
@@ -1945,7 +2347,14 @@ final class WindowBrowserSlotView: NSView {
         overlay.autoresizingMask = [.width, .height]
         addSubview(overlay, positioned: .above, relativeTo: nil)
         paneInteractionOverlay = overlay
-        _ = overlay.requestKeyboardFocus(reason: "browserPortal.create")
+        paneInteractionActivityCancellable = configuration.runtime.$active
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                DispatchQueue.main.async { [weak self] in
+                    self?.refreshInteractionLayersAndFocus(reason: "paneInteractionActivity")
+                }
+            }
+        refreshInteractionLayersAndFocus(reason: "paneInteractionCreated")
     }
 
     @discardableResult
@@ -1990,6 +2399,8 @@ final class WindowBrowserSlotView: NSView {
         guard needsFrameHosting else {
             needsLayout = true
             layoutSubtreeIfNeeded()
+            companionOverlayHost?.updateCoveredViews(companionCoveredViews())
+            refreshInteractionLayersAndFocus(reason: "hostedWebViewStable")
             return
         }
 
@@ -2006,6 +2417,8 @@ final class WindowBrowserSlotView: NSView {
         }
         needsLayout = true
         layoutSubtreeIfNeeded()
+        companionOverlayHost?.updateCoveredViews(companionCoveredViews())
+        refreshInteractionLayersAndFocus(reason: "hostedWebViewPinned")
     }
 
     private static func frameDiffersFromBounds(_ frame: NSRect, bounds: NSRect, epsilon: CGFloat = 0.5) -> Bool {
@@ -2036,8 +2449,11 @@ final class WindowBrowserSlotView: NSView {
     override func didAddSubview(_ subview: NSView) {
         super.didAddSubview(subview)
         onHierarchyChanged?(self)
+        if subview !== companionOverlayHost {
+            companionOverlayHost?.updateCoveredViews(companionCoveredViews())
+        }
         guard subview !== paneDropTargetView else { return }
-        bringInteractionLayersToFrontIfNeeded()
+        refreshInteractionLayersAndFocus(reason: "subviewAdded")
     }
 
     private var activeDropZone: DropZone? {
@@ -2058,7 +2474,7 @@ final class WindowBrowserSlotView: NSView {
     private func applyResolvedDropZoneOverlay() {
         let resolvedZone = activeDropZone
         if resolvedZone != nil, (bounds.width <= 2 || bounds.height <= 2) {
-            bringInteractionLayersToFrontIfNeeded()
+            refreshInteractionLayersAndFocus(reason: "dropZoneTiny")
             return
         }
 
@@ -2068,14 +2484,14 @@ final class WindowBrowserSlotView: NSView {
 
         guard let zone = resolvedZone else {
             guard !dropZoneOverlayView.isHidden else {
-                bringInteractionLayersToFrontIfNeeded()
+                refreshInteractionLayersAndFocus(reason: "dropZoneAlreadyHidden")
                 return
             }
 
             dropZoneOverlayAnimationGeneration &+= 1
             let animationGeneration = dropZoneOverlayAnimationGeneration
             dropZoneOverlayView.layer?.removeAllAnimations()
-            bringInteractionLayersToFrontIfNeeded()
+            refreshInteractionLayersAndFocus(reason: "dropZoneHiding")
 
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.14
@@ -2097,7 +2513,7 @@ final class WindowBrowserSlotView: NSView {
         let zoneChanged = previousZone != zone
 
         if !dropZoneOverlayView.isHidden && !needsFrameUpdate && !zoneChanged {
-            bringInteractionLayersToFrontIfNeeded()
+            refreshInteractionLayersAndFocus(reason: "dropZoneStable")
             return
         }
 
@@ -2108,7 +2524,7 @@ final class WindowBrowserSlotView: NSView {
             applyDropZoneOverlayFrame(targetFrame)
             dropZoneOverlayView.alphaValue = 0
             dropZoneOverlayView.isHidden = false
-            bringInteractionLayersToFrontIfNeeded()
+            refreshInteractionLayersAndFocus(reason: "dropZoneRevealing")
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.18
                 context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
@@ -2117,7 +2533,7 @@ final class WindowBrowserSlotView: NSView {
             return
         }
 
-        bringInteractionLayersToFrontIfNeeded()
+        refreshInteractionLayersAndFocus(reason: "dropZoneUpdated")
         NSAnimationContext.runAnimationGroup { context in
             context.duration = 0.18
             context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
@@ -2131,11 +2547,14 @@ final class WindowBrowserSlotView: NSView {
     }
 
     private func interactionLayerPriority(of view: NSView) -> Int {
-        if view === paneDropTargetView { return 1 }
+        if view === searchOverlayHostingView { return 1 }
+        if view === companionOverlayHost { return 2 }
+        if view === paneDropTargetView { return 3 }
+        if view === paneInteractionOverlay { return 4 }
         return 0
     }
 
-    private func bringInteractionLayersToFrontIfNeeded() {
+    private func refreshInteractionLayersAndFocus(reason: String) {
         guard !isRefreshingInteractionLayers else { return }
         isRefreshingInteractionLayers = true
         defer { isRefreshingInteractionLayers = false }
@@ -2159,6 +2578,27 @@ final class WindowBrowserSlotView: NSView {
             if lhsPriority == rhsPriority { return .orderedSame }
             return lhsPriority < rhsPriority ? .orderedAscending : .orderedDescending
         }, context: context)
+
+        if let paneInteractionOverlay, !paneInteractionOverlay.isHidden {
+            _ = paneInteractionOverlay.requestKeyboardFocus(reason: "browserPortal.\(reason)")
+        } else {
+            _ = companionOverlayHost?.requestKeyboardFocus(reason: reason)
+        }
+    }
+
+    private func companionCoveredViews() -> [NSView] {
+        subviews.filter { view in
+            if view === hostedWebView { return true }
+            guard interactionLayerPriority(of: view) == 0 else { return false }
+            var stack = [view]
+            while let candidate = stack.popLast() {
+                if String(describing: type(of: candidate)).contains("WK") {
+                    return true
+                }
+                stack.append(contentsOf: candidate.subviews)
+            }
+            return false
+        }
     }
 
     private func applyDropZoneOverlayFrame(_ frame: CGRect) {
@@ -2217,6 +2657,7 @@ final class WindowBrowserPortal: NSObject {
         var dropZone: DropZone?
         var paneDropContext: BrowserPaneDropContext?
         var searchOverlay: BrowserPortalSearchOverlayConfiguration?
+        var companion: BrowserPortalCompanionConfiguration?
         var paneInteraction: BrowserPortalPaneInteractionConfiguration?
         var workspaceFrameStyle: PortalWorkspaceFrameStyle?
         var paneTopChromeHeight: CGFloat
@@ -2728,6 +3169,7 @@ final class WindowBrowserPortal: NSObject {
         if let existing = entry.containerView {
             existing.setPaneDropContext(entry.paneDropContext)
             existing.setSearchOverlay(entry.searchOverlay)
+            existing.setCompanion(entry.companion)
             existing.setPaneInteraction(entry.paneInteraction)
             existing.setPaneTopChromeHeight(entry.paneTopChromeHeight)
             return existing
@@ -2735,6 +3177,7 @@ final class WindowBrowserPortal: NSObject {
         let created = WindowBrowserSlotView(frame: .zero)
         created.setPaneDropContext(entry.paneDropContext)
         created.setSearchOverlay(entry.searchOverlay)
+        created.setCompanion(entry.companion)
         created.setPaneInteraction(entry.paneInteraction)
         created.setPaneTopChromeHeight(entry.paneTopChromeHeight)
 #if DEBUG
@@ -2954,6 +3397,7 @@ final class WindowBrowserPortal: NSObject {
             "hadContainerSuperview=\(hadContainerSuperview) hadWebSuperview=\(hadWebSuperview)"
         )
 #endif
+        entry.containerView?.setCompanion(nil)
         entry.webView?.browserPortalNotifyHidden(reason: "detach")
         entry.webView?.removeFromSuperview()
         entry.containerView?.removeFromSuperview()
@@ -3022,6 +3466,26 @@ final class WindowBrowserPortal: NSObject {
         entry.searchOverlay = configuration
         entriesByWebViewId[webViewId] = entry
         entry.containerView?.setSearchOverlay(configuration)
+    }
+
+    func updateCompanion(
+        forWebViewId webViewId: ObjectIdentifier,
+        configuration: BrowserPortalCompanionConfiguration?
+    ) {
+        guard var entry = entriesByWebViewId[webViewId] else { return }
+        let searchOverlayToClose: BrowserPortalSearchOverlayConfiguration?
+        if configuration?.state.blocksWebContent == true,
+           let searchOverlay = entry.searchOverlay {
+            entry.searchOverlay = nil
+            entry.containerView?.setSearchOverlay(nil)
+            searchOverlayToClose = searchOverlay
+        } else {
+            searchOverlayToClose = nil
+        }
+        entry.companion = configuration
+        entriesByWebViewId[webViewId] = entry
+        searchOverlayToClose?.onClose()
+        entriesByWebViewId[webViewId]?.containerView?.setCompanion(configuration)
     }
 
     func updatePaneInteraction(
@@ -3109,6 +3573,7 @@ final class WindowBrowserPortal: NSObject {
                 dropZone: nil,
                 paneDropContext: nil,
                 searchOverlay: nil,
+                companion: nil,
                 paneInteraction: nil,
                 workspaceFrameStyle: nil,
                 paneTopChromeHeight: 0,
@@ -3147,6 +3612,7 @@ final class WindowBrowserPortal: NSObject {
             dropZone: previousEntry?.dropZone,
             paneDropContext: previousEntry?.paneDropContext,
             searchOverlay: previousEntry?.searchOverlay,
+            companion: previousEntry?.companion,
             paneInteraction: previousEntry?.paneInteraction,
             workspaceFrameStyle: previousEntry?.workspaceFrameStyle,
             paneTopChromeHeight: previousEntry?.paneTopChromeHeight ?? 0,
@@ -3379,6 +3845,7 @@ final class WindowBrowserPortal: NSObject {
         func hideContainerView(reason: String) {
             containerView.setPaneTopChromeHeight(0)
             containerView.setSearchOverlay(nil)
+            containerView.setCompanion(nil)
             containerView.setPaneDropContext(nil)
             containerView.setPortalDragDropZone(nil)
             containerView.setDropZoneOverlay(zone: nil)
@@ -3783,6 +4250,7 @@ final class WindowBrowserPortal: NSObject {
         }
         containerView.setPaneTopChromeHeight(shouldHide ? 0 : entry.paneTopChromeHeight)
         containerView.setSearchOverlay(shouldHide ? nil : entry.searchOverlay)
+        containerView.setCompanion(shouldHide ? nil : entry.companion)
         // Re-raise the pane-interaction overlay above the WKWebView the portal just
         // re-added during this sync pass. The overlay host observes the runtime
         // itself — we only need to ensure it stays on top of the z-order.
@@ -4119,6 +4587,16 @@ enum BrowserWindowPortalRegistry {
         guard let windowId = webViewToWindowId[webViewId],
               let portal = portalsByWindowId[windowId] else { return }
         portal.updateSearchOverlay(forWebViewId: webViewId, configuration: configuration)
+    }
+
+    static func updateCompanion(
+        for webView: WKWebView,
+        configuration: BrowserPortalCompanionConfiguration?
+    ) {
+        let webViewId = ObjectIdentifier(webView)
+        guard let windowId = webViewToWindowId[webViewId],
+              let portal = portalsByWindowId[windowId] else { return }
+        portal.updateCompanion(forWebViewId: webViewId, configuration: configuration)
     }
 
     static func updatePaneInteraction(

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1338,6 +1338,14 @@ private final class BrowserCompanionRevealButton: NSButton {
 
     override var acceptsFirstResponder: Bool { true }
 
+    override func keyDown(with event: NSEvent) {
+        companionHost?.keyDown(with: event)
+    }
+
+    override func keyUp(with event: NSEvent) {
+        companionHost?.keyUp(with: event)
+    }
+
     override func mouseDown(with event: NSEvent) {
         companionHost?.beginPointerSequence()
         defer { companionHost?.endPointerSequence() }
@@ -1367,6 +1375,7 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
     private var accessibilitySnapshots: [ObjectIdentifier: BrowserCompanionAccessibilitySnapshot] = [:]
     private weak var priorFirstResponder: NSResponder?
     private var isPointerSequenceActive = false
+    private var activationKeyCode: UInt16?
     private var hasPendingConfiguration = false
     private var pendingConfiguration: BrowserPortalCompanionConfiguration?
 
@@ -1480,6 +1489,8 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
         guard isBlocking else { return }
         switch event.keyCode {
         case 36, 49, 76: // Return, Space, keypad Enter
+            guard activationKeyCode == nil else { return }
+            activationKeyCode = event.keyCode
             requestReveal()
         case 48: // Tab: keep traversal inside the AppKit overlay layer.
             if event.modifierFlags.contains(.shift) {
@@ -1494,12 +1505,19 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
         }
     }
 
+    override func keyUp(with event: NSEvent) {
+        guard isBlocking || activationKeyCode != nil else { return }
+        guard activationKeyCode == event.keyCode else { return }
+        activationKeyCode = nil
+        finishDeferredRevealInputIfNeeded()
+    }
+
     func apply(
         configuration: BrowserPortalCompanionConfiguration?,
         coveredViews: [NSView],
         restoreResponder: Bool
     ) {
-        if isPointerSequenceActive,
+        if (isPointerSequenceActive || activationKeyCode != nil),
            configuration?.state.blocksWebContent != true {
             pendingConfiguration = configuration
             hasPendingConfiguration = true
@@ -1549,6 +1567,11 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
 
     fileprivate func endPointerSequence() {
         isPointerSequenceActive = false
+        finishDeferredRevealInputIfNeeded()
+    }
+
+    private func finishDeferredRevealInputIfNeeded() {
+        guard !isPointerSequenceActive, activationKeyCode == nil else { return }
         guard hasPendingConfiguration else { return }
         let pending = pendingConfiguration
         pendingConfiguration = nil
@@ -1629,6 +1652,10 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
             snapshot.view?.setAccessibilityHidden(snapshot.wasHidden)
         }
         accessibilitySnapshots.removeAll()
+        isPointerSequenceActive = false
+        activationKeyCode = nil
+        pendingConfiguration = nil
+        hasPendingConfiguration = false
         isHidden = true
 
         guard let window else {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1378,6 +1378,7 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
     private var activationKeyCode: UInt16?
     private var hasPendingConfiguration = false
     private var pendingConfiguration: BrowserPortalCompanionConfiguration?
+    private var shouldAcquireKeyboardFocus = false
 
     override var acceptsFirstResponder: Bool { isBlocking }
 
@@ -1450,7 +1451,8 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
     }
 
     override func viewWillMove(toWindow newWindow: NSWindow?) {
-        if newWindow == nil {
+        if newWindow == nil || (window != nil && newWindow !== window) {
+            configuration = nil
             deactivate(restoreResponder: false)
         }
         super.viewWillMove(toWindow: newWindow)
@@ -1517,11 +1519,18 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
         coveredViews: [NSView],
         restoreResponder: Bool
     ) {
-        if (isPointerSequenceActive || activationKeyCode != nil),
-           configuration?.state.blocksWebContent != true {
-            pendingConfiguration = configuration
-            hasPendingConfiguration = true
-            return
+        if isPointerSequenceActive || activationKeyCode != nil {
+            if configuration?.state.blocksWebContent == true {
+                // A newer blocking state supersedes a reveal queued by the
+                // current input sequence. Never let stale nonblocking state
+                // expose WebKit when the matching mouse/key release arrives.
+                pendingConfiguration = nil
+                hasPendingConfiguration = false
+            } else {
+                pendingConfiguration = configuration
+                hasPendingConfiguration = true
+                return
+            }
         }
 
         self.configuration = configuration
@@ -1550,10 +1559,21 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
     }
 
     @discardableResult
-    func requestKeyboardFocus(reason: String) -> Bool {
+    func requestKeyboardFocus(reason: String, force: Bool = false) -> Bool {
         guard isBlocking, let window else { return false }
         if window.firstResponder === revealButton || window.firstResponder === self {
             return true
+        }
+        if force {
+            shouldAcquireKeyboardFocus = true
+        }
+        guard shouldAcquireKeyboardFocus else { return false }
+        if let currentResponder = window.firstResponder,
+           !responderBelongsToCoveredView(currentResponder) {
+            // The operator moved to another pane. Layer refreshes must never
+            // pull focus back merely because this browser remains veiled.
+            shouldAcquireKeyboardFocus = false
+            return false
         }
         if window.makeFirstResponder(revealButton) { return true }
         window.makeFirstResponder(nil)
@@ -1645,6 +1665,15 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
               coveredViews.contains(where: { owningView === $0 || owningView.isDescendant(of: $0) })
         else { return }
         priorFirstResponder = responder
+        shouldAcquireKeyboardFocus = true
+    }
+
+    private func responderBelongsToCoveredView(_ responder: NSResponder) -> Bool {
+        guard let owningView = responder.browserPortalOwningView else { return false }
+        return accessibilitySnapshots.values.contains { snapshot in
+            guard let coveredView = snapshot.view else { return false }
+            return owningView === coveredView || owningView.isDescendant(of: coveredView)
+        }
     }
 
     private func deactivate(restoreResponder: Bool) {
@@ -1656,18 +1685,22 @@ final class BrowserCompanionOverlayHost: NSVisualEffectView {
         activationKeyCode = nil
         pendingConfiguration = nil
         hasPendingConfiguration = false
+        shouldAcquireKeyboardFocus = false
         isHidden = true
 
         guard let window else {
             priorFirstResponder = nil
             return
         }
+        let overlayOwnsFirstResponder =
+            window.firstResponder === self || window.firstResponder === revealButton
         if restoreResponder,
+           overlayOwnsFirstResponder || window.firstResponder == nil,
            let priorFirstResponder,
            priorFirstResponder.acceptsFirstResponder,
            priorFirstResponder.browserPortalOwningView?.window === window {
             _ = window.makeFirstResponder(priorFirstResponder)
-        } else if window.firstResponder === self || window.firstResponder === revealButton {
+        } else if overlayOwnsFirstResponder {
             _ = window.makeFirstResponder(nil)
         }
         priorFirstResponder = nil
@@ -2203,7 +2236,7 @@ final class WindowBrowserSlotView: NSView {
 
     func setSearchOverlay(_ configuration: BrowserPortalSearchOverlayConfiguration?) {
         if let configuration, companionConfiguration?.state.blocksWebContent == true {
-            closeSearchOverlayBeforeVeil(configuration)
+            _ = closeSearchOverlayBeforeVeil(configuration)
             return
         }
 
@@ -2283,8 +2316,9 @@ final class WindowBrowserSlotView: NSView {
     /// same slot class used by local-inline browser hosting.
     func setCompanion(_ configuration: BrowserPortalCompanionConfiguration?) {
         let beginsBlocking = configuration?.state.blocksWebContent == true
+        var yieldedSearchFocus = false
         if beginsBlocking, let searchOverlayConfiguration {
-            closeSearchOverlayBeforeVeil(searchOverlayConfiguration)
+            yieldedSearchFocus = closeSearchOverlayBeforeVeil(searchOverlayConfiguration)
         }
 
         companionConfiguration = configuration
@@ -2306,12 +2340,21 @@ final class WindowBrowserSlotView: NSView {
             coveredViews: companionCoveredViews(),
             restoreResponder: paneInteractionOverlay?.isHidden != false
         )
+        if yieldedSearchFocus {
+            _ = overlay.requestKeyboardFocus(reason: "searchYieldedForCompanion", force: true)
+        }
         refreshInteractionLayersAndFocus(reason: "companionUpdated")
     }
 
-    private func closeSearchOverlayBeforeVeil(_ configuration: BrowserPortalSearchOverlayConfiguration) {
+    @discardableResult
+    private func closeSearchOverlayBeforeVeil(
+        _ configuration: BrowserPortalSearchOverlayConfiguration
+    ) -> Bool {
+        let yieldedFocus: Bool
         if let window {
-            _ = yieldSearchOverlayFocusIfOwned(by: configuration.panelId, in: window)
+            yieldedFocus = yieldSearchOverlayFocusIfOwned(by: configuration.panelId, in: window)
+        } else {
+            yieldedFocus = false
         }
         searchOverlayConfiguration = nil
         if let overlay = searchOverlayHostingView {
@@ -2325,6 +2368,7 @@ final class WindowBrowserSlotView: NSView {
         }
         searchOverlayHostingView = nil
         configuration.onClose()
+        return yieldedFocus
     }
 
     func searchOverlayPanelId(for responder: NSResponder) -> UUID? {
@@ -3504,15 +3548,20 @@ final class WindowBrowserPortal: NSObject {
         if configuration?.state.blocksWebContent == true,
            let searchOverlay = entry.searchOverlay {
             entry.searchOverlay = nil
-            entry.containerView?.setSearchOverlay(nil)
             searchOverlayToClose = searchOverlay
         } else {
             searchOverlayToClose = nil
         }
         entry.companion = configuration
         entriesByWebViewId[webViewId] = entry
-        searchOverlayToClose?.onClose()
-        entriesByWebViewId[webViewId]?.containerView?.setCompanion(configuration)
+        if let containerView = entriesByWebViewId[webViewId]?.containerView {
+            // Let the slot close/yield its live search overlay so it can carry
+            // a same-pane focus claim into the veil without stealing focus
+            // from unrelated panes.
+            containerView.setCompanion(configuration)
+        } else {
+            searchOverlayToClose?.onClose()
+        }
     }
 
     func updatePaneInteraction(

--- a/c11Tests/BrowserCompanionPortalTests.swift
+++ b/c11Tests/BrowserCompanionPortalTests.swift
@@ -121,12 +121,14 @@ final class BrowserCompanionPortalTests: XCTestCase {
         let (window, slot, _) = makeWindowSlotAndWebView()
         defer { window.orderOut(nil) }
         var revealCount = 0
-        slot.setCompanion(
-            configuration(
-                for: .veiled(linked: linkedAgent, active: activeAgent),
-                onReveal: { revealCount += 1 }
-            )
+        let blockingConfiguration = configuration(
+            for: .veiled(linked: linkedAgent, active: activeAgent),
+            onReveal: {
+                revealCount += 1
+                slot.setCompanion(nil)
+            }
         )
+        slot.setCompanion(blockingConfiguration)
         guard let overlay = companionOverlay(in: slot) else {
             XCTFail("Expected companion overlay")
             return
@@ -135,8 +137,27 @@ final class BrowserCompanionPortalTests: XCTestCase {
         overlay.keyDown(with: keyEvent(characters: "a", keyCode: 0, window: window))
         XCTAssertEqual(revealCount, 0)
         overlay.keyDown(with: keyEvent(characters: "\r", keyCode: 36, window: window))
-        overlay.keyDown(with: keyEvent(characters: " ", keyCode: 49, window: window))
+        XCTAssertEqual(revealCount, 1)
+        XCTAssertFalse(
+            overlay.isHidden,
+            "Synchronous keyboard reveal must retain the veil until matching key-up"
+        )
+        overlay.keyUp(with: keyEvent(type: .keyUp, characters: "\r", keyCode: 36, window: window))
+        XCTAssertTrue(overlay.isHidden)
+
+        slot.setCompanion(blockingConfiguration)
+        guard let revealButton = descendantRevealButton(in: overlay) else {
+            XCTFail("Expected focused reveal button")
+            return
+        }
+        revealButton.keyDown(with: keyEvent(characters: " ", keyCode: 49, window: window))
         XCTAssertEqual(revealCount, 2)
+        XCTAssertFalse(
+            overlay.isHidden,
+            "The focused button must route activation through the same key-up hold"
+        )
+        revealButton.keyUp(with: keyEvent(type: .keyUp, characters: " ", keyCode: 49, window: window))
+        XCTAssertTrue(overlay.isHidden)
     }
 
     func testBlockingCompanionClosesSearchBeforeInstallingVeilAndRejectsReopen() {
@@ -285,6 +306,15 @@ final class BrowserCompanionPortalTests: XCTestCase {
         slot.subviews.compactMap { $0 as? BrowserCompanionOverlayHost }.first
     }
 
+    private func descendantRevealButton(in root: NSView) -> NSButton? {
+        var stack = root.subviews
+        while let view = stack.popLast() {
+            if let button = view as? NSButton { return button }
+            stack.append(contentsOf: view.subviews)
+        }
+        return nil
+    }
+
     private func owningView(for responder: NSResponder?) -> NSView? {
         if let editor = responder as? NSTextView,
            editor.isFieldEditor,
@@ -311,9 +341,14 @@ final class BrowserCompanionPortalTests: XCTestCase {
         return event
     }
 
-    private func keyEvent(characters: String, keyCode: UInt16, window: NSWindow) -> NSEvent {
+    private func keyEvent(
+        type: NSEvent.EventType = .keyDown,
+        characters: String,
+        keyCode: UInt16,
+        window: NSWindow
+    ) -> NSEvent {
         guard let event = NSEvent.keyEvent(
-            with: .keyDown,
+            with: type,
             location: .zero,
             modifierFlags: [],
             timestamp: ProcessInfo.processInfo.systemUptime,

--- a/c11Tests/BrowserCompanionPortalTests.swift
+++ b/c11Tests/BrowserCompanionPortalTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import WebKit
 
 #if canImport(c11_DEV)
 @testable import c11_DEV
@@ -6,5 +7,329 @@ import XCTest
 @testable import c11
 #endif
 
-/// Membership scaffold for ACB-02 AppKit/WebKit portal acceptance tests.
-final class BrowserCompanionPortalTests: XCTestCase {}
+@MainActor
+final class BrowserCompanionPortalTests: XCTestCase {
+    private let linkedAgent = AgentDescriptor(
+        identity: CompanionSurfaceIdentity(
+            surfaceID: UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            surfaceRef: "surface:11",
+            surfaceOrdinal: 11,
+            displayName: "Linked Agent"
+        ),
+        terminalKind: "codex"
+    )
+    private let activeAgent = AgentDescriptor(
+        identity: CompanionSurfaceIdentity(
+            surfaceID: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            surfaceRef: "surface:22",
+            surfaceOrdinal: 22,
+            displayName: "Active Agent"
+        ),
+        terminalKind: "claude"
+    )
+
+    func testVeilBlocksHitTestingHidesWebKitAccessibilityAndRestoresExactStateAndResponder() {
+        let (window, slot, webView) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+
+        let inspector = CompanionWKInspectorResponderView(frame: slot.bounds)
+        inspector.setAccessibilityHidden(true)
+        slot.addSubview(inspector)
+        XCTAssertTrue(window.makeFirstResponder(inspector))
+
+        slot.setCompanion(configuration(for: .veiled(linked: linkedAgent, active: activeAgent)))
+
+        guard let overlay = companionOverlay(in: slot) else {
+            XCTFail("Expected an AppKit companion veil")
+            return
+        }
+        XCTAssertFalse(overlay.isHidden)
+        let hit = slot.hitTest(NSPoint(x: slot.bounds.midX, y: slot.bounds.midY))
+        XCTAssertTrue(hit === overlay || hit?.isDescendant(of: overlay) == true)
+        XCTAssertFalse(hit === webView)
+        XCTAssertTrue(webView.isAccessibilityHidden())
+        XCTAssertTrue(inspector.isAccessibilityHidden())
+        let firstResponderView = owningView(for: window.firstResponder)
+        XCTAssertTrue(
+            window.firstResponder === overlay ||
+                firstResponderView?.isDescendant(of: overlay) == true
+        )
+
+        slot.setCompanion(configuration(for: .aligned(linked: linkedAgent)))
+
+        XCTAssertTrue(overlay.isHidden)
+        XCTAssertFalse(webView.isAccessibilityHidden(), "Page AX state should restore to its exact prior value")
+        XCTAssertTrue(inspector.isAccessibilityHidden(), "Inspector AX state should restore to its exact prior value")
+        XCTAssertTrue(window.firstResponder === inspector)
+    }
+
+    func testRemovingCoveredInspectorWhileVeiledRestoresItsAccessibilityImmediately() {
+        let (window, slot, webView) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+
+        webView.setAccessibilityHidden(true)
+        let inspector = CompanionWKInspectorResponderView(frame: slot.bounds)
+        inspector.setAccessibilityHidden(false)
+        slot.addSubview(inspector)
+        slot.setCompanion(configuration(for: .veiled(linked: linkedAgent, active: activeAgent)))
+
+        XCTAssertTrue(webView.isAccessibilityHidden())
+        XCTAssertTrue(inspector.isAccessibilityHidden())
+
+        inspector.removeFromSuperview()
+        XCTAssertFalse(
+            inspector.isAccessibilityHidden(),
+            "A WebKit root leaving the covered slot must not retain veil-owned AX state"
+        )
+
+        slot.setCompanion(nil)
+        XCTAssertTrue(
+            webView.isAccessibilityHidden(),
+            "Teardown must restore a page that was already AX-hidden before the veil"
+        )
+    }
+
+    func testMouseRevealKeepsVeilInstalledThroughMatchingMouseUp() {
+        let (window, slot, _) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+        var revealCount = 0
+        let configuration = configuration(
+            for: .veiled(linked: linkedAgent, active: activeAgent),
+            onReveal: {
+                revealCount += 1
+                slot.setCompanion(nil)
+            }
+        )
+        slot.setCompanion(configuration)
+        guard let overlay = companionOverlay(in: slot) else {
+            XCTFail("Expected companion overlay")
+            return
+        }
+
+        overlay.mouseDown(with: mouseEvent(type: .leftMouseDown, window: window))
+        XCTAssertEqual(revealCount, 1)
+        XCTAssertFalse(
+            overlay.isHidden,
+            "Synchronous reveal state changes must not expose WebKit before mouse-up is consumed"
+        )
+
+        overlay.mouseUp(with: mouseEvent(type: .leftMouseUp, window: window))
+        XCTAssertTrue(overlay.isHidden)
+    }
+
+    func testReturnAndSpaceRevealWhileOtherKeysRemainConsumed() {
+        let (window, slot, _) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+        var revealCount = 0
+        slot.setCompanion(
+            configuration(
+                for: .veiled(linked: linkedAgent, active: activeAgent),
+                onReveal: { revealCount += 1 }
+            )
+        )
+        guard let overlay = companionOverlay(in: slot) else {
+            XCTFail("Expected companion overlay")
+            return
+        }
+
+        overlay.keyDown(with: keyEvent(characters: "a", keyCode: 0, window: window))
+        XCTAssertEqual(revealCount, 0)
+        overlay.keyDown(with: keyEvent(characters: "\r", keyCode: 36, window: window))
+        overlay.keyDown(with: keyEvent(characters: " ", keyCode: 49, window: window))
+        XCTAssertEqual(revealCount, 2)
+    }
+
+    func testBlockingCompanionClosesSearchBeforeInstallingVeilAndRejectsReopen() {
+        let (window, slot, _) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+        var closeCount = 0
+        let search = searchConfiguration(onClose: { closeCount += 1 })
+        slot.setSearchOverlay(search)
+        XCTAssertTrue(slot.subviews.contains { String(describing: type(of: $0)).contains("NSHostingView") })
+
+        slot.setCompanion(configuration(for: .veiled(linked: linkedAgent, active: activeAgent)))
+
+        XCTAssertEqual(closeCount, 1)
+        XCTAssertFalse(slot.subviews.contains { String(describing: type(of: $0)).contains("NSHostingView") })
+        XCTAssertFalse(companionOverlay(in: slot)?.isHidden ?? true)
+
+        slot.setSearchOverlay(search)
+        XCTAssertEqual(closeCount, 2)
+        XCTAssertFalse(slot.subviews.contains { String(describing: type(of: $0)).contains("NSHostingView") })
+    }
+
+    func testInteractionLayerOrderIsWebKitThenSearchThenVeilThenDragThenModal() {
+        let (window, slot, webView) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+
+        slot.setCompanion(configuration(for: .veiled(linked: linkedAgent, active: activeAgent)))
+        slot.setCompanion(configuration(for: .revealed(linked: linkedAgent, active: activeAgent)))
+        slot.setSearchOverlay(searchConfiguration(onClose: {}))
+        slot.setPaneInteraction(
+            BrowserPortalPaneInteractionConfiguration(
+                panelId: UUID(),
+                runtime: PaneInteractionRuntime()
+            )
+        )
+
+        let subviews = slot.subviews
+        guard let webIndex = subviews.firstIndex(where: { $0 === webView }),
+              let searchIndex = subviews.firstIndex(where: {
+                  String(describing: type(of: $0)).contains("NSHostingView")
+              }),
+              let veilIndex = subviews.firstIndex(where: { $0 is BrowserCompanionOverlayHost }),
+              let dragIndex = subviews.firstIndex(where: {
+                  String(describing: type(of: $0)).contains("BrowserPaneDropTargetView")
+              }),
+              let modalIndex = subviews.firstIndex(where: { $0 is PaneInteractionOverlayHost })
+        else {
+            XCTFail("Expected all five portal interaction layers")
+            return
+        }
+
+        XCTAssertLessThan(webIndex, searchIndex)
+        XCTAssertLessThan(searchIndex, veilIndex)
+        XCTAssertLessThan(veilIndex, dragIndex)
+        XCTAssertLessThan(dragIndex, modalIndex)
+    }
+
+    func testRegistrySetterAppliesVeilAndDetachRestoresAccessibility() {
+        _ = NSApplication.shared
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = contentView
+        let anchor = NSView(frame: NSRect(x: 30, y: 30, width: 420, height: 220))
+        contentView.addSubview(anchor)
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+
+        BrowserWindowPortalRegistry.bind(webView: webView, to: anchor, visibleInUI: true)
+        BrowserWindowPortalRegistry.synchronizeForAnchor(anchor)
+        defer {
+            BrowserWindowPortalRegistry.detach(webView: webView)
+            window.orderOut(nil)
+        }
+
+        BrowserWindowPortalRegistry.updateCompanion(
+            for: webView,
+            configuration: configuration(for: .orphaned(link: AgentSurfaceLink(
+                surfaceID: linkedAgent.identity.surfaceID,
+                lastKnownName: linkedAgent.identity.displayName
+            )))
+        )
+
+        guard let slot = webView.superview as? WindowBrowserSlotView else {
+            XCTFail("Expected registry-bound portal slot")
+            return
+        }
+        XCTAssertFalse(companionOverlay(in: slot)?.isHidden ?? true)
+        XCTAssertTrue(webView.isAccessibilityHidden())
+
+        BrowserWindowPortalRegistry.detach(webView: webView)
+        XCTAssertFalse(webView.isAccessibilityHidden())
+    }
+
+    private func makeWindowSlotAndWebView() -> (NSWindow, WindowBrowserSlotView, WKWebView) {
+        _ = NSApplication.shared
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = contentView
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 30, y: 30, width: 420, height: 220))
+        contentView.addSubview(slot)
+        let webView = WKWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
+        webView.autoresizingMask = [.width, .height]
+        slot.addSubview(webView)
+        slot.pinHostedWebView(webView)
+        window.makeKeyAndOrderFront(nil)
+        contentView.layoutSubtreeIfNeeded()
+        return (window, slot, webView)
+    }
+
+    private func configuration(
+        for presentation: BrowserCompanionPresentation,
+        onReveal: @escaping @MainActor @Sendable () -> Void = {},
+        onHide: @escaping @MainActor @Sendable () -> Void = {}
+    ) -> BrowserPortalCompanionConfiguration {
+        BrowserPortalCompanionConfiguration(
+            state: BrowserPortalCompanionState(presentation: presentation),
+            onReveal: onReveal,
+            onHide: onHide
+        )
+    }
+
+    private func searchConfiguration(onClose: @escaping () -> Void) -> BrowserPortalSearchOverlayConfiguration {
+        BrowserPortalSearchOverlayConfiguration(
+            panelId: UUID(),
+            searchState: BrowserSearchState(),
+            focusRequestGeneration: 0,
+            canApplyFocusRequest: { _ in true },
+            onNext: {},
+            onPrevious: {},
+            onClose: onClose,
+            onFieldDidFocus: {}
+        )
+    }
+
+    private func companionOverlay(in slot: WindowBrowserSlotView) -> BrowserCompanionOverlayHost? {
+        slot.subviews.compactMap { $0 as? BrowserCompanionOverlayHost }.first
+    }
+
+    private func owningView(for responder: NSResponder?) -> NSView? {
+        if let editor = responder as? NSTextView,
+           editor.isFieldEditor,
+           let editedView = editor.delegate as? NSView {
+            return editedView
+        }
+        return responder as? NSView
+    }
+
+    private func mouseEvent(type: NSEvent.EventType, window: NSWindow) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: NSPoint(x: 100, y: 100),
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: type == .leftMouseDown ? 1 : 0
+        ) else {
+            fatalError("Failed to create pointer event")
+        }
+        return event
+    }
+
+    private func keyEvent(characters: String, keyCode: UInt16, window: NSWindow) -> NSEvent {
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        ) else {
+            fatalError("Failed to create key event")
+        }
+        return event
+    }
+}
+
+private final class CompanionWKInspectorResponderView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}

--- a/c11Tests/BrowserCompanionPortalTests.swift
+++ b/c11Tests/BrowserCompanionPortalTests.swift
@@ -160,6 +160,93 @@ final class BrowserCompanionPortalTests: XCTestCase {
         XCTAssertTrue(overlay.isHidden)
     }
 
+    func testVeilRefreshDoesNotStealFirstResponderFromAnotherPane() {
+        let (window, slot, _) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+        let outsideResponder = CompanionOutsideResponderView(
+            frame: NSRect(x: 460, y: 30, width: 40, height: 40)
+        )
+        window.contentView?.addSubview(outsideResponder)
+        XCTAssertTrue(window.makeFirstResponder(outsideResponder))
+
+        slot.setCompanion(configuration(for: .veiled(linked: linkedAgent, active: activeAgent)))
+        slot.setPaneTopChromeHeight(18)
+
+        XCTAssertTrue(window.firstResponder === outsideResponder)
+        XCTAssertFalse(companionOverlay(in: slot)?.isHidden ?? true)
+    }
+
+    func testRevealDoesNotRestoreCoveredResponderOverAnotherPane() {
+        let (window, slot, _) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+        let coveredResponder = CompanionWKInspectorResponderView(frame: slot.bounds)
+        slot.addSubview(coveredResponder)
+        XCTAssertTrue(window.makeFirstResponder(coveredResponder))
+        slot.setCompanion(configuration(for: .veiled(linked: linkedAgent, active: activeAgent)))
+
+        let outsideResponder = CompanionOutsideResponderView(
+            frame: NSRect(x: 460, y: 30, width: 40, height: 40)
+        )
+        window.contentView?.addSubview(outsideResponder)
+        XCTAssertTrue(window.makeFirstResponder(outsideResponder))
+        slot.setCompanion(configuration(for: .aligned(linked: linkedAgent)))
+
+        XCTAssertTrue(window.firstResponder === outsideResponder)
+    }
+
+    func testNewBlockingStateSupersedesRevealQueuedUntilKeyUp() {
+        let (window, slot, webView) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+        slot.setCompanion(
+            configuration(
+                for: .veiled(linked: linkedAgent, active: activeAgent),
+                onReveal: { slot.setCompanion(nil) }
+            )
+        )
+        guard let overlay = companionOverlay(in: slot) else {
+            XCTFail("Expected companion overlay")
+            return
+        }
+
+        overlay.keyDown(with: keyEvent(characters: "\r", keyCode: 36, window: window))
+        slot.setCompanion(configuration(for: .orphaned(link: AgentSurfaceLink(
+            surfaceID: linkedAgent.identity.surfaceID,
+            lastKnownName: linkedAgent.identity.displayName
+        ))))
+        overlay.keyUp(with: keyEvent(type: .keyUp, characters: "\r", keyCode: 36, window: window))
+
+        XCTAssertFalse(overlay.isHidden, "Newer blocking state must cancel queued reveal state")
+        XCTAssertTrue(webView.isAccessibilityHidden())
+    }
+
+    func testReparentDuringHeldRevealDoesNotResurrectStaleVeil() {
+        let (window, slot, webView) = makeWindowSlotAndWebView()
+        defer { window.orderOut(nil) }
+        guard let parent = slot.superview else {
+            XCTFail("Expected slot parent")
+            return
+        }
+        slot.setCompanion(
+            configuration(
+                for: .veiled(linked: linkedAgent, active: activeAgent),
+                onReveal: { slot.setCompanion(nil) }
+            )
+        )
+        guard let overlay = companionOverlay(in: slot) else {
+            XCTFail("Expected companion overlay")
+            return
+        }
+
+        overlay.keyDown(with: keyEvent(characters: "\r", keyCode: 36, window: window))
+        XCTAssertFalse(overlay.isHidden)
+        slot.removeFromSuperview()
+        XCTAssertFalse(webView.isAccessibilityHidden())
+        parent.addSubview(slot)
+
+        XCTAssertTrue(overlay.isHidden, "Detached stale blocking state must not reappear on reparent")
+        XCTAssertFalse(webView.isAccessibilityHidden())
+    }
+
     func testBlockingCompanionClosesSearchBeforeInstallingVeilAndRejectsReopen() {
         let (window, slot, _) = makeWindowSlotAndWebView()
         defer { window.orderOut(nil) }
@@ -366,5 +453,9 @@ final class BrowserCompanionPortalTests: XCTestCase {
 }
 
 private final class CompanionWKInspectorResponderView: NSView {
+    override var acceptsFirstResponder: Bool { true }
+}
+
+private final class CompanionOutsideResponderView: NSView {
     override var acceptsFirstResponder: Bool { true }
 }


### PR DESCRIPTION
## What changed

Adds the default-off AppKit portal veil primitive for agent-linked companion browsers:

- mounts a real input-blocking overlay above the WKWebView and hosted inspector roots while keeping c11 chrome available;
- establishes deterministic WebKit/search/veil/drag/modal layer ordering across bind, rebind, reparent, inspector, and geometry churn;
- consumes complete pointer and keyboard reveal sequences so the first activation cannot click through;
- preserves unrelated-pane focus and restores only the exact covered responder when appropriate;
- caches and restores the exact accessibility-hidden state of page and inspector roots;
- adds focused host coverage for portal lifecycle, responder isolation, event consumption, accessibility restoration, stale-state supersession, and reparent teardown.

## Why

ACB-02 is the portal feasibility lane for agent-linked companion browsers. A mismatched browser needs to become visibly and interactively inert above WebKit without changing pane geometry, selected surfaces, or durable browser linkage.

The generic deterministic WebKit occlusion/layer-order host may be worth offering upstream to cmux. Agent-companion identity and policy remain c11-specific.

## Validation

Exact pushed HEAD: `b7057cfd7081c7c90fd210794aa9a2f8c6221302`

- Debug app build: `** BUILD SUCCEEDED **`; XCBuildData `d863482fce37e7a5cc7120212b6f6041`.
- Focused host suite: `BrowserCompanionPortalTests`, 11/11 passed with `** TEST SUCCEEDED **`.
- Result bundle: `/Users/atin/Projects/Stage11/code/c11-acb-worktrees/acb-02-portal-veil/build-test-local/Logs/Test/Test-c11-unit-2026.07.22_16-53-57--0400.xcresult`.
- Fresh exact-HEAD review: PASS WITH NITS, no Critical or Major findings (`art_01KY5SEDD71DA9KWDT56KTWCKK`).
- Exact-HEAD validation artifact: `art_01KY5ST6HN9K0VP277XJ2990M6`.

No untagged app was launched, and no computer-use run was authorized for this lane.

## Rollout boundary

The feature remains default-off. Standalone popup panels, JavaScript dialogs, permission/file panels, native sheets outside the slot, WebKit fullscreen promotion, and pointer lock remain explicitly unproven default-enable blockers for later integration/tagged validation. This PR does not claim those topologies are safe.

## Merge order

Draft only. ACB-01 precedes this PR in the Wave 1 merge order; do not mark ready or merge out of order.
