### PR TITLE
Restore c11 as a regular Dock app; hide menu-bar item by default

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -37,8 +37,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
-	<key>LSUIElement</key>
-	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
 	<key>NSMainStoryboardFile</key>

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13666,7 +13666,10 @@ enum MenuBarBuildHintFormatter {
 
 enum MenuBarExtraSettings {
     static let showInMenuBarKey = "showMenuBarExtra"
-    static let defaultShowInMenuBar = true
+    // The menu-bar status item (the small c11 glyph in the top-right menu bar)
+    // is off by default; opt in via Settings. It is not the app's primary
+    // surface — c11 is a regular Dock app — so it should not appear unbidden.
+    static let defaultShowInMenuBar = false
 
     static func showsMenuBarExtra(defaults: UserDefaults = .standard) -> Bool {
         if defaults.object(forKey: showInMenuBarKey) == nil {
@@ -13684,8 +13687,15 @@ enum MenuBarExtraSettings {
 }
 
 enum AppPresentationPolicy {
+    // c11 is a regular app: it keeps its Dock icon, the application menu bar
+    // (File/Edit/…), and — critically — the active-app render wakeups the
+    // Ghostty terminal surfaces rely on. A prior `.accessory` policy blanked
+    // every terminal/agent surface whenever the app wasn't frontmost and
+    // stripped the menu bar; do not demote to `.accessory` to hide the Dock
+    // icon. Menu-bar-icon opt-out lives in `MenuBarExtraSettings`, independent
+    // of activation policy.
     static func activationPolicy(isRunningUnderXCTest: Bool) -> NSApplication.ActivationPolicy {
-        isRunningUnderXCTest ? .regular : .accessory
+        .regular
     }
 
     static func apply(

--- a/c11Tests/NotificationAndMenuBarTests.swift
+++ b/c11Tests/NotificationAndMenuBarTests.swift
@@ -59,7 +59,7 @@ final class NotificationAndMenuBarTests: XCTestCase {
         XCTAssertTrue(NotificationPaneFlashSettings.isEnabled(defaults: defaults))
     }
 
-    func testMenuBarExtraPreferenceDefaultsToVisible() {
+    func testMenuBarExtraPreferenceDefaultsToHidden() {
         let suiteName = "MenuBarExtraVisibilityTests.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create isolated UserDefaults suite")
@@ -69,7 +69,7 @@ final class NotificationAndMenuBarTests: XCTestCase {
             defaults.removePersistentDomain(forName: suiteName)
         }
 
-        XCTAssertTrue(MenuBarExtraSettings.showsMenuBarExtra(defaults: defaults))
+        XCTAssertFalse(MenuBarExtraSettings.showsMenuBarExtra(defaults: defaults))
 
         defaults.set(false, forKey: MenuBarExtraSettings.showInMenuBarKey)
         XCTAssertFalse(MenuBarExtraSettings.showsMenuBarExtra(defaults: defaults))
@@ -103,8 +103,11 @@ final class NotificationAndMenuBarTests: XCTestCase {
         )
     }
 
-    func testNormalLaunchUsesAccessoryActivationPolicy() {
-        XCTAssertEqual(AppPresentationPolicy.activationPolicy(isRunningUnderXCTest: false), .accessory)
+    func testLaunchAlwaysUsesRegularActivationPolicy() {
+        // c11 is a regular Dock app in every launch mode. A `.accessory` policy
+        // removed the Dock icon and the menu bar and starved the Ghostty
+        // renderer (blank terminals when not frontmost); it must never be used.
+        XCTAssertEqual(AppPresentationPolicy.activationPolicy(isRunningUnderXCTest: false), .regular)
         XCTAssertEqual(AppPresentationPolicy.activationPolicy(isRunningUnderXCTest: true), .regular)
     }
 


### PR DESCRIPTION
## Problem

#365 attempted to remove the top-right **menu-bar status item** ("+"-looking c11 glyph) but implemented it as `LSUIElement=true` + `NSApp.setActivationPolicy(.accessory)`. That overshot massively — an `.accessory` app:

- has **no Dock icon** (unwanted),
- has **no application menu bar** — File/Edit/etc. vanish,
- and starves c11's **Ghostty renderer**, which only gets draw wakeups while the app is an active *regular* app → **every terminal/agent surface goes blank** when the app isn't frontmost.

All three showed up together in the staging build off `main` (blank terminals, no File menu, no Dock icon). Prod (v0.59.0) predates #365 and was never affected.

## Fix — separate the two conflated intents

| Change | Effect |
|---|---|
| Remove `LSUIElement` from `Info.plist`; `AppPresentationPolicy.activationPolicy` → always `.regular` | Dock icon, menu bar, and terminal rendering all restored |
| `MenuBarExtraSettings.defaultShowInMenuBar` → `false` | The menu-bar status item is hidden by default (opt-in via Settings) — the actual surgical change #365 was reaching for |

Tests updated: activation policy is `.regular` in every launch mode; the menu-bar-extra preference defaults to hidden.

## Validation
Tagged Debug build (`dockfix`): `NSRunningApplication.activationPolicy == 0` (Regular), normal ⌘-Tab/activation works again, and all four surfaces (terminal, browser, markdown, Claude Code) **render live** — no blank surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)