### PR TITLE
docs(skill): isolation between agents is a prompt rule, not a topology rule

### DIFF
--- a/skills/c11/SKILL.md
+++ b/skills/c11/SKILL.md
@@ -16,7 +16,7 @@ This card is deliberately short. It covers **orientation** — the one thing eve
 
 Refs accept UUIDs, short refs, or indexes: `workspace:1`, `pane:2`, `surface:3`, `tab:1`. **A bare number from the operator is a surface ref.** With the "Show Surface IDs in Tab Titles" setting on, every tab displays `N: title` where N is its `surface:N` ordinal — so "send that to 292" means target `surface:292` (with its `--workspace`). Always write the `surface:N` form; a bare integer in a CLI flag is a positional index, a different thing. Your own N is `$C11_SURFACE_NUM`.
 
-**Where new work goes:** a new **pane** when the work wants its own spatial slot (a sub-agent, a log tail, a browser for validation); a new **surface** when a pane just wants another tab; a new **workspace** when the operator names a different project or mission. Default to one workspace per project unless the operator's setup says otherwise.
+**Where new work goes:** a new **pane** when the work wants its own spatial slot (a sub-agent, a log tail, a browser for validation); a new **surface** when a pane just wants another tab; a new **workspace** when the operator names a different project or mission. Default to one workspace per project unless the operator's setup says otherwise. **Wanting agents isolated from each other is not a reason for a new workspace** — same-workspace agents are already separate processes with separate context; blindness between agents comes from their prompts, never from topology (see [references/orchestration.md](references/orchestration.md#isolation-is-a-prompt-rule-not-a-topology-rule)).
 
 ## Boot fast, orient lazily
 

--- a/skills/c11/references/orchestration.md
+++ b/skills/c11/references/orchestration.md
@@ -19,6 +19,14 @@ Patterns for running multiple agents in parallel panes: layout, tab naming, laun
 
 Within a single orchestration run, keep the agents as surfaces (tabs) within panes of the run's workspace rather than spawning a fresh workspace per agent. One workspace per agent fragments the run across the sidebar and makes it hard to read; grouping them keeps the whole run legible in one place.
 
+### Isolation is a prompt rule, not a topology rule
+
+**Do not reach for `--new-workspace` to keep agents from influencing each other.** Agents in the same workspace are *already* isolated: separate processes, separate context, no shared state. Nothing about sharing a workspace lets one agent see another's work. If you need agents not to consult each other — independent audits, blind reviews, a bake-off — say so **in the prompt** ("work alone; do not read, message, or coordinate with any other agent, surface, or pane; do not read other agents' transcripts"). That is the only mechanism that actually binds. A separate workspace adds zero isolation and costs real legibility.
+
+Observed failure (2026-07-25): an orchestrator asked to open two blind auditors "as surfaces" spawned each with `--new-workspace`, reasoning that the operator's "don't let them look at each other" called for a hard barrier. The barrier was imaginary — the prompt was already doing the work — and the run ended up scattered across three workspaces the operator then had to hunt through. Note that `launch-agent` defaults to `$C11_WORKSPACE_ID` and the focused pane, so **the correct call was the one with fewer flags**.
+
+Before adding any separation flag, ask what it actually isolates. If the answer is "nothing the prompt doesn't already handle," drop it.
+
 Standard orchestration layout for a single project:
 
 ```


### PR DESCRIPTION
Records a real failure mode from an Acetate orchestration run today.

An orchestrator was asked to open two blind auditors **as surfaces**. It spawned each with `--new-workspace`, reading the operator's "don't let them look at each other" as calling for a hard barrier. The barrier was imaginary — same-workspace agents are already separate processes with separate context, and the prompt was already carrying the blindness requirement. The run scattered across three workspaces the operator then had to hunt through.

The sharp edge: `launch-agent` already defaults to `$C11_WORKSPACE_ID` and the focused pane, so **the correct call was the one with fewer flags**. Getting it wrong required actively opting out of the right default.

- `references/orchestration.md` — new subsection under Layout philosophy, with the general test: before adding a separation flag, ask what it actually isolates.
- `SKILL.md` — one clause on the "Where new work goes" line, since that is what an agent reads when deciding where to put a sub-agent.

Docs only. Installed copy synced via `scripts/sync-installed-skills.sh c11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)