### PR TITLE
Workspace pulse: sidebar-card agent rollup + wrapper-less agent detection

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2977,6 +2977,9 @@ struct CMUXCLI {
                 throw error
             }
 
+        case "codex-hook":
+            try runCodexHook(commandArgs: commandArgs, client: client)
+
         case "set-app-focus":
             guard let value = commandArgs.first else { throw CLIError(message: "set-app-focus requires a value") }
             let response = try sendV1Command("set_app_focus \(value)", client: client)
@@ -15787,6 +15790,32 @@ struct CMUXCLI {
         }
     }
 
+    /// Bundle-private lifecycle bridge used by Resources/bin/codex. Codex's
+    /// interactive process keeps the outer shell in `running` for its entire
+    /// lifetime, so the wrapper seeds the truthful resting state explicitly.
+    /// Turn submission/completion transitions are reported by c11's terminal
+    /// input and notification seams inside the app.
+    private func runCodexHook(commandArgs: [String], client: SocketClient) throws {
+        guard let rawActivity = commandArgs.first?.lowercased(),
+              rawActivity == "working" || rawActivity == "idle" else {
+            throw CLIError(message: "codex-hook requires working or idle")
+        }
+        let environment = ProcessInfo.processInfo.environment
+        guard let workspaceId = environment["CMUX_WORKSPACE_ID"] ?? environment["C11_WORKSPACE_ID"],
+              UUID(uuidString: workspaceId) != nil else {
+            throw CLIError(message: "codex-hook requires a c11 workspace id")
+        }
+        guard let surfaceId = environment["CMUX_SURFACE_ID"] ?? environment["C11_SURFACE_ID"],
+              UUID(uuidString: surfaceId) != nil else {
+            throw CLIError(message: "codex-hook requires a c11 surface id")
+        }
+        let response = try sendV1Command(
+            "report_agent_activity \(rawActivity) --tab=\(workspaceId) --panel=\(surfaceId)",
+            client: client
+        )
+        print(response)
+    }
+
     private func runClaudeHook(
         commandArgs: [String],
         client: SocketClient,
@@ -15831,6 +15860,12 @@ struct CMUXCLI {
                 surfaceArg,
                 workspaceId: workspaceId,
                 client: client
+            )
+            _ = try? reportAgentActivity(
+                client: client,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                activity: "idle"
             )
             let claudePid: Int? = {
                 guard let raw = ProcessInfo.processInfo.environment["CMUX_CLAUDE_PID"]?
@@ -15918,6 +15953,19 @@ struct CMUXCLI {
                 workspaceId = mappedWorkspace
                 surfaceId = mapped.surfaceId
             }
+            let resolvedLifecycleSurface = try? resolveSurfaceIdForClaudeHook(
+                surfaceId,
+                workspaceId: workspaceId,
+                client: client
+            )
+            if let resolvedLifecycleSurface {
+                _ = try? reportAgentActivity(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceId: resolvedLifecycleSurface,
+                    activity: "idle"
+                )
+            }
 
             // Update session with transcript summary and send completion notification.
             let completion = summarizeClaudeHookStop(
@@ -15960,10 +16008,24 @@ struct CMUXCLI {
         case "prompt-submit":
             telemetry.breadcrumb("claude-hook.prompt-submit")
             var workspaceId = fallbackWorkspaceId
+            var preferredSurface = surfaceArg
             if let sessionId = parsedInput.sessionId,
                let mapped = try? sessionStore.lookup(sessionId: sessionId),
                let mappedWorkspace = try? resolveWorkspaceIdForClaudeHook(mapped.workspaceId, client: client) {
                 workspaceId = mappedWorkspace
+                preferredSurface = mapped.surfaceId
+            }
+            if let resolvedSurface = try? resolveSurfaceIdForClaudeHook(
+                preferredSurface,
+                workspaceId: workspaceId,
+                client: client
+            ) {
+                _ = try? reportAgentActivity(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceId: resolvedSurface,
+                    activity: "working"
+                )
             }
             _ = try sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
             try setClaudeStatus(
@@ -15998,6 +16060,12 @@ struct CMUXCLI {
                 preferredSurface,
                 workspaceId: workspaceId,
                 client: client
+            )
+            _ = try? reportAgentActivity(
+                client: client,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                activity: "idle"
             )
 
             let title = "Claude Code"
@@ -16104,11 +16172,13 @@ struct CMUXCLI {
             // (e.g. after permission grant). Runs async so it doesn't block tool execution.
             var workspaceId = fallbackWorkspaceId
             var claudePid: Int? = nil
+            var preferredSurface = surfaceArg
             if let sessionId = parsedInput.sessionId,
                let mapped = try? sessionStore.lookup(sessionId: sessionId),
                let mappedWorkspace = try? resolveWorkspaceIdForClaudeHook(mapped.workspaceId, client: client) {
                 workspaceId = mappedWorkspace
                 claudePid = mapped.pid
+                preferredSurface = mapped.surfaceId
             }
 
             // AskUserQuestion means Claude is about to ask the user something.
@@ -16129,6 +16199,18 @@ struct CMUXCLI {
                     lastSubtitle: "Waiting",
                     lastBody: question
                 )
+                if let resolvedSurface = try? resolveSurfaceIdForClaudeHook(
+                    preferredSurface,
+                    workspaceId: workspaceId,
+                    client: client
+                ) {
+                    _ = try? reportAgentActivity(
+                        client: client,
+                        workspaceId: workspaceId,
+                        surfaceId: resolvedSurface,
+                        activity: "idle"
+                    )
+                }
                 // Don't clear notifications or set status here.
                 // The Notification hook fires right after and will use the saved question.
                 print("OK")
@@ -16136,6 +16218,18 @@ struct CMUXCLI {
             }
 
             _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+            if let resolvedSurface = try? resolveSurfaceIdForClaudeHook(
+                preferredSurface,
+                workspaceId: workspaceId,
+                client: client
+            ) {
+                _ = try? reportAgentActivity(
+                    client: client,
+                    workspaceId: workspaceId,
+                    surfaceId: resolvedSurface,
+                    activity: "working"
+                )
+            }
 
             let statusValue: String
             if UserDefaults.standard.bool(forKey: "claudeCodeVerboseStatus"),
@@ -16180,6 +16274,18 @@ struct CMUXCLI {
             cmd += " --pid=\(pid)"
         }
         _ = try client.send(command: cmd)
+    }
+
+    private func reportAgentActivity(
+        client: SocketClient,
+        workspaceId: String,
+        surfaceId: String,
+        activity: String
+    ) throws {
+        _ = try sendV1Command(
+            "report_agent_activity \(activity) --tab=\(workspaceId) --panel=\(surfaceId)",
+            client: client
+        )
     }
 
     private func clearClaudeStatus(client: SocketClient, workspaceId: String) throws {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53629,6 +53629,100 @@
         }
       }
     },
+    "sidebar.workspacePulse.agentCount.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント 1件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 个代理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 個代理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 1개"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 агент"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 агент"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.agentCount.other": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld agents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント %lld件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个代理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個代理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 %lld개"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld агентов"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld агентів"
+          }
+        }
+      }
+    },
     "sidebar.workspacePulse.cold": {
       "extractionState": "manual",
       "localizations": {
@@ -53676,6 +53770,53 @@
         }
       }
     },
+    "sidebar.workspacePulse.moreWaiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "… and %lld more"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "…ほか%lld件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "…以及另外 %lld 个"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "…以及另外 %lld 個"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "…외 %lld개"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "…и ещё %lld"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "…і ще %lld"
+          }
+        }
+      }
+    },
     "sidebar.workspacePulse.needsYou": {
       "extractionState": "manual",
       "localizations": {
@@ -53719,6 +53860,147 @@
           "stringUnit": {
             "state": "translated",
             "value": "Потребує вашої уваги"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.terminalCount.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル 1件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 个终端"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 個終端"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 1개"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 терминал"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 термінал"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.terminalCount.other": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld terminals"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル %lld件"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 个终端"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個終端"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 %lld개"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld терминалов"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld терміналів"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.terminalsOnly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminals only · no agent surfaces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのみ · エージェントサーフェスなし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅终端 · 无代理界面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "僅終端 · 無代理介面"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널만 · 에이전트 서피스 없음"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Только терминалы · нет поверхностей агентов"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Лише термінали · немає поверхонь агентів"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53629,6 +53629,100 @@
         }
       }
     },
+    "sidebar.workspacePulse.cold": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cold"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コールド"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "冷态"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "冷態"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "콜드"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Холодная"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Холодна"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.needsYou": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Needs you"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "対応が必要"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要你处理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要你處理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인 필요"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Требует вашего внимания"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Потребує вашої уваги"
+          }
+        }
+      }
+    },
     "socketControl.allowAll.description": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/bin/codex
+++ b/Resources/bin/codex
@@ -157,6 +157,17 @@ if [[ -n "$c11_bin" ]]; then
     CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
         "$c11_bin" --socket "${CMUX_SOCKET_PATH}" "${claim_args[@]}" \
         >/dev/null 2>&1 || true
+
+    # A newly opened interactive Codex TUI is resting at its prompt. The
+    # outer shell remains "command running" for the TUI's whole lifetime, so
+    # seed the agent-loop truth separately; c11 marks it working on prompt
+    # submission and idle again when Codex emits its completion notification.
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" codex-hook idle \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
 fi
 
 exec "$REAL_CODEX" "$@"

--- a/Resources/bin/codex
+++ b/Resources/bin/codex
@@ -38,6 +38,31 @@
 
 set -uo pipefail
 
+# Codex invokes the configured `notify` command after every completed agent
+# turn, even when its own TUI notification is suppressed because the terminal
+# is focused. Route that exact lifecycle edge back through c11 so the surface
+# becomes an unread "waiting agent" and its underlying activity settles idle.
+# This private callback runs only as a child of the c11-scoped Codex process;
+# it never writes Codex config or changes behavior outside c11.
+if [[ "${1:-}" == "__c11-notify" ]]; then
+    socket="${CMUX_SOCKET_PATH:-${C11_SOCKET_PATH:-}}"
+    workspace_id="${CMUX_WORKSPACE_ID:-${C11_WORKSPACE_ID:-}}"
+    surface_id="${CMUX_SURFACE_ID:-${C11_SURFACE_ID:-}}"
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    c11_bin="$self_dir/c11"
+    [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+
+    if [[ -n "$socket" && -S "$socket" && -n "$workspace_id" && -n "$surface_id" && -n "$c11_bin" ]]; then
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "$socket" notify \
+            --title "Codex" \
+            --workspace "$workspace_id" \
+            --surface "$surface_id" \
+            >/dev/null 2>&1 || true
+    fi
+    exit 0
+fi
+
 # Find the real codex binary, skipping our own directory.
 find_real_codex() {
     local self_dir
@@ -121,6 +146,7 @@ fi
 # later target runtime capture is newer than the marker and remains
 # authoritative. This preserves causal ordering without turning a stale socket
 # into launch latency.
+codex_notify_config=""
 if [[ -n "$c11_bin" ]]; then
     boundary_surface="${CMUX_SURFACE_ID:-}"
     if [[ "$boundary_surface" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]]; then
@@ -168,6 +194,18 @@ if [[ -n "$c11_bin" ]]; then
             >/dev/null 2>&1
     ) &
     disown 2>/dev/null || true
+
+    # Runtime-only completion bridge. Prepending the override keeps any
+    # explicit `-c notify=...` supplied by the operator later in argv in
+    # control, while the normal c11 launch path gains a focus-independent
+    # completion signal without touching ~/.codex/config.toml.
+    notify_handler="$self_dir/codex"
+    notify_handler="${notify_handler//\\/\\\\}"
+    notify_handler="${notify_handler//\"/\\\"}"
+    codex_notify_config="notify=[\"${notify_handler}\",\"__c11-notify\"]"
 fi
 
+if [[ -n "$codex_notify_config" ]]; then
+    exec "$REAL_CODEX" -c "$codex_notify_config" "$@"
+fi
 exec "$REAL_CODEX" "$@"

--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -243,15 +243,17 @@ final class AgentDetector: @unchecked Sendable {
             return manifest.kind
         }
 
-        // JS/TS-runtime-wrapped CLIs: comm is the runtime (node/bun/deno) and
-        // the agent identity lives in the args. Two invocation shapes:
+        // Interpreter-wrapped CLIs: comm is the runtime and the agent identity
+        // lives in the args. Covers JS/TS runtimes (node/bun/deno) and Python
+        // (a pipx/venv shebang execs the interpreter, so `kimi` shows up as
+        // comm=`python` with the script path in argv). Two invocation shapes:
         //  - module path (`node …/@anthropic-ai/claude-code/cli.js`) → match a
         //    distinctive args substring.
-        //  - shim/symlink (`bun /Users/x/.bun/bin/omp`, `node /Users/x/.bun/bin/pi`)
+        //  - shim/symlink (`bun /Users/x/.bun/bin/omp`, `python …/bin/kimi`)
         //    → the module path isn't in argv, but the invoked script's basename
         //    is the agent's binary name. (Matching only the *last* path
         //    component avoids false positives from mid-path directory names.)
-        if c == "node" || c == "bun" || c == "deno" {
+        if c == "node" || c == "bun" || c == "deno" || c.hasPrefix("python") {
             for manifest in AgentRegistry.shared.all
             where manifest.detectNodeArgsSubstrings.contains(where: { a.contains($0) }) {
                 return manifest.kind

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8603,6 +8603,30 @@ struct VerticalTabsSidebar: View {
                                     guard let focusedId = tab.focusedPanelId else { return nil }
                                     return SurfaceMetricsSampler.shared.sample(forSurfaceId: focusedId)
                                 }()
+                                // Workspace Pulse preview: project existing exact
+                                // notification + agent liveness truth once in the
+                                // parent. TabItemView receives an immutable value so
+                                // its typing-hot body does no metadata/store work.
+                                let unreadCount = notificationStore.unreadCount(forTabId: tab.id)
+                                let workspacePulse = WorkspacePulseProjector.project(
+                                    hasWorkspaceDemand: unreadCount > 0,
+                                    surfaceStates: tab.sidebarOrderedPanelIds().compactMap { panelId in
+                                        let state = tab.resolvedSurfaceTabActivityState(
+                                            panelId: panelId,
+                                            hasExactSurfaceNotification: notificationStore.hasUnreadNotification(
+                                                forTabId: tab.id,
+                                                surfaceId: panelId
+                                            )
+                                        )
+                                        switch state {
+                                        case .waiting: return .waiting
+                                        case .running: return .working
+                                        case .idle: return .idle
+                                        case .cold: return .cold
+                                        case nil: return nil
+                                        }
+                                    }
+                                )
                                 TabItemView(
                                     tabManager: tabManager,
                                     notificationStore: notificationStore,
@@ -8618,7 +8642,8 @@ struct VerticalTabsSidebar: View {
                                     ),
                                     canCloseWorkspace: canCloseWorkspace,
                                     accessibilityWorkspaceCount: workspaceCount,
-                                    unreadCount: notificationStore.unreadCount(forTabId: tab.id),
+                                    unreadCount: unreadCount,
+                                    workspacePulse: workspacePulse,
                                     latestNotificationText: {
                                         guard showsSidebarNotificationMessage,
                                               let notification = notificationStore.latestNotification(forTabId: tab.id) else {
@@ -11274,6 +11299,7 @@ private struct TabItemView: View, Equatable {
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&
         lhs.accessibilityWorkspaceCount == rhs.accessibilityWorkspaceCount &&
         lhs.unreadCount == rhs.unreadCount &&
+        lhs.workspacePulse == rhs.workspacePulse &&
         lhs.latestNotificationText == rhs.latestNotificationText &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
@@ -11343,6 +11369,9 @@ private struct TabItemView: View, Equatable {
     let canCloseWorkspace: Bool
     let accessibilityWorkspaceCount: Int
     let unreadCount: Int
+    /// Cheap, value-typed rollup of the workspace's existing notification and
+    /// agent-liveness truth. Precomputed by VerticalTabsSidebar.
+    let workspacePulse: WorkspacePulseSummary
     let latestNotificationText: String?
     let rowSpacing: CGFloat
     let setSelectionToTabs: () -> Void
@@ -11555,6 +11584,193 @@ private struct TabItemView: View, Equatable {
         }
     }
 
+    private var workspacePulseColors: BonsplitConfiguration.Appearance.TabActivityColors {
+        Workspace.resolvedSurfaceTabActivityColors(
+            from: colorScheme == .light
+                ? NSColor(calibratedWhite: 0.96, alpha: 1)
+                : NSColor(calibratedWhite: 0.06, alpha: 1)
+        )
+    }
+
+    private func workspacePulseColor(for state: WorkspacePulseState) -> Color {
+        let hex: String?
+        switch state {
+        case .waiting: hex = workspacePulseColors.waitingHex
+        case .working: hex = workspacePulseColors.runningHex
+        case .idle: hex = workspacePulseColors.idleHex
+        case .cold: hex = workspacePulseColors.coldHex
+        }
+        return Color(nsColor: hex.flatMap(NSColor.init(hex:)) ?? .secondaryLabelColor)
+    }
+
+    private var workspacePulseWaitingInk: Color {
+        Color(nsColor: workspacePulseColors.waitingInkHex.flatMap(NSColor.init(hex:)) ?? .textColor)
+    }
+
+    private func workspacePulseLabel(for state: WorkspacePulseState) -> String {
+        switch state {
+        case .waiting:
+            return String(localized: "sidebar.workspacePulse.needsYou", defaultValue: "Needs you")
+        case .working:
+            return SidebarActivityProjector.derivedText(.working)
+        case .idle:
+            return SidebarActivityProjector.derivedText(.idle)
+        case .cold:
+            return String(localized: "sidebar.workspacePulse.cold", defaultValue: "Cold")
+        }
+    }
+
+    private func workspacePulseSymbol(for state: WorkspacePulseState) -> String {
+        switch state {
+        case .waiting: return "exclamationmark"
+        case .working: return "arrow.triangle.2.circlepath"
+        case .idle: return "pause.fill"
+        case .cold: return "minus"
+        }
+    }
+
+    private var workspacePulseCornerRadius: CGFloat {
+        switch workspacePulse.dominant {
+        case .waiting, .idle: return 4
+        case .working, .cold: return 9
+        }
+    }
+
+    @ViewBuilder
+    private var workspacePulseMark: some View {
+        let state = workspacePulse.dominant
+        let color = workspacePulseColor(for: state)
+        let shape = RoundedRectangle(cornerRadius: workspacePulseCornerRadius, style: .continuous)
+        ZStack {
+            shape
+                .fill(state == .waiting ? color : Color.clear)
+            shape
+                .strokeBorder(
+                    color.opacity(state == .cold ? 0.7 : 0.9),
+                    style: StrokeStyle(
+                        lineWidth: 1,
+                        dash: state == .cold ? [2, 2] : []
+                    )
+                )
+            Image(systemName: workspacePulseSymbol(for: state))
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .foregroundColor(state == .waiting ? workspacePulseWaitingInk : color)
+        }
+        .frame(width: 18, height: 18)
+        .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private func workspacePulseChip(for state: WorkspacePulseState) -> some View {
+        let color = workspacePulseColor(for: state)
+        let label = workspacePulseLabel(for: state)
+        HStack(spacing: 3) {
+            Image(systemName: workspacePulseSymbol(for: state))
+                .font(.system(size: 7, weight: .bold))
+            Text("\(workspacePulse.count(for: state))")
+                .font(.system(size: 8, weight: .bold, design: .monospaced))
+                .monospacedDigit()
+        }
+        .foregroundColor(color)
+        .padding(.horizontal, 4)
+        .frame(minWidth: 25, minHeight: 18)
+        .overlay {
+            RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .strokeBorder(color.opacity(0.42), lineWidth: 1)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(label))
+        .accessibilityValue(Text("\(workspacePulse.count(for: state))"))
+    }
+
+    @ViewBuilder
+    private var workspacePulseRow: some View {
+        let dominant = workspacePulse.dominant
+        let dominantColor = workspacePulseColor(for: dominant)
+        HStack(spacing: 7) {
+            workspacePulseMark
+
+            HStack(spacing: 4) {
+                if workspacePulse.count(for: dominant) > 0 {
+                    Text("\(workspacePulse.count(for: dominant))")
+                        .font(.system(size: 9, weight: .bold, design: .monospaced))
+                        .monospacedDigit()
+                }
+                Text(workspacePulseLabel(for: dominant))
+                    .font(.system(size: 9, weight: .bold, design: .monospaced))
+                    .textCase(.uppercase)
+                    .lineLimit(1)
+            }
+            .foregroundColor(dominantColor)
+            .layoutPriority(1)
+
+            Spacer(minLength: 2)
+
+            HStack(spacing: 4) {
+                ForEach(
+                    WorkspacePulseState.allCases.filter {
+                        $0 != dominant && workspacePulse.count(for: $0) > 0
+                    },
+                    id: \.self
+                ) { state in
+                    workspacePulseChip(for: state)
+                }
+            }
+        }
+        .padding(.top, 2)
+        .accessibilityElement(children: .contain)
+    }
+
+    private var workspacePulseCardOpacity: Double {
+        workspacePulse.dominant == .cold && !isActive ? 0.72 : 1
+    }
+
+    @ViewBuilder
+    private var workspacePulseCardBackground: some View {
+        RoundedRectangle(cornerRadius: 6)
+            .fill(backgroundColor)
+            .overlay {
+                if workspacePulse.dominant == .waiting {
+                    LinearGradient(
+                        colors: [
+                            workspacePulseColor(for: .waiting).opacity(0.14),
+                            workspacePulseColor(for: .waiting).opacity(0)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: 6))
+                }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
+            }
+            .overlay(alignment: .leading) {
+                if showsLeadingRail {
+                    Capsule(style: .continuous)
+                        .fill(railColor)
+                        .frame(width: 3)
+                        .padding(.leading, 4)
+                        .padding(.vertical, 5)
+                        .offset(x: -1)
+                }
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(sidebarFlashFillColor.opacity(sidebarFlashOpacity))
+                    .allowsHitTesting(false)
+            }
+            .overlay(alignment: .bottom) {
+                if workspacePulse.dominant == .waiting {
+                    Capsule(style: .continuous)
+                        .fill(workspacePulseColor(for: .waiting))
+                        .frame(height: 3)
+                        .padding(.horizontal, 8)
+                }
+            }
+    }
+
     @ViewBuilder
     private var remoteWorkspaceSection: some View {
         if sidebarShowSSH, let remoteWorkspaceSidebarText {
@@ -11692,6 +11908,8 @@ private struct TabItemView: View, Equatable {
                 .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
                 .frame(width: workspaceHintSlotWidth, height: 16, alignment: .trailing)
             }
+
+            workspacePulseRow
 
             if agentChip != nil {
                 HStack(spacing: 4) {
@@ -11842,35 +12060,7 @@ private struct TabItemView: View, Equatable {
         .animation(.easeInOut(duration: 0.2), value: tab.metadataBlocks.count)
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(backgroundColor)
-                .overlay {
-                    RoundedRectangle(cornerRadius: 6)
-                        .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
-                }
-                .overlay(alignment: .leading) {
-                    if showsLeadingRail {
-                        Capsule(style: .continuous)
-                            .fill(railColor)
-                            .frame(width: 3)
-                            .padding(.leading, 4)
-                            .padding(.vertical, 5)
-                            .offset(x: -1)
-                    }
-                }
-                .overlay {
-                    // Sidebar flash pulse. Single, gentle accent fill that
-                    // signals "a panel in this workspace was flashed" without
-                    // shouting from the sidebar. Hit testing is disabled so
-                    // the pulse never intercepts clicks/drags.
-                    // CMUX-10: color sourced via FlashAppearance seam, or
-                    // tinted by `--color` when the trigger carried one.
-                    RoundedRectangle(cornerRadius: 6)
-                        .fill(sidebarFlashFillColor.opacity(sidebarFlashOpacity))
-                        .allowsHitTesting(false)
-                }
-        )
+        .background(workspacePulseCardBackground)
         .onChange(of: sidebarFlashToken) { _, newValue in
             guard newValue != lastObservedSidebarFlashToken else { return }
             lastObservedSidebarFlashToken = newValue
@@ -11889,7 +12079,7 @@ private struct TabItemView: View, Equatable {
             }
         }
         .contentShape(Rectangle())
-        .opacity(isBeingDragged ? 0.6 : 1)
+        .opacity((isBeingDragged ? 0.6 : 1) * workspacePulseCardOpacity)
         .overlay {
             MiddleClickCapture {
                 #if DEBUG
@@ -14745,4 +14935,3 @@ extension NSColor {
         return String(format: "#%02X%02X%02X", redByte, greenByte, blueByte)
     }
 }
-

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8608,6 +8608,7 @@ struct VerticalTabsSidebar: View {
                                 // parent. TabItemView receives an immutable value so
                                 // its typing-hot body does no metadata/store work.
                                 let unreadCount = notificationStore.unreadCount(forTabId: tab.id)
+                                let latestNotification = notificationStore.latestNotification(forTabId: tab.id)
                                 let workspacePulse = WorkspacePulseProjector.project(
                                     hasWorkspaceDemand: unreadCount > 0,
                                     surfaceStates: tab.sidebarOrderedPanelIds().compactMap { panelId in
@@ -8644,9 +8645,11 @@ struct VerticalTabsSidebar: View {
                                     accessibilityWorkspaceCount: workspaceCount,
                                     unreadCount: unreadCount,
                                     workspacePulse: workspacePulse,
+                                    waitingNotificationId: unreadCount > 0 ? latestNotification?.id : nil,
+                                    waitingSurfaceId: unreadCount > 0 ? latestNotification?.surfaceId : nil,
                                     latestNotificationText: {
                                         guard showsSidebarNotificationMessage,
-                                              let notification = notificationStore.latestNotification(forTabId: tab.id) else {
+                                              let notification = latestNotification else {
                                             return nil
                                         }
                                         let text = notification.body.isEmpty ? notification.title : notification.body
@@ -11300,6 +11303,8 @@ private struct TabItemView: View, Equatable {
         lhs.accessibilityWorkspaceCount == rhs.accessibilityWorkspaceCount &&
         lhs.unreadCount == rhs.unreadCount &&
         lhs.workspacePulse == rhs.workspacePulse &&
+        lhs.waitingNotificationId == rhs.waitingNotificationId &&
+        lhs.waitingSurfaceId == rhs.waitingSurfaceId &&
         lhs.latestNotificationText == rhs.latestNotificationText &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
@@ -11372,6 +11377,8 @@ private struct TabItemView: View, Equatable {
     /// Cheap, value-typed rollup of the workspace's existing notification and
     /// agent-liveness truth. Precomputed by VerticalTabsSidebar.
     let workspacePulse: WorkspacePulseSummary
+    let waitingNotificationId: UUID?
+    let waitingSurfaceId: UUID?
     let latestNotificationText: String?
     let rowSpacing: CGFloat
     let setSelectionToTabs: () -> Void
@@ -11683,26 +11690,76 @@ private struct TabItemView: View, Equatable {
         .accessibilityValue(Text("\(workspacePulse.count(for: state))"))
     }
 
+    private var canOpenWaitingNotification: Bool {
+        workspacePulse.dominant == .waiting && waitingNotificationId != nil
+    }
+
+    private func openWaitingNotification() {
+        guard canOpenWaitingNotification else { return }
+        _ = AppDelegate.shared?.openNotification(
+            tabId: tab.id,
+            surfaceId: waitingSurfaceId,
+            notificationId: waitingNotificationId
+        )
+    }
+
+    @ViewBuilder
+    private var workspacePulsePrimaryContent: some View {
+        let dominant = workspacePulse.dominant
+        let dominantColor = workspacePulseColor(for: dominant)
+        HStack(alignment: .center, spacing: 7) {
+            workspacePulseMark
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    if workspacePulse.count(for: dominant) > 0 {
+                        Text("\(workspacePulse.count(for: dominant))")
+                            .font(.system(size: 9, weight: .bold, design: .monospaced))
+                            .monospacedDigit()
+                    }
+                    Text(workspacePulseLabel(for: dominant))
+                        .font(.system(size: 9, weight: .bold, design: .monospaced))
+                        .textCase(.uppercase)
+                        .lineLimit(1)
+                }
+                .foregroundColor(dominantColor)
+
+                Group {
+                    if let latestNotificationText {
+                        Text(latestNotificationText)
+                            .font(.system(size: chromeTokens.sidebarWorkspaceDetail, design: .monospaced))
+                            .foregroundColor(activeSecondaryColor(0.72))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    } else {
+                        Color.clear
+                    }
+                }
+                .frame(height: 11, alignment: .topLeading)
+            }
+            .frame(minWidth: 0, alignment: .leading)
+        }
+        .contentShape(Rectangle())
+        .layoutPriority(1)
+    }
+
+    @ViewBuilder
+    private var workspacePulsePrimary: some View {
+        if canOpenWaitingNotification {
+            Button(action: openWaitingNotification) {
+                workspacePulsePrimaryContent
+            }
+            .buttonStyle(.plain)
+        } else {
+            workspacePulsePrimaryContent
+        }
+    }
+
     @ViewBuilder
     private var workspacePulseRow: some View {
         let dominant = workspacePulse.dominant
-        let dominantColor = workspacePulseColor(for: dominant)
-        HStack(spacing: 7) {
-            workspacePulseMark
-
-            HStack(spacing: 4) {
-                if workspacePulse.count(for: dominant) > 0 {
-                    Text("\(workspacePulse.count(for: dominant))")
-                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                        .monospacedDigit()
-                }
-                Text(workspacePulseLabel(for: dominant))
-                    .font(.system(size: 9, weight: .bold, design: .monospaced))
-                    .textCase(.uppercase)
-                    .lineLimit(1)
-            }
-            .foregroundColor(dominantColor)
-            .layoutPriority(1)
+        HStack(alignment: .center, spacing: 7) {
+            workspacePulsePrimary
 
             Spacer(minLength: 2)
 
@@ -11717,7 +11774,8 @@ private struct TabItemView: View, Equatable {
                 }
             }
         }
-        .padding(.top, 2)
+        .frame(minHeight: 31, alignment: .center)
+        .padding(.top, 1)
         .accessibilityElement(children: .contain)
     }
 
@@ -11818,8 +11876,6 @@ private struct TabItemView: View, Equatable {
         let accessibilityHintText = String(localized: "sidebar.workspace.accessibilityHint", defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions.")
         let moveUpActionText = String(localized: "sidebar.workspace.moveUpAction", defaultValue: "Move Up")
         let moveDownActionText = String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down")
-        let latestNotificationSubtitle = latestNotificationText
-        let effectiveSubtitle = latestNotificationSubtitle
         let detailVisibility = visibleAuxiliaryDetails
         // C11-104 v2 — branch+directory text-line precomputes retired.
         // The new chip render (precomputed upstream in
@@ -11948,15 +12004,6 @@ private struct TabItemView: View, Equatable {
                     secondary: activeSecondaryColor(0.7)
                 )
                 .padding(.top, 1)
-            }
-
-            if let subtitle = effectiveSubtitle {
-                Text(subtitle)
-                    .font(.system(size: chromeTokens.sidebarWorkspaceDetail))
-                    .foregroundColor(activeSecondaryColor(0.8))
-                    .lineLimit(2)
-                    .truncationMode(.tail)
-                    .multilineTextAlignment(.leading)
             }
 
             remoteWorkspaceSection

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8560,19 +8560,6 @@ struct VerticalTabsSidebar: View {
                                     isActive: isActive,
                                     isMultiSelected: isMultiSelected
                                 )
-                                let agentChip: AgentChip? = {
-                                    guard let focusedId = tab.focusedPanelId else {
-                                        return nil
-                                    }
-                                    let (values, sources) = TerminalController.canonicalMetadataSnapshot(
-                                        workspaceId: tab.id, surfaceId: focusedId
-                                    )
-                                    return AgentChipResolver.resolve(
-                                        focusedSurfaceId: focusedId,
-                                        metadata: values,
-                                        sources: sources
-                                    )
-                                }()
                                 // C11-104 v2: precompute worktree+branch
                                 // chips for the focused surface. Reads the
                                 // resolver output directly from the
@@ -8646,7 +8633,6 @@ struct VerticalTabsSidebar: View {
                                     tab: tab,
                                     index: index,
                                     isActive: isActive,
-                                    agentChip: agentChip,
                                     worktreeChipRows: worktreeChipRows,
                                     surfaceMetricsSample: surfaceMetricsSample,
                                     workspaceShortcutDigit: WorkspaceShortcutMapper.commandDigitForWorkspace(
@@ -11299,7 +11285,6 @@ private struct TabItemView: View, Equatable {
         lhs.tab === rhs.tab &&
         lhs.index == rhs.index &&
         lhs.isActive == rhs.isActive &&
-        lhs.agentChip == rhs.agentChip &&
         lhs.worktreeChipRows == rhs.worktreeChipRows &&
         TabItemView.surfaceMetricsEqual(lhs.surfaceMetricsSample, rhs.surfaceMetricsSample) &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
@@ -11364,7 +11349,6 @@ private struct TabItemView: View, Equatable {
     @ObservedObject var tab: Tab
     let index: Int
     let isActive: Bool
-    let agentChip: AgentChip?
     /// C11-104: precomputed worktree/branch chip rows for the focused
     /// surface. Empty when the setting is disabled or the surface is
     /// not in a git directory. Keeping the projection upstream means
@@ -11974,28 +11958,17 @@ private struct TabItemView: View, Equatable {
 
             workspacePulseRow
 
-            if agentChip != nil, !isMinimalMode {
-                HStack(spacing: 4) {
-                    AgentChipBadge(
-                        chip: agentChip,
-                        showsLabel: !isMinimalMode,
-                        foreground: activeSecondaryColor(0.78),
-                        secondary: activeSecondaryColor(0.68)
-                    )
+            // C11-25: preserve the focused surface's CPU/RSS reading without
+            // the legacy focused-agent identity badge. Workspace Pulse owns
+            // agent state and identity in this card.
+            if let sample = surfaceMetricsSample {
+                HStack {
                     Spacer(minLength: 0)
-                    // C11-25: per-surface CPU/RSS rendered next to the
-                    // agent chip when a sample is available. Terminal
-                    // PID resolution is a follow-up; terminals show no
-                    // metrics until that lands. Format keeps the row
-                    // narrow: integer percent + integer MB or 1-decimal
-                    // GB. Equality in `==` is rounded for stability.
-                    if let sample = surfaceMetricsSample {
-                        Text(TabItemView.formatSurfaceMetrics(sample))
-                            .font(.system(size: 9, design: .monospaced))
-                            .monospacedDigit()
-                            .foregroundColor(activeSecondaryColor(0.55))
-                            .accessibilityIdentifier("SidebarTabSurfaceMetrics")
-                    }
+                    Text(TabItemView.formatSurfaceMetrics(sample))
+                        .font(.system(size: 9, design: .monospaced))
+                        .monospacedDigit()
+                        .foregroundColor(activeSecondaryColor(0.55))
+                        .accessibilityIdentifier("SidebarTabSurfaceMetrics")
                 }
                 .padding(.top, 1)
             }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8595,37 +8595,57 @@ struct VerticalTabsSidebar: View {
                                 // parent. TabItemView receives an immutable value so
                                 // its typing-hot body does no metadata/store work.
                                 let unreadCount = notificationStore.unreadCount(forTabId: tab.id)
-                                let latestNotification = notificationStore.latestNotification(forTabId: tab.id)
-                                let waitingAgentContext: WorkspacePulseAgentContext? = {
-                                    guard showsSidebarNotificationMessage,
-                                          unreadCount > 0,
-                                          let surfaceId = latestNotification?.surfaceId else {
-                                        return nil
-                                    }
-                                    let state = tab.surfaceTitleBarState(panelId: surfaceId)
-                                    return WorkspacePulseAgentContextProjector.project(
-                                        title: state.title,
-                                        subtitle: state.description
-                                    )
-                                }()
-                                let workspacePulse = WorkspacePulseProjector.project(
-                                    hasWorkspaceDemand: unreadCount > 0,
-                                    surfaceStates: tab.sidebarOrderedPanelIds().compactMap { panelId in
-                                        let state = tab.resolvedSurfaceTabActivityState(
+                                let pulseRoster: (agents: [WorkspacePulseAgent], terminalCount: Int) = {
+                                    var agents: [WorkspacePulseAgent] = []
+                                    var terminalCount = 0
+                                    for panelId in tab.sidebarOrderedPanelIds() {
+                                        let terminalKind = tab.surfaceTerminalKind(panelId: panelId)
+                                        guard PaneSizePolicy.isAgentKind(terminalKind) else {
+                                            if tab.panels[panelId]?.panelType == .terminal {
+                                                terminalCount += 1
+                                            }
+                                            continue
+                                        }
+                                        let resolved = tab.resolvedSurfaceTabActivityState(
                                             panelId: panelId,
                                             hasExactSurfaceNotification: notificationStore.hasUnreadNotification(
                                                 forTabId: tab.id,
                                                 surfaceId: panelId
                                             )
                                         )
-                                        switch state {
-                                        case .waiting: return .waiting
-                                        case .running: return .working
-                                        case .idle: return .idle
-                                        case .cold: return .cold
-                                        case nil: return nil
+                                        let pulseState: WorkspacePulseState
+                                        switch resolved {
+                                        case .waiting: pulseState = .waiting
+                                        case .running: pulseState = .working
+                                        case .idle: pulseState = .idle
+                                        case .cold: pulseState = .cold
+                                        case nil: continue
                                         }
+                                        let titleBarState = tab.surfaceTitleBarState(panelId: panelId)
+                                        let reportedTitle = titleBarState.title?
+                                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                                        let context = WorkspacePulseAgentContextProjector.project(
+                                            title: reportedTitle?.isEmpty == false
+                                                ? titleBarState.title
+                                                : tab.panels[panelId]?.displayTitle,
+                                            subtitle: showsSidebarNotificationMessage
+                                                ? titleBarState.description
+                                                : nil
+                                        )
+                                        agents.append(
+                                            WorkspacePulseAgent(
+                                                surfaceId: panelId,
+                                                state: pulseState,
+                                                context: context
+                                            )
+                                        )
                                     }
+                                    return (agents, terminalCount)
+                                }()
+                                let workspacePulse = WorkspacePulseProjector.project(
+                                    hasWorkspaceDemand: unreadCount > 0,
+                                    agents: pulseRoster.agents,
+                                    terminalCount: pulseRoster.terminalCount
                                 )
                                 TabItemView(
                                     tabManager: tabManager,
@@ -8643,9 +8663,6 @@ struct VerticalTabsSidebar: View {
                                     accessibilityWorkspaceCount: workspaceCount,
                                     unreadCount: unreadCount,
                                     workspacePulse: workspacePulse,
-                                    waitingNotificationId: unreadCount > 0 ? latestNotification?.id : nil,
-                                    waitingSurfaceId: unreadCount > 0 ? latestNotification?.surfaceId : nil,
-                                    waitingAgentContext: waitingAgentContext,
                                     rowSpacing: tabRowSpacing,
                                     setSelectionToTabs: { selection = .tabs },
                                     selectedTabIds: $selectedTabIds,
@@ -11267,6 +11284,68 @@ enum SidebarWorkspaceShortcutHintMetrics {
     #endif
 }
 
+private struct WorkspacePulseMarksLayout: Layout {
+    let spacing: CGFloat
+
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        let availableWidth = proposal.width ?? sizes.reduce(0) {
+            $0 + $1.width
+        } + spacing * CGFloat(max(0, sizes.count - 1))
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        var widestRow: CGFloat = 0
+
+        for size in sizes {
+            if x > 0, x + size.width > availableWidth {
+                widestRow = max(widestRow, x - spacing)
+                y += rowHeight + spacing
+                x = 0
+                rowHeight = 0
+            }
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+        widestRow = max(widestRow, max(0, x - spacing))
+        return CGSize(
+            width: min(availableWidth, widestRow),
+            height: y + rowHeight
+        )
+    }
+
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > bounds.minX, x + size.width > bounds.maxX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(
+                at: CGPoint(x: x, y: y),
+                anchor: .topLeading,
+                proposal: ProposedViewSize(size)
+            )
+            x += size.width + spacing
+            rowHeight = max(rowHeight, size.height)
+        }
+    }
+}
+
 // PERF: TabItemView is Equatable so SwiftUI skips body re-evaluation when
 // the parent rebuilds with unchanged values. Without this, every TabManager
 // or NotificationStore publish causes ALL tab items to re-evaluate (~18% of
@@ -11292,9 +11371,6 @@ private struct TabItemView: View, Equatable {
         lhs.accessibilityWorkspaceCount == rhs.accessibilityWorkspaceCount &&
         lhs.unreadCount == rhs.unreadCount &&
         lhs.workspacePulse == rhs.workspacePulse &&
-        lhs.waitingNotificationId == rhs.waitingNotificationId &&
-        lhs.waitingSurfaceId == rhs.waitingSurfaceId &&
-        lhs.waitingAgentContext == rhs.waitingAgentContext &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.themedBackgroundColor?.hexString(includeAlpha: true) == rhs.themedBackgroundColor?.hexString(includeAlpha: true) &&
@@ -11365,9 +11441,6 @@ private struct TabItemView: View, Equatable {
     /// Cheap, value-typed rollup of the workspace's existing notification and
     /// agent-liveness truth. Precomputed by VerticalTabsSidebar.
     let workspacePulse: WorkspacePulseSummary
-    let waitingNotificationId: UUID?
-    let waitingSurfaceId: UUID?
-    let waitingAgentContext: WorkspacePulseAgentContext?
     let rowSpacing: CGFloat
     let setSelectionToTabs: () -> Void
     @Binding var selectedTabIds: Set<UUID>
@@ -11452,34 +11525,8 @@ private struct TabItemView: View, Equatable {
         .semibold
     }
 
-    private var showsLeadingRail: Bool {
-        explicitRailColor != nil
-    }
-
-    // Every workspace row carries a rule-gray hairline so it reads as one
-    // cohesive card against the void. Selection is conveyed by one consistent
-    // signal in every indicator style: the hairline thickens into a white
-    // outline. Custom-colored workspaces keep their color as a rail
-    // (.leftRail) or fill (.solidFill) for identity, but selection itself is
-    // always the white outline.
-    private var activeBorderLineWidth: CGFloat {
-        isActive ? 2.5 : 1
-    }
-
-    private var activeBorderColor: Color {
-        isActive ? BrandColors.whiteSwiftUI : BrandColors.ruleSwiftUI
-    }
-
-    // When a workspace has a custom color and is selected in .solidFill mode,
-    // the fill stays the workspace color (subconsciously reinforcing which
-    // workspace you're in) and emphasis comes from the white outline above
-    // instead of swapping the fill to black.
-    private var hasActiveCustomColorFill: Bool {
-        isActive && activeTabIndicatorStyle == .solidFill && resolvedCustomTabColor != nil
-    }
-
     private var usesInvertedActiveForeground: Bool {
-        isActive && activeTabIndicatorStyle == .solidFill && !hasActiveCustomColorFill
+        false
     }
 
     private var activePrimaryTextColor: Color {
@@ -11492,10 +11539,6 @@ private struct TabItemView: View, Equatable {
         usesInvertedActiveForeground
             ? Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat(opacity)))
             : .secondary
-    }
-
-    private var activeUnreadBadgeFillColor: Color {
-        cmuxAccentColor()
     }
 
     private var activeProgressTrackColor: Color {
@@ -11615,208 +11658,308 @@ private struct TabItemView: View, Equatable {
         }
     }
 
-    private func workspacePulseSymbol(for state: WorkspacePulseState) -> String {
+    @ViewBuilder
+    private func workspacePulseMark(
+        for state: WorkspacePulseState,
+        summaryScale: Bool = false
+    ) -> some View {
+        let color = workspacePulseColor(for: state)
         switch state {
-        case .waiting: return "exclamationmark"
-        case .working: return "arrow.triangle.2.circlepath"
-        case .idle: return "pause.fill"
-        case .cold: return "minus"
+        case .waiting:
+            ZStack {
+                RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    .fill(color)
+                Text(verbatim: "W")
+                    .font(.system(size: summaryScale ? 8 : 7, weight: .black, design: .monospaced))
+                    .foregroundColor(workspacePulseWaitingInk)
+            }
+            .frame(width: summaryScale ? 16 : 14, height: summaryScale ? 16 : 14)
+        case .working:
+            Circle()
+                .trim(from: 0.12, to: 0.88)
+                .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .rotationEffect(.degrees(-42))
+                .frame(width: summaryScale ? 11 : 10, height: summaryScale ? 11 : 10)
+        case .idle:
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(color)
+                .frame(width: summaryScale ? 9 : 8, height: summaryScale ? 9 : 8)
+        case .cold:
+            Circle()
+                .fill(color.opacity(0.82))
+                .frame(width: summaryScale ? 7 : 6, height: summaryScale ? 7 : 6)
         }
     }
 
-    private var workspacePulseCornerRadius: CGFloat {
-        switch workspacePulse.dominant {
-        case .waiting, .idle: return 4
-        case .working, .cold: return 9
-        }
+    private var workspacePulseVisibleAgents: [WorkspacePulseAgent] {
+        Array(workspacePulse.relevantAgents.prefix(2))
     }
 
-    @ViewBuilder
-    private var workspacePulseMark: some View {
-        let state = workspacePulse.dominant
-        let color = workspacePulseColor(for: state)
-        let shape = RoundedRectangle(cornerRadius: workspacePulseCornerRadius, style: .continuous)
-        ZStack {
-            shape
-                .fill(state == .waiting ? color : Color.clear)
-            shape
-                .strokeBorder(
-                    color.opacity(state == .cold ? 0.7 : 0.9),
-                    style: StrokeStyle(
-                        lineWidth: 1,
-                        dash: state == .cold ? [2, 2] : []
-                    )
-                )
-            Image(systemName: workspacePulseSymbol(for: state))
-                .font(.system(size: 8, weight: .bold, design: .monospaced))
-                .foregroundColor(state == .waiting ? workspacePulseWaitingInk : color)
-        }
-        .frame(width: 18, height: 18)
-        .accessibilityHidden(true)
+    private var workspacePulseWaitingOverflow: Int {
+        max(
+            0,
+            workspacePulse.agentCount(for: .waiting)
+                - workspacePulseVisibleAgents.filter { $0.state == .waiting }.count
+        )
     }
 
-    @ViewBuilder
-    private func workspacePulseChip(for state: WorkspacePulseState) -> some View {
-        let color = workspacePulseColor(for: state)
-        let label = workspacePulseLabel(for: state)
-        HStack(spacing: 3) {
-            Image(systemName: workspacePulseSymbol(for: state))
-                .font(.system(size: 7, weight: .bold))
-            Text("\(workspacePulse.count(for: state))")
-                .font(.system(size: 8, weight: .bold, design: .monospaced))
-                .monospacedDigit()
-        }
-        .foregroundColor(color)
-        .padding(.horizontal, 4)
-        .frame(minWidth: 25, minHeight: 18)
-        .overlay {
-            RoundedRectangle(cornerRadius: 4, style: .continuous)
-                .strokeBorder(color.opacity(0.42), lineWidth: 1)
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(Text(label))
-        .accessibilityValue(Text("\(workspacePulse.count(for: state))"))
-    }
-
-    private var canOpenWaitingNotification: Bool {
-        workspacePulse.dominant == .waiting && waitingNotificationId != nil
-    }
-
-    private func openWaitingNotification() {
-        guard canOpenWaitingNotification else { return }
+    private func openWorkspacePulseAgent(_ agent: WorkspacePulseAgent) {
+        guard agent.state == .waiting else { return }
         _ = AppDelegate.shared?.openNotification(
             tabId: tab.id,
-            surfaceId: waitingSurfaceId,
-            notificationId: waitingNotificationId
+            surfaceId: agent.surfaceId,
+            notificationId: nil
         )
     }
 
     @ViewBuilder
-    private var workspacePulsePrimaryContent: some View {
-        let dominant = workspacePulse.dominant
-        let dominantColor = workspacePulseColor(for: dominant)
-        HStack(alignment: .center, spacing: 7) {
-            workspacePulseMark
+    private func workspacePulseSummaryRow(
+        _ agent: WorkspacePulseAgent,
+        index: Int
+    ) -> some View {
+        let context = agent.context
+        let content = HStack(spacing: 7) {
+            workspacePulseMark(for: agent.state, summaryScale: true)
+                .frame(width: 16, height: 16)
 
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 4) {
-                    if workspacePulse.count(for: dominant) > 0 {
-                        Text("\(workspacePulse.count(for: dominant))")
-                            .font(.system(size: 9, weight: .bold, design: .monospaced))
-                            .monospacedDigit()
-                    }
-                    Text(workspacePulseLabel(for: dominant))
-                        .font(.system(size: 9, weight: .bold, design: .monospaced))
-                        .textCase(.uppercase)
-                        .lineLimit(1)
+            Group {
+                if let context {
+                    (
+                        Text(verbatim: context.title).fontWeight(.medium)
+                        + Text(verbatim: context.subtitle.map { " · \($0)" } ?? "")
+                    )
+                } else {
+                    Text(verbatim: workspacePulseLabel(for: agent.state))
                 }
-                .foregroundColor(dominantColor)
-
-                Group {
-                    if let waitingAgentContext {
-                        (
-                            Text(waitingAgentContext.title).fontWeight(.semibold)
-                            + Text(waitingAgentContext.subtitle.map { " — \($0)" } ?? "")
-                        )
-                            .font(.system(size: chromeTokens.sidebarWorkspaceDetail, design: .monospaced))
-                            .foregroundColor(activeSecondaryColor(0.72))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                    } else {
-                        Color.clear
-                    }
-                }
-                .frame(height: 11, alignment: .topLeading)
             }
-            .frame(minWidth: 0, alignment: .leading)
-        }
-        .contentShape(Rectangle())
-        .layoutPriority(1)
-    }
+            .font(.system(size: chromeTokens.sidebarWorkspaceDetail + 1))
+            .foregroundColor(index == 0 ? Color.primary.opacity(0.86) : Color.secondary.opacity(0.72))
+            .lineLimit(1)
+            .truncationMode(.tail)
 
-    @ViewBuilder
-    private var workspacePulsePrimary: some View {
-        if canOpenWaitingNotification {
-            Button(action: openWaitingNotification) {
-                workspacePulsePrimaryContent
+            Spacer(minLength: 0)
+        }
+
+        if agent.state == .waiting {
+            Button(action: { openWorkspacePulseAgent(agent) }) {
+                content
             }
             .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
         } else {
-            workspacePulsePrimaryContent
+            content
         }
     }
 
     @ViewBuilder
-    private var workspacePulseRow: some View {
-        let dominant = workspacePulse.dominant
-        HStack(alignment: .center, spacing: 7) {
-            workspacePulsePrimary
-
-            Spacer(minLength: 2)
-
-            HStack(spacing: 4) {
-                ForEach(
-                    WorkspacePulseState.allCases.filter {
-                        $0 != dominant && workspacePulse.count(for: $0) > 0
-                    },
-                    id: \.self
-                ) { state in
-                    workspacePulseChip(for: state)
+    private var workspacePulseSummaries: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            if workspacePulseVisibleAgents.isEmpty {
+                Text(String(
+                    localized: "sidebar.workspacePulse.terminalsOnly",
+                    defaultValue: "Terminals only · no agent surfaces"
+                ))
+                .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
+                .foregroundColor(.secondary.opacity(0.65))
+                .lineLimit(1)
+            } else {
+                ForEach(Array(workspacePulseVisibleAgents.enumerated()), id: \.element.id) { index, agent in
+                    workspacePulseSummaryRow(agent, index: index)
+                }
+                if workspacePulseWaitingOverflow > 0 {
+                    Text(String(
+                        localized: "sidebar.workspacePulse.moreWaiting",
+                        defaultValue: "… and \(workspacePulseWaitingOverflow) more"
+                    ))
+                    .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, design: .monospaced))
+                    .foregroundColor(.secondary.opacity(0.62))
+                    .padding(.leading, 23)
                 }
             }
         }
-        .frame(minHeight: 31, alignment: .center)
-        .padding(.top, 1)
-        .accessibilityElement(children: .contain)
+        .padding(.top, 9)
+    }
+
+    private var workspacePulseAgentCountText: String {
+        if workspacePulse.agents.count == 1 {
+            return String(
+                localized: "sidebar.workspacePulse.agentCount.one",
+                defaultValue: "1 agent"
+            )
+        }
+        return String(
+            localized: "sidebar.workspacePulse.agentCount.other",
+            defaultValue: "\(workspacePulse.agents.count) agents"
+        )
+    }
+
+    private var workspacePulseTerminalCountText: String {
+        if workspacePulse.terminalCount == 1 {
+            return String(
+                localized: "sidebar.workspacePulse.terminalCount.one",
+                defaultValue: "1 terminal"
+            )
+        }
+        return String(
+            localized: "sidebar.workspacePulse.terminalCount.other",
+            defaultValue: "\(workspacePulse.terminalCount) terminals"
+        )
+    }
+
+    private var workspacePulseFooter: some View {
+        HStack(alignment: .top, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(verbatim: workspacePulseAgentCountText)
+                Circle()
+                    .fill(Color.secondary.opacity(0.65))
+                    .frame(width: 2, height: 2)
+                Text(verbatim: workspacePulseTerminalCountText)
+            }
+            .fixedSize(horizontal: true, vertical: false)
+
+            Spacer(minLength: 4)
+
+            WorkspacePulseMarksLayout(spacing: 7) {
+                ForEach(workspacePulse.agents) { agent in
+                    workspacePulseMark(for: agent.state)
+                        .frame(width: 14, height: 14)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(Text(agent.context?.title ?? workspacePulseLabel(for: agent.state)))
+                        .accessibilityValue(Text(workspacePulseLabel(for: agent.state)))
+                }
+            }
+        }
+        .font(.system(size: chromeTokens.sidebarWorkspaceMetadata - 0.5, design: .monospaced))
+        .foregroundColor(.secondary.opacity(0.68))
+        .padding(.top, 8)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(workspacePulseIdentityColor.opacity(0.18))
+                .frame(height: 1)
+        }
+        .padding(.top, 10)
+    }
+
+    private var workspacePulseCompositionRail: some View {
+        GeometryReader { proxy in
+            let populatedStates = WorkspacePulseState.allCases.filter {
+                workspacePulse.agentCount(for: $0) > 0
+            }
+            let gap: CGFloat = 2
+            let totalGaps = gap * CGFloat(max(0, populatedStates.count - 1))
+            let availableWidth = max(0, proxy.size.width - totalGaps)
+            HStack(spacing: gap) {
+                ForEach(populatedStates, id: \.self) { state in
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(workspacePulseColor(for: state))
+                        .frame(
+                            width: availableWidth
+                                * CGFloat(workspacePulse.agentCount(for: state))
+                                / CGFloat(max(1, workspacePulse.agents.count))
+                        )
+                }
+            }
+        }
+        .frame(height: 4)
+        .background(
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(BrandColors.ruleSwiftUI.opacity(workspacePulse.agents.isEmpty ? 0.55 : 0.35))
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
+        .padding(.top, 9)
+        .accessibilityHidden(true)
+    }
+
+    private var workspacePulseIdentityColor: Color {
+        if let themedRailColor {
+            return Color(nsColor: themedRailColor)
+        }
+        if let resolvedCustomTabColor {
+            return resolvedCustomTabColor
+        }
+        return Color(nsColor: NSColor(
+            srgbRed: 0.44,
+            green: 0.51,
+            blue: 0.57,
+            alpha: 1
+        ))
+    }
+
+    private var workspacePulseBaseColor: Color {
+        if let themedBackgroundColor {
+            return Color(nsColor: themedBackgroundColor)
+        }
+        if colorScheme == .light {
+            return Color(nsColor: NSColor(
+                srgbRed: 0.96,
+                green: 0.95,
+                blue: 0.93,
+                alpha: 1
+            ))
+        }
+        return Color(nsColor: NSColor(
+            srgbRed: 0.067,
+            green: 0.075,
+            blue: 0.09,
+            alpha: 1
+        ))
+    }
+
+    private var workspacePulseBorderColor: Color {
+        if isActive {
+            return colorScheme == .light
+                ? BrandColors.blackSwiftUI.opacity(0.82)
+                : BrandColors.whiteSwiftUI.opacity(0.9)
+        }
+        if workspacePulse.waitingCount > 0 {
+            return workspacePulseColor(for: .waiting).opacity(0.38)
+        }
+        return workspacePulseIdentityColor.opacity(0.32)
     }
 
     private var workspacePulseCardOpacity: Double {
-        workspacePulse.dominant == .cold && !isActive ? 0.72 : 1
+        1
     }
 
     @ViewBuilder
     private var workspacePulseCardBackground: some View {
-        RoundedRectangle(cornerRadius: 6)
-            .fill(backgroundColor)
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(workspacePulseBaseColor)
             .overlay {
-                if workspacePulse.dominant == .waiting {
-                    LinearGradient(
-                        colors: [
-                            workspacePulseColor(for: .waiting).opacity(0.14),
-                            workspacePulseColor(for: .waiting).opacity(0)
-                        ],
-                        startPoint: .leading,
-                        endPoint: .trailing
+                RadialGradient(
+                    colors: [
+                        workspacePulseIdentityColor.opacity(colorScheme == .light ? 0.07 : 0.09),
+                        workspacePulseIdentityColor.opacity(0)
+                    ],
+                    center: .topLeading,
+                    startRadius: 0,
+                    endRadius: 180
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .overlay {
+                LinearGradient(
+                    colors: [
+                        Color.white.opacity(colorScheme == .light ? 0.22 : 0.025),
+                        Color.clear
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(
+                        workspacePulseBorderColor,
+                        lineWidth: isActive ? 2 : 1
                     )
-                    .clipShape(RoundedRectangle(cornerRadius: 6))
-                }
             }
             .overlay {
-                RoundedRectangle(cornerRadius: 6)
-                    .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
-            }
-            .overlay(alignment: .leading) {
-                if showsLeadingRail {
-                    Capsule(style: .continuous)
-                        .fill(railColor)
-                        .frame(width: 3)
-                        .padding(.leading, 4)
-                        .padding(.vertical, 5)
-                        .offset(x: -1)
-                }
-            }
-            .overlay {
-                RoundedRectangle(cornerRadius: 6)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(sidebarFlashFillColor.opacity(sidebarFlashOpacity))
                     .allowsHitTesting(false)
-            }
-            .overlay(alignment: .bottom) {
-                if workspacePulse.dominant == .waiting {
-                    Capsule(style: .continuous)
-                        .fill(workspacePulseColor(for: .waiting))
-                        .frame(height: 3)
-                        .padding(.horizontal, 8)
-                }
             }
     }
 
@@ -11839,7 +11982,7 @@ private struct TabItemView: View, Equatable {
                         .lineLimit(1)
                 }
             }
-            .padding(.top, waitingAgentContext == nil ? 1 : 2)
+            .padding(.top, 2)
             .safeHelp(remoteStateHelpText)
         }
     }
@@ -11880,43 +12023,25 @@ private struct TabItemView: View, Equatable {
             return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
         }()
 
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(alignment: .top, spacing: 6) {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(alignment: .center, spacing: 7) {
                 Text(tab.title)
-                    .font(.system(size: chromeTokens.sidebarWorkspaceTitle, weight: titleFontWeight))
-                    .foregroundColor(activePrimaryTextColor)
-                    .lineLimit(2)
+                    .font(.system(size: chromeTokens.sidebarWorkspaceTitle + 1.5, weight: titleFontWeight))
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
                     .truncationMode(.tail)
-                    .multilineTextAlignment(.leading)
-                    .fixedSize(horizontal: false, vertical: true)
                     .layoutPriority(1)
 
                 Spacer(minLength: 4)
 
                 HStack(spacing: 5) {
                     if tab.isPinned {
-                        Image(systemName: "pin.fill")
-                            .font(.system(size: chromeTokens.sidebarWorkspaceAccessory, weight: .semibold))
-                            .foregroundColor(activeSecondaryColor(0.8))
+                        Image(systemName: "diamond.fill")
+                            .font(.system(size: chromeTokens.sidebarWorkspaceAccessory + 1, weight: .semibold))
+                            .foregroundColor(.secondary.opacity(0.7))
                     }
 
-                    if unreadCount > 0 {
-                        ZStack {
-                            Circle()
-                                .fill(activeUnreadBadgeFillColor)
-                            Text("\(unreadCount)")
-                                .font(.system(size: chromeTokens.sidebarWorkspaceAccessory, weight: .semibold))
-                                // Badge fill is always gold (`activeUnreadBadgeFillColor`).
-                                // Use black on the gold circle whenever the tab is the
-                                // active selection in .solidFill — including custom-color
-                                // workspaces, where the broader text palette stays primary
-                                // but black-on-gold remains the only legible badge choice.
-                                .foregroundColor(isActive && activeTabIndicatorStyle == .solidFill ? BrandColors.blackSwiftUI : .white)
-                        }
-                        .frame(width: 16, height: 16)
-                    }
                 }
-                .padding(.top, 1)
 
                 ZStack(alignment: .trailing) {
                     Button(action: {
@@ -11953,10 +12078,12 @@ private struct TabItemView: View, Equatable {
                     }
                 }
                 .animation(.easeInOut(duration: 0.14), value: showsModifierShortcutHints || alwaysShowShortcutHints)
-                .frame(width: workspaceHintSlotWidth, height: 16, alignment: .trailing)
+                .frame(width: workspaceHintSlotWidth, height: 19, alignment: .trailing)
             }
 
-            workspacePulseRow
+            workspacePulseSummaries
+
+            workspacePulseFooter
 
             // C11-25: preserve the focused surface's CPU/RSS reading without
             // the legacy focused-agent identity badge. Workspace Pulse owns
@@ -12081,12 +12208,15 @@ private struct TabItemView: View, Equatable {
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
+
+            workspacePulseCompositionRail
         }
         .animation(.easeInOut(duration: 0.2), value: tab.logEntries.count)
         .animation(.easeInOut(duration: 0.2), value: tab.progress != nil)
         .animation(.easeInOut(duration: 0.2), value: tab.metadataBlocks.count)
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 13)
+        .padding(.top, 13)
+        .padding(.bottom, 11)
         .background(workspacePulseCardBackground)
         .onChange(of: sidebarFlashToken) { _, newValue in
             guard newValue != lastObservedSidebarFlashToken else { return }
@@ -12435,47 +12565,6 @@ private struct TabItemView: View, Equatable {
             markTabsUnread(targetIds)
         }
         .disabled(!hasReadNotifications(in: targetIds))
-    }
-
-    private var backgroundColor: Color {
-        if let themedBackgroundColor {
-            return Color(nsColor: themedBackgroundColor)
-        }
-
-        switch activeTabIndicatorStyle {
-        case .leftRail:
-            if isMultiSelected { return cmuxAccentColor().opacity(0.25) }
-            return Color.clear
-        case .solidFill:
-            if isActive {
-                if let custom = resolvedCustomTabColor { return custom }
-                return Color(nsColor: sidebarSelectedWorkspaceBackgroundNSColor(for: colorScheme))
-            }
-            if let custom = resolvedCustomTabColor {
-                if isMultiSelected { return custom.opacity(0.35) }
-                return custom.opacity(0.7)
-            }
-            if isMultiSelected { return cmuxAccentColor().opacity(0.25) }
-            return Color.clear
-        }
-    }
-
-    private var railColor: Color {
-        if let themedRailColor {
-            return Color(nsColor: themedRailColor)
-        }
-        return explicitRailColor ?? .clear
-    }
-
-    private var explicitRailColor: Color? {
-        guard activeTabIndicatorStyle == .leftRail else { return nil }
-        // The custom color shows as a rail for identity (whether selected or
-        // not). Selection itself is the white outline (see activeBorderColor),
-        // so there is no gold selection rail for uncolored workspaces.
-        if let custom = resolvedCustomTabColor {
-            return custom.opacity(0.95)
-        }
-        return nil
     }
 
     private var resolvedCustomTabColor: Color? {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8609,6 +8609,18 @@ struct VerticalTabsSidebar: View {
                                 // its typing-hot body does no metadata/store work.
                                 let unreadCount = notificationStore.unreadCount(forTabId: tab.id)
                                 let latestNotification = notificationStore.latestNotification(forTabId: tab.id)
+                                let waitingAgentContext: WorkspacePulseAgentContext? = {
+                                    guard showsSidebarNotificationMessage,
+                                          unreadCount > 0,
+                                          let surfaceId = latestNotification?.surfaceId else {
+                                        return nil
+                                    }
+                                    let state = tab.surfaceTitleBarState(panelId: surfaceId)
+                                    return WorkspacePulseAgentContextProjector.project(
+                                        title: state.title,
+                                        subtitle: state.description
+                                    )
+                                }()
                                 let workspacePulse = WorkspacePulseProjector.project(
                                     hasWorkspaceDemand: unreadCount > 0,
                                     surfaceStates: tab.sidebarOrderedPanelIds().compactMap { panelId in
@@ -8647,15 +8659,7 @@ struct VerticalTabsSidebar: View {
                                     workspacePulse: workspacePulse,
                                     waitingNotificationId: unreadCount > 0 ? latestNotification?.id : nil,
                                     waitingSurfaceId: unreadCount > 0 ? latestNotification?.surfaceId : nil,
-                                    latestNotificationText: {
-                                        guard showsSidebarNotificationMessage,
-                                              let notification = latestNotification else {
-                                            return nil
-                                        }
-                                        let text = notification.body.isEmpty ? notification.title : notification.body
-                                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                                        return trimmed.isEmpty ? nil : trimmed
-                                    }(),
+                                    waitingAgentContext: waitingAgentContext,
                                     rowSpacing: tabRowSpacing,
                                     setSelectionToTabs: { selection = .tabs },
                                     selectedTabIds: $selectedTabIds,
@@ -11305,7 +11309,7 @@ private struct TabItemView: View, Equatable {
         lhs.workspacePulse == rhs.workspacePulse &&
         lhs.waitingNotificationId == rhs.waitingNotificationId &&
         lhs.waitingSurfaceId == rhs.waitingSurfaceId &&
-        lhs.latestNotificationText == rhs.latestNotificationText &&
+        lhs.waitingAgentContext == rhs.waitingAgentContext &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.themedBackgroundColor?.hexString(includeAlpha: true) == rhs.themedBackgroundColor?.hexString(includeAlpha: true) &&
@@ -11379,7 +11383,7 @@ private struct TabItemView: View, Equatable {
     let workspacePulse: WorkspacePulseSummary
     let waitingNotificationId: UUID?
     let waitingSurfaceId: UUID?
-    let latestNotificationText: String?
+    let waitingAgentContext: WorkspacePulseAgentContext?
     let rowSpacing: CGFloat
     let setSelectionToTabs: () -> Void
     @Binding var selectedTabIds: Set<UUID>
@@ -11725,8 +11729,11 @@ private struct TabItemView: View, Equatable {
                 .foregroundColor(dominantColor)
 
                 Group {
-                    if let latestNotificationText {
-                        Text(latestNotificationText)
+                    if let waitingAgentContext {
+                        (
+                            Text(waitingAgentContext.title).fontWeight(.semibold)
+                            + Text(waitingAgentContext.subtitle.map { " — \($0)" } ?? "")
+                        )
                             .font(.system(size: chromeTokens.sidebarWorkspaceDetail, design: .monospaced))
                             .foregroundColor(activeSecondaryColor(0.72))
                             .lineLimit(1)
@@ -11848,7 +11855,7 @@ private struct TabItemView: View, Equatable {
                         .lineLimit(1)
                 }
             }
-            .padding(.top, latestNotificationText == nil ? 1 : 2)
+            .padding(.top, waitingAgentContext == nil ? 1 : 2)
             .safeHelp(remoteStateHelpText)
         }
     }
@@ -11967,7 +11974,7 @@ private struct TabItemView: View, Equatable {
 
             workspacePulseRow
 
-            if agentChip != nil {
+            if agentChip != nil, !isMinimalMode {
                 HStack(spacing: 4) {
                     AgentChipBadge(
                         chip: agentChip,
@@ -13431,18 +13438,10 @@ private struct SidebarProgressIndicator: View {
     }
 }
 
-/// TEL-4: derived-activity takeover pill. When a workspace's explicit
-/// agent-claimed status is absent or has aged past expiry, the sidebar falls
-/// back to a *derived* pill computed from low-level activity so the row still
-/// tells the truth. Rendered visually distinct from an agent-claimed pill
-/// (outlined capsule + italic + a "sensed" glyph). Observes the decay clock
-/// in this child subview so the takeover flips without invalidating the row.
-/// C11-162 (TEL-4, m1): owns the single-pill takeover decision for a workspace
-/// row's status region. Observes the decay clock here (a child, never in
-/// `TabItemView`'s Equatable body) and renders EITHER the explicit status rows
-/// OR — once the representative explicit status has expired and a derived
-/// activity exists — the derived pill in their place, so the operator sees one
-/// pill, not a grayed tombstone plus a derived pill.
+/// Agent-authored status region. Workspace Pulse now owns derived activity, so
+/// this section renders fresh/stale explicit status rows only. When explicit
+/// status expires and the projector hands off to derived truth, this row goes
+/// quiet instead of duplicating the pulse with a second Idle/Working pill.
 private struct SidebarStatusSection: View {
     @ObservedObject var tab: Tab
     let isActive: Bool
@@ -13482,80 +13481,9 @@ private struct SidebarStatusSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            if takeoverActive {
-                SidebarDerivedActivityPill(tab: tab, isActive: isActive, onFocus: onFocus)
-            } else if !entries.isEmpty {
+            if !takeoverActive, !entries.isEmpty {
                 SidebarMetadataRows(entries: entries, isActive: isActive, onFocus: onFocus)
             }
-        }
-    }
-}
-
-private struct SidebarDerivedActivityPill: View {
-    @ObservedObject var tab: Tab
-    let isActive: Bool
-    let onFocus: () -> Void
-
-    @Environment(\.chromeScaleTokens) private var chromeTokens
-    @ObservedObject private var decayClock = SidebarDecayClock.shared
-    @AppStorage(SidebarStalenessSettings.staleThresholdKey)
-    private var staleThresholdRaw = SidebarStalenessSettings.defaultStaleSeconds
-    @AppStorage(SidebarStalenessSettings.expiryThresholdKey)
-    private var expiryThresholdRaw = SidebarStalenessSettings.defaultExpirySeconds
-
-    /// Most-recently-written explicit status entry, used as the representative
-    /// against which the derived takeover is decided.
-    private var representativeEntry: SidebarStatusEntry? {
-        tab.sidebarStatusEntriesInDisplayOrder().max { $0.timestamp < $1.timestamp }
-    }
-
-    private var pill: SidebarVisiblePill? {
-        let entry = representativeEntry
-        // C11-162 (m4): pass the trimmed value through even when empty, so the
-        // projector's empty-string handling (empty explicit → derived takeover)
-        // works instead of being defeated by substituting the key name.
-        let explicitText: String? = entry.map { e in
-            e.value.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        let age = entry.map { decayClock.now.timeIntervalSince($0.timestamp) }
-        return SidebarActivityProjector.project(
-            explicitText: explicitText,
-            explicitAgeSeconds: age,
-            derived: tab.aggregatedDerivedActivity,
-            staleSeconds: SidebarStalenessSettings.staleSeconds(),
-            expirySeconds: SidebarStalenessSettings.expirySeconds()
-        )
-    }
-
-    private var derivedColor: Color {
-        isActive ? Color.white.opacity(0.7) : .secondary
-    }
-
-    var body: some View {
-        // Only surface this row when the projection is a derived takeover;
-        // a fresh/stale explicit status is already rendered by the metadata
-        // rows above (with their own TEL-2 decay treatment).
-        if let pill, pill.isDerived {
-            HStack(spacing: 4) {
-                Image(systemName: "wave.3.right")
-                    .font(.system(size: chromeTokens.sidebarWorkspaceLogIcon, weight: .medium))
-                Text(pill.text)
-                    .font(.system(size: chromeTokens.sidebarWorkspaceMetadata, weight: .regular).italic())
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                Spacer(minLength: 0)
-            }
-            .foregroundColor(derivedColor)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .overlay(
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .stroke(derivedColor.opacity(0.5), lineWidth: 0.75)
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-            .onTapGesture { onFocus() }
-            .safeHelp(String(localized: "sidebar.derivedActivity.tooltip", defaultValue: "Derived activity — no recent agent status"))
         }
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11284,68 +11284,6 @@ enum SidebarWorkspaceShortcutHintMetrics {
     #endif
 }
 
-private struct WorkspacePulseMarksLayout: Layout {
-    let spacing: CGFloat
-
-    func sizeThatFits(
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) -> CGSize {
-        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
-        let availableWidth = proposal.width ?? sizes.reduce(0) {
-            $0 + $1.width
-        } + spacing * CGFloat(max(0, sizes.count - 1))
-        var x: CGFloat = 0
-        var y: CGFloat = 0
-        var rowHeight: CGFloat = 0
-        var widestRow: CGFloat = 0
-
-        for size in sizes {
-            if x > 0, x + size.width > availableWidth {
-                widestRow = max(widestRow, x - spacing)
-                y += rowHeight + spacing
-                x = 0
-                rowHeight = 0
-            }
-            x += size.width + spacing
-            rowHeight = max(rowHeight, size.height)
-        }
-        widestRow = max(widestRow, max(0, x - spacing))
-        return CGSize(
-            width: min(availableWidth, widestRow),
-            height: y + rowHeight
-        )
-    }
-
-    func placeSubviews(
-        in bounds: CGRect,
-        proposal: ProposedViewSize,
-        subviews: Subviews,
-        cache: inout ()
-    ) {
-        var x = bounds.minX
-        var y = bounds.minY
-        var rowHeight: CGFloat = 0
-
-        for subview in subviews {
-            let size = subview.sizeThatFits(.unspecified)
-            if x > bounds.minX, x + size.width > bounds.maxX {
-                x = bounds.minX
-                y += rowHeight + spacing
-                rowHeight = 0
-            }
-            subview.place(
-                at: CGPoint(x: x, y: y),
-                anchor: .topLeading,
-                proposal: ProposedViewSize(size)
-            )
-            x += size.width + spacing
-            rowHeight = max(rowHeight, size.height)
-        }
-    }
-}
-
 // PERF: TabItemView is Equatable so SwiftUI skips body re-evaluation when
 // the parent rebuilds with unchanged values. Without this, every TabManager
 // or NotificationStore publish causes ALL tab items to re-evaluate (~18% of
@@ -11808,7 +11746,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private var workspacePulseFooter: some View {
-        HStack(alignment: .top, spacing: 8) {
+        VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 6) {
                 Text(verbatim: workspacePulseAgentCountText)
                 Circle()
@@ -11818,9 +11756,7 @@ private struct TabItemView: View, Equatable {
             }
             .fixedSize(horizontal: true, vertical: false)
 
-            Spacer(minLength: 4)
-
-            WorkspacePulseMarksLayout(spacing: 7) {
+            HStack(spacing: 7) {
                 ForEach(workspacePulse.agents) { agent in
                     workspacePulseMark(for: agent.state)
                         .frame(width: 14, height: 14)
@@ -11829,6 +11765,8 @@ private struct TabItemView: View, Equatable {
                         .accessibilityValue(Text(workspacePulseLabel(for: agent.state)))
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .frame(height: 14)
         }
         .font(.system(size: chromeTokens.sidebarWorkspaceMetadata - 0.5, design: .monospaced))
         .foregroundColor(.secondary.opacity(0.68))

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3907,6 +3907,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
     /// Inject straight into Ghostty when there is no window; every key in
     /// `TerminalKey` is a control key, so the keycode alone encodes it.
     func sendKey(_ key: TextBoxKeyRouting.TerminalKey) {
+        if case .returnKey = key {
+            SurfaceLivenessDeriver.onAgentLifecycleChanged(
+                surfaceId: id,
+                workspaceId: tabId,
+                activity: .working
+            )
+        }
         if surfaceView.window == nil, let surface {
             sendKeyDirectlyToSurface(keyCode: key.keyCode, surface: surface)
             return
@@ -5456,6 +5463,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 tabId: terminalSurface.tabId,
                 surfaceId: terminalSurface.id
             )
+            let submitFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if !event.isARepeat,
+               (event.keyCode == 36 || event.keyCode == 76),
+               !submitFlags.contains(.command),
+               !hasMarkedText() {
+                SurfaceLivenessDeriver.onAgentLifecycleChanged(
+                    surfaceId: terminalSurface.id,
+                    workspaceId: terminalSurface.tabId,
+                    activity: .working
+                )
+            }
 #if DEBUG
             dismissNotificationMs = (ProcessInfo.processInfo.systemUptime - dismissNotificationStart) * 1000.0
 #endif

--- a/Sources/Sidebar/SidebarActivityProjector.swift
+++ b/Sources/Sidebar/SidebarActivityProjector.swift
@@ -45,6 +45,36 @@ struct WorkspacePulseSummary: Equatable {
     }
 }
 
+/// Compact identity for the exact agent surface whose unread notification is
+/// driving a workspace into `waiting`. The pulse owns only one detail line, so
+/// normalize title-bar metadata into a stable single-line title + subtitle.
+struct WorkspacePulseAgentContext: Equatable {
+    let title: String
+    let subtitle: String?
+}
+
+enum WorkspacePulseAgentContextProjector {
+    static func project(title: String?, subtitle: String?) -> WorkspacePulseAgentContext? {
+        let title = normalized(title)
+        let subtitle = normalized(subtitle)
+        if let title {
+            return WorkspacePulseAgentContext(title: title, subtitle: subtitle)
+        }
+        if let subtitle {
+            return WorkspacePulseAgentContext(title: subtitle, subtitle: nil)
+        }
+        return nil
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        return normalized.isEmpty ? nil : normalized
+    }
+}
+
 enum WorkspacePulseProjector {
     /// Rolls exact agent-surface states up with workspace-level operator
     /// demand. A surface-less notification still makes the workspace demand

--- a/Sources/Sidebar/SidebarActivityProjector.swift
+++ b/Sources/Sidebar/SidebarActivityProjector.swift
@@ -7,7 +7,7 @@ import Foundation
 /// silent (expires) or was never set, the sidebar falls back to a *derived*
 /// pill so the row still tells the truth about whether the workspace is
 /// doing anything.
-public enum SidebarActivityState: String {
+public enum SidebarActivityState: String, Sendable {
     case working
     case idle
 }

--- a/Sources/Sidebar/SidebarActivityProjector.swift
+++ b/Sources/Sidebar/SidebarActivityProjector.swift
@@ -22,11 +22,37 @@ enum WorkspacePulseState: String, CaseIterable {
     case cold
 }
 
+struct WorkspacePulseAgent: Equatable, Identifiable {
+    let surfaceId: UUID
+    let state: WorkspacePulseState
+    let context: WorkspacePulseAgentContext?
+
+    var id: UUID { surfaceId }
+}
+
 struct WorkspacePulseSummary: Equatable {
     let waitingCount: Int
     let workingCount: Int
     let idleCount: Int
     let coldCount: Int
+    let agents: [WorkspacePulseAgent]
+    let terminalCount: Int
+
+    init(
+        waitingCount: Int,
+        workingCount: Int,
+        idleCount: Int,
+        coldCount: Int,
+        agents: [WorkspacePulseAgent] = [],
+        terminalCount: Int = 0
+    ) {
+        self.waitingCount = waitingCount
+        self.workingCount = workingCount
+        self.idleCount = idleCount
+        self.coldCount = coldCount
+        self.agents = agents
+        self.terminalCount = terminalCount
+    }
 
     var dominant: WorkspacePulseState {
         if waitingCount > 0 { return .waiting }
@@ -41,6 +67,16 @@ struct WorkspacePulseSummary: Equatable {
         case .working: return workingCount
         case .idle: return idleCount
         case .cold: return coldCount
+        }
+    }
+
+    func agentCount(for state: WorkspacePulseState) -> Int {
+        agents.lazy.filter { $0.state == state }.count
+    }
+
+    var relevantAgents: [WorkspacePulseAgent] {
+        WorkspacePulseState.allCases.flatMap { state in
+            agents.filter { $0.state == state }
         }
     }
 }
@@ -76,6 +112,25 @@ enum WorkspacePulseAgentContextProjector {
 }
 
 enum WorkspacePulseProjector {
+    static func project(
+        hasWorkspaceDemand: Bool,
+        agents: [WorkspacePulseAgent],
+        terminalCount: Int
+    ) -> WorkspacePulseSummary {
+        var waiting = agents.filter { $0.state == .waiting }.count
+        if hasWorkspaceDemand && waiting == 0 {
+            waiting = 1
+        }
+        return WorkspacePulseSummary(
+            waitingCount: waiting,
+            workingCount: agents.filter { $0.state == .working }.count,
+            idleCount: agents.filter { $0.state == .idle }.count,
+            coldCount: agents.filter { $0.state == .cold }.count,
+            agents: agents,
+            terminalCount: max(0, terminalCount)
+        )
+    }
+
     /// Rolls exact agent-surface states up with workspace-level operator
     /// demand. A surface-less notification still makes the workspace demand
     /// attention, represented as one waiting item without inventing an agent.

--- a/Sources/Sidebar/SidebarActivityProjector.swift
+++ b/Sources/Sidebar/SidebarActivityProjector.swift
@@ -12,6 +12,60 @@ public enum SidebarActivityState: String {
     case idle
 }
 
+/// Visual rollup states for a workspace sidebar card. This is deliberately a
+/// presentation projection over the existing per-surface liveness and
+/// notification truth; it is not a new metadata or persistence state.
+enum WorkspacePulseState: String, CaseIterable {
+    case waiting
+    case working
+    case idle
+    case cold
+}
+
+struct WorkspacePulseSummary: Equatable {
+    let waitingCount: Int
+    let workingCount: Int
+    let idleCount: Int
+    let coldCount: Int
+
+    var dominant: WorkspacePulseState {
+        if waitingCount > 0 { return .waiting }
+        if workingCount > 0 { return .working }
+        if idleCount > 0 { return .idle }
+        return .cold
+    }
+
+    func count(for state: WorkspacePulseState) -> Int {
+        switch state {
+        case .waiting: return waitingCount
+        case .working: return workingCount
+        case .idle: return idleCount
+        case .cold: return coldCount
+        }
+    }
+}
+
+enum WorkspacePulseProjector {
+    /// Rolls exact agent-surface states up with workspace-level operator
+    /// demand. A surface-less notification still makes the workspace demand
+    /// attention, represented as one waiting item without inventing an agent.
+    static func project(
+        hasWorkspaceDemand: Bool,
+        surfaceStates: [WorkspacePulseState]
+    ) -> WorkspacePulseSummary {
+        var waiting = surfaceStates.filter { $0 == .waiting }.count
+        if hasWorkspaceDemand && waiting == 0 {
+            waiting = 1
+        }
+        return WorkspacePulseSummary(
+            waitingCount: waiting,
+            workingCount: surfaceStates.filter { $0 == .working }.count,
+            idleCount: surfaceStates.filter { $0 == .idle }.count,
+            coldCount: surfaceStates.filter { $0 == .cold }.count
+        )
+    }
+}
+
 /// The single pill the sidebar status region should render for a row, after
 /// reconciling an (optional) explicit agent-reported status against the
 /// (optional) derived activity fallback.

--- a/Sources/SocketHandlers/SocketDispatch.swift
+++ b/Sources/SocketHandlers/SocketDispatch.swift
@@ -146,6 +146,8 @@ extension TerminalController {
             return reportPwdWorker(args)
         case "report_shell_state":
             return reportShellStateWorker(args)
+        case "report_agent_activity":
+            return reportAgentActivityWorker(args)
         case "report_git_branch":
             return reportGitBranchWorker(args)
         case "clear_git_branch":
@@ -351,6 +353,39 @@ extension TerminalController {
                     tabId: target.workspaceId,
                     surfaceId: target.panelId,
                     state: state
+                )
+            }
+        }
+        return "OK"
+    }
+
+    private nonisolated func reportAgentActivityWorker(_ args: String) -> String? {
+        let parsed = Self.parseOptionsStatic(args)
+        guard let rawActivity = parsed.positional.first, !rawActivity.isEmpty else {
+            return "ERROR: Missing agent activity — usage: report_agent_activity <working|idle> [--tab=X] [--panel=Y]"
+        }
+        guard let activity = Self.parseReportedAgentActivity(rawActivity) else {
+            return "ERROR: Invalid agent activity '\(rawActivity)' — expected working or idle"
+        }
+        guard let scope = Self.explicitSocketScope(options: parsed.options) else {
+            return nil
+        }
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                guard let app = AppDelegate.shared else { return }
+                guard let target = TerminalController.resolveShellActivityTarget(
+                    panelId: scope.panelId,
+                    workspaceForPanel: { panel in
+                        app.workspaceContainingPanel(
+                            panelId: panel,
+                            preferredWorkspaceId: scope.workspaceId
+                        )?.workspace.id
+                    }
+                ) else { return }
+                SurfaceLivenessDeriver.onAgentLifecycleChanged(
+                    surfaceId: target.panelId,
+                    workspaceId: target.workspaceId,
+                    activity: activity
                 )
             }
         }
@@ -631,6 +666,9 @@ extension TerminalController {
 
         case "report_shell_state":
             return reportShellState(args)
+
+        case "report_agent_activity":
+            return reportAgentActivity(args)
 
         case "report_pwd":
             return reportPwd(args)

--- a/Sources/SurfaceLivenessDeriver.swift
+++ b/Sources/SurfaceLivenessDeriver.swift
@@ -120,6 +120,45 @@ enum SurfaceLivenessDeriver {
         }
     }
 
+    /// Exact agent-loop lifecycle signal. Claude/Codex wrappers and terminal
+    /// completion/input seams use this when they know whether the agent is at
+    /// its prompt or actively handling a turn. This deliberately updates the
+    /// same derived truth as the shell fallback, without pretending the outer
+    /// shell's long-running TUI process is itself useful activity.
+    static func onAgentLifecycleChanged(
+        surfaceId: UUID,
+        workspaceId: UUID,
+        activity: SidebarActivityState
+    ) {
+        queue.async {
+            let prior = currentActivityRaw(workspaceId: workspaceId, surfaceId: surfaceId)
+            applyToStore(
+                derived: activity,
+                workspaceId: workspaceId,
+                surfaceId: surfaceId
+            )
+            let after = currentActivityRaw(workspaceId: workspaceId, surfaceId: surfaceId)
+            if prior != after {
+                emitLivenessTransition(
+                    from: prior,
+                    to: after,
+                    surfaceId: surfaceId,
+                    workspaceId: workspaceId
+                )
+            }
+            let mirrored = after.flatMap { SidebarActivityState(rawValue: $0) }
+            DispatchQueue.main.async {
+                MainActor.assumeIsolated {
+                    guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
+                          let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
+                        return
+                    }
+                    workspace.setDerivedActivity(mirrored, forSurface: surfaceId)
+                }
+            }
+        }
+    }
+
     // MARK: - Coarse reconcile (TEL-4/5)
 
     /// Coarse recompute entry point invoked from the AgentDetector 10 s sweep,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -8495,16 +8495,29 @@ class TerminalController {
 
         if let scope = Self.explicitSocketScope(options: parsed.options) {
             DispatchQueue.main.async {
-                guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceId),
-                      let tab = tabManager.tabs.first(where: { $0.id == scope.workspaceId }) else {
+                // C11-171 (extended to report_tty): resolve the workspace from the
+                // PANEL, never from `--tab`. Shell integration sends the surface
+                // uuid in `--tab` (a legacy alias — see GhosttyTerminalView env
+                // injection), so trusting it makes `tabManagerFor` miss and this
+                // registration silently no-op while still returning "OK". That left
+                // every wrapper-less agent (grok/opencode/kimi/pi/omp) unclassified
+                // and port scanning unregistered for these surfaces. The
+                // shell-activity path already resolves panel→workspace this way.
+                guard let app = AppDelegate.shared,
+                      let located = app.workspaceContainingPanel(
+                          panelId: scope.panelId,
+                          preferredWorkspaceId: scope.workspaceId
+                      ) else {
                     return
                 }
+                let tab = located.workspace
+                let workspaceId = tab.id
                 let validSurfaceIds = Set(tab.panels.keys)
                 tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
                 guard validSurfaceIds.contains(scope.panelId) else { return }
                 tab.surfaceTTYNames[scope.panelId] = ttyName
-                PortScanner.shared.registerTTY(workspaceId: scope.workspaceId, panelId: scope.panelId, ttyName: ttyName)
-                AgentDetector.shared.registerTTY(workspaceId: scope.workspaceId, panelId: scope.panelId, ttyName: ttyName)
+                PortScanner.shared.registerTTY(workspaceId: workspaceId, panelId: scope.panelId, ttyName: ttyName)
+                AgentDetector.shared.registerTTY(workspaceId: workspaceId, panelId: scope.panelId, ttyName: ttyName)
                 // C11-25 fix DoD #5: install a Sendable PID provider so
                 // the per-surface CPU/MEM sampler can attribute usage to
                 // the foreground process running on this tty (typically

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -741,6 +741,19 @@ class TerminalController {
         }
     }
 
+    nonisolated static func parseReportedAgentActivity(
+        _ rawActivity: String
+    ) -> SidebarActivityState? {
+        switch rawActivity.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "working":
+            return .working
+        case "idle":
+            return .idle
+        default:
+            return nil
+        }
+    }
+
     /// Update which window's TabManager receives socket commands.
     /// This is used when the user switches between multiple terminal windows.
     func setActiveTabManager(_ tabManager: TabManager?) {
@@ -1984,6 +1997,7 @@ class TerminalController {
     nonisolated static let socketWorkerV1Commands: Set<String> = [
         "report_pwd",
         "report_shell_state",
+        "report_agent_activity",
         "report_git_branch",
         "clear_git_branch",
         "ports_kick",
@@ -8373,6 +8387,67 @@ class TerminalController {
             }
 
             tabManager.updateSurfaceShellActivity(tabId: tab.id, surfaceId: surfaceId, state: state)
+        }
+        return result
+    }
+
+    func reportAgentActivity(_ args: String) -> String {
+        let parsed = parseOptions(args)
+        guard let rawActivity = parsed.positional.first, !rawActivity.isEmpty else {
+            return "ERROR: Missing agent activity — usage: report_agent_activity <working|idle> [--tab=X] [--panel=Y]"
+        }
+        guard let activity = Self.parseReportedAgentActivity(rawActivity) else {
+            return "ERROR: Invalid agent activity '\(rawActivity)' — expected working or idle"
+        }
+
+        if let scope = Self.explicitSocketScope(options: parsed.options) {
+            DispatchQueue.main.async {
+                guard let app = AppDelegate.shared else { return }
+                guard let target = Self.resolveShellActivityTarget(
+                    panelId: scope.panelId,
+                    workspaceForPanel: { panel in
+                        app.workspaceContainingPanel(
+                            panelId: panel,
+                            preferredWorkspaceId: scope.workspaceId
+                        )?.workspace.id
+                    }
+                ) else { return }
+                SurfaceLivenessDeriver.onAgentLifecycleChanged(
+                    surfaceId: target.panelId,
+                    workspaceId: target.workspaceId,
+                    activity: activity
+                )
+            }
+            return "OK"
+        }
+
+        guard tabManager != nil else { return "ERROR: TabManager not available" }
+
+        var result = "OK"
+        v2MainSync {
+            guard let tab = resolveTabForReport(args) else {
+                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+                return
+            }
+            let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
+            let surfaceId: UUID
+            if let panelArg {
+                guard let parsedId = UUID(uuidString: panelArg), tab.panels[parsedId] != nil else {
+                    result = "ERROR: Panel not found '\(panelArg)'"
+                    return
+                }
+                surfaceId = parsedId
+            } else if let focused = tab.focusedPanelId {
+                surfaceId = focused
+            } else {
+                result = "ERROR: Missing panel id (no focused surface)"
+                return
+            }
+            SurfaceLivenessDeriver.onAgentLifecycleChanged(
+                surfaceId: surfaceId,
+                workspaceId: tab.id,
+                activity: activity
+            )
         }
         return result
     }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -841,6 +841,19 @@ final class TerminalNotificationStore: ObservableObject {
         let isAppFocused = AppFocusState.isAppFocused()
         let shouldSuppressExternalDelivery = isAppFocused && isFocusedPanel
 
+        // An agent notification is a lifecycle boundary: the turn either
+        // completed or paused for operator input. Waiting still dominates the
+        // card while unread; once the operator opens it, the underlying state
+        // must settle to idle instead of snapping back to the outer shell's
+        // misleading long-running-TUI "working" state.
+        if let surfaceId {
+            SurfaceLivenessDeriver.onAgentLifecycleChanged(
+                surfaceId: surfaceId,
+                workspaceId: tabId,
+                activity: .idle
+            )
+        }
+
         if WorkspaceAutoReorderSettings.isEnabled() {
             AppDelegate.shared?.tabManager?.moveTabToTopForNotification(tabId)
         }

--- a/c11Tests/AgentDetectorTests.swift
+++ b/c11Tests/AgentDetectorTests.swift
@@ -86,4 +86,45 @@ final class AgentDetectorTests: XCTestCase {
             AgentDetector.classify(comm: "node", args: "node /Users/me/pi/app/server.js"),
             "unknown")
     }
+
+    // MARK: - Python-shebang shims
+
+    /// kimi installs as a pipx/venv console script whose shebang points at the
+    /// venv python, so the kernel execs the interpreter: comm=`python` with the
+    /// script path in argv. The Python interpreter branch + `/kimi` substring
+    /// (and the basename rail) classify it — previously it fell through to
+    /// `unknown` because only node/bun/deno were treated as interpreters.
+    func testClassifyPythonShimKimiReturnsKimi() {
+        XCTAssertEqual(
+            AgentDetector.classify(comm: "python", args: "python /Users/atin/.local/bin/kimi"),
+            "kimi")
+    }
+
+    /// Versioned interpreter comm (`python3.13`, a venv symlink) still counts as
+    /// a Python runtime via the `python` prefix match.
+    func testClassifyVersionedPythonShimKimiReturnsKimi() {
+        XCTAssertEqual(
+            AgentDetector.classify(
+                comm: "python3.13",
+                args: "python3.13 /Users/atin/.local/pipx/venvs/kimi-cli/bin/kimi"),
+            "kimi")
+    }
+
+    /// An unrelated Python process must not be misclassified as an agent.
+    func testClassifyUnrelatedPythonProcessReturnsUnknown() {
+        XCTAssertEqual(
+            AgentDetector.classify(comm: "python", args: "python /Users/me/project/manage.py runserver"),
+            "unknown")
+    }
+
+    // MARK: - Native binary comms for wrapper-less agents
+
+    /// grok / opencode ship as native binaries (no runtime wrapper), so the
+    /// foreground comm is the agent name itself and the direct comm table
+    /// classifies them. These are the agents whose detection depended on the
+    /// TTY reaching AgentDetector (fixed in the report_tty workspace resolution).
+    func testClassifyNativeGrokAndOpencode() {
+        XCTAssertEqual(AgentDetector.classify(comm: "grok", args: "grok --always-approve"), "grok")
+        XCTAssertEqual(AgentDetector.classify(comm: "opencode", args: "opencode"), "opencode")
+    }
 }

--- a/c11Tests/SidebarActivityProjectorTests.swift
+++ b/c11Tests/SidebarActivityProjectorTests.swift
@@ -88,4 +88,56 @@ final class SidebarActivityProjectorTests: XCTestCase {
         )
         XCTAssertEqual(pill?.isDerived, true)
     }
+
+    // MARK: - Workspace Pulse rollup
+
+    func testWorkspacePulsePreservesCountsAndUsesDemandPrecedence() {
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: true,
+            surfaceStates: [.waiting, .working, .working, .idle, .cold]
+        )
+
+        XCTAssertEqual(summary.dominant, .waiting)
+        XCTAssertEqual(summary.waitingCount, 1)
+        XCTAssertEqual(summary.workingCount, 2)
+        XCTAssertEqual(summary.idleCount, 1)
+        XCTAssertEqual(summary.coldCount, 1)
+    }
+
+    func testWorkspacePulseRepresentsSurfaceLessDemandWithoutInventingAgentCounts() {
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: true,
+            surfaceStates: [.working, .idle]
+        )
+
+        XCTAssertEqual(summary.dominant, .waiting)
+        XCTAssertEqual(summary.waitingCount, 1)
+        XCTAssertEqual(summary.workingCount, 1)
+        XCTAssertEqual(summary.idleCount, 1)
+        XCTAssertEqual(summary.coldCount, 0)
+    }
+
+    func testWorkspacePulseFallsThroughWorkingIdleAndCold() {
+        XCTAssertEqual(
+            WorkspacePulseProjector.project(
+                hasWorkspaceDemand: false,
+                surfaceStates: [.working, .idle, .cold]
+            ).dominant,
+            .working
+        )
+        XCTAssertEqual(
+            WorkspacePulseProjector.project(
+                hasWorkspaceDemand: false,
+                surfaceStates: [.idle, .cold]
+            ).dominant,
+            .idle
+        )
+        XCTAssertEqual(
+            WorkspacePulseProjector.project(
+                hasWorkspaceDemand: false,
+                surfaceStates: []
+            ).dominant,
+            .cold
+        )
+    }
 }

--- a/c11Tests/SidebarActivityProjectorTests.swift
+++ b/c11Tests/SidebarActivityProjectorTests.swift
@@ -133,6 +133,51 @@ final class SidebarActivityProjectorTests: XCTestCase {
         XCTAssertEqual(summary.coldCount, 0)
     }
 
+    func testWorkspacePulseCarriesRosterTerminalCountAndPrecedenceOrder() {
+        let idleId = UUID()
+        let waitingId = UUID()
+        let workingId = UUID()
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: true,
+            agents: [
+                WorkspacePulseAgent(
+                    surfaceId: idleId,
+                    state: .idle,
+                    context: WorkspacePulseAgentContext(title: "Docs", subtitle: "ready")
+                ),
+                WorkspacePulseAgent(
+                    surfaceId: waitingId,
+                    state: .waiting,
+                    context: WorkspacePulseAgentContext(title: "Release gate", subtitle: "review requested")
+                ),
+                WorkspacePulseAgent(
+                    surfaceId: workingId,
+                    state: .working,
+                    context: WorkspacePulseAgentContext(title: "Build", subtitle: "verifying push")
+                ),
+            ],
+            terminalCount: 3
+        )
+
+        XCTAssertEqual(summary.agents.count, 3)
+        XCTAssertEqual(summary.terminalCount, 3)
+        XCTAssertEqual(summary.agentCount(for: .waiting), 1)
+        XCTAssertEqual(summary.relevantAgents.map(\.surfaceId), [waitingId, workingId, idleId])
+    }
+
+    func testWorkspacePulseWorkspaceDemandDoesNotCreateRosterAgent() {
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: true,
+            agents: [],
+            terminalCount: 2
+        )
+
+        XCTAssertEqual(summary.dominant, .waiting)
+        XCTAssertEqual(summary.waitingCount, 1)
+        XCTAssertTrue(summary.agents.isEmpty)
+        XCTAssertEqual(summary.terminalCount, 2)
+    }
+
     func testWorkspacePulseFallsThroughWorkingIdleAndCold() {
         XCTAssertEqual(
             WorkspacePulseProjector.project(

--- a/c11Tests/SidebarActivityProjectorTests.swift
+++ b/c11Tests/SidebarActivityProjectorTests.swift
@@ -10,6 +10,22 @@ import XCTest
 /// reconciling an explicit agent-claimed status against derived-activity
 /// fallback. C11-162 (Telemetry truth).
 final class SidebarActivityProjectorTests: XCTestCase {
+    func testWorkspacePulseAgentContextUsesTitleThenSubtitle() {
+        XCTAssertEqual(
+            WorkspacePulseAgentContextProjector.project(
+                title: "Review agent",
+                subtitle: "Lineage: primary → review\nChecking the sidebar"
+            ),
+            WorkspacePulseAgentContext(
+                title: "Review agent",
+                subtitle: "Lineage: primary → review Checking the sidebar"
+            )
+        )
+    }
+
+    func testWorkspacePulseAgentContextDoesNotInventMissingIdentity() {
+        XCTAssertNil(WorkspacePulseAgentContextProjector.project(title: "  ", subtitle: nil))
+    }
 
     private let stale: Double = 300
     private let expiry: Double = 900

--- a/c11Tests/SurfaceLivenessDeriverTests.swift
+++ b/c11Tests/SurfaceLivenessDeriverTests.swift
@@ -56,6 +56,37 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
         XCTAssertNil(SurfaceLivenessDeriver.activityState(for: .unknown))
     }
 
+    func testReportedAgentActivityParserAcceptsLifecycleVocabulary() {
+        XCTAssertEqual(TerminalController.parseReportedAgentActivity("working"), .working)
+        XCTAssertEqual(TerminalController.parseReportedAgentActivity("idle"), .idle)
+        XCTAssertNil(TerminalController.parseReportedAgentActivity("mystery"))
+    }
+
+    func testExactAgentLifecycleIdleOverridesOuterShellWorking() {
+        let workspaceId = UUID()
+        let surfaceId = UUID()
+        defer { store.removeSurface(workspaceId: workspaceId, surfaceId: surfaceId) }
+
+        XCTAssertTrue(store.setInternal(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            key: MetadataKey.activity,
+            value: SidebarActivityState.working.rawValue,
+            source: .derived
+        ))
+
+        SurfaceLivenessDeriver.onAgentLifecycleChanged(
+            surfaceId: surfaceId,
+            workspaceId: workspaceId,
+            activity: .idle
+        )
+
+        XCTAssertTrue(poll {
+            self.activityValue(workspaceId, surfaceId) == SidebarActivityState.idle.rawValue
+        })
+        XCTAssertEqual(activitySource(workspaceId, surfaceId), .derived)
+    }
+
     func testSurfaceTabResolverMapsRecognizedAgentStates() {
         XCTAssertEqual(
             SurfaceTabActivityResolver.resolve(

--- a/tests/test_codex_wrapper_hooks.py
+++ b/tests/test_codex_wrapper_hooks.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Regression tests for the c11-scoped Codex completion bridge."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "codex"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read_lines(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+def wait_for_line(path: Path, needle: str) -> list[str]:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        lines = read_lines(path)
+        if any(needle in line for line in lines):
+            return lines
+        time.sleep(0.02)
+    return read_lines(path)
+
+
+def run_wrapper(
+    *,
+    socket_state: str,
+    argv: list[str],
+    callback: bool = False,
+) -> tuple[int, list[str], list[str], str, str]:
+    with tempfile.TemporaryDirectory(prefix="c11-codex-wrapper-test-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "wrapper bin"
+        real_dir = tmp / "real-bin"
+        wrapper_dir.mkdir()
+        real_dir.mkdir()
+
+        wrapper = wrapper_dir / "codex"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        real_args_log = tmp / "real-args.log"
+        c11_log = tmp / "c11.log"
+        socket_path = str(tmp / "c11.sock")
+
+        make_executable(
+            real_dir / "codex",
+            """#!/usr/bin/env bash
+set -euo pipefail
+for arg in "$@"; do
+  printf '%s\\n' "$arg" >> "$FAKE_REAL_ARGS_LOG"
+done
+""",
+        )
+        make_executable(
+            wrapper_dir / "c11",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s timeout=%s\\n' "$*" "${CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC-__UNSET__}" >> "$FAKE_C11_LOG"
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" && "${FAKE_C11_PING_OK:-0}" != "1" ]]; then
+  exit 1
+fi
+""",
+        )
+
+        test_socket: socket.socket | None = None
+        if socket_state in {"live", "stale"}:
+            test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket.bind(socket_path)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{wrapper_dir}:{real_dir}:/usr/bin:/bin"
+        env["CMUX_SOCKET_PATH"] = socket_path
+        env["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        env["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        env["FAKE_REAL_ARGS_LOG"] = str(real_args_log)
+        env["FAKE_C11_LOG"] = str(c11_log)
+        env["FAKE_C11_PING_OK"] = "1" if socket_state == "live" else "0"
+
+        command = [str(wrapper)]
+        if callback:
+            command.append("__c11-notify")
+            command.append('{"type":"agent-turn-complete"}')
+        else:
+            command.extend(argv)
+
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            c11_lines = wait_for_line(
+                c11_log,
+                " notify " if callback else " codex-hook idle",
+            )
+        finally:
+            if test_socket is not None:
+                test_socket.close()
+
+        return (
+            proc.returncode,
+            read_lines(real_args_log),
+            c11_lines,
+            proc.stdout.strip(),
+            proc.stderr.strip(),
+        )
+
+
+def expect(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def test_live_socket_injects_completion_callback(failures: list[str]) -> None:
+    code, real_argv, c11_log, _, stderr = run_wrapper(
+        socket_state="live",
+        argv=["hello"],
+    )
+    expect(code == 0, f"live socket: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv[:1] == ["-c"], f"live socket: missing config prefix: {real_argv}", failures)
+    expect(
+        len(real_argv) >= 3
+        and real_argv[1].startswith('notify=["')
+        and real_argv[1].endswith('","__c11-notify"]'),
+        f"live socket: malformed completion notify config: {real_argv}",
+        failures,
+    )
+    expect(real_argv[-1] == "hello", f"live socket: original argv was not preserved: {real_argv}", failures)
+    expect(any(" codex-hook idle" in line for line in c11_log), f"missing initial idle seed: {c11_log}", failures)
+
+
+def test_completion_callback_creates_surface_notification(failures: list[str]) -> None:
+    code, real_argv, c11_log, _, stderr = run_wrapper(
+        socket_state="live",
+        argv=[],
+        callback=True,
+    )
+    expect(code == 0, f"callback: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == [], f"callback: real Codex must not launch: {real_argv}", failures)
+    notify_lines = [line for line in c11_log if " notify " in line]
+    expect(len(notify_lines) == 1, f"callback: expected one c11 notification: {c11_log}", failures)
+    if notify_lines:
+        line = notify_lines[0]
+        expect("--title Codex" in line, f"callback: missing Codex title: {line}", failures)
+        expect(
+            "--workspace 11111111-1111-1111-1111-111111111111" in line,
+            f"callback: missing workspace scope: {line}",
+            failures,
+        )
+        expect(
+            "--surface 22222222-2222-2222-2222-222222222222" in line,
+            f"callback: missing surface scope: {line}",
+            failures,
+        )
+        expect("timeout=0.75" in line, f"callback: notification call is not bounded: {line}", failures)
+
+
+def test_missing_socket_is_unchanged_passthrough(failures: list[str]) -> None:
+    code, real_argv, c11_log, _, stderr = run_wrapper(
+        socket_state="missing",
+        argv=["hello"],
+    )
+    expect(code == 0, f"missing socket: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["hello"], f"missing socket: expected passthrough argv: {real_argv}", failures)
+    expect(c11_log == [], f"missing socket: c11 should not be called: {c11_log}", failures)
+
+
+def test_explicit_notify_override_remains_later_in_argv(failures: list[str]) -> None:
+    custom = 'notify=["/custom/notifier"]'
+    code, real_argv, _, _, stderr = run_wrapper(
+        socket_state="live",
+        argv=["-c", custom],
+    )
+    expect(code == 0, f"explicit override: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv[-2:] == ["-c", custom], f"explicit override lost precedence: {real_argv}", failures)
+
+
+def main() -> int:
+    failures: list[str] = []
+    test_live_socket_injects_completion_callback(failures)
+    test_completion_callback_creates_surface_notification(failures)
+    test_missing_socket_is_unchanged_passthrough(failures)
+    test_explicit_notify_override_remains_later_in_argv(failures)
+
+    if failures:
+        print("FAIL: Codex wrapper completion checks failed")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: Codex wrapper reports focus-independent turn completion to c11")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Adds the **workspace pulse** to the sidebar: each workspace card rolls its surfaces' agent liveness up to a single **waiting / working / idle / cold** state, so you can scan the sidebar and see which workspaces have an agent *waiting on you* vs. working vs. cold. Also fixes a root-cause bug that kept **wrapper-less agents from being detected as agents at all**.

## Two parts

### 1. Workspace pulse sidebar cards (7 commits)
Name → agent identity chip → `N agents · M terminals` count → a colored **state mark + pulse bar**. Color encodes **state**, not agent brand (blue=working, green=idle, gold=waiting, gray=cold); gold-waiting is the actionable signal. It's a presentation projection over existing per-surface liveness + notifications — no new persistence state.

### 2. Wrapper-less agent detection fix (`49f9efb94`)
The pulse counted **grok / opencode / kimi / pi / omp** as terminals, not agents — a card full of live agents read "0 agents." Claude/Codex were immune only because their PATH wrappers set `terminal_type` directly; every wrapper-less agent depends on the `AgentDetector` ps-scan, which never ran for them.

**Root cause:** shell integration reports `report_tty --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID` with both set to the *surface* uuid (`CMUX_TAB_ID` is a legacy surface alias). `reportTTY` trusted `--tab` as the workspace via `explicitSocketScope`, so `tabManagerFor(surfaceUUID)` missed and `AgentDetector.registerTTY` / `PortScanner.registerTTY` never fired — silently, since the socket returned "OK" before the async resolution ran. This is the `report_tty` sibling of the **C11-171** fix that already resolves the workspace from the panel for `report_shell_state`.

- `reportTTY`: resolve the workspace from the panel via `workspaceContainingPanel` (mirrors the shell-activity path). Fixes agent detection **and** port-scanner registration for all wrapper-less surfaces.
- `AgentDetector.classify`: treat Python (`python`/`python3.x`) as an interpreter runtime alongside node/bun/deno, so kimi's pipx/venv shebang (comm=`python`, script path in argv) classifies via its `/kimi` substring.
- Tests: Python-shebang kimi (versioned + negative), native grok/opencode comms.

## Validation
- Rebased cleanly onto current `main` (was behind the Codex mass-resume refactor; codex-wrapper conflicts resolved keeping main's synchronous claim + the pulse's `codex-hook idle` seeding).
- Real-artifact smoke: launched grok in a tagged build → card went from **"0 agents"** to **"2 agents · 0 terminals"** with grok shown as an agent. Operator confirmed live.

## Not included
**gemini** is absent from `AgentRegistry` entirely — supporting it is a new-agent feature (ripples through the `AgentType` enum + ~10 exhaustive switches), intentionally left out of this detection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)