### PR TITLE
Sidebar: prominent user-color card outline + unmistakable selection ring

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11883,16 +11883,68 @@ private struct TabItemView: View, Equatable {
         ))
     }
 
+    /// Full-strength workspace identity color for the card outline, or nil
+    /// when the workspace has no identity color of its own (those cards stay
+    /// on the neutral hairline). Prefers the theme's resolved rail color when
+    /// the theme path supplies one, otherwise resolves the user's custom hex
+    /// against the current appearance — deliberately *not* force-brightened
+    /// like `resolvedCustomTabColor`, so the outline stays legible on the
+    /// light card base as well as the void-black one.
+    private var workspaceIdentityOutlineColor: Color? {
+        if let themedRailColor {
+            return Color(nsColor: themedRailColor)
+        }
+        guard let hex = tab.customColor else { return nil }
+        return WorkspaceTabColorSettings.displayColor(hex: hex, colorScheme: colorScheme)
+    }
+
+    /// True when the card fill already *is* the workspace color (the
+    /// `.solidFill` indicator style with a custom color). Stacking an inner
+    /// identity ring on an identity-colored fill only muddies the edge, so
+    /// the double border collapses to the selection ring there.
+    private var cardFillCarriesIdentityColor: Bool {
+        tab.customColor != nil && themedBackgroundColor != nil
+    }
+
+    private var cardSelectionRingColor: Color {
+        colorScheme == .light
+            ? BrandColors.blackSwiftUI.opacity(0.9)
+            : BrandColors.whiteSwiftUI.opacity(0.98)
+    }
+
+    /// Outer ring. Priority: selection, then the live waiting signal, then
+    /// the workspace's own color, then the neutral hairline. Whenever
+    /// selection or waiting claims the outer ring, the workspace color moves
+    /// to the inner ring rather than disappearing.
     private var workspacePulseBorderColor: Color {
         if isActive {
-            return colorScheme == .light
-                ? BrandColors.blackSwiftUI.opacity(0.82)
-                : BrandColors.whiteSwiftUI.opacity(0.9)
+            return cardSelectionRingColor
         }
         if workspacePulse.waitingCount > 0 {
-            return workspacePulseColor(for: .waiting).opacity(0.38)
+            return workspacePulseColor(for: .waiting).opacity(0.7)
+        }
+        if let workspaceIdentityOutlineColor {
+            return workspaceIdentityOutlineColor
         }
         return workspacePulseIdentityColor.opacity(0.32)
+    }
+
+    private var workspacePulseBorderLineWidth: CGFloat {
+        if isActive { return 2 }
+        if workspacePulse.waitingCount > 0 { return 1.5 }
+        return workspaceIdentityOutlineColor == nil ? 1 : 2
+    }
+
+    /// Inner ring, inset just inside the outer one. Carries the workspace
+    /// color when selection or the waiting signal has claimed the outer ring,
+    /// so a selected card is unmistakably selected *and* still identifiable
+    /// by color at a glance.
+    private var workspacePulseInnerRingColor: Color? {
+        guard !cardFillCarriesIdentityColor,
+              let workspaceIdentityOutlineColor,
+              isActive || workspacePulse.waitingCount > 0
+        else { return nil }
+        return workspaceIdentityOutlineColor
     }
 
     private var workspacePulseCardOpacity: Double {
@@ -11930,8 +11982,16 @@ private struct TabItemView: View, Equatable {
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .strokeBorder(
                         workspacePulseBorderColor,
-                        lineWidth: isActive ? 2 : 1
+                        lineWidth: workspacePulseBorderLineWidth
                     )
+            }
+            .overlay {
+                if let workspacePulseInnerRingColor {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(workspacePulseInnerRingColor, lineWidth: 2)
+                        .padding(2)
+                        .allowsHitTesting(false)
+                }
             }
             .overlay {
                 RoundedRectangle(cornerRadius: 12, style: .continuous)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11908,8 +11908,22 @@ private struct TabItemView: View, Equatable {
 
     private var cardSelectionRingColor: Color {
         colorScheme == .light
-            ? BrandColors.blackSwiftUI.opacity(0.9)
-            : BrandColors.whiteSwiftUI.opacity(0.98)
+            ? BrandColors.blackSwiftUI.opacity(0.92)
+            : BrandColors.whiteSwiftUI
+    }
+
+    /// Inner-ring accent for selected workspaces that have no color of their
+    /// own: the c11 brand gold, deepened in light mode so it keeps its bite
+    /// against the parchment card base (the void-black base needs no help).
+    private var cardSelectionAccentColor: Color {
+        colorScheme == .light
+            ? Color(nsColor: NSColor(
+                srgbRed: 0x8F / 255.0,
+                green: 0x77 / 255.0,
+                blue: 0x33 / 255.0,
+                alpha: 1
+            ))
+            : BrandColors.goldSwiftUI
     }
 
     /// Outer ring. Priority: selection, then the live waiting signal, then
@@ -11930,21 +11944,39 @@ private struct TabItemView: View, Equatable {
     }
 
     private var workspacePulseBorderLineWidth: CGFloat {
-        if isActive { return 2 }
+        if isActive { return 2.5 }
         if workspacePulse.waitingCount > 0 { return 1.5 }
         return workspaceIdentityOutlineColor == nil ? 1 : 2
     }
 
-    /// Inner ring, inset just inside the outer one. Carries the workspace
+    /// Inner ring, inset flush against the outer one. Carries the workspace
     /// color when selection or the waiting signal has claimed the outer ring,
     /// so a selected card is unmistakably selected *and* still identifiable
-    /// by color at a glance.
+    /// by color at a glance. Selected workspaces with no color of their own
+    /// fall back to the brand gold, so selection always reads as a filled
+    /// double edge rather than a lone outline.
+    ///
+    /// Waiting and selection both land on gold-family hues, so the grammar of
+    /// the card edge is what separates them: gold on the *outermost* edge
+    /// with no white ring means waiting; white on the outermost edge with the
+    /// gold inset *inside* it means selected. The widths reinforce it — the
+    /// selection ring is 2.5pt against waiting's 1.5pt.
     private var workspacePulseInnerRingColor: Color? {
-        guard !cardFillCarriesIdentityColor,
-              let workspaceIdentityOutlineColor,
-              isActive || workspacePulse.waitingCount > 0
-        else { return nil }
-        return workspaceIdentityOutlineColor
+        if !cardFillCarriesIdentityColor,
+           let workspaceIdentityOutlineColor,
+           isActive || workspacePulse.waitingCount > 0 {
+            return workspaceIdentityOutlineColor
+        }
+        if isActive, !cardFillCarriesIdentityColor {
+            return cardSelectionAccentColor
+        }
+        return nil
+    }
+
+    /// Keeps the inner ring flush against the outer one whatever width the
+    /// outer ring resolved to, and keeps the two radii concentric.
+    private var workspacePulseInnerRingInset: CGFloat {
+        workspacePulseBorderLineWidth
     }
 
     private var workspacePulseCardOpacity: Double {
@@ -11987,9 +12019,10 @@ private struct TabItemView: View, Equatable {
             }
             .overlay {
                 if let workspacePulseInnerRingColor {
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    let inset = workspacePulseInnerRingInset
+                    RoundedRectangle(cornerRadius: 12 - inset, style: .continuous)
                         .strokeBorder(workspacePulseInnerRingColor, lineWidth: 2)
-                        .padding(2)
+                        .padding(inset)
                         .allowsHitTesting(false)
                 }
             }


### PR DESCRIPTION
## Problem (operator-reported, staging build)

Workspace cards in the sidebar can carry a user-chosen color, but:

1. The color outline was far too weak — `workspacePulseIdentityColor.opacity(0.32)` at `lineWidth: 1`. A barely-there tint on a void-black card.
2. Selecting a workspace replaced the outline outright with a white ring, so **you could not tell what color a selected workspace was at all**.

Operator's suggestion: "a border inside of a border that's more prominent that aligns with the user color."

Second round, after seeing the double ring live: keep the white box on the outside, but make selection more visually clear — a selected card with **no** custom color still read as a lone white outline and needed coloration of its own.

## Design

The card edge is two concentric rings on the existing 12pt-radius geometry:

- **Outer ring** carries *state*, in priority order: selection → waiting signal → workspace identity color → neutral hairline.
- **Inner ring**, inset flush against the outer one (the inset tracks the outer ring's resolved width, so the two stay concentric at every width), carries *identity*. It is drawn whenever selection or the waiting signal has claimed the outer ring. The workspace color is never evicted by selection — it moves inward. When a selected workspace has no color of its own, the inner ring falls back to the **c11 brand gold**, so selection always reads as a filled double edge rather than a lone outline.

Against the void-black sidebar this reads as a white ring wrapping a color (or gold) ring: the white edge separates the inner color from the surrounding void, which makes it pop harder than the old low-opacity hairline, while selection stays the loudest thing on the card.

## Waiting-gold vs selection-gold: how they stay distinguishable

The waiting pulse color (`#D0AA45` dark / `#9B7415` light) and the brand gold (`#C9A84C`) are near-identical hues, so hue alone cannot separate "selected, uncolored" from "waiting, unselected". The card edge is disambiguated by **grammar and weight** instead:

- **Gold on the outermost edge, no white ring at all → waiting.** 1.5pt.
- **White on the outermost edge with gold inset inside it → selected.** 2.5pt outer + 2pt inner.

So the two states differ in the presence of white on the outer edge, in where the gold sits (outermost vs inset), and in ring mass (1.5pt vs 4.5pt total). None of those is a fine distinction at sidebar scale.

This holds under the incoming white/gray agent-state palette on `fix/pulse-neutral-palette` (`Workspace.resolvedSurfaceTabActivityColors`, untouched here), where waiting remains the only gold pulse state — the gold inner ring will no longer compete with green/blue pulse squares either.

One deliberate collapse: a card that is **selected and waiting with no custom color** shows white + gold, identical to selected-uncolored. Selection owns the outer ring and identity owns the inner one, and the waiting state is still carried inside the card by the pulse composition rail and the "Needs you" pill. Preserving the outer-edge grammar (white outermost always and only means selected) is worth more than encoding a third state on the edge.

## Before / after by state

| State | Before | After |
|---|---|---|
| Unselected, no custom color | 1pt neutral @ 0.32 | **unchanged** — 1pt neutral @ 0.32 |
| Unselected, custom color | 1pt custom @ 0.32 (nearly invisible) | **2pt custom at full strength** |
| Unselected, waiting agent(s), no color | 1pt waiting @ 0.38 | 1.5pt waiting @ 0.7 |
| Unselected, waiting agent(s), custom color | 1pt waiting @ 0.38, color lost | 1.5pt waiting @ 0.7 **outer** + 2pt custom **inner** |
| Selected, no custom color | 2pt white @ 0.9 (dark) / black @ 0.82 (light) | **2.5pt full white / black @ 0.92 outer + 2pt brand gold inner** |
| Selected, custom color | 2pt white, **color entirely lost** | **2.5pt white outer + 2pt custom inner** |

Light mode deepens the inner gold to `#8F7733` so it keeps its bite against the parchment card base; the void-black base takes `BrandColors.gold` unmodified.

### Per indicator style

- **`.leftRail`** — the leading rail capsule no longer exists on `main` (already retired when the card moved to `workspacePulseCardBackground` in #366), so nothing to retire here. `.leftRail` semantics are preserved through `themedRailColor`: when the theme path supplies a rail color for the active card, that resolved color is what the inner ring draws, including the `sidebar_activeTabRailFallback` accent for active workspaces with no custom color. Net effect: `.leftRail` gets its accent back as a ring instead of a capsule.
- **`.solidFill`** — when the fill already *is* the workspace color, the inner ring is suppressed (`cardFillCarriesIdentityColor`); a second color ring on an identity-colored fill only muddies the edge, and gold there would compete with the user's own color. Selected `.solidFill` colored cards therefore get the strong white ring over a full-strength color fill. Selected `.solidFill` cards with **no** custom color do get the gold inner ring, since the fallback fill carries no identity. Unselected `.solidFill` colored cards keep the color fill *and* gain the crisp 2pt color outline, reading as a solid color chip with a clean edge.
- **Theme disabled** — `themedBackgroundColor`/`themedRailColor` are both nil, so every card is void-black and the rings are the *only* carrier of workspace identity and selection. This is the configuration where the old treatment was worst and where the change is most visible.

## Color resolution

`workspaceIdentityOutlineColor` prefers the theme's resolved rail color when one exists, otherwise resolves `tab.customColor` via `WorkspaceTabColorSettings.displayColor(hex:colorScheme:)` — deliberately **not** `forceBright`, unlike `resolvedCustomTabColor` (which force-brightens for the left-rail capsule). Force-brightening washes a color out against the light card base; the dark base already gets brightening automatically from `colorScheme == .dark`.

## Hot-path safety

`TabItemView` is a typing-latency hot path:

- **No new stored properties.** All additions are computed vars over inputs already in `==` (`isActive`, `themedRailColor`, `themedBackgroundColor`, `workspacePulse`) plus `tab.customColor` (already observed) and `colorScheme` (already an `@Environment`). `nonisolated static func ==` and the `.equatable()` call site are untouched.
- No `@EnvironmentObject` / `@ObservedObject` / `@Binding` added.
- The extra per-body work is a few color computations and one conditional overlay — no allocations in `forceRefresh()`-adjacent paths.
- No `dlog` calls added; no new user-facing strings.

## Testing

Verified `xcrun swiftc -parse` clean; CI's `build` gate (compile + logic tests) passed on the first commit, and the follow-up is the same shape. No local `xcodebuild` per project policy. No unit test added: the treatment lives entirely in a `private struct TabItemView`'s SwiftUI body with no runtime seam, and per the repo test-quality policy a source-text/shape assertion here would be a fake regression test rather than a behavioral one.

Visual verification wanted on a tagged build across: theme on/off × `.leftRail`/`.solidFill` × colored/uncolored × selected/unselected, a selected-uncolored card sitting next to a waiting-unselected card (the gold-vs-gold case above), a flash-pulse (`c11 flash`) to confirm the pulse overlay still washes over both rings, and light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
