### PR TITLE
Add global (all-terminals) font-size control

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -13820,6 +13820,194 @@
         }
       }
     },
+    "command.globalFont.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルフォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "终端字体"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終端機字型"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널 글꼴"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифт терминала"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифт термінала"
+          }
+        }
+      }
+    },
+    "command.globalFontDecrease.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズを縮小（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "减小字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縮小字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 축소 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уменьшить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зменшити розмір шрифту (усі термінали)"
+          }
+        }
+      }
+    },
+    "command.globalFontIncrease.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズを拡大（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "增大字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "放大字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 확대 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увеличить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Збільшити розмір шрифту (усі термінали)"
+          }
+        }
+      }
+    },
+    "command.globalFontReset.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズをリセット（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重設字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 재설정 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути розмір шрифту (усі термінали)"
+          }
+        }
+      }
+    },
     "command.installCLI.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -28245,6 +28433,147 @@
           "stringUnit": {
             "state": "translated",
             "value": "Закрити інші вкладки в панелі"
+          }
+        }
+      }
+    },
+    "menu.pane.globalFontDecrease": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズを縮小（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "减小字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縮小字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 축소 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уменьшить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зменшити розмір шрифту (усі термінали)"
+          }
+        }
+      }
+    },
+    "menu.pane.globalFontIncrease": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズを拡大（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "增大字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "放大字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 확대 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увеличить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Збільшити розмір шрифту (усі термінали)"
+          }
+        }
+      }
+    },
+    "menu.pane.globalFontReset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズをリセット（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重設字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 재설정 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути розмір шрифту (усі термінали)"
           }
         }
       }
@@ -46861,6 +47190,53 @@
         }
       }
     },
+    "settings.shortcuts.group.font": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Font"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字体"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "字型"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифт"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Шрифт"
+          }
+        }
+      }
+    },
     "settings.shortcuts.group.help": {
       "extractionState": "manual",
       "localizations": {
@@ -49395,6 +49771,147 @@
           "stringUnit": {
             "state": "translated",
             "value": "Фокус на панель зверху"
+          }
+        }
+      }
+    },
+    "shortcut.globalFontDecrease.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Decrease Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズを縮小（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "减小字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "縮小字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 축소 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Уменьшить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зменшити розмір шрифту (усі термінали)"
+          }
+        }
+      }
+    },
+    "shortcut.globalFontIncrease.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Increase Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズを拡大（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "增大字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "放大字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 확대 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Увеличить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Збільшити розмір шрифту (усі термінали)"
+          }
+        }
+      }
+    },
+    "shortcut.globalFontReset.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset Font Size (All Terminals)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォントサイズをリセット（すべてのターミナル）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重置字体大小（所有终端）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重設字型大小（所有終端機）"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "글꼴 크기 재설정 (모든 터미널)"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сбросить размер шрифта (все терминалы)"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скинути розмір шрифту (усі термінали)"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5108,6 +5108,12 @@ struct ContentView: View {
             return .toggleSplitZoom
         case "palette.triggerFlash":
             return .triggerFlash
+        case "palette.globalFontIncrease":
+            return .globalFontIncrease
+        case "palette.globalFontDecrease":
+            return .globalFontDecrease
+        case "palette.globalFontReset":
+            return .globalFontReset
         default:
             return nil
         }
@@ -5938,6 +5944,30 @@ struct ContentView: View {
                 when: { $0.bool(CommandPaletteContextKeys.workspaceHasSplits) }
             )
         )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.globalFontIncrease",
+                title: constant(String(localized: "command.globalFontIncrease.title", defaultValue: "Increase Font Size (All Terminals)")),
+                subtitle: constant(String(localized: "command.globalFont.subtitle", defaultValue: "Terminal Font")),
+                keywords: ["font", "size", "increase", "bigger", "zoom", "all", "global", "terminal"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.globalFontDecrease",
+                title: constant(String(localized: "command.globalFontDecrease.title", defaultValue: "Decrease Font Size (All Terminals)")),
+                subtitle: constant(String(localized: "command.globalFont.subtitle", defaultValue: "Terminal Font")),
+                keywords: ["font", "size", "decrease", "smaller", "zoom", "all", "global", "terminal"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.globalFontReset",
+                title: constant(String(localized: "command.globalFontReset.title", defaultValue: "Reset Font Size (All Terminals)")),
+                subtitle: constant(String(localized: "command.globalFont.subtitle", defaultValue: "Terminal Font")),
+                keywords: ["font", "size", "reset", "default", "zoom", "all", "global", "terminal"]
+            )
+        )
 
         return contributions
     }
@@ -6278,6 +6308,15 @@ struct ContentView: View {
                 NSSound.beep()
                 return
             }
+        }
+        registry.register(commandId: "palette.globalFontIncrease") {
+            GlobalTerminalFontSize.apply(.increase)
+        }
+        registry.register(commandId: "palette.globalFontDecrease") {
+            GlobalTerminalFontSize.apply(.decrease)
+        }
+        registry.register(commandId: "palette.globalFontReset") {
+            GlobalTerminalFontSize.apply(.reset)
         }
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2551,6 +2551,45 @@ final class TerminalSurfaceRegistry {
     }
 }
 
+/// Global (all-terminals) font-size control.
+///
+/// Fans a *relative* Ghostty font-size binding action out to every live
+/// terminal surface. Ghostty's `increase_font_size` / `decrease_font_size`
+/// step from each surface's own current size, so terminals that were zoomed
+/// independently stay relatively offset — the whole board moves together
+/// without collapsing to a single shared size. This is distinct from the
+/// per-surface Cmd +/-/0 path, which only touches the focused surface.
+enum GlobalTerminalFontSize {
+    enum Direction {
+        case increase
+        case decrease
+        case reset
+
+        /// Ghostty binding-action string. The `:1` steps by one point.
+        var bindingAction: String {
+            switch self {
+            case .increase: return "increase_font_size:1"
+            case .decrease: return "decrease_font_size:1"
+            case .reset: return "reset_font_size"
+            }
+        }
+    }
+
+    /// Apply `direction` to every live terminal surface. Returns the count of
+    /// surfaces that accepted the action. Must be called on the main thread
+    /// (it drives Ghostty surfaces).
+    @discardableResult
+    static func apply(_ direction: Direction) -> Int {
+        let action = direction.bindingAction
+        var applied = 0
+        for surface in TerminalSurfaceRegistry.shared.allSurfaces()
+        where surface.performBindingAction(action) {
+            applied += 1
+        }
+        return applied
+    }
+}
+
 // MARK: - Terminal Surface (owns the ghostty_surface_t lifecycle)
 
 final class TerminalSurface: Identifiable, ObservableObject {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -48,6 +48,11 @@ enum KeyboardShortcutSettings {
         // Input
         case toggleTextBoxInput
 
+        // Font (all terminals)
+        case globalFontIncrease
+        case globalFontDecrease
+        case globalFontReset
+
         var id: String { rawValue }
 
         var label: String {
@@ -83,6 +88,9 @@ enum KeyboardShortcutSettings {
             case .toggleBrowserDeveloperTools: return String(localized: "shortcut.toggleBrowserDevTools.label", defaultValue: "Toggle Browser Developer Tools")
             case .showBrowserJavaScriptConsole: return String(localized: "shortcut.showBrowserJSConsole.label", defaultValue: "Show Browser JavaScript Console")
             case .toggleTextBoxInput: return String(localized: "shortcut.toggleTextBoxInput.label", defaultValue: "Toggle TextBox Input")
+            case .globalFontIncrease: return String(localized: "shortcut.globalFontIncrease.label", defaultValue: "Increase Font Size (All Terminals)")
+            case .globalFontDecrease: return String(localized: "shortcut.globalFontDecrease.label", defaultValue: "Decrease Font Size (All Terminals)")
+            case .globalFontReset: return String(localized: "shortcut.globalFontReset.label", defaultValue: "Reset Font Size (All Terminals)")
             }
         }
 
@@ -119,6 +127,9 @@ enum KeyboardShortcutSettings {
             case .toggleBrowserDeveloperTools: return "shortcut.toggleBrowserDeveloperTools"
             case .showBrowserJavaScriptConsole: return "shortcut.showBrowserJavaScriptConsole"
             case .toggleTextBoxInput: return "shortcut.toggleTextBoxInput"
+            case .globalFontIncrease: return "shortcut.globalFontIncrease"
+            case .globalFontDecrease: return "shortcut.globalFontDecrease"
+            case .globalFontReset: return "shortcut.globalFontReset"
             }
         }
 
@@ -193,6 +204,13 @@ enum KeyboardShortcutSettings {
                 // own source comment calls out Cmd+Option+B as the conflict-free
                 // choice. See plan §4.5.
                 return StoredShortcut(key: "b", command: true, shift: false, option: true, control: false)
+            case .globalFontIncrease:
+                // ⌘⌃= — distinct from per-surface ⌘= which zooms only the focused surface.
+                return StoredShortcut(key: "=", command: true, shift: false, option: false, control: true)
+            case .globalFontDecrease:
+                return StoredShortcut(key: "-", command: true, shift: false, option: false, control: true)
+            case .globalFontReset:
+                return StoredShortcut(key: "0", command: true, shift: false, option: false, control: true)
             }
         }
 

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -182,6 +182,9 @@ struct cmuxApp: App {
     @AppStorage(KeyboardShortcutSettings.Action.newSurface.defaultsKey) private var newSurfaceShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.openBrowser.defaultsKey) private var openBrowserShortcutData = Data()
     @AppStorage(KeyboardShortcutSettings.Action.renameTab.defaultsKey) private var renameTabShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.globalFontIncrease.defaultsKey) private var globalFontIncreaseShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.globalFontDecrease.defaultsKey) private var globalFontDecreaseShortcutData = Data()
+    @AppStorage(KeyboardShortcutSettings.Action.globalFontReset.defaultsKey) private var globalFontResetShortcutData = Data()
     @AppStorage(ChromeScaleSettings.presetKey) private var chromeScalePresetRaw = ChromeScaleSettings.defaultPreset.rawValue
     @AppStorage(ChromeScaleSettings.customMultiplierKey) private var chromeScaleCustomMultiplier: Double = Double(ChromeScaleSettings.defaultCustomMultiplier)
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
@@ -989,6 +992,22 @@ struct cmuxApp: App {
                 }
                 .keyboardShortcut("t", modifiers: [.command, .option])
                 .disabled(!activeTabManager.canCloseOtherTabsInFocusedPane())
+
+                Divider()
+
+                // Global font size: fans out to every terminal surface at once,
+                // relative to each surface's current size (unlike per-surface Cmd +/-/0).
+                splitCommandButton(title: String(localized: "menu.pane.globalFontIncrease", defaultValue: "Increase Font Size (All Terminals)"), shortcut: globalFontIncreaseMenuShortcut) {
+                    GlobalTerminalFontSize.apply(.increase)
+                }
+
+                splitCommandButton(title: String(localized: "menu.pane.globalFontDecrease", defaultValue: "Decrease Font Size (All Terminals)"), shortcut: globalFontDecreaseMenuShortcut) {
+                    GlobalTerminalFontSize.apply(.decrease)
+                }
+
+                splitCommandButton(title: String(localized: "menu.pane.globalFontReset", defaultValue: "Reset Font Size (All Terminals)"), shortcut: globalFontResetMenuShortcut) {
+                    GlobalTerminalFontSize.apply(.reset)
+                }
             }
 
             // C11-41 Browser menu: every browser-surface verb in one home.
@@ -1236,6 +1255,18 @@ struct cmuxApp: App {
 
     private var renameTabMenuShortcut: StoredShortcut {
         decodeShortcut(from: renameTabShortcutData, fallback: KeyboardShortcutSettings.Action.renameTab.defaultShortcut)
+    }
+
+    private var globalFontIncreaseMenuShortcut: StoredShortcut {
+        decodeShortcut(from: globalFontIncreaseShortcutData, fallback: KeyboardShortcutSettings.Action.globalFontIncrease.defaultShortcut)
+    }
+
+    private var globalFontDecreaseMenuShortcut: StoredShortcut {
+        decodeShortcut(from: globalFontDecreaseShortcutData, fallback: KeyboardShortcutSettings.Action.globalFontDecrease.defaultShortcut)
+    }
+
+    private var globalFontResetMenuShortcut: StoredShortcut {
+        decodeShortcut(from: globalFontResetShortcutData, fallback: KeyboardShortcutSettings.Action.globalFontReset.defaultShortcut)
     }
 
     private func openNewMarkdownSurface() {
@@ -6433,6 +6464,11 @@ struct SettingsView: View {
                 id: "panes",
                 title: String(localized: "settings.shortcuts.group.panes", defaultValue: "Panes"),
                 actions: [.focusLeft, .focusRight, .focusUp, .focusDown, .splitRight, .splitDown, .toggleSplitZoom, .splitBrowserRight, .splitBrowserDown]
+            ),
+            ShortcutSettingsGroup(
+                id: "font",
+                title: String(localized: "settings.shortcuts.group.font", defaultValue: "Font"),
+                actions: [.globalFontIncrease, .globalFontDecrease, .globalFontReset]
             ),
             ShortcutSettingsGroup(
                 id: "browser",


### PR DESCRIPTION
## What

Adds an app-wide font-size command that resizes **every open terminal at once**, independent of which surface is focused. Requested for a cyberdeck-style global font up/down control.

Uses Ghostty's **relative** binding actions (`increase_font_size` / `decrease_font_size` / `reset_font_size`) fanned across every live surface via the existing `TerminalSurfaceRegistry`. Relative means each terminal steps from *its own* current size, so panes you'd zoomed independently stay relatively offset — the whole board moves together rather than snapping to one shared size.

The per-surface `⌘=` / `⌘-` / `⌘0` zoom is **untouched** — still targets only the focused surface.

## How it's exposed

One `GlobalTerminalFontSize` helper, surfaced three ways:
- **Keyboard shortcuts** (Settings → Keyboard Shortcuts → **Font**), default `⌘⌃=` / `⌘⌃-` / `⌘⌃0` — conflict-free and rebindable (e.g. to cyberdeck keys).
- **Pane menu** items: "Increase/Decrease/Reset Font Size (All Terminals)".
- **Command palette** entries.

No persistence — session-live only, so newly-spawned surfaces open at Ghostty's config default.

## Files
- `Sources/GhosttyTerminalView.swift` — `GlobalTerminalFontSize` fan-out helper.
- `Sources/KeyboardShortcutSettings.swift` — three bindable actions + defaults.
- `Sources/c11App.swift` — menu items, shortcut wiring, settings group.
- `Sources/ContentView.swift` — command-palette contributions + handlers.
- `Resources/Localizable.xcstrings` — 11 new keys, full 7-language translations.

## Validation

Smoke-tested end-to-end on a tagged build (not just a green compile). Two terminals with distinct content:

| State | Result |
|---|---|
| Baseline | both terminals normal |
| 3× global increase | **both** terminals larger (together) |
| Global reset | both back to baseline (together) |

One global invocation moved both independent panes in lockstep and reset restored them. Menu path shares identical wiring with the keyboard shortcut and command palette.

## Notes
- Default keybinding (`⌘⌃=/-/0`) is a taste choice — easy to rebind in Settings.
- No unit test added: the fan-out needs live Ghostty surfaces + a host app, and a direction→string test would be a tautology against the source. The real-artifact smoke test above is the intended gate per the repo's test policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)