### PR TITLE
Agent-state marks: hard-cell grammar on a white/gray ramp with gold waiting

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11618,10 +11618,6 @@ private struct TabItemView: View, Equatable {
         return Color(nsColor: hex.flatMap(NSColor.init(hex:)) ?? .secondaryLabelColor)
     }
 
-    private var workspacePulseWaitingInk: Color {
-        Color(nsColor: workspacePulseColors.waitingInkHex.flatMap(NSColor.init(hex:)) ?? .textColor)
-    }
-
     private func workspacePulseLabel(for state: WorkspacePulseState) -> String {
         switch state {
         case .waiting:
@@ -11635,36 +11631,30 @@ private struct TabItemView: View, Equatable {
         }
     }
 
+    /// Agent-state mark: a hard-edged terminal cell, matching the surface-tab
+    /// chips bonsplit draws. Fill state carries the meaning — solid for
+    /// working, hollow for idle, a flat line for cold, solid gold for waiting —
+    /// so the state reads without relying on color alone. Nothing animates.
     @ViewBuilder
     private func workspacePulseMark(
         for state: WorkspacePulseState,
         summaryScale: Bool = false
     ) -> some View {
         let color = workspacePulseColor(for: state)
+        let side: CGFloat = summaryScale ? 10 : 9
         switch state {
-        case .waiting:
-            ZStack {
-                RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(color)
-                Text(verbatim: "W")
-                    .font(.system(size: summaryScale ? 8 : 7, weight: .black, design: .monospaced))
-                    .foregroundColor(workspacePulseWaitingInk)
-            }
-            .frame(width: summaryScale ? 16 : 14, height: summaryScale ? 16 : 14)
-        case .working:
-            Circle()
-                .trim(from: 0.12, to: 0.88)
-                .stroke(color, style: StrokeStyle(lineWidth: 2, lineCap: .round))
-                .rotationEffect(.degrees(-42))
-                .frame(width: summaryScale ? 11 : 10, height: summaryScale ? 11 : 10)
-        case .idle:
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
+        case .waiting, .working:
+            Rectangle()
                 .fill(color)
-                .frame(width: summaryScale ? 9 : 8, height: summaryScale ? 9 : 8)
+                .frame(width: side, height: side)
+        case .idle:
+            Rectangle()
+                .strokeBorder(color, lineWidth: 1)
+                .frame(width: side, height: side)
         case .cold:
-            Circle()
-                .fill(color.opacity(0.82))
-                .frame(width: summaryScale ? 7 : 6, height: summaryScale ? 7 : 6)
+            Rectangle()
+                .fill(color)
+                .frame(width: side, height: 2)
         }
     }
 
@@ -11828,7 +11818,7 @@ private struct TabItemView: View, Equatable {
             let availableWidth = max(0, proxy.size.width - totalGaps)
             HStack(spacing: gap) {
                 ForEach(populatedStates, id: \.self) { state in
-                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    Rectangle()
                         .fill(workspacePulseColor(for: state))
                         .frame(
                             width: availableWidth
@@ -11840,10 +11830,10 @@ private struct TabItemView: View, Equatable {
         }
         .frame(height: 4)
         .background(
-            RoundedRectangle(cornerRadius: 2, style: .continuous)
+            Rectangle()
                 .fill(BrandColors.ruleSwiftUI.opacity(workspacePulse.agents.isEmpty ? 0.55 : 0.35))
         )
-        .clipShape(RoundedRectangle(cornerRadius: 2, style: .continuous))
+        .clipShape(Rectangle())
         .padding(.top, 9)
         .accessibilityHidden(true)
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5615,22 +5615,28 @@ final class Workspace: Identifiable, ObservableObject {
         .init(backgroundHex: backgroundColor.hexString())
     }
 
+    /// Agent-state palette shared by sidebar workspace pulse marks, the card
+    /// agent rollup bar, and bonsplit surface-tab activity chips.
+    ///
+    /// running/idle/cold are a neutral white-to-gray ramp (running most present,
+    /// cold most receded) so `waiting` gold stays the only chromatic mark in the
+    /// chrome: the brand's deliberate "needs you" signal.
     nonisolated static func resolvedSurfaceTabActivityColors(
         from backgroundColor: NSColor
     ) -> BonsplitConfiguration.Appearance.TabActivityColors {
         if backgroundColor.isLightColor {
             return .init(
-                runningHex: "#326D9E",
-                idleHex: "#357B61",
-                coldHex: "#7F8289",
+                runningHex: "#1D2024",
+                idleHex: "#585D66",
+                coldHex: "#8D939C",
                 waitingHex: "#9B7415",
                 waitingInkHex: "#FFFDF8"
             )
         }
         return .init(
-            runningHex: "#79AEE8",
-            idleHex: "#78B59E",
-            coldHex: "#707681",
+            runningHex: "#E8E8E8",
+            idleHex: "#9AA0A9",
+            coldHex: "#62676F",
             waitingHex: "#D0AA45",
             waitingInkHex: "#08090B"
         )

--- a/c11Tests/SurfaceLivenessDeriverTests.swift
+++ b/c11Tests/SurfaceLivenessDeriverTests.swift
@@ -174,16 +174,16 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
 
     func testSurfaceTabActivityColorsMatchDarkAndLightContract() {
         let dark = Workspace.resolvedSurfaceTabActivityColors(from: NSColor(hex: "#101114")!)
-        XCTAssertEqual(dark.runningHex, "#79AEE8")
-        XCTAssertEqual(dark.idleHex, "#78B59E")
-        XCTAssertEqual(dark.coldHex, "#707681")
+        XCTAssertEqual(dark.runningHex, "#E8E8E8")
+        XCTAssertEqual(dark.idleHex, "#9AA0A9")
+        XCTAssertEqual(dark.coldHex, "#62676F")
         XCTAssertEqual(dark.waitingHex, "#D0AA45")
         XCTAssertEqual(dark.waitingInkHex, "#08090B")
 
         let light = Workspace.resolvedSurfaceTabActivityColors(from: NSColor(hex: "#F5F3EF")!)
-        XCTAssertEqual(light.runningHex, "#326D9E")
-        XCTAssertEqual(light.idleHex, "#357B61")
-        XCTAssertEqual(light.coldHex, "#7F8289")
+        XCTAssertEqual(light.runningHex, "#1D2024")
+        XCTAssertEqual(light.idleHex, "#585D66")
+        XCTAssertEqual(light.coldHex, "#8D939C")
         XCTAssertEqual(light.waitingHex, "#9B7415")
         XCTAssertEqual(light.waitingInkHex, "#FFFDF8")
     }

--- a/docs/design-prototypes/agent-pulse-surface-tabs/index.html
+++ b/docs/design-prototypes/agent-pulse-surface-tabs/index.html
@@ -19,9 +19,9 @@
       --dim: #777b84;
       --selection: #f0f0ed;
       --gold: #d0aa45;
-      --running: #79aee8;
-      --idle: #78b59e;
-      --cold: #707681;
+      --running: #e8e8e8;
+      --idle: #9aa0a9;
+      --cold: #62676f;
       --badge-ink: #08090b;
       --shadow: rgba(0, 0, 0, .72);
       --terminal-line: #b8bcc4;
@@ -43,9 +43,9 @@
       --dim: #777a81;
       --selection: #24252a;
       --gold: #9b7415;
-      --running: #326d9e;
-      --idle: #357b61;
-      --cold: #7f8289;
+      --running: #1d2024;
+      --idle: #585d66;
+      --cold: #8d939c;
       --badge-ink: #fffdf8;
       --shadow: rgba(35, 34, 30, .25);
       --terminal-line: #4b4e55;

--- a/docs/design-prototypes/agent-pulse/index.html
+++ b/docs/design-prototypes/agent-pulse/index.html
@@ -18,9 +18,9 @@
       --dim: #777b84;
       --selection: #f0f0ed;
       --gold: #d0aa45;
-      --running: #79aee8;
-      --idle: #78b59e;
-      --cold: #707681;
+      --running: #e8e8e8;
+      --idle: #9aa0a9;
+      --cold: #62676f;
       --shadow: rgba(0, 0, 0, .72);
       --mono: "SFMono-Regular", "JetBrains Mono", Menlo, monospace;
       --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", sans-serif;
@@ -39,9 +39,9 @@
       --dim: #777a81;
       --selection: #24252a;
       --gold: #9b7415;
-      --running: #326d9e;
-      --idle: #357b61;
-      --cold: #7f8289;
+      --running: #1d2024;
+      --idle: #585d66;
+      --cold: #8d939c;
       --shadow: rgba(35, 34, 30, .25);
     }
 


### PR DESCRIPTION
Two rounds of operator feedback on the v0.60.0 staging build, in one branch.

**Round 1 — the color.** "We have this like green color, it's not a brand color. We should move to white or gray based icons." c11's brand is void-black dominant with gold accents; white and rule-gray are the neutrals.

**Round 2 — the form.** With the neutral ramp live: "I just don't like how they look. Can they be more engineer, more future terminal?" The soft filled squares read as generic status chips. Five mark-language directions were prototyped and the operator chose **Hard Cell**, with three modifications: no blinking anywhere, waiting is simply the gold version of running, and cold becomes a flat line so it can't be confused with idle.

## 1. Palette — neutral ramp, gold waiting

`Workspace.resolvedSurfaceTabActivityColors(from:)` is the single palette for the whole agent-state system. `waiting` gold and `waitingInk` are untouched.

### Dark background

| State | Before | After |
|---|---|---|
| running | `#79AEE8` (blue) | `#E8E8E8` (BrandColors white) |
| idle | `#78B59E` (green) | `#9AA0A9` |
| cold | `#707681` | `#62676F` |
| waiting | `#D0AA45` (gold) | `#D0AA45` (unchanged) |
| waitingInk | `#08090B` | `#08090B` (unchanged) |

### Light background

| State | Before | After |
|---|---|---|
| running | `#326D9E` (blue) | `#1D2024` |
| idle | `#357B61` (green) | `#585D66` |
| cold | `#7F8289` | `#8D939C` |
| waiting | `#9B7415` (gold) | `#9B7415` (unchanged) |
| waitingInk | `#FFFDF8` | `#FFFDF8` (unchanged) |

## 2. Mark language — Hard Cell

One grammar across every context, zero corner radius:

| State | Mark |
|---|---|
| running | solid cell, near-white |
| idle | hollow cell, 1 pt stroke, mid-gray |
| cold | flat centered line, dim gray |
| waiting | solid cell, gold |

Cold is a line rather than a smaller square specifically so it can never be read as idle at a glance — a bar and a box stay distinct at 9 pt in a way two squares do not. Waiting is simply the gold cell; it earns attention through the brand's one chromatic mark plus the existing card-level treatments (tinted card, gold rail segment, attention badge), not through motion.

**Nothing animates.** The old running mark was a trimmed rotating arc, and bonsplit drove it via `TimelineView(.animation)` at 30 fps *per running tab* — on `TabItemView`, a path CLAUDE.md flags as typing-latency-sensitive. Marks now redraw only on state change. Blinking was prototyped and rejected by the operator: a sidebar of blinking marks is noise, not signal.

### Where it renders

- **Sidebar card summary rows** (16 pt frame, 10 pt cell) and **footer agent squares** (14 pt frame, 9 pt cell) — `workspacePulseMark(for:summaryScale:)`, `Sources/ContentView.swift`
- **Composition rail** — corner radius 2 to 0 on the segments, track, and clip shape; it read soft against the new marks
- **Surface-tab chips** — `TabActivityMark` in `vendor/bonsplit`

### Tab slot is now uniform

All four states share a 10 pt slot with a 4 pt leading inset (previously 10/8/6 with waiting at 17). A tab's title no longer shifts horizontally when its surface enters or leaves the waiting state. Per-state opacity multipliers are gone too — the palette already encodes how present each state should read, and multiplying it again just made cold muddy.

The waiting mark's monospaced `W` glyph is dropped, along with the now-unused `workspacePulseWaitingInk`. `waitingInkHex` stays in the palette and the bonsplit appearance contract.

## Legibility

A neutral ramp separates on luminance alone, so contrast was computed rather than eyeballed:

| Pair | Old | New |
|---|---|---|
| dark running/idle | 1.01 | **2.15** |
| dark idle/cold | 1.94 | **2.16** |
| light running/idle | 1.09 | **2.47** |
| light idle/cold | 1.31 | **2.14** |

Every state also holds at least 2.79:1 against its own background. The old palette leaned almost entirely on hue — running and idle were near-identical in brightness and told apart only by blue-vs-green, which fails for a color-blind operator and fails again in a greyscale screenshot. With shape now carrying state on top of that, the four states are identifiable with the color channel switched off.

## Submodule

`vendor/bonsplit` d4ff0e4, pushed to the fork's `main` **before** the pointer bump here, on a branch (never a detached HEAD), verified with `git merge-base --is-ancestor HEAD origin/main`.

## Judgment call to flag

The operator named the **green**. Swapping the **running blue** was the orchestrator's call for brand coherence — a lone blue in an otherwise neutral+gold ramp would read as a leftover. Trivially reversible: restore `#79AEE8` (dark) / `#326D9E` (light) for `runningHex` in `Sources/Workspace.swift` plus the matching assertions.

## Testing

- `testSurfaceTabActivityColorsMatchDarkAndLightContract` (`c11Tests`) pins the ten hexes — updated to the new contract.
- bonsplit `testActivityMarksAndTrailingCloseUseLockedGeometry` now asserts every state shares a 10 pt visible size and an 18 pt leading accessory width, which is the property that matters (no title shift).
- bonsplit `testRunningActivityMarkStopsAnimatingWithReduceMotion` becomes `testRunningActivityMarkNeverAnimates` — it renders the mark and compares frames 0.8 s apart, so it now proves the stronger unconditional claim.
- The bonsplit package builds clean and those three tests pass locally via `swift build` / `swift test` (SwiftPM only — no `xcodebuild`; CI is the gate for the app).

Worth a visual pass on a tagged build before merge: the real question is how the cells read on the dark void sidebar at true size.
