### PR TITLE
Keep the workspace pulse card inside the sidebar

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -55509,6 +55509,52 @@
         }
       }
     },
+    "sidebar.workspacePulse.browserCount.one": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 browser"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.browserCount.other": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld browsers"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.censusEmpty": {
+      "comment" : "Workspace pulse card surface census when the workspace holds no countable surfaces.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No surfaces"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.censusSeparator": {
+      "comment" : "Joins the parts of the workspace pulse surface census, e.g. \"13 agents, 2 browsers\". Use the list separator conventional for the locale.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
+          }
+        }
+      }
+    },
     "sidebar.workspacePulse.cold": {
       "extractionState": "manual",
       "localizations": {
@@ -55552,6 +55598,30 @@
           "stringUnit": {
             "state": "translated",
             "value": "Холодна"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.documentCount.one": {
+      "comment" : "One markdown surface in the workspace pulse census. Keep it short; the card is narrow.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 doc"
+          }
+        }
+      }
+    },
+    "sidebar.workspacePulse.documentCount.other": {
+      "comment" : "Markdown surfaces in the workspace pulse census. Keep it short; the card is narrow.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld docs"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -55556,6 +55556,18 @@
         }
       }
     },
+    "sidebar.workspacePulse.markOverflow": {
+      "comment" : "Accessibility label for the workspace pulse agent-mark row when the census does not fit the sidebar; %lld is the number of agents not drawn.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld more agents"
+          }
+        }
+      }
+    },
     "sidebar.workspacePulse.moreWaiting": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8625,14 +8625,24 @@ struct VerticalTabsSidebar: View {
                                 // parent. TabItemView receives an immutable value so
                                 // its typing-hot body does no metadata/store work.
                                 let unreadCount = notificationStore.unreadCount(forTabId: tab.id)
-                                let pulseRoster: (agents: [WorkspacePulseAgent], terminalCount: Int) = {
+                                let pulseRoster: (
+                                    agents: [WorkspacePulseAgent],
+                                    terminalCount: Int,
+                                    browserCount: Int,
+                                    documentCount: Int
+                                ) = {
                                     var agents: [WorkspacePulseAgent] = []
                                     var terminalCount = 0
+                                    var browserCount = 0
+                                    var documentCount = 0
                                     for panelId in tab.sidebarOrderedPanelIds() {
                                         let terminalKind = tab.surfaceTerminalKind(panelId: panelId)
                                         guard PaneSizePolicy.isAgentKind(terminalKind) else {
-                                            if tab.panels[panelId]?.panelType == .terminal {
-                                                terminalCount += 1
+                                            switch tab.panels[panelId]?.panelType {
+                                            case .terminal: terminalCount += 1
+                                            case .browser: browserCount += 1
+                                            case .markdown: documentCount += 1
+                                            case nil: break
                                             }
                                             continue
                                         }
@@ -8641,7 +8651,8 @@ struct VerticalTabsSidebar: View {
                                             hasExactSurfaceNotification: notificationStore.hasUnreadNotification(
                                                 forTabId: tab.id,
                                                 surfaceId: panelId
-                                            )
+                                            ),
+                                            terminalKind: .some(terminalKind)
                                         )
                                         let pulseState: WorkspacePulseState
                                         switch resolved {
@@ -8670,12 +8681,14 @@ struct VerticalTabsSidebar: View {
                                             )
                                         )
                                     }
-                                    return (agents, terminalCount)
+                                    return (agents, terminalCount, browserCount, documentCount)
                                 }()
                                 let workspacePulse = WorkspacePulseProjector.project(
                                     hasWorkspaceDemand: unreadCount > 0,
                                     agents: pulseRoster.agents,
-                                    terminalCount: pulseRoster.terminalCount
+                                    terminalCount: pulseRoster.terminalCount,
+                                    browserCount: pulseRoster.browserCount,
+                                    documentCount: pulseRoster.documentCount
                                 )
                                 TabItemView(
                                     tabManager: tabManager,
@@ -8713,6 +8726,24 @@ struct VerticalTabsSidebar: View {
                             }
                         }
                         .padding(.vertical, 8)
+                        // Structural guarantee for the card metaphor.
+                        //
+                        // A vertical ScrollView does not clamp its rows to the
+                        // viewport. Any descendant whose *minimum* width beats
+                        // the sidebar — a fixed-slot row, a `fixedSize` label,
+                        // anything that cannot truncate — widens the whole
+                        // stack, and centre alignment then shifts every card
+                        // left until its border, its inset, and the first
+                        // characters of every line are outside the window.
+                        //
+                        // Individual offenders get fixed where they live (the
+                        // pulse mark row measures and compresses). This is the
+                        // backstop that keeps the next one from breaking the
+                        // card at all: pinned to the viewport and leading
+                        // aligned, an over-wide row can only clip its own
+                        // right edge.
+                        .frame(width: proxy.size.width, alignment: .leading)
+                        .clipped()
 
                         SidebarEmptyArea(
                             rowSpacing: tabRowSpacing,
@@ -11369,6 +11400,23 @@ enum WorkspacePulseMarkRowMetrics {
     }
 }
 
+/// Joins the workspace pulse card's surface census.
+///
+/// Absent kinds are dropped rather than reported as zero: a card that spends
+/// its one census line on "0 browsers" has nothing left for the kinds the
+/// workspace actually holds, and the sidebar is narrow enough that the line
+/// truncates when every kind is listed.
+enum WorkspacePulseCensus {
+    static func line(
+        parts: [(count: Int, label: String)],
+        separator: String,
+        empty: String
+    ) -> String {
+        let present = parts.filter { $0.count > 0 }.map(\.label)
+        return present.isEmpty ? empty : present.joined(separator: separator)
+    }
+}
+
 enum SidebarWorkspaceShortcutHintMetrics {
     private static let measurementFont = NSFont.systemFont(ofSize: 10, weight: .semibold)
     /// Held for the close button (16pt) when the workspace has no ⌘-digit
@@ -11904,6 +11952,53 @@ private struct TabItemView: View, Equatable {
         )
     }
 
+    private var workspacePulseBrowserCountText: String {
+        if workspacePulse.browserCount == 1 {
+            return String(
+                localized: "sidebar.workspacePulse.browserCount.one",
+                defaultValue: "1 browser"
+            )
+        }
+        return String(
+            localized: "sidebar.workspacePulse.browserCount.other",
+            defaultValue: "\(workspacePulse.browserCount) browsers"
+        )
+    }
+
+    private var workspacePulseDocumentCountText: String {
+        if workspacePulse.documentCount == 1 {
+            return String(
+                localized: "sidebar.workspacePulse.documentCount.one",
+                defaultValue: "1 doc"
+            )
+        }
+        return String(
+            localized: "sidebar.workspacePulse.documentCount.other",
+            defaultValue: "\(workspacePulse.documentCount) docs"
+        )
+    }
+
+    /// The workspace's whole surface census on one line, every kind it
+    /// actually holds: "13 agents, 2 browsers, 1 doc".
+    private var workspacePulseCensusText: String {
+        WorkspacePulseCensus.line(
+            parts: [
+                (workspacePulse.agents.count, workspacePulseAgentCountText),
+                (workspacePulse.terminalCount, workspacePulseTerminalCountText),
+                (workspacePulse.browserCount, workspacePulseBrowserCountText),
+                (workspacePulse.documentCount, workspacePulseDocumentCountText)
+            ],
+            separator: String(
+                localized: "sidebar.workspacePulse.censusSeparator",
+                defaultValue: ", "
+            ),
+            empty: String(
+                localized: "sidebar.workspacePulse.censusEmpty",
+                defaultValue: "No surfaces"
+            )
+        )
+    }
+
     /// Trailing-aligned census of per-agent state marks.
     ///
     /// Sized against measured geometry rather than a fixed slot per agent so
@@ -11951,13 +12046,14 @@ private struct TabItemView: View, Equatable {
     private var workspacePulseFooter: some View {
         VStack(alignment: .leading, spacing: 7) {
             HStack(spacing: 6) {
-                Text(verbatim: workspacePulseAgentCountText)
+                // Three or four kinds on a ~160pt card outruns the line.
+                // Shrinking the census is a better trade than cutting the
+                // last kind off it: the counts stay readable, and a card
+                // that lists browsers is exactly the card that needed the
+                // extra room.
+                Text(verbatim: workspacePulseCensusText)
                     .lineLimit(1)
-                Circle()
-                    .fill(Color.secondary.opacity(0.65))
-                    .frame(width: 2, height: 2)
-                Text(verbatim: workspacePulseTerminalCountText)
-                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
                     .truncationMode(.tail)
                 Spacer(minLength: 0)
             }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11260,9 +11260,121 @@ enum SidebarPathFormatter {
     }
 }
 
+/// Sizing for the workspace-pulse per-agent mark row.
+///
+/// The row is trailing-aligned inside the card and every mark is a
+/// fixed-width slot, so its minimum width grows linearly with the agent
+/// count. Past roughly nine agents that minimum exceeds the sidebar, and
+/// SwiftUI answers an oversized child by growing the whole row and
+/// centre-clipping it: the card loses its rounded edges and every line of
+/// text in it shifts off the left edge of the window. Measuring the real
+/// width and compressing here is what keeps the card inside the sidebar.
+///
+/// Compression order: gaps first (they carry no information), then the
+/// marks themselves, and only once both bottom out does the row drop
+/// marks in favour of a leading `+N` count.
+enum WorkspacePulseMarkRowMetrics {
+    static let preferredSlot: CGFloat = 14
+    static let preferredSpacing: CGFloat = 7
+    static let minimumSlot: CGFloat = 8
+    static let minimumSpacing: CGFloat = 2
+    /// Room held back for the `+N` overflow count when marks get dropped.
+    static let overflowLabelWidth: CGFloat = 24
+
+    struct Layout: Equatable {
+        var slot: CGFloat
+        var spacing: CGFloat
+        var visibleCount: Int
+        var hiddenCount: Int
+
+        /// Square side for a mark in this layout. The preferred slot carries
+        /// 5pt of breathing room around a 9pt square; once the slot itself is
+        /// compressed the square follows it down.
+        var markSide: CGFloat {
+            min(9, slot)
+        }
+    }
+
+    static func width(count: Int, slot: CGFloat, spacing: CGFloat) -> CGFloat {
+        guard count > 0 else { return 0 }
+        return slot * CGFloat(count) + spacing * CGFloat(count - 1)
+    }
+
+    static func layout(count: Int, availableWidth: CGFloat) -> Layout {
+        guard count > 0 else {
+            return Layout(
+                slot: preferredSlot,
+                spacing: preferredSpacing,
+                visibleCount: 0,
+                hiddenCount: 0
+            )
+        }
+
+        // A width of zero is the first layout pass before the geometry
+        // resolves; render at preferred metrics rather than collapsing to a
+        // `+N` count that would flash on every appearance.
+        guard availableWidth > 0 else {
+            return Layout(
+                slot: preferredSlot,
+                spacing: preferredSpacing,
+                visibleCount: count,
+                hiddenCount: 0
+            )
+        }
+
+        if width(count: count, slot: preferredSlot, spacing: preferredSpacing) <= availableWidth {
+            return Layout(
+                slot: preferredSlot,
+                spacing: preferredSpacing,
+                visibleCount: count,
+                hiddenCount: 0
+            )
+        }
+
+        if count > 1 {
+            let fittedSpacing = (availableWidth - preferredSlot * CGFloat(count)) / CGFloat(count - 1)
+            if fittedSpacing >= minimumSpacing {
+                return Layout(
+                    slot: preferredSlot,
+                    spacing: min(preferredSpacing, fittedSpacing),
+                    visibleCount: count,
+                    hiddenCount: 0
+                )
+            }
+        }
+
+        let gaps = minimumSpacing * CGFloat(count - 1)
+        let fittedSlot = (availableWidth - gaps) / CGFloat(count)
+        if fittedSlot >= minimumSlot {
+            return Layout(
+                slot: min(preferredSlot, fittedSlot),
+                spacing: minimumSpacing,
+                visibleCount: count,
+                hiddenCount: 0
+            )
+        }
+
+        let widthForMarks = availableWidth - overflowLabelWidth - minimumSpacing
+        let stride = minimumSlot + minimumSpacing
+        let fitCount = widthForMarks > 0
+            ? Int(((widthForMarks + minimumSpacing) / stride).rounded(.down))
+            : 0
+        let visible = max(0, min(count - 1, fitCount))
+        return Layout(
+            slot: minimumSlot,
+            spacing: minimumSpacing,
+            visibleCount: visible,
+            hiddenCount: count - visible
+        )
+    }
+}
+
 enum SidebarWorkspaceShortcutHintMetrics {
     private static let measurementFont = NSFont.systemFont(ofSize: 10, weight: .semibold)
-    private static let minimumSlotWidth: CGFloat = 28
+    /// Held for the close button (16pt) when the workspace has no ⌘-digit
+    /// shortcut to reserve pill width for. Everything wider than the button
+    /// here is title text the operator does not get to read.
+    private static let minimumSlotWidth: CGFloat = 18
     private static let horizontalPadding: CGFloat = 12
     private static let lock = NSLock()
     private static var cachedHintWidths: [String: CGFloat] = [:]
@@ -11655,10 +11767,11 @@ private struct TabItemView: View, Equatable {
     @ViewBuilder
     private func workspacePulseMark(
         for state: WorkspacePulseState,
-        summaryScale: Bool = false
+        summaryScale: Bool = false,
+        side overrideSide: CGFloat? = nil
     ) -> some View {
         let color = workspacePulseColor(for: state)
-        let side: CGFloat = summaryScale ? 10 : 9
+        let side: CGFloat = overrideSide ?? (summaryScale ? 10 : 9)
         switch state {
         case .waiting, .working:
             Rectangle()
@@ -11791,28 +11904,65 @@ private struct TabItemView: View, Equatable {
         )
     }
 
-    private var workspacePulseFooter: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            HStack(spacing: 6) {
-                Text(verbatim: workspacePulseAgentCountText)
-                Circle()
-                    .fill(Color.secondary.opacity(0.65))
-                    .frame(width: 2, height: 2)
-                Text(verbatim: workspacePulseTerminalCountText)
-            }
-            .fixedSize(horizontal: true, vertical: false)
+    /// Trailing-aligned census of per-agent state marks.
+    ///
+    /// Sized against measured geometry rather than a fixed slot per agent so
+    /// a busy workspace cannot push the card wider than the sidebar. When
+    /// even the compressed metrics run out of room the row keeps the marks
+    /// nearest the trailing edge and counts the rest in a leading `+N`; the
+    /// composition rail at the foot of the card still carries the full
+    /// state distribution.
+    @ViewBuilder
+    private var workspacePulseMarkRow: some View {
+        let agents = workspacePulse.agents
+        GeometryReader { proxy in
+            let layout = WorkspacePulseMarkRowMetrics.layout(
+                count: agents.count,
+                availableWidth: proxy.size.width
+            )
+            let visible = Array(agents.suffix(layout.visibleCount))
+            // Trailing alignment comes from the outer frame rather than a
+            // leading Spacer: a Spacer would add one more `layout.spacing`
+            // gap on top of the width the metrics just fitted.
+            HStack(spacing: layout.spacing) {
+                if layout.hiddenCount > 0 {
+                    Text(verbatim: "+\(layout.hiddenCount)")
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .accessibilityLabel(Text(String(
+                            localized: "sidebar.workspacePulse.markOverflow",
+                            defaultValue: "\(layout.hiddenCount) more agents"
+                        )))
+                }
 
-            HStack(spacing: 7) {
-                ForEach(workspacePulse.agents) { agent in
-                    workspacePulseMark(for: agent.state)
-                        .frame(width: 14, height: 14)
+                ForEach(visible) { agent in
+                    workspacePulseMark(for: agent.state, side: layout.markSide)
+                        .frame(width: layout.slot, height: 14)
                         .accessibilityElement(children: .ignore)
                         .accessibilityLabel(Text(agent.context?.title ?? workspacePulseLabel(for: agent.state)))
                         .accessibilityValue(Text(workspacePulseLabel(for: agent.state)))
                 }
             }
-            .frame(maxWidth: .infinity, alignment: .trailing)
-            .frame(height: 14)
+            .frame(width: proxy.size.width, height: 14, alignment: .trailing)
+        }
+        .frame(height: 14)
+    }
+
+    private var workspacePulseFooter: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack(spacing: 6) {
+                Text(verbatim: workspacePulseAgentCountText)
+                    .lineLimit(1)
+                Circle()
+                    .fill(Color.secondary.opacity(0.65))
+                    .frame(width: 2, height: 2)
+                Text(verbatim: workspacePulseTerminalCountText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Spacer(minLength: 0)
+            }
+
+            workspacePulseMarkRow
         }
         .font(.system(size: chromeTokens.sidebarWorkspaceMetadata - 0.5, design: .monospaced))
         .foregroundColor(.secondary.opacity(0.68))
@@ -12101,7 +12251,12 @@ private struct TabItemView: View, Equatable {
         }()
 
         VStack(alignment: .leading, spacing: 0) {
-            HStack(alignment: .center, spacing: 7) {
+            // Spacing and the trailing accessory slot are both held back from
+            // the title on every card, so anything reserved here is title the
+            // operator never gets to read in a narrow sidebar. Keep the pin
+            // inline (an empty container still claims spacing on both sides)
+            // and keep the gaps tight.
+            HStack(alignment: .center, spacing: 5) {
                 Text(tab.title)
                     .font(.system(size: chromeTokens.sidebarWorkspaceTitle + 1.5, weight: titleFontWeight))
                     .foregroundColor(.primary)
@@ -12109,15 +12264,12 @@ private struct TabItemView: View, Equatable {
                     .truncationMode(.tail)
                     .layoutPriority(1)
 
-                Spacer(minLength: 4)
+                Spacer(minLength: 2)
 
-                HStack(spacing: 5) {
-                    if tab.isPinned {
-                        Image(systemName: "diamond.fill")
-                            .font(.system(size: chromeTokens.sidebarWorkspaceAccessory + 1, weight: .semibold))
-                            .foregroundColor(.secondary.opacity(0.7))
-                    }
-
+                if tab.isPinned {
+                    Image(systemName: "diamond.fill")
+                        .font(.system(size: chromeTokens.sidebarWorkspaceAccessory + 1, weight: .semibold))
+                        .foregroundColor(.secondary.opacity(0.7))
                 }
 
                 ZStack(alignment: .trailing) {

--- a/Sources/Sidebar/SidebarActivityProjector.swift
+++ b/Sources/Sidebar/SidebarActivityProjector.swift
@@ -37,6 +37,8 @@ struct WorkspacePulseSummary: Equatable {
     let coldCount: Int
     let agents: [WorkspacePulseAgent]
     let terminalCount: Int
+    let browserCount: Int
+    let documentCount: Int
 
     init(
         waitingCount: Int,
@@ -44,7 +46,9 @@ struct WorkspacePulseSummary: Equatable {
         idleCount: Int,
         coldCount: Int,
         agents: [WorkspacePulseAgent] = [],
-        terminalCount: Int = 0
+        terminalCount: Int = 0,
+        browserCount: Int = 0,
+        documentCount: Int = 0
     ) {
         self.waitingCount = waitingCount
         self.workingCount = workingCount
@@ -52,6 +56,8 @@ struct WorkspacePulseSummary: Equatable {
         self.coldCount = coldCount
         self.agents = agents
         self.terminalCount = terminalCount
+        self.browserCount = browserCount
+        self.documentCount = documentCount
     }
 
     var dominant: WorkspacePulseState {
@@ -115,7 +121,9 @@ enum WorkspacePulseProjector {
     static func project(
         hasWorkspaceDemand: Bool,
         agents: [WorkspacePulseAgent],
-        terminalCount: Int
+        terminalCount: Int,
+        browserCount: Int = 0,
+        documentCount: Int = 0
     ) -> WorkspacePulseSummary {
         var waiting = agents.filter { $0.state == .waiting }.count
         if hasWorkspaceDemand && waiting == 0 {
@@ -127,7 +135,9 @@ enum WorkspacePulseProjector {
             idleCount: agents.filter { $0.state == .idle }.count,
             coldCount: agents.filter { $0.state == .cold }.count,
             agents: agents,
-            terminalCount: max(0, terminalCount)
+            terminalCount: max(0, terminalCount),
+            browserCount: max(0, browserCount),
+            documentCount: max(0, documentCount)
         )
     }
 

--- a/Sources/SurfaceMetadataStore.swift
+++ b/Sources/SurfaceMetadataStore.swift
@@ -437,6 +437,44 @@ final class SurfaceMetadataStore: @unchecked Sendable {
         }
     }
 
+    /// One metadata value, without materialising the surface's source map.
+    ///
+    /// `getMetadata` converts every source entry to JSON on every call. The
+    /// sidebar reads `terminal_type` for every surface of every workspace on
+    /// each evaluation of its body, so on a workspace holding tens of agents
+    /// that conversion was being paid hundreds of times per frame for a
+    /// single string. Callers that want one key should ask for one key.
+    func metadataValue(workspaceId: UUID, surfaceId: UUID, key: String) -> Any? {
+        return queue.sync {
+            metadata[workspaceId]?[surfaceId]?[key]
+        }
+    }
+
+    /// Metadata plus sources for a named subset of keys. Same reasoning as
+    /// `metadataValue`: converting the keys the caller asked about is bounded
+    /// work, converting all of them is not.
+    func getMetadata(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        keys: [String]
+    ) -> (metadata: [String: Any], sources: [String: [String: Any]]) {
+        return queue.sync {
+            let allMetadata = metadata[workspaceId]?[surfaceId]
+            let allSources = sources[workspaceId]?[surfaceId]
+            var md: [String: Any] = [:]
+            var src: [String: [String: Any]] = [:]
+            for key in keys {
+                if let value = allMetadata?[key] {
+                    md[key] = value
+                }
+                if let source = allSources?[key] {
+                    src[key] = source.toJSON()
+                }
+            }
+            return (md, src)
+        }
+    }
+
     /// Read the monotonic revision counter. Used by the autosave fingerprint
     /// so metadata-only mutations trigger a write at the next tick.
     func currentRevision() -> UInt64 {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6682,14 +6682,18 @@ final class Workspace: Identifiable, ObservableObject {
         AppDelegate.shared?.notificationStore?.hasUnreadNotification(forTabId: id, surfaceId: panelId) ?? false
     }
 
+    /// `terminalKind` lets a caller that has already read the surface's kind
+    /// hand it in. The sidebar roster reads it for its agent test and would
+    /// otherwise pay for the same lookup twice per surface, per evaluation.
     func resolvedSurfaceTabActivityState(
         panelId: UUID,
-        hasExactSurfaceNotification: Bool? = nil
+        hasExactSurfaceNotification: Bool? = nil,
+        terminalKind: String?? = nil
     ) -> BonsplitTabActivityState? {
         SurfaceTabActivityResolver.resolve(
             hasExactSurfaceNotification: hasExactSurfaceNotification ?? hasUnreadNotification(panelId: panelId),
             derivedActivity: derivedActivityBySurface[panelId],
-            terminalType: surfaceTerminalKind(panelId: panelId)
+            terminalType: terminalKind ?? surfaceTerminalKind(panelId: panelId)
         )
     }
 
@@ -7480,7 +7484,14 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Read the current M7 title-bar state for a surface as a SwiftUI view state.
     func surfaceTitleBarState(panelId: UUID) -> SurfaceTitleBarState {
-        let snapshot = SurfaceMetadataStore.shared.getMetadata(workspaceId: id, surfaceId: panelId)
+        // Sidebar-hot: called for every agent surface of every workspace on
+        // each sidebar body evaluation. Ask for the two keys it reads rather
+        // than a whole converted source map.
+        let snapshot = SurfaceMetadataStore.shared.getMetadata(
+            workspaceId: id,
+            surfaceId: panelId,
+            keys: [MetadataKey.title, MetadataKey.description]
+        )
         let title = snapshot.metadata[MetadataKey.title] as? String
         let description = snapshot.metadata[MetadataKey.description] as? String
         return SurfaceTitleBarState(
@@ -8254,8 +8265,11 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Read a surface's declared `terminal_type` (canonical metadata key), if any.
     func surfaceTerminalKind(panelId: UUID) -> String? {
-        let md = SurfaceMetadataStore.shared.getMetadata(workspaceId: id, surfaceId: panelId).metadata
-        return md[MetadataKey.terminalType] as? String
+        SurfaceMetadataStore.shared.metadataValue(
+            workspaceId: id,
+            surfaceId: panelId,
+            key: MetadataKey.terminalType
+        ) as? String
     }
 
     /// Optional per-surface minimum override (`min_cols` / `min_rows` metadata) —

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -2294,11 +2294,125 @@ final class SidebarWorkspaceShortcutHintMetricsTests: XCTestCase {
 
     func testSlotWidthAppliesMinimumAndDebugInset() {
         let nilLabelWidth = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: nil, debugXOffset: 999)
-        XCTAssertEqual(nilLabelWidth, 28)
+        XCTAssertEqual(nilLabelWidth, 18)
 
         let base = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 0)
         let widened = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 10)
         XCTAssertGreaterThan(widened, base)
+    }
+
+    /// A shortcut label still reserves the measured pill width, so trimming
+    /// the label-less minimum must not narrow the labelled slot.
+    func testSlotWidthForLabelledWorkspaceStillFitsPill() {
+        let labelled = SidebarWorkspaceShortcutHintMetrics.slotWidth(label: "⌘1", debugXOffset: 0)
+        XCTAssertGreaterThanOrEqual(labelled, SidebarWorkspaceShortcutHintMetrics.hintWidth(for: "⌘1"))
+    }
+}
+
+@MainActor
+final class WorkspacePulseMarkRowMetricsTests: XCTestCase {
+    private let sidebarCardContentWidth: CGFloat = 178
+
+    private func fittedWidth(_ layout: WorkspacePulseMarkRowMetrics.Layout) -> CGFloat {
+        WorkspacePulseMarkRowMetrics.width(
+            count: layout.visibleCount,
+            slot: layout.slot,
+            spacing: layout.spacing
+        ) + (layout.hiddenCount > 0
+            ? WorkspacePulseMarkRowMetrics.overflowLabelWidth + WorkspacePulseMarkRowMetrics.minimumSpacing
+            : 0)
+    }
+
+    func testSmallRosterKeepsPreferredMetrics() {
+        let layout = WorkspacePulseMarkRowMetrics.layout(count: 4, availableWidth: sidebarCardContentWidth)
+        XCTAssertEqual(layout.slot, WorkspacePulseMarkRowMetrics.preferredSlot)
+        XCTAssertEqual(layout.spacing, WorkspacePulseMarkRowMetrics.preferredSpacing)
+        XCTAssertEqual(layout.visibleCount, 4)
+        XCTAssertEqual(layout.hiddenCount, 0)
+    }
+
+    /// The bug this row was rebuilt for: at twelve agents a fixed 14pt slot
+    /// with 7pt gaps needs 245pt in a 178pt card, and the overflow grew and
+    /// centre-clipped the whole workspace card.
+    func testCrowdedRosterStaysInsideTheCard() {
+        for count in 1...40 {
+            let layout = WorkspacePulseMarkRowMetrics.layout(
+                count: count,
+                availableWidth: sidebarCardContentWidth
+            )
+            XCTAssertLessThanOrEqual(
+                fittedWidth(layout),
+                sidebarCardContentWidth + 0.01,
+                "count=\(count) overflows the card"
+            )
+            XCTAssertEqual(layout.visibleCount + layout.hiddenCount, count, "count=\(count) lost agents")
+        }
+    }
+
+    func testCrowdedRosterCompressesGapsBeforeMarks() {
+        let layout = WorkspacePulseMarkRowMetrics.layout(count: 10, availableWidth: sidebarCardContentWidth)
+        XCTAssertEqual(layout.slot, WorkspacePulseMarkRowMetrics.preferredSlot)
+        XCTAssertLessThan(layout.spacing, WorkspacePulseMarkRowMetrics.preferredSpacing)
+        XCTAssertGreaterThanOrEqual(layout.spacing, WorkspacePulseMarkRowMetrics.minimumSpacing)
+        XCTAssertEqual(layout.hiddenCount, 0)
+    }
+
+    func testVeryCrowdedRosterShrinksMarksAndKeepsThemAllVisible() {
+        let layout = WorkspacePulseMarkRowMetrics.layout(count: 16, availableWidth: sidebarCardContentWidth)
+        XCTAssertEqual(layout.spacing, WorkspacePulseMarkRowMetrics.minimumSpacing)
+        XCTAssertLessThan(layout.slot, WorkspacePulseMarkRowMetrics.preferredSlot)
+        XCTAssertGreaterThanOrEqual(layout.slot, WorkspacePulseMarkRowMetrics.minimumSlot)
+        XCTAssertEqual(layout.visibleCount, 16)
+        XCTAssertEqual(layout.hiddenCount, 0)
+        XCTAssertEqual(layout.markSide, min(9, layout.slot), accuracy: 0.01)
+        XCTAssertLessThanOrEqual(layout.markSide, layout.slot)
+    }
+
+    func testOverflowingRosterCountsTheRemainder() {
+        let layout = WorkspacePulseMarkRowMetrics.layout(count: 60, availableWidth: sidebarCardContentWidth)
+        XCTAssertGreaterThan(layout.hiddenCount, 0)
+        XCTAssertGreaterThan(layout.visibleCount, 0)
+        XCTAssertEqual(layout.visibleCount + layout.hiddenCount, 60)
+        XCTAssertLessThanOrEqual(fittedWidth(layout), sidebarCardContentWidth + 0.01)
+    }
+
+    func testNarrowSidebarStillFits() {
+        for width in stride(from: 60.0, through: 400.0, by: 10.0) {
+            let layout = WorkspacePulseMarkRowMetrics.layout(count: 24, availableWidth: CGFloat(width))
+            XCTAssertLessThanOrEqual(
+                fittedWidth(layout),
+                CGFloat(width) + 0.01,
+                "width=\(width) overflows"
+            )
+            XCTAssertEqual(layout.visibleCount + layout.hiddenCount, 24)
+        }
+    }
+
+    /// Below the width of the overflow count itself the row has nothing left
+    /// to give; it must still return a usable layout rather than negative
+    /// metrics or a lost agent count.
+    func testDegenerateWidthStaysSane() {
+        for width in stride(from: 1.0, through: 55.0, by: 3.0) {
+            let layout = WorkspacePulseMarkRowMetrics.layout(count: 24, availableWidth: CGFloat(width))
+            XCTAssertGreaterThanOrEqual(layout.slot, WorkspacePulseMarkRowMetrics.minimumSlot)
+            XCTAssertGreaterThanOrEqual(layout.spacing, WorkspacePulseMarkRowMetrics.minimumSpacing)
+            XCTAssertGreaterThanOrEqual(layout.visibleCount, 0)
+            XCTAssertEqual(layout.visibleCount + layout.hiddenCount, 24)
+        }
+    }
+
+    /// Geometry is zero on the first layout pass; rendering a `+N` there
+    /// would flash on every card appearance.
+    func testUnresolvedGeometryRendersEveryMark() {
+        let layout = WorkspacePulseMarkRowMetrics.layout(count: 12, availableWidth: 0)
+        XCTAssertEqual(layout.visibleCount, 12)
+        XCTAssertEqual(layout.hiddenCount, 0)
+    }
+
+    func testEmptyRosterRendersNothing() {
+        let layout = WorkspacePulseMarkRowMetrics.layout(count: 0, availableWidth: sidebarCardContentWidth)
+        XCTAssertEqual(layout.visibleCount, 0)
+        XCTAssertEqual(layout.hiddenCount, 0)
     }
 }
 

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -2310,6 +2310,165 @@ final class SidebarWorkspaceShortcutHintMetricsTests: XCTestCase {
 }
 
 @MainActor
+final class WorkspacePulseCensusTests: XCTestCase {
+    private func line(_ parts: [(Int, String)]) -> String {
+        WorkspacePulseCensus.line(
+            parts: parts.map { (count: $0.0, label: $0.1) },
+            separator: ", ",
+            empty: "No surfaces"
+        )
+    }
+
+    func testJoinsEveryPresentKindInOrder() {
+        XCTAssertEqual(
+            line([(13, "13 agents"), (2, "2 terminals"), (3, "3 browsers"), (1, "1 doc")]),
+            "13 agents, 2 terminals, 3 browsers, 1 doc"
+        )
+    }
+
+    /// The card has one census line in a ~178pt column, so absent kinds have
+    /// to yield their space to the kinds that are actually there.
+    func testDropsAbsentKinds() {
+        XCTAssertEqual(
+            line([(13, "13 agents"), (0, "0 terminals"), (2, "2 browsers"), (0, "0 docs")]),
+            "13 agents, 2 browsers"
+        )
+    }
+
+    func testSingleKindHasNoSeparator() {
+        XCTAssertEqual(line([(0, "0 agents"), (4, "4 terminals")]), "4 terminals")
+    }
+
+    func testEmptyCensusFallsBackRatherThanRenderingBlank() {
+        XCTAssertEqual(line([(0, "0 agents"), (0, "0 terminals")]), "No surfaces")
+        XCTAssertEqual(line([]), "No surfaces")
+    }
+
+    func testNegativeCountsAreTreatedAsAbsent() {
+        XCTAssertEqual(line([(-1, "-1 agents"), (1, "1 browser")]), "1 browser")
+    }
+}
+
+@MainActor
+final class SurfaceMetadataStoreTargetedReadTests: XCTestCase {
+    private let workspaceId = UUID()
+
+    /// The targeted reads exist to keep the sidebar off the whole-source-map
+    /// conversion; they are only worth having if they agree with it.
+    func testTargetedReadsMatchTheFullSnapshot() throws {
+        let store = SurfaceMetadataStore.shared
+        let surfaceId = UUID()
+        _ = try store.setMetadata(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            partial: [
+                MetadataKey.terminalType: "claude-code",
+                MetadataKey.title: "Sidebar card bug",
+                MetadataKey.description: "Lineage: operator → fix"
+            ],
+            mode: .merge,
+            source: .explicit
+        )
+        defer {
+            _ = try? store.clearMetadata(
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                keys: nil,
+                source: .explicit
+            )
+        }
+
+        let full = store.getMetadata(workspaceId: workspaceId, surfaceId: surfaceId)
+
+        XCTAssertEqual(
+            store.metadataValue(
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                key: MetadataKey.terminalType
+            ) as? String,
+            full.metadata[MetadataKey.terminalType] as? String
+        )
+
+        let subset = store.getMetadata(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            keys: [MetadataKey.title, MetadataKey.description]
+        )
+        XCTAssertEqual(subset.metadata[MetadataKey.title] as? String, full.metadata[MetadataKey.title] as? String)
+        XCTAssertEqual(
+            subset.metadata[MetadataKey.description] as? String,
+            full.metadata[MetadataKey.description] as? String
+        )
+        XCTAssertEqual(
+            subset.sources[MetadataKey.title]?["source"] as? String,
+            full.sources[MetadataKey.title]?["source"] as? String
+        )
+        // The subset carries only what was asked for.
+        XCTAssertNil(subset.metadata[MetadataKey.terminalType])
+        XCTAssertNil(subset.sources[MetadataKey.terminalType])
+    }
+
+    func testTargetedReadsOnUnknownSurfaceAreEmpty() {
+        let store = SurfaceMetadataStore.shared
+        let missing = UUID()
+        XCTAssertNil(store.metadataValue(workspaceId: workspaceId, surfaceId: missing, key: MetadataKey.terminalType))
+        let subset = store.getMetadata(workspaceId: workspaceId, surfaceId: missing, keys: [MetadataKey.title])
+        XCTAssertTrue(subset.metadata.isEmpty)
+        XCTAssertTrue(subset.sources.isEmpty)
+    }
+}
+
+@MainActor
+final class WorkspacePulseSurfaceCensusProjectionTests: XCTestCase {
+    func testProjectorCarriesEverySurfaceKind() {
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: false,
+            agents: [
+                WorkspacePulseAgent(surfaceId: UUID(), state: .working, context: nil),
+                WorkspacePulseAgent(surfaceId: UUID(), state: .idle, context: nil)
+            ],
+            terminalCount: 3,
+            browserCount: 2,
+            documentCount: 1
+        )
+        XCTAssertEqual(summary.agents.count, 2)
+        XCTAssertEqual(summary.terminalCount, 3)
+        XCTAssertEqual(summary.browserCount, 2)
+        XCTAssertEqual(summary.documentCount, 1)
+    }
+
+    func testNegativeSurfaceCountsClampToZero() {
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: false,
+            agents: [],
+            terminalCount: -4,
+            browserCount: -1,
+            documentCount: -9
+        )
+        XCTAssertEqual(summary.terminalCount, 0)
+        XCTAssertEqual(summary.browserCount, 0)
+        XCTAssertEqual(summary.documentCount, 0)
+    }
+
+    /// Browser and document counts join the card's Equatable identity, so a
+    /// browser opening in a background workspace has to redraw its card.
+    func testSurfaceCountsParticipateInEquality() {
+        func summary(browsers: Int, documents: Int) -> WorkspacePulseSummary {
+            WorkspacePulseProjector.project(
+                hasWorkspaceDemand: false,
+                agents: [],
+                terminalCount: 1,
+                browserCount: browsers,
+                documentCount: documents
+            )
+        }
+        XCTAssertEqual(summary(browsers: 1, documents: 1), summary(browsers: 1, documents: 1))
+        XCTAssertNotEqual(summary(browsers: 1, documents: 1), summary(browsers: 2, documents: 1))
+        XCTAssertNotEqual(summary(browsers: 1, documents: 1), summary(browsers: 1, documents: 0))
+    }
+}
+
+@MainActor
 final class WorkspacePulseMarkRowMetricsTests: XCTestCase {
     private let sidebarCardContentWidth: CGFloat = 178
 


### PR DESCRIPTION
## The bug

Two problems in the v0.60.0 sidebar, both visible on a busy workspace:

1. **The card renders off-screen.** The workspace pulse card's per-agent mark row gave every agent a fixed 14pt slot with a 7pt gap, so its minimum width grew as `21N - 7`. Past roughly nine agents that exceeds the sidebar, and SwiftUI answers an oversized child by growing the row and centre-clipping it: the card loses its rounded edges, runs edge to edge, and every line of text inside shifts off the left of the window. Reproduced live at 11–13 agents (245pt of marks in a 178pt card).
2. **Titles truncate early.** The title row held back 7pt of spacing on either side of an *empty* pin container, a 4pt minimum spacer, and a 28pt minimum accessory slot for a 16pt close button. Measured on the running app: 61pt of a 178pt card reserved before the title got any room, so `acetate marketing` came out as `acetate marketi…` with obvious blank space beside it.

## The fix

`WorkspacePulseMarkRowMetrics` sizes the mark row against measured geometry and compresses to fit: gaps first (they carry no information), then the marks, and only once both bottom out does it keep the marks nearest the trailing edge and count the rest in a leading `+N`. Sizing inside a `GeometryReader` means the row can no longer widen the card whatever the roster does. The composition rail at the foot of the card still carries the full state distribution.

Also drops `.fixedSize(horizontal: true)` from the agent/terminal count line — it could not truncate, making it a second latent way to push the card wide.

For the title: the pin moves inline, gaps tighten to 5/2/5, and the label-less accessory slot sizes to the button it actually holds. Reserved chrome goes 61pt → 44pt, measured. Workspaces 1–9 still reserve the full ⌘-digit pill width, so holding ⌘ does not reflow titles.

## Validation

Tagged build (`--tag cardfit`, QA-fresh launch) driven to a 13-agent workspace over the socket:

- **Before** (`/Applications/c11.app` v0.60.0, live): card full-bleed, no left border, title and every metadata line clipped off the window edge.
- **After**: card keeps its border and its content, 13 marks compressed inside it, nothing clipped.

Reserved title chrome measured at 44pt on the tagged build vs 61pt on the shipped app. At the operator's sidebar width (178pt card content) that takes the title band from 117pt to 134pt, against the 123pt `acetate marketing` needs. The tagged window's sidebar is narrower (159pt content), so the demo workspace is titled `acetate market` there; I could not drive the sidebar divider synthetically to reproduce the exact shipped width.

New tests in `WorkspacePulseMarkRowMetricsTests` sweep 1–40 agents and 60–400pt widths asserting the row never exceeds its available width and never loses an agent from the census. Host-target tests, so they run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)