### PR TITLE
Hide c11 from the Dock and app switcher

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -37,6 +37,8 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
+	<key>LSUIElement</key>
+	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSMainStoryboardFile</key>

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -54475,6 +54475,53 @@
         }
       }
     },
+    "statusMenu.showC11": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show c11"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11を表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示 c11"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示 c11"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "c11 표시"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать c11"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати c11"
+          }
+        }
+      }
+    },
     "statusMenu.showNotifications": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2530,6 +2530,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
         let telemetryEnabled = TelemetrySettings.enabledForCurrentLaunch
+        AppPresentationPolicy.apply(isRunningUnderXCTest: isRunningUnderXCTest)
 
         DistributedNotificationCenter.default().addObserver(
             self,
@@ -7639,6 +7640,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let store = TerminalNotificationStore.shared
         menuBarExtraController = MenuBarExtraController(
             notificationStore: store,
+            onShowMainWindow: { [weak self] in
+                self?.showMainWindowFromMenuBar()
+            },
             onShowNotifications: { [weak self] in
                 self?.showNotificationsPopoverFromMenuBar()
             },
@@ -7678,7 +7682,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func syncMenuBarExtraVisibility(defaults: UserDefaults = .standard) {
-        if MenuBarExtraSettings.showsMenuBarExtra(defaults: defaults) {
+        if MenuBarExtraSettings.shouldInstallMenuBarExtra(
+            activationPolicy: NSApp.activationPolicy(),
+            defaults: defaults
+        ) {
             setupMenuBarExtra()
             return
         }
@@ -7785,6 +7792,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func refreshMenuBarExtraForDebug() {
         menuBarExtraController?.refreshForDebugControls()
+    }
+
+    func showMainWindowFromMenuBar() {
+        let context: MainWindowContext? = {
+            if let keyWindow = NSApp.keyWindow,
+               let keyContext = contextForMainTerminalWindow(keyWindow) {
+                return keyContext
+            }
+            if let mainWindow = NSApp.mainWindow,
+               let mainContext = contextForMainTerminalWindow(mainWindow) {
+                return mainContext
+            }
+            if let visibleContext = mainWindowContexts.values.first(where: { context in
+                guard let window = resolvedWindow(for: context) else { return false }
+                return window.isVisible && !window.isMiniaturized
+            }) {
+                return visibleContext
+            }
+            return mainWindowContexts.values.first
+        }()
+
+        let window: NSWindow? = {
+            if let context {
+                if let window = resolvedWindow(for: context) {
+                    return window
+                }
+                discardOrphanedMainWindowContext(context)
+            }
+            let windowId = createMainWindow()
+            return windowForMainWindowId(windowId)
+        }()
+
+        guard let window else {
+            NSSound.beep()
+            return
+        }
+
+        NSApp.unhide(nil)
+        setActiveMainWindow(window)
+        bringToFront(window)
     }
 
     func showNotificationsPopoverFromMenuBar() {
@@ -13126,6 +13173,7 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
     private let statusItem: NSStatusItem
     private let menu = NSMenu(title: "c11")
     private let notificationStore: TerminalNotificationStore
+    private let onShowMainWindow: () -> Void
     private let onShowNotifications: () -> Void
     private let onOpenNotification: (TerminalNotification) -> Void
     private let onJumpToLatestUnread: () -> Void
@@ -13137,6 +13185,7 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
 
     private let stateHintItem = NSMenuItem(title: String(localized: "statusMenu.noUnread", defaultValue: "No unread notifications"), action: nil, keyEquivalent: "")
     private let buildHintItem = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+    private let showMainWindowItem = NSMenuItem(title: String(localized: "statusMenu.showC11", defaultValue: "Show c11"), action: nil, keyEquivalent: "")
     private let notificationListSeparator = NSMenuItem.separator()
     private let notificationSectionSeparator = NSMenuItem.separator()
     private let showNotificationsItem = NSMenuItem(title: String(localized: "statusMenu.showNotifications", defaultValue: "Show Notifications"), action: nil, keyEquivalent: "")
@@ -13152,6 +13201,7 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
 
     init(
         notificationStore: TerminalNotificationStore,
+        onShowMainWindow: @escaping () -> Void,
         onShowNotifications: @escaping () -> Void,
         onOpenNotification: @escaping (TerminalNotification) -> Void,
         onJumpToLatestUnread: @escaping () -> Void,
@@ -13160,6 +13210,7 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
         onQuitApp: @escaping () -> Void
     ) {
         self.notificationStore = notificationStore
+        self.onShowMainWindow = onShowMainWindow
         self.onShowNotifications = onShowNotifications
         self.onOpenNotification = onOpenNotification
         self.onJumpToLatestUnread = onJumpToLatestUnread
@@ -13199,6 +13250,12 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
             buildHintItem.isEnabled = false
             menu.addItem(buildHintItem)
         }
+
+        menu.addItem(.separator())
+
+        showMainWindowItem.target = self
+        showMainWindowItem.action = #selector(showMainWindowAction)
+        menu.addItem(showMainWindowItem)
 
         menu.addItem(notificationListSeparator)
         notificationSectionSeparator.isHidden = true
@@ -13359,6 +13416,10 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
     @objc private func openNotificationItemAction(_ sender: NSMenuItem) {
         guard let payload = sender.representedObject as? NotificationMenuItemPayload else { return }
         onOpenNotification(payload.notification)
+    }
+
+    @objc private func showMainWindowAction() {
+        onShowMainWindow()
     }
 
     @objc private func showNotificationsAction() {
@@ -13612,6 +13673,28 @@ enum MenuBarExtraSettings {
             return defaultShowInMenuBar
         }
         return defaults.bool(forKey: showInMenuBarKey)
+    }
+
+    static func shouldInstallMenuBarExtra(
+        activationPolicy: NSApplication.ActivationPolicy,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        activationPolicy == .accessory || showsMenuBarExtra(defaults: defaults)
+    }
+}
+
+enum AppPresentationPolicy {
+    static func activationPolicy(isRunningUnderXCTest: Bool) -> NSApplication.ActivationPolicy {
+        isRunningUnderXCTest ? .regular : .accessory
+    }
+
+    static func apply(
+        isRunningUnderXCTest: Bool,
+        application: NSApplication = .shared
+    ) {
+        let targetPolicy = activationPolicy(isRunningUnderXCTest: isRunningUnderXCTest)
+        guard application.activationPolicy() != targetPolicy else { return }
+        application.setActivationPolicy(targetPolicy)
     }
 }
 

--- a/Sources/StatusBar/StatusBarButtonDisplay.swift
+++ b/Sources/StatusBar/StatusBarButtonDisplay.swift
@@ -16,8 +16,7 @@ struct StatusBarButtonDisplay: Equatable {
     }
 
     /// Two-digit cap matches `MenuBarBadgeLabelFormatter.badgeText(for:)`
-    /// (AppDelegate.swift) and `TerminalNotificationStore.dockBadgeLabel`
-    /// so the bar agrees with the menu-bar and dock surfaces.
+    /// (AppDelegate.swift) so the bar agrees with the menu-bar surface.
     private static func badgeText(for count: Int) -> String? {
         guard count > 0 else { return nil }
         if count > 99 { return "99+" }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -515,18 +515,6 @@ enum NotificationSoundSettings {
     }
 }
 
-enum NotificationBadgeSettings {
-    static let dockBadgeEnabledKey = "notificationDockBadgeEnabled"
-    static let defaultDockBadgeEnabled = true
-
-    static func isDockBadgeEnabled(defaults: UserDefaults = .standard) -> Bool {
-        if defaults.object(forKey: dockBadgeEnabledKey) == nil {
-            return defaultDockBadgeEnabled
-        }
-        return defaults.bool(forKey: dockBadgeEnabledKey)
-    }
-}
-
 enum NotificationPaneRingSettings {
     static let enabledKey = "notificationPaneRingEnabled"
     static let defaultEnabled = true
@@ -568,25 +556,6 @@ enum NotificationFlashDurationSettings {
 
     private static func clamp(_ ms: Int) -> Int {
         return min(maxMs, max(minMs, ms))
-    }
-}
-
-enum TaggedRunBadgeSettings {
-    static let environmentKey = "C11_TAG"
-    private static let maxTagLength = 10
-
-    static func normalizedTag(from env: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        normalizedTag(c11Env(environmentKey, in: env))
-    }
-
-    static func normalizedTag(_ rawTag: String?) -> String? {
-        guard var tag = rawTag?.trimmingCharacters(in: .whitespacesAndNewlines), !tag.isEmpty else {
-            return nil
-        }
-        if tag.count > maxTagLength {
-            tag = String(tag.prefix(maxTagLength))
-        }
-        return tag
     }
 }
 
@@ -690,7 +659,6 @@ final class TerminalNotificationStore: ObservableObject {
             // rebuild so waiting-agent edges can be detected (amendment H).
             let previousUnreadByTab = indexes.unreadCountByTabId
             indexes = Self.buildIndexes(for: notifications)
-            refreshDockBadge()
             emitWaitingEdges(previous: previousUnreadByTab, current: indexes.unreadCountByTabId)
         }
     }
@@ -700,7 +668,6 @@ final class TerminalNotificationStore: ObservableObject {
     private var hasRequestedAutomaticAuthorization = false
     private var hasDeferredAuthorizationRequest = false
     private var hasPromptedForSettings = false
-    private var userDefaultsObserver: NSObjectProtocol?
     private let settingsPromptWindowRetryDelay: TimeInterval = 0.5
     private let settingsPromptWindowRetryLimit = 20
     private var notificationSettingsWindowProvider: () -> NSWindow? = {
@@ -747,40 +714,7 @@ final class TerminalNotificationStore: ObservableObject {
 
     private init() {
         indexes = Self.buildIndexes(for: notifications)
-        userDefaultsObserver = NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.refreshDockBadge()
-        }
-        refreshDockBadge()
         refreshAuthorizationStatus()
-    }
-
-    deinit {
-        if let userDefaultsObserver {
-            NotificationCenter.default.removeObserver(userDefaultsObserver)
-        }
-    }
-
-    static func dockBadgeLabel(unreadCount: Int, isEnabled: Bool, runTag: String? = nil) -> String? {
-        let unreadLabel: String? = {
-            guard isEnabled, unreadCount > 0 else { return nil }
-            if unreadCount > 99 {
-                return "99+"
-            }
-            return String(unreadCount)
-        }()
-
-        if let tag = TaggedRunBadgeSettings.normalizedTag(runTag) {
-            if let unreadLabel {
-                return "\(tag):\(unreadLabel)"
-            }
-            return tag
-        }
-
-        return unreadLabel
     }
 
     var unreadCount: Int {
@@ -1161,7 +1095,7 @@ final class TerminalNotificationStore: ObservableObject {
         logAuthorization(
             "request starting origin=\(origin.rawValue) automatic=\(isAutomaticRequest) hasRequestedAutomatic=\(hasRequestedAutomaticAuthorization)"
         )
-        center.requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
             DispatchQueue.main.async {
                 if granted {
                     self.authorizationState = .authorized
@@ -1321,12 +1255,4 @@ final class TerminalNotificationStore: ObservableObject {
     }
 #endif
 
-    private func refreshDockBadge() {
-        let label = Self.dockBadgeLabel(
-            unreadCount: unreadCount,
-            isEnabled: NotificationBadgeSettings.isDockBadgeEnabled(),
-            runTag: TaggedRunBadgeSettings.normalizedTag()
-        )
-        NSApp?.dockTile.badgeLabel = label
-    }
 }

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4416,11 +4416,9 @@ struct SettingsView: View {
     @AppStorage(NotificationSoundSettings.customFilePathKey)
     private var notificationSoundCustomFilePath = NotificationSoundSettings.defaultCustomFilePath
     @AppStorage(NotificationSoundSettings.customCommandKey) private var notificationCustomCommand = NotificationSoundSettings.defaultCustomCommand
-    @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
     @AppStorage(NotificationPaneRingSettings.enabledKey) private var notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
     @AppStorage(NotificationPaneFlashSettings.enabledKey) private var notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
     @AppStorage(NotificationFlashDurationSettings.storageKey) private var notificationFlashDurationMs: Int = NotificationFlashDurationSettings.defaultMs
-    @AppStorage(MenuBarExtraSettings.showInMenuBarKey) private var showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
     @AppStorage(QuitWarningSettings.warnBeforeQuitKey) private var warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
     @AppStorage(CommandPaletteRenameSelectionSettings.selectAllOnFocusKey)
     private var commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
@@ -5959,31 +5957,6 @@ struct SettingsView: View {
         SettingsSectionHeader(title: String(localized: "settings.section.systemSignals", defaultValue: "System Signals"))
         SettingsCard {
             SettingsCardRow(
-                String(localized: "settings.app.dockBadge", defaultValue: "Dock Badge"),
-                subtitle: String(localized: "settings.app.dockBadge.subtitle", defaultValue: "Show unread count on app icon (Dock and Cmd+Tab).")
-            ) {
-                Toggle("", isOn: $notificationDockBadgeEnabled)
-                    .labelsHidden()
-                    .controlSize(.small)
-            }
-
-            SettingsCardDivider()
-
-            SettingsCardRow(
-                String(localized: "settings.app.showInMenuBar", defaultValue: "Show in Menu Bar"),
-                subtitle: String(localized: "settings.app.showInMenuBar.subtitle", defaultValue: "Keep c11 in the menu bar for unread notifications and quick actions.")
-            ) {
-                Toggle("", isOn: $showMenuBarExtra)
-                    .labelsHidden()
-                    .controlSize(.small)
-                    .accessibilityLabel(
-                        String(localized: "settings.app.showInMenuBar", defaultValue: "Show in Menu Bar")
-                    )
-            }
-
-            SettingsCardDivider()
-
-            SettingsCardRow(
                 String(localized: "settings.notifications.desktop.title", defaultValue: "Desktop Notifications"),
                 subtitle: notificationPermissionSubtitle
             ) {
@@ -6535,10 +6508,8 @@ struct SettingsView: View {
         showNotificationCustomSoundErrorAlert = false
         notificationCustomSoundErrorAlertMessage = ""
         notificationCustomCommand = NotificationSoundSettings.defaultCustomCommand
-        notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
         notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
         notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
-        showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
         warnBeforeQuitShortcut = QuitWarningSettings.defaultWarnBeforeQuit
         commandPaletteRenameSelectAllOnFocus = CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus
         commandPaletteSearchAllSurfaces = CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces

--- a/c11Tests/NotificationAndMenuBarTests.swift
+++ b/c11Tests/NotificationAndMenuBarTests.swift
@@ -14,7 +14,7 @@ import UserNotifications
 #endif
 
 @MainActor
-final class NotificationDockBadgeTests: XCTestCase {
+final class NotificationAndMenuBarTests: XCTestCase {
     private final class NotificationSettingsAlertSpy: NSAlert {
         private(set) var beginSheetModalCallCount = 0
         private(set) var runModalCallCount = 0
@@ -38,54 +38,6 @@ final class NotificationDockBadgeTests: XCTestCase {
         TerminalNotificationStore.shared.resetNotificationSettingsPromptHooksForTesting()
         TerminalNotificationStore.shared.replaceNotificationsForTesting([])
         super.tearDown()
-    }
-
-    func testDockBadgeLabelEnabledAndCounted() {
-        XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 1, isEnabled: true), "1")
-        XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 42, isEnabled: true), "42")
-        XCTAssertEqual(TerminalNotificationStore.dockBadgeLabel(unreadCount: 100, isEnabled: true), "99+")
-    }
-
-    func testDockBadgeLabelHiddenWhenDisabledOrZero() {
-        XCTAssertNil(TerminalNotificationStore.dockBadgeLabel(unreadCount: 0, isEnabled: true))
-        XCTAssertNil(TerminalNotificationStore.dockBadgeLabel(unreadCount: 5, isEnabled: false))
-    }
-
-    func testDockBadgeLabelShowsRunTagEvenWithoutUnread() {
-        XCTAssertEqual(
-            TerminalNotificationStore.dockBadgeLabel(unreadCount: 0, isEnabled: true, runTag: "verify-tag"),
-            "verify-tag"
-        )
-    }
-
-    func testDockBadgeLabelCombinesRunTagAndUnreadCount() {
-        XCTAssertEqual(
-            TerminalNotificationStore.dockBadgeLabel(unreadCount: 7, isEnabled: true, runTag: "verify"),
-            "verify:7"
-        )
-        XCTAssertEqual(
-            TerminalNotificationStore.dockBadgeLabel(unreadCount: 120, isEnabled: true, runTag: "verify"),
-            "verify:99+"
-        )
-    }
-
-    func testNotificationBadgePreferenceDefaultsToEnabled() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            XCTFail("Failed to create isolated UserDefaults suite")
-            return
-        }
-        defer {
-            defaults.removePersistentDomain(forName: suiteName)
-        }
-
-        XCTAssertTrue(NotificationBadgeSettings.isDockBadgeEnabled(defaults: defaults))
-
-        defaults.set(false, forKey: NotificationBadgeSettings.dockBadgeEnabledKey)
-        XCTAssertFalse(NotificationBadgeSettings.isDockBadgeEnabled(defaults: defaults))
-
-        defaults.set(true, forKey: NotificationBadgeSettings.dockBadgeEnabledKey)
-        XCTAssertTrue(NotificationBadgeSettings.isDockBadgeEnabled(defaults: defaults))
     }
 
     func testNotificationPaneFlashPreferenceDefaultsToEnabled() {
@@ -126,8 +78,38 @@ final class NotificationDockBadgeTests: XCTestCase {
         XCTAssertTrue(MenuBarExtraSettings.showsMenuBarExtra(defaults: defaults))
     }
 
+    func testAccessoryPolicyAlwaysKeepsMenuBarExtraReachable() {
+        let suiteName = "MenuBarExtraAccessoryPolicyTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        defaults.set(false, forKey: MenuBarExtraSettings.showInMenuBarKey)
+        XCTAssertTrue(
+            MenuBarExtraSettings.shouldInstallMenuBarExtra(
+                activationPolicy: .accessory,
+                defaults: defaults
+            )
+        )
+        XCTAssertFalse(
+            MenuBarExtraSettings.shouldInstallMenuBarExtra(
+                activationPolicy: .regular,
+                defaults: defaults
+            )
+        )
+    }
+
+    func testNormalLaunchUsesAccessoryActivationPolicy() {
+        XCTAssertEqual(AppPresentationPolicy.activationPolicy(isRunningUnderXCTest: false), .accessory)
+        XCTAssertEqual(AppPresentationPolicy.activationPolicy(isRunningUnderXCTest: true), .regular)
+    }
+
     func testNotificationSoundUsesSystemSoundForDefaultAndNamedSounds() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
+        let suiteName = "NotificationAndMenuBarTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
             return
@@ -144,7 +126,7 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationSoundDisablesSystemSoundForNoneAndCustomFile() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
+        let suiteName = "NotificationAndMenuBarTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
             return
@@ -163,7 +145,7 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationCustomFileURLExpandsTildePath() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
+        let suiteName = "NotificationAndMenuBarTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
             return
@@ -179,7 +161,7 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationCustomFileSelectionMustBeExplicit() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
+        let suiteName = "NotificationAndMenuBarTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
             return
@@ -201,7 +183,7 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationCustomStagingPreservesSourceFileWithCmuxPrefix() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
+        let suiteName = "NotificationAndMenuBarTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
             return
@@ -290,7 +272,7 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationCustomPreparationKeepsActiveSourceMetadataSidecar() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
+        let suiteName = "NotificationAndMenuBarTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
             return
@@ -349,7 +331,7 @@ final class NotificationDockBadgeTests: XCTestCase {
     }
 
     func testNotificationCustomSoundReturnsNilWhenPreparationFails() {
-        let suiteName = "NotificationDockBadgeTests.\(UUID().uuidString)"
+        let suiteName = "NotificationAndMenuBarTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
             return
@@ -397,29 +379,6 @@ final class NotificationDockBadgeTests: XCTestCase {
                 return
             }
         }
-    }
-
-    func testDockBadgeEnabledByDefaultAndLabelIsNonNilWhenUnreadCountIsPositive() {
-        // Verifies the end-to-end dock badge path: the default preference is
-        // enabled, and dockBadgeLabel returns a non-nil label when there are
-        // unread notifications. This path only functions at runtime when
-        // notification authorization includes .badge — the authorization
-        // options fix (Pick 3) enables the Dock to honor the badgeLabel
-        // assignment that refreshDockBadge() makes.
-        let suiteName = "DockBadgeAuthorizationPickThreeTests.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            XCTFail("Failed to create isolated UserDefaults suite")
-            return
-        }
-        defer { defaults.removePersistentDomain(forName: suiteName) }
-
-        XCTAssertTrue(NotificationBadgeSettings.isDockBadgeEnabled(defaults: defaults))
-        let label = TerminalNotificationStore.dockBadgeLabel(
-            unreadCount: 3,
-            isEnabled: NotificationBadgeSettings.isDockBadgeEnabled(defaults: defaults)
-        )
-        XCTAssertNotNil(label, "Dock badge label must be non-nil when badge is enabled and unread count is positive")
-        XCTAssertEqual(label, "3")
     }
 
     func testNotificationAuthorizationStateMappingCoversKnownUNAuthorizationStatuses() {


### PR DESCRIPTION
## Summary

- run c11 as a macOS accessory/UIElement app so it does not appear in the Dock or Cmd+Tab
- keep the menu bar item always available and add a localized **Show c11** command for restoring the main window
- remove obsolete Dock badge settings and badge-notification plumbing
- preserve regular activation policy under XCTest so host-bound tests remain reliable

## Why

c11 is a persistent command center rather than an app the operator selects through the Dock. Its Dock and app-switcher representation added clutter without providing a useful navigation path.

## Validation

- `git diff --check origin/main...HEAD`
- `plutil -lint Resources/Info.plist`
- `jq empty Resources/Localizable.xcstrings`
- `scripts/test-unit-local.sh -only-testing:c11Tests/NotificationAndMenuBarTests test` — 21 tests, 0 failures
- clean Debug host build succeeded on current `origin/main`
- prior tagged runtime validation confirmed `ApplicationType=UIElement`, accessory activation policy, and a functioning four-pane workspace