### PR TITLE
Instrument resume decisions and recover durable OMP/Grok sessions

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -12424,6 +12424,7 @@ struct CMUXCLI {
         let capturedVia: String?
         let quarantineReason: String?
         let diagnosticReason: String?
+        let payload: [String: Any]?
     }
 
     /// Read-only resume-decision dry run. The recovery mode is mandatory and
@@ -12482,7 +12483,8 @@ struct CMUXCLI {
                         placeholder: active["placeholder"] as? Bool ?? false,
                         capturedVia: (active["captured_via"] ?? active["capturedVia"]) as? String,
                         quarantineReason: (active["quarantine_reason"] ?? active["quarantineReason"]) as? String,
-                        diagnosticReason: (active["diagnostic_reason"] ?? active["diagnosticReason"]) as? String
+                        diagnosticReason: (active["diagnostic_reason"] ?? active["diagnosticReason"]) as? String,
+                        payload: active["payload"] as? [String: Any]
                     ))
                 }
             }
@@ -12722,7 +12724,7 @@ struct CMUXCLI {
         let persistedState = ResumePersistedState(rawValue: input.state) ?? .unknown
         let idValid: Bool
         switch input.kind {
-        case "codex", "claude-code":
+        case "codex", "claude-code", "omp", "grok":
             idValid = isUUIDv4(input.id)
         case "opencode":
             idValid = isValidOpencodeSessionId(input.id)
@@ -12753,6 +12755,18 @@ struct CMUXCLI {
             case .some(let exists): transcriptEvidence = exists ? .verified : .missing
             case .none: transcriptEvidence = .unavailable
             }
+        } else if input.kind == "omp", idValid,
+                  let path = input.payload?["session_file_path"] as? String,
+                  !path.isEmpty {
+            transcriptEvidence = FileManager.default.fileExists(atPath: path)
+                ? .verified
+                : .missing
+        } else if input.kind == "grok", idValid,
+                  let path = input.payload?["session_directory_path"] as? String,
+                  !path.isEmpty {
+            transcriptEvidence = FileManager.default.fileExists(atPath: path)
+                ? .verified
+                : .missing
         } else {
             transcriptEvidence = .unavailable
         }
@@ -12768,6 +12782,12 @@ struct CMUXCLI {
                 command = "cd '\(cwd)' && \(command)"
             }
             fallback = ResumeCommand(text: command)
+        } else if input.kind == "omp", idValid {
+            fallback = ResumeCommand(text: "omp --resume=\(shellQuote(input.id))")
+        } else if input.kind == "grok", idValid {
+            fallback = ResumeCommand(
+                text: "grok --always-approve --resume \(shellQuote(input.id))"
+            )
         } else {
             fallback = nil
         }

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 		C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1CDE00001A1B2C3D4E5F719 /* codex */; };
 		C1F1E00002A1B2C3D4E5F719 /* pi in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F1E00001A1B2C3D4E5F719 /* pi */; };
 		C1F2E00002A1B2C3D4E5F719 /* omp in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F2E00001A1B2C3D4E5F719 /* omp */; };
+		C1F3E00002A1B2C3D4E5F719 /* grok in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F3E00001A1B2C3D4E5F719 /* grok */; };
 		C22557799917F42164A6C855 /* TitlebarSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F01B /* TitlebarSnapshotTests.swift */; };
 		C49B42317DA68794CC9C29E4 /* MailboxULIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7105BF1A1B2C3D4E5F60718 /* MailboxULIDTests.swift */; };
 		C622796239CFCFB69D68C5D9 /* CLIHealthRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH015BF1A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift */; };
@@ -487,6 +488,7 @@
 				C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */,
 				C1F1E00002A1B2C3D4E5F719 /* pi in Copy CLI */,
 				C1F2E00002A1B2C3D4E5F719 /* omp in Copy CLI */,
+				C1F3E00002A1B2C3D4E5F719 /* grok in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
 				4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */,
 			);
@@ -747,6 +749,7 @@
 		C1CDE00001A1B2C3D4E5F719 /* codex */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/codex; sourceTree = SOURCE_ROOT; };
 		C1F1E00001A1B2C3D4E5F719 /* pi */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/pi; sourceTree = SOURCE_ROOT; };
 		C1F2E00001A1B2C3D4E5F719 /* omp */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/omp; sourceTree = SOURCE_ROOT; };
+		C1F3E00001A1B2C3D4E5F719 /* grok */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/grok; sourceTree = SOURCE_ROOT; };
 		C28AE9F41DE55AB88CAE431D /* AgentManifest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
 		ACB000000000000000000001 /* AgentCompanionContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentCompanionContext.swift; sourceTree = "<group>"; };
 		ACB000000000000000000002 /* BrowserCompanionPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BrowserCompanionPolicyTests.swift; sourceTree = "<group>"; };
@@ -961,6 +964,7 @@
 				C1CDE00001A1B2C3D4E5F719 /* codex */,
 				C1F1E00001A1B2C3D4E5F719 /* pi */,
 				C1F2E00001A1B2C3D4E5F719 /* omp */,
+				C1F3E00001A1B2C3D4E5F719 /* grok */,
 				D8017BF1A1B2C3D4E5F60718 /* Blueprints */,
 				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,

--- a/Resources/bin/grok
+++ b/Resources/bin/grok
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# c11 Grok wrapper - exact durable-session identity for restart/resume.
+#
+# Grok supports `--session-id <uuid>` for a new conversation and
+# `--resume <uuid>` for an existing one. Inside c11 this wrapper injects the
+# new UUID, but publishes it to c11 only after Grok creates that UUID's
+# session directory (the first real message). Empty sessions remain uncaptured
+# and intentionally do not resume.
+
+set -uo pipefail
+
+find_real_grok() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/grok" ]] && printf '%s' "$d/grok" && return 0
+    done
+    return 1
+}
+
+c11_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+    local self_dir c11_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    c11_bin="$self_dir/c11"
+    [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+    [[ -n "$c11_bin" ]] || return 1
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$c11_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+REAL_GROK="$(find_real_grok)" || {
+    echo "Error: grok not found in PATH" >&2
+    exit 127
+}
+if [[ -z "${CMUX_SURFACE_ID:-}" || "${CMUX_GROK_HOOKS_DISABLED:-}" == "1" ]] \
+    || ! c11_socket_available; then
+    exec "$REAL_GROK" "$@"
+fi
+
+case "${1:-}" in
+    agent|completions|dashboard|doctor|export|help|inspect|leader|login|logout|mcp|memory|models|plugin|sessions|setup|trace|update|version|worktree|wrap|--help|-h|--version|-v)
+        exec "$REAL_GROK" "$@"
+        ;;
+esac
+for arg in "$@"; do
+    case "$arg" in
+        -p|--single|--prompt-file|--prompt-json)
+            exec "$REAL_GROK" "$@"
+            ;;
+    esac
+done
+
+self_dir="$(cd "$(dirname "$0")" && pwd)"
+c11_bin="$self_dir/c11"
+[[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+
+is_uuid() {
+    [[ "$1" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]
+}
+
+session_id=""
+resume_id=""
+expect_session_id=0
+expect_resume_id=0
+continue_latest=0
+fork_session=0
+for arg in "$@"; do
+    if [[ "$expect_session_id" == "1" ]]; then
+        session_id="$arg"
+        expect_session_id=0
+        continue
+    fi
+    if [[ "$expect_resume_id" == "1" ]]; then
+        if [[ "$arg" != -* ]]; then resume_id="$arg"; fi
+        expect_resume_id=0
+        continue
+    fi
+    case "$arg" in
+        --session-id=*) session_id="${arg#--session-id=}" ;;
+        --session-id|-s) expect_session_id=1 ;;
+        --resume=*) resume_id="${arg#--resume=}" ;;
+        -r=*) resume_id="${arg#-r=}" ;;
+        --resume|-r) expect_resume_id=1 ;;
+        --continue|-c) continue_latest=1 ;;
+        --fork-session) fork_session=1 ;;
+    esac
+done
+
+capture_id=""
+injected_id=0
+if [[ "$fork_session" == "1" && -n "$session_id" ]] && is_uuid "$session_id"; then
+    capture_id="$session_id"
+elif [[ -n "$resume_id" ]] && is_uuid "$resume_id"; then
+    capture_id="$resume_id"
+elif [[ -n "$session_id" ]] && is_uuid "$session_id"; then
+    capture_id="$session_id"
+elif [[ "$continue_latest" == "0" && "$expect_resume_id" == "0"
+        && -z "$resume_id" && -z "$session_id" ]]; then
+    capture_id="$(/usr/bin/uuidgen)"
+    injected_id=1
+fi
+
+if [[ -n "$c11_bin" ]]; then
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" set-agent --type grok \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+fi
+
+if [[ -n "$c11_bin" && -n "$capture_id" ]]; then
+    wrapped_pid="$$"
+    (
+        sessions_root="${HOME}/.grok/sessions"
+        while /bin/kill -0 "$wrapped_pid" >/dev/null 2>&1; do
+            session_dir="$(/usr/bin/find "$sessions_root" -type d -name "$capture_id" -print -quit 2>/dev/null || true)"
+            if [[ -n "$session_dir" && -d "$session_dir" ]]; then
+                payload_dir="$(/usr/bin/mktemp -d /tmp/c11-grok-capture.XXXXXX 2>/dev/null || true)"
+                payload_file="${payload_dir}/payload.json"
+                if [[ -n "$payload_dir" ]] \
+                    && /usr/bin/plutil -create xml1 "$payload_file" >/dev/null 2>&1 \
+                    && /usr/bin/plutil -insert session_directory_path -string "$session_dir" "$payload_file" >/dev/null 2>&1 \
+                    && /usr/bin/plutil -convert json "$payload_file" >/dev/null 2>&1; then
+                    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+                        "$c11_bin" --socket "${CMUX_SOCKET_PATH}" \
+                        conversation push --kind grok --id "$capture_id" \
+                        --source hook --state alive --cwd "$PWD" \
+                        --reason "grok persisted exact injected session" \
+                        --payload "@${payload_file}" \
+                        >/dev/null 2>&1
+                fi
+                if [[ -n "$payload_dir" ]]; then
+                    /bin/unlink "$payload_file" >/dev/null 2>&1 || true
+                    /bin/rmdir "$payload_dir" >/dev/null 2>&1 || true
+                fi
+                exit 0
+            fi
+            /bin/sleep 0.25
+        done
+    ) &
+    disown 2>/dev/null || true
+fi
+
+if [[ "$injected_id" == "1" ]]; then
+    exec "$REAL_GROK" --session-id "$capture_id" "$@"
+fi
+exec "$REAL_GROK" "$@"

--- a/Resources/bin/omp
+++ b/Resources/bin/omp
@@ -5,25 +5,19 @@
 # this wrapper:
 #   1. declares the surface as terminal_type=omp (sidebar chip / role hint),
 #      and
-#   2. wrapper-claims a placeholder ConversationRef so c11's conversation
-#      store records a post-launch claim time before omp creates its
-#      session file. The OmpStrategy's pull-scrape on next workspace open
-#      then keeps only candidates whose mtime is >= that claim time, which
-#      floors out the older sessions that accumulate in a cwd's slug dir
-#      (`~/.omp/agent/sessions/<slug>/`) so exact resume resolves *this*
-#      pane's session instead of going ambiguous.
+#   2. wrapper-claims a placeholder ConversationRef at launch, and
+#   3. watches OMP's tty-scoped pointer until its JSONL actually exists,
+#      then pushes the exact UUID, effective cwd, and path as causal evidence.
 #
 # Outside c11 (or when the socket is unreachable), it passes through to the
 # real omp binary unchanged.
 #
-# === Why this exists (the "pi fails, omp passes" resume bug) =================
-# omp resumes scrape-primary, exactly like pi: c11 resolves the real session
-# id at restore time from the cwd's slug dir, and omp exposes no SessionStart
-# hook to learn the id while it runs. Without a wrapper-claim the restore
-# scrape has no time floor, so a cwd with more than one omp session resolves
-# to state=unknown and resume SKIPS. omp happened to pass the staging smoke
-# because its slug dirs usually hold one session, but it carries the same
-# latent bug pi hit; this wrapper gives omp the codex-style time floor too.
+# === Why this exists ==========================================================
+# OMP can move an interactive session away from the shell's cwd (for example
+# from $HOME to /tmp), so a later cwd scrape can miss the session even after it
+# has persisted. OMP's tty pointer identifies the exact effective cwd and JSONL
+# without reading transcript bytes. The placeholder remains the conservative
+# fallback when no message ever creates that durable file.
 #
 # See `Resources/bin/claude` for the reference implementation of the
 # session-resume wrapper pattern and the four constraints all wrappers
@@ -99,10 +93,9 @@ c11_bin="$self_dir/c11"
 [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
 
 # (1) Mark the surface as terminal_type=omp (sidebar chip / role hint).
-# (2) Wrapper-claim a placeholder ConversationRef so the conversation store
-#     records a post-launch claim time. Idempotent: a second invocation in
-#     the same surface cannot regress a real id back to a placeholder
-#     (ConversationStore.claim never displaces a non-wrapperClaim source).
+# (2) Keep the placeholder claim until OMP has persisted a real session.
+# (3) Watch its own tty pointer and push only after the JSONL exists. Empty
+#     sessions deliberately remain placeholders and are not resumable.
 #
 # Both run in the background so omp startup latency is unaffected; `disown`
 # so a stale write can't keep the wrapper process alive after `exec` (moot
@@ -122,6 +115,81 @@ if [[ -n "$c11_bin" ]]; then
             >/dev/null 2>&1
     ) &
     disown 2>/dev/null || true
+
+    tty_path="$(/usr/bin/tty 2>/dev/null || true)"
+    tty_name=""
+    if [[ "$tty_path" == /dev/* ]]; then
+        tty_name="${tty_path##*/}"
+    fi
+    omp_agent_dir="${PI_CODING_AGENT_DIR:-${HOME}/.omp/agent}"
+    pointer_file="${omp_agent_dir}/terminal-sessions/${tty_name}"
+    old_session_path=""
+    if [[ -n "$tty_name" && -f "$pointer_file" ]]; then
+        old_session_path="$(/usr/bin/sed -n '2p' "$pointer_file" 2>/dev/null || true)"
+    fi
+
+    expected_resume_id=""
+    expect_resume_value=0
+    for arg in "$@"; do
+        if [[ "$expect_resume_value" == "1" ]]; then
+            expected_resume_id="$arg"
+            expect_resume_value=0
+            continue
+        fi
+        case "$arg" in
+            --resume=*) expected_resume_id="${arg#--resume=}" ;;
+            -r=*) expected_resume_id="${arg#-r=}" ;;
+            --resume|-r) expect_resume_value=1 ;;
+        esac
+    done
+
+    if [[ -n "$tty_name" ]]; then
+        wrapped_pid="$$"
+        (
+            while /bin/kill -0 "$wrapped_pid" >/dev/null 2>&1; do
+                if [[ -f "$pointer_file" ]]; then
+                    effective_cwd="$(/usr/bin/sed -n '1p' "$pointer_file" 2>/dev/null || true)"
+                    session_path="$(/usr/bin/sed -n '2p' "$pointer_file" 2>/dev/null || true)"
+                    session_file="${session_path##*/}"
+                    session_stem="${session_file%.jsonl}"
+                    session_id="${session_stem##*_}"
+                    pointer_is_current=0
+                    if [[ -n "$expected_resume_id" && "$session_id" == "$expected_resume_id" ]]; then
+                        pointer_is_current=1
+                    elif [[ -z "$expected_resume_id" && -n "$session_path" && "$session_path" != "$old_session_path" ]]; then
+                        pointer_is_current=1
+                    fi
+                    if [[ "$pointer_is_current" == "1"
+                          && "$session_path" == *.jsonl
+                          && -f "$session_path"
+                          && "$session_id" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+                        payload_dir="$(/usr/bin/mktemp -d /tmp/c11-omp-capture.XXXXXX 2>/dev/null || true)"
+                        payload_file="${payload_dir}/payload.json"
+                        if [[ -n "$payload_dir" ]] \
+                            && /usr/bin/plutil -create xml1 "$payload_file" >/dev/null 2>&1 \
+                            && /usr/bin/plutil -insert session_file_path -string "$session_path" "$payload_file" >/dev/null 2>&1 \
+                            && /usr/bin/plutil -convert json "$payload_file" >/dev/null 2>&1; then
+                            CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+                                "$c11_bin" --socket "${CMUX_SOCKET_PATH}" \
+                                conversation push --kind omp --id "$session_id" \
+                                --source hook --state alive \
+                                --cwd "${effective_cwd:-$PWD}" \
+                                --reason "omp persisted exact tty session" \
+                                --payload "@${payload_file}" \
+                                >/dev/null 2>&1
+                        fi
+                        if [[ -n "$payload_dir" ]]; then
+                            /bin/unlink "$payload_file" >/dev/null 2>&1 || true
+                            /bin/rmdir "$payload_dir" >/dev/null 2>&1 || true
+                        fi
+                        exit 0
+                    fi
+                fi
+                /bin/sleep 0.25
+            done
+        ) &
+        disown 2>/dev/null || true
+    fi
 fi
 
 exec "$REAL_OMP" "$@"

--- a/Sources/AgentManifest.swift
+++ b/Sources/AgentManifest.swift
@@ -303,6 +303,10 @@ struct AgentRegistry: Sendable {
             detectNodeArgsSubstrings: [],
             iconAsset: "AgentIcons/grok",
             sfSymbolFallback: "bolt.fill",
+            // Resources/bin/grok injects a UUID but publishes it only after
+            // the first message creates a durable session directory. The
+            // conversation strategy then resumes that exact UUID. Keep this
+            // no-id command only for the legacy disabled-store path.
             resume: .fixed("grok --always-approve --resume\n"),
             launch: AgentLaunchTemplate(
                 modelArg: .flag("--model"),
@@ -422,13 +426,10 @@ struct AgentRegistry: Sendable {
             detectNodeArgsSubstrings: ["@oh-my-pi/"],
             iconAsset: nil,
             sfSymbolFallback: "o.circle",
-            // Exact-session resume via the conversation rail: the omp wrapper
-            // (`Resources/bin/omp`) mints a wrapper-claim whose time floor lets
-            // `OmpScraper` (JSONL metadata over ~/.omp/agent/sessions/) feed
-            // `OmpStrategy`, which emits `omp --resume='<id>'`. No fixed-command
-            // fallback exists for the legacy `resume` path (the TUI offers
-            // `/resume` only), so `resume` stays `.none` while the strategy owns
-            // exact resume — same split as the codex row.
+            // Exact-session resume via the conversation rail: after the first
+            // message persists, Resources/bin/omp reads OMP's tty pointer and
+            // pushes the exact JSONL path + UUID to OmpStrategy, which emits
+            // `omp --resume='<id>'`. Empty sessions remain placeholders.
             resume: .none,
             launch: AgentLaunchTemplate(
                 modelArg: .flag("--model"),

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2271,6 +2271,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// would masquerade as the prior shutdown — so the capture must be armed
     /// from whichever path runs first.
     private var didArmShutdownSentinel = false
+    private var resolvedResumeRecoveryMode: ResumeRecoveryMode?
+    private var didEmitResolvedResumeRecoveryMode = false
     private var didAttemptStartupSessionRestore = false
     private var isApplyingStartupSessionRestore = false
     private var sessionAutosaveTimer: DispatchSourceTimer?
@@ -2470,6 +2472,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ShutdownSentinel.writeDirty(bundleId: bundleId)
     }
 
+    private func recordResolvedResumeRecoveryMode(_ mode: ResumeRecoveryMode) {
+        resolvedResumeRecoveryMode = mode
+        guard !didEmitResolvedResumeRecoveryMode else { return }
+        didEmitResolvedResumeRecoveryMode =
+            EventEmitter.shared.emitConversationResumeMode(mode)
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         mirrorC11CmuxEnv()
 
@@ -2477,6 +2486,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // recreates workspaces/surfaces — so surface.created and the
         // log.opened marker land from the first instant (amendment K).
         EventEmitter.shared.start()
+        if let resolvedResumeRecoveryMode {
+            recordResolvedResumeRecoveryMode(resolvedResumeRecoveryMode)
+        }
 
         // C11-24/C11-131: capture the prior-shutdown decision and arm this
         // run's dirty sentinel as early as possible — before any potential
@@ -3267,7 +3279,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // prior-shutdown decision, not the default `.missing`, before the
         // dirty-recovery branch below consumes it. Idempotent.
         armShutdownSentinelIfNeeded()
-        guard SessionRestorePolicy.shouldAttemptRestore() else { return }
+        guard SessionRestorePolicy.shouldAttemptRestore() else {
+            recordResolvedResumeRecoveryMode(.noResume)
+            return
+        }
         let snapshot = SessionPersistenceStore.load()
         startupSessionSnapshot = snapshot
 
@@ -3285,6 +3300,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             explicitNoResume: explicitNoResume,
             priorShutdown: priorShutdownAtLaunch
         )
+        recordResolvedResumeRecoveryMode(mode)
         let epoch = ResumeStartupEpochGate.shared.begin(mode: mode)
 
         guard let snapshot, !ConversationStorePolicy.isDisabled else {

--- a/Sources/CLIResolutionSnapshot.swift
+++ b/Sources/CLIResolutionSnapshot.swift
@@ -51,6 +51,7 @@ public struct ResumeCommand: Sendable, Equatable {
 public enum ResumeSkipCode: String, Codable, Sendable, Equatable {
     case policyNoResume = "policy-no-resume"
     case startupUnaudited = "startup-unaudited"
+    case conversationUnavailable = "conversation-unavailable"
     case duplicateOwnership = "duplicate-ownership"
     case ambiguousOwnership = "ambiguous-ownership"
     case ownershipUnaudited = "ownership-unaudited"

--- a/Sources/Conversation/Strategies/Grok.swift
+++ b/Sources/Conversation/Strategies/Grok.swift
@@ -1,22 +1,20 @@
 import Foundation
 
-/// Best-effort resume strategy for Grok Build. Grok exposes `grok --resume`
-/// (no id) to attach to the most recent session globally, but ships no
-/// SessionStart hook and no verified per-session transcript path c11 can
-/// scrape. So capture is fresh-launch-only — it acts on a hook/manual push
-/// or a wrapper-claim placeholder, same shape as Kimi/Opencode in v1.
-///
-/// When a non-placeholder ref does exist (alive/suspended), `resume()` types
-/// the best-effort `grok --always-approve --resume`, mirroring the
-/// `AgentRestartRegistry.phase1` fallback row. The command carries no
-/// interpolated id, so there is no untrusted-input surface to shell-quote.
+/// Exact resume strategy for durable Grok Build sessions. The c11 PATH wrapper
+/// injects a UUID for new sessions but pushes it only after Grok creates that
+/// UUID's session directory (the first real message). Empty sessions remain
+/// uncaptured. Restore always names the exact UUID, never "most recent".
 struct GrokStrategy: ConversationStrategy {
     let kind: String = "grok"
+    static let sessionDirectoryPayloadKey = "session_directory_path"
 
     init() {}
 
     func capture(inputs: ConversationStrategyInputs) -> ConversationRef? {
-        if let push = inputs.push, !push.placeholder {
+        if let push = inputs.push,
+           !push.placeholder,
+           push.capturedVia.isCausal,
+           isValidConversationUUID(push.id) {
             return push
         }
         return inputs.wrapperClaim
@@ -26,13 +24,29 @@ struct GrokStrategy: ConversationStrategy {
         if ref.placeholder {
             return .skip(reason: "fresh-launch-only")
         }
-        switch ref.state {
-        case .alive, .suspended:
-            // grok --resume (no id) attaches to the most recent session.
-            // Best-effort: may not match the exact session in the snapshot.
-            return .typeCommand(text: "grok --always-approve --resume", submitWithReturn: true)
-        default:
+        guard ref.state == .alive || ref.state == .suspended else {
             return .skip(reason: "state=\(ref.state.rawValue) not auto-resumable")
         }
+        guard isValidConversationUUID(ref.id) else {
+            return .skip(reason: "invalid id grammar")
+        }
+        return .typeCommand(
+            text: "grok --always-approve --resume \(conversationShellQuote(ref.id))",
+            submitWithReturn: true
+        )
+    }
+
+    func isValidId(_ id: String) -> Bool {
+        isValidConversationUUID(id)
+    }
+
+    func transcriptExists(
+        for ref: ConversationRef,
+        filesystem: ConversationFilesystem
+    ) -> Bool? {
+        guard isValidConversationUUID(ref.id) else { return false }
+        guard case .string(let path)? = ref.payload?[Self.sessionDirectoryPayloadKey],
+              !path.isEmpty else { return nil }
+        return filesystem.fileExists(atPath: path)
     }
 }

--- a/Sources/Conversation/Strategies/Omp.swift
+++ b/Sources/Conversation/Strategies/Omp.swift
@@ -1,14 +1,12 @@
 import Foundation
 
-/// Pull-primary strategy for oh-my-pi (`omp`). Like codex, omp exposes no
-/// session-id injection flag and no SessionStart hook, so the c11 omp wrapper
-/// (`Resources/bin/omp`) mints a placeholder wrapper-claim at launch; the
-/// scraper resolves the real id from
-/// `~/.omp/agent/sessions/<cwd-slug>/<ts>_<uuid>.jsonl` (id = the trailing
-/// UUIDv7), filtered by cwd, mtime ≥ wrapper-claim time, and mtime ≥ surface
-/// `lastActivityTimestamp`. The claim time floors out the older sessions a
-/// cwd accumulates so resume resolves this pane's session instead of going
-/// `.unknown` (the same latent bug pi hit; see `Resources/bin/omp`).
+/// Causal-primary strategy for oh-my-pi (`omp`). OMP writes a tty-scoped
+/// pointer under `~/.omp/agent/terminal-sessions/` containing the effective
+/// cwd and exact session JSONL path. Once that JSONL exists (after the first
+/// real message), the c11 wrapper pushes its UUIDv7 and exact path as hook
+/// evidence. This remains correct when OMP refuses `$HOME` and moves to `/tmp`.
+///
+/// The older cwd scraper remains as a compatibility fallback.
 ///
 /// Ambiguity policy (mirrors `CodexStrategy`): when more than one candidate
 /// matches the surface filter, return a ref with `state = .unknown`,
@@ -22,10 +20,18 @@ import Foundation
 /// `<ts>_<uuid>.jsonl` filename, so `resume`/`capture` receive a clean id).
 struct OmpStrategy: ConversationStrategy {
     let kind: String = "omp"
+    static let sessionFilePayloadKey = "session_file_path"
 
     init() {}
 
     func capture(inputs: ConversationStrategyInputs) -> ConversationRef? {
+        if let push = inputs.push,
+           !push.placeholder,
+           push.capturedVia.isCausal,
+           isValidConversationUUID(push.id) {
+            return push
+        }
+
         // Filter the candidates by what we know about the surface.
         let activityFloor = inputs.lastActivityTimestamp
         let claimTime = inputs.wrapperClaim?.capturedAt
@@ -112,6 +118,10 @@ struct OmpStrategy: ConversationStrategy {
         filesystem: ConversationFilesystem
     ) -> Bool? {
         guard isValidConversationUUID(ref.id) else { return false }
+        if case .string(let path)? = ref.payload?[Self.sessionFilePayloadKey],
+           !path.isEmpty {
+            return filesystem.fileExists(atPath: path)
+        }
         return OmpScraper(filesystem: filesystem)
             .candidates(cwd: ref.cwd)
             .contains { $0.id == ref.id }

--- a/Sources/Events/EventEmitter.swift
+++ b/Sources/Events/EventEmitter.swift
@@ -179,18 +179,64 @@ final class EventEmitter {
         )
     }
 
+    /// Records the recovery policy selected for this launch before any
+    /// per-surface decisions are evaluated. Returns false when the event log
+    /// has not started yet so AppDelegate can retry after launch setup.
+    @discardableResult
+    func emitConversationResumeMode(_ mode: ResumeRecoveryMode) -> Bool {
+        emit(.conversationResumeMode, payload: ["mode": mode.rawValue])
+    }
+
+    /// One durable outcome for each restored agent candidate. The command
+    /// itself is intentionally excluded: the kind + exact conversation id
+    /// identify the target without duplicating shell text in diagnostics.
+    @discardableResult
+    func emitConversationResumeDecision(
+        workspace: UUID,
+        surface: UUID,
+        kind: String,
+        conversationId: String?,
+        mode: ResumeRecoveryMode,
+        decision: ResumeDecision
+    ) -> Bool {
+        var payload: [String: Any] = [
+            "kind": kind,
+            "conversation_id": conversationId ?? NSNull(),
+            "mode": mode.rawValue,
+        ]
+        switch decision {
+        case .command:
+            payload["decision"] = "command"
+            payload["skip_code"] = NSNull()
+        case .skip(let code, let reason):
+            payload["decision"] = "skip"
+            payload["skip_code"] = code.rawValue
+            payload["reason"] = reason
+        }
+        return emit(
+            .conversationResumeDecision,
+            workspace: workspace,
+            surface: surface,
+            payload: payload
+        )
+    }
+
     // MARK: - Core
 
+    @discardableResult
     private func emit(
         _ type: EventEnvelope.EventType,
         workspace: UUID? = nil,
         surface: UUID? = nil,
         pane: UUID? = nil,
         payload: [String: Any] = [:]
-    ) {
+    ) -> Bool {
         // Capture ts + snapshot the log under the lock; build + append outside.
         lock.lock()
-        guard enabled, let log else { lock.unlock(); return }
+        guard enabled, let log else {
+            lock.unlock()
+            return false
+        }
         let instance = instanceId
         lock.unlock()
 
@@ -204,6 +250,7 @@ final class EventEmitter {
             payload: payload
         )
         log.append(envelope)
+        return true
     }
 
     private func currentLog() -> EventLog? {

--- a/Sources/Events/EventEnvelope.swift
+++ b/Sources/Events/EventEnvelope.swift
@@ -52,6 +52,8 @@ struct EventEnvelope {
         case waitingLeft = "waiting.left"
         case mailboxAccepted = "mailbox.accepted"
         case mailboxDelivered = "mailbox.delivered"
+        case conversationResumeMode = "conversation.resume.mode"
+        case conversationResumeDecision = "conversation.resume.decision"
         // Stream-control markers:
         case logOpened = "log.opened"
         case logRotated = "log.rotated"

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -491,9 +491,39 @@ extension Workspace {
             guard panelSnapshot.type == .terminal else { continue }
             let key = panelSnapshot.id.uuidString
             guard let surface = storeSnapshot[key], let ref = surface.active else {
+                let persistedRef = panelSnapshot.surfaceConversations?.active
+                let metadataKind = Self.stringValues(from: panelSnapshot.metadata)[
+                    SurfaceMetadataKeyName.terminalType
+                ]?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let kind = persistedRef?.kind ?? metadataKind,
+                   !kind.isEmpty,
+                   registry.contains(kind: kind) {
+                    EventEmitter.shared.emitConversationResumeDecision(
+                        workspace: id,
+                        surface: panelSnapshot.id,
+                        kind: kind,
+                        conversationId: persistedRef?.id,
+                        mode: startup.mode,
+                        decision: .skip(
+                            code: .conversationUnavailable,
+                            reason: "no active conversation in restore store"
+                        )
+                    )
+                }
                 continue
             }
             guard let strategy = registry.strategy(forKind: ref.kind) else {
+                EventEmitter.shared.emitConversationResumeDecision(
+                    workspace: id,
+                    surface: panelSnapshot.id,
+                    kind: ref.kind,
+                    conversationId: ref.id,
+                    mode: startup.mode,
+                    decision: .skip(
+                        code: .strategyUnavailable,
+                        reason: "no registered resume strategy for kind \(ref.kind)"
+                    )
+                )
                 continue
             }
             let strategyAction = strategy.resume(ref: ref)
@@ -516,6 +546,14 @@ extension Workspace {
                 diagnosticReason: ref.diagnosticReason,
                 fallbackCommand: fallbackCommand
             ))
+            EventEmitter.shared.emitConversationResumeDecision(
+                workspace: id,
+                surface: panelSnapshot.id,
+                kind: ref.kind,
+                conversationId: ref.id,
+                mode: startup.mode,
+                decision: decision
+            )
             guard case .command(let command) = decision else { continue }
             result.append((
                 panelId: panelSnapshot.id,

--- a/c11Tests/ConversationStrategyTests.swift
+++ b/c11Tests/ConversationStrategyTests.swift
@@ -275,11 +275,11 @@ final class ConversationStrategyTests: XCTestCase {
 
     // MARK: - Grok strategy
 
-    func testGrokAliveTypesBestEffortResume() {
+    func testGrokAliveTypesExactResume() {
         let strategy = GrokStrategy()
         let ref = ConversationRef(
             kind: "grok",
-            id: "real-id",
+            id: validUUID,
             placeholder: false,
             capturedAt: Date(),
             capturedVia: .hook,
@@ -289,7 +289,10 @@ final class ConversationStrategyTests: XCTestCase {
             XCTFail("expected typeCommand")
             return
         }
-        XCTAssertEqual(text, "grok --always-approve --resume")
+        XCTAssertEqual(
+            text,
+            "grok --always-approve --resume '\(validUUID)'"
+        )
         XCTAssertTrue(submit)
     }
 

--- a/c11Tests/EventLogTests.swift
+++ b/c11Tests/EventLogTests.swift
@@ -214,6 +214,63 @@ final class EventLogTests: XCTestCase {
         XCTAssertEqual(payload?["scope"] as? String, "surface")
     }
 
+    func testEmitterRecordsResumeModeAndTypedDecisions() {
+        let log = EventLog(url: logURL(), instance: "resume-inst")
+        EventEmitter.shared.startForTesting(log: log, instance: "resume-inst")
+        let ws = UUID()
+        let skippedSurface = UUID()
+        let commandSurface = UUID()
+
+        XCTAssertTrue(EventEmitter.shared.emitConversationResumeMode(.dirty))
+        XCTAssertTrue(EventEmitter.shared.emitConversationResumeDecision(
+            workspace: ws,
+            surface: skippedSurface,
+            kind: "claude-code",
+            conversationId: "abc12345-ef67-890a-bcde-f0123456789a",
+            mode: .dirty,
+            decision: .skip(
+                code: .transcriptMissing,
+                reason: "transcript not found"
+            )
+        ))
+        XCTAssertTrue(EventEmitter.shared.emitConversationResumeDecision(
+            workspace: ws,
+            surface: commandSurface,
+            kind: "opencode",
+            conversationId: "ses_example",
+            mode: .dirty,
+            decision: .command(ResumeCommand(text: "not persisted"))
+        ))
+        EventEmitter.shared.flush()
+
+        let events = readLines(logURL()).map(parse)
+        XCTAssertEqual(events.count, 3)
+
+        XCTAssertEqual(events[0]["type"] as? String, "conversation.resume.mode")
+        let modePayload = events[0]["payload"] as? [String: Any]
+        XCTAssertEqual(modePayload?["mode"] as? String, "dirty")
+
+        XCTAssertEqual(events[1]["type"] as? String, "conversation.resume.decision")
+        XCTAssertEqual(events[1]["workspace"] as? String, ws.uuidString)
+        XCTAssertEqual(events[1]["surface"] as? String, skippedSurface.uuidString)
+        let skipPayload = events[1]["payload"] as? [String: Any]
+        XCTAssertEqual(skipPayload?["kind"] as? String, "claude-code")
+        XCTAssertEqual(
+            skipPayload?["conversation_id"] as? String,
+            "abc12345-ef67-890a-bcde-f0123456789a"
+        )
+        XCTAssertEqual(skipPayload?["mode"] as? String, "dirty")
+        XCTAssertEqual(skipPayload?["decision"] as? String, "skip")
+        XCTAssertEqual(skipPayload?["skip_code"] as? String, "transcript-missing")
+        XCTAssertEqual(skipPayload?["reason"] as? String, "transcript not found")
+
+        XCTAssertEqual(events[2]["surface"] as? String, commandSurface.uuidString)
+        let commandPayload = events[2]["payload"] as? [String: Any]
+        XCTAssertEqual(commandPayload?["decision"] as? String, "command")
+        XCTAssertTrue(commandPayload?["skip_code"] is NSNull)
+        XCTAssertNil(commandPayload?["command"], "resume command text must not be logged")
+    }
+
     // MARK: - C11-171: set_status mirror emits metadata.changed via the store
 
     /// The set_status fast path mirrors a canonical `status` write into the

--- a/c11Tests/OmpConversationTests.swift
+++ b/c11Tests/OmpConversationTests.swift
@@ -223,6 +223,24 @@ final class OmpConversationTests: XCTestCase {
         XCTAssertFalse(ref?.placeholder ?? true)
     }
 
+    func testOmpPersistedPointerPushWinsOverMismatchedCwdScrape() {
+        let exactPath = "/Users/test/.omp/agent/sessions/--private-tmp--/session_\(v7Id).jsonl"
+        let push = ConversationRef(
+            kind: "omp", id: v7Id, cwd: "/tmp",
+            capturedAt: Date(), capturedVia: .hook, state: .alive,
+            payload: [OmpStrategy.sessionFilePayloadKey: .string(exactPath)]
+        )
+        let captured = OmpStrategy().capture(inputs: ConversationStrategyInputs(
+            surfaceId: "surface:1",
+            cwd: "/Users/test",
+            push: push,
+            scrapeCandidates: [
+                candidate(id: v7Id2, mtime: Date(), cwd: "/Users/test")
+            ]
+        ))
+        XCTAssertEqual(captured, push)
+    }
+
     func testOmpResumeEmitsResumeFlagWithSpecificId() {
         let strategy = OmpStrategy()
         let ref = ConversationRef(
@@ -341,6 +359,21 @@ final class OmpConversationTests: XCTestCase {
         XCTAssertEqual(strategy.transcriptExists(for: present, filesystem: mock), true)
         let absent = ConversationRef(kind: "omp", id: v7Id2, placeholder: false, cwd: cwd, capturedVia: .scrape, state: .suspended)
         XCTAssertEqual(strategy.transcriptExists(for: absent, filesystem: mock), false)
+    }
+
+    func testOmpTranscriptExistsStatsExactPointerPath() {
+        let mock = MockFS()
+        let exactPath = "/Users/test/.omp/agent/sessions/--private-tmp--/session_\(v7Id).jsonl"
+        mock.existingPaths.insert(exactPath)
+        let ref = ConversationRef(
+            kind: "omp", id: v7Id, placeholder: false, cwd: "/tmp",
+            capturedVia: .hook, state: .alive,
+            payload: [OmpStrategy.sessionFilePayloadKey: .string(exactPath)]
+        )
+        XCTAssertEqual(
+            OmpStrategy().transcriptExists(for: ref, filesystem: mock),
+            true
+        )
     }
 
     // MARK: - Registry wiring

--- a/skills/c11/references/conversation.md
+++ b/skills/c11/references/conversation.md
@@ -74,9 +74,9 @@ Reconciliation first respects evidence strength: causal `runtimeEnv`/hook identi
 | `claude-code` | Strong (push-id deterministic) | SessionStart hook → `c11 conversation push`. Pull-scrape `~/.claude/projects/<cwd-slug>/` is the fallback when the hook was missed. | `claude --dangerously-skip-permissions --resume <id>` (id shell-quoted) |
 | `codex` | Exact, causal | Before its expiry-bounded claim, the wrapper atomically writes a c11-owned per-surface launch-boundary marker beside the active socket. The marker survives acknowledged and failed/expired claims so a crash before autosave cannot expose the older on-disk owner. The listener records its actual post-fallback socket path per bundle, allowing startup to find that marker before the new listener binds. Marker replay is retained intentionally and is harmless after a durable placeholder or newer runtime capture; the next launch overwrites it. The running target executes `capture-runtime`, which records its exact `CODEX_THREAD_ID`. `CodexScraper` remains a conservative crash fallback when causal capture was missed. | `codex resume <id>` (specific id; never `--last`) |
 | `pi` | Exact, ambiguity-aware | Wrapper-claim placeholder → `PiScraper` resolves the real id from the cwd slug dir, claim-time + activity floors narrowing past stale sessions. | `pi --session '<id>'` (specific id) |
-| `omp` | Exact, ambiguity-aware | Wrapper-claim placeholder → `OmpScraper` resolves the real id from the cwd slug dir, claim-time + activity floors. | `omp --resume='<id>'` (specific id) |
+| `omp` | Exact, causal after persistence | Wrapper watches OMP's tty pointer and, once the first message creates its JSONL, pushes the exact UUID, effective cwd, and path. The cwd scraper remains a legacy fallback. Empty sessions stay placeholders. | `omp --resume='<id>'` (specific id) |
 | `opencode` | Push (plugin rail) | Plugin-emitted push of the real id. No scraper in the pull registry. | `cd '<dir>' && opencode -s <id>` — `.skip` for placeholders |
-| `grok` | Best-effort resume | Wrapper-claim placeholder | `grok --always-approve --resume` (no id) — `.skip` for placeholders |
+| `grok` | Exact after persistence | PATH wrapper injects a UUID, then pushes it with the exact session directory after the first message persists. Empty sessions remain uncaptured. | `grok --always-approve --resume '<id>'` |
 | `kimi` | Fresh-launch only | Wrapper-claim placeholder | `kimi` (process launch) — `.skip` for placeholders |
 | `github-copilot` | Fresh-launch only | Wrapper-claim placeholder | `copilot` (process launch) — `.skip` for placeholders |
 
@@ -91,8 +91,10 @@ The forced-kill (`kill -9`) path is a first-class, tested guarantee as of the Tr
 The contract: after a crash, **every conversation either resumes exactly per its kind's tier, or the surface carries an honest, specific `diagnostic_reason`.** There are no silent fresh-launches presented as resumes.
 
 - **claude-code** — resumes when the hook-captured (or scrape-recovered) id has a transcript on disk; otherwise `transcript not found`.
-- **codex / pi / omp** — the scraper resolves the placeholder to the real id at restore, then reclassify verifies it. A surface whose session file is absent stays a placeholder and simply skips (no wrong resume).
-- **opencode / grok / kimi / github-copilot** — no exact-resume rail; a fresh launch is the honest outcome (placeholders skip).
+- **codex / pi** — the scraper resolves the placeholder to the real id at restore, then reclassify verifies it. A surface whose session file is absent stays a placeholder and simply skips (no wrong resume).
+- **omp / grok** — their PATH wrappers publish exact causal identity only after the first message creates the durable JSONL/session directory. Dirty restore stats that exact payload path. An empty session never reaches this tier and skips.
+- **opencode** — the plugin pushes exact identity; restore resumes that id.
+- **kimi / github-copilot** — no exact-resume rail; a fresh launch is the honest outcome (placeholders skip).
 
 ### Codex real-cwd disambiguation
 
@@ -106,7 +108,7 @@ The per-surface **activity floor** (`SurfaceActivityTracker`, persisted in the s
 ## Wrapper-claim flow (TUI integrators)
 
 ```bash
-# Pseudo-shape; real wrappers stay bash. See Resources/bin/{claude,codex,pi,omp}.
+# Pseudo-shape; real wrappers stay bash. See Resources/bin/{claude,codex,pi,omp,grok}.
 1. Detect c11 environment (CMUX_SURFACE_ID + live socket). Pass through if absent.
 2. For Codex, synchronously run `conversation claim ... --ttl-ms <short-bound>`.
    The server checks the absolute expiry at the store mutation boundary.

--- a/skills/c11/references/events.md
+++ b/skills/c11/references/events.md
@@ -41,7 +41,7 @@ Every line is a flat JSON object. Five fields are required; the subject refs and
 
 ## v1 taxonomy
 
-The nine taxonomy types below are the closed v1 enum. `workspace` / `surface` / `pane` mark which subject refs are populated; `payload` shows the type-specific shape.
+The eleven taxonomy types below are the closed v1 enum. `workspace` / `surface` / `pane` mark which subject refs are populated; `payload` shows the type-specific shape.
 
 | `type` | Subject refs | Payload | Notes |
 |--------|--------------|---------|-------|
@@ -54,6 +54,8 @@ The nine taxonomy types below are the closed v1 enum. `workspace` / `surface` / 
 | `waiting.left` | workspace (= tabId) + surface? | — | Paired exit edge for `waiting.entered`. |
 | `mailbox.accepted` | workspace | `{id, from, to?, topic?}` | A mailbox message was accepted onto the bus. |
 | `mailbox.delivered` | workspace + surface? | `{id, recipient}` | A mailbox message reached a recipient. |
+| `conversation.resume.mode` | — | `{mode}` | The resolved recovery mode (`clean`, `dirty`, or `no-resume`) once per app launch. |
+| `conversation.resume.decision` | workspace + surface | `{kind, conversation_id, mode, decision, skip_code, reason?}` | One outcome for each restored agent candidate. `decision` is `command` or `skip`; `skip_code` is null for a command. |
 
 ## Stream-control markers
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -17,7 +17,7 @@ where `<instance>` is the per-process instance id (e.g. `com.stage11.c11-12345`)
 
 - `seq` is an integer ≥ 0 — the monotonic per-instance sequence number.
 - `ts` is an RFC3339 / ISO-8601 UTC timestamp with `Z` suffix and optional fractional seconds.
-- `type` is one of the closed v1 enum: `surface.created`, `surface.closed`, `workspace.selected`, `metadata.changed`, `liveness.derived`, `waiting.entered`, `waiting.left`, `mailbox.accepted`, `mailbox.delivered`, plus the stream-control markers `log.opened`, `log.rotated`, `log.dropped`.
+- `type` is one of the closed v1 enum: `surface.created`, `surface.closed`, `workspace.selected`, `metadata.changed`, `liveness.derived`, `waiting.entered`, `waiting.left`, `mailbox.accepted`, `mailbox.delivered`, `conversation.resume.mode`, `conversation.resume.decision`, plus the stream-control markers `log.opened`, `log.rotated`, `log.dropped`.
 - `instance` is a non-empty string.
 - `v` is the integer `1`.
 - `workspace`, `surface`, `pane` are optional UUID strings.

--- a/spec/event-envelope.v1.schema.json
+++ b/spec/event-envelope.v1.schema.json
@@ -28,11 +28,13 @@
         "waiting.left",
         "mailbox.accepted",
         "mailbox.delivered",
+        "conversation.resume.mode",
+        "conversation.resume.decision",
         "log.opened",
         "log.rotated",
         "log.dropped"
       ],
-      "description": "Dotted event type. The v1 taxonomy (EVT-2): surface.created, surface.closed, workspace.selected, metadata.changed, liveness.derived, waiting.entered, waiting.left, mailbox.accepted, mailbox.delivered. The trailing three (log.opened, log.rotated, log.dropped) are stream-control markers — not taxonomy members — that let consumers detect instance boundaries, rotation, and backpressure drops. The taxonomy is extensible in future schema versions; v1 pins the closed enum above (all wire values match ^[a-z][a-z0-9_.]*$)."
+      "description": "Dotted event type. The v1 taxonomy (EVT-2): surface.created, surface.closed, workspace.selected, metadata.changed, liveness.derived, waiting.entered, waiting.left, mailbox.accepted, mailbox.delivered, conversation.resume.mode, conversation.resume.decision. The trailing three (log.opened, log.rotated, log.dropped) are stream-control markers — not taxonomy members — that let consumers detect instance boundaries, rotation, and backpressure drops. The taxonomy is extensible in future schema versions; v1 pins the closed enum above (all wire values match ^[a-z][a-z0-9_.]*$)."
     },
     "instance": {
       "type": "string",
@@ -61,7 +63,7 @@
     },
     "payload": {
       "type": "object",
-      "description": "Optional, type-specific detail. Free-form object; any keys allowed inside. Shape is keyed by type — e.g. surface.created carries { kind, title }; metadata.changed carries { key, value, prior, source, scope }; workspace.selected carries { previous }; mailbox.accepted carries { id, from, to, topic }; mailbox.delivered carries { id, recipient }; log.opened carries { pid }; log.rotated carries { rolled_to }; log.dropped carries { count }. Omitted (not encoded as null) when empty."
+      "description": "Optional, type-specific detail. Free-form object; any keys allowed inside. Shape is keyed by type — e.g. surface.created carries { kind, title }; metadata.changed carries { key, value, prior, source, scope }; workspace.selected carries { previous }; mailbox.accepted carries { id, from, to, topic }; mailbox.delivered carries { id, recipient }; conversation.resume.mode carries { mode }; conversation.resume.decision carries { kind, conversation_id, mode, decision, skip_code, reason? }; log.opened carries { pid }; log.rotated carries { rolled_to }; log.dropped carries { count }. Omitted (not encoded as null) when empty."
     }
   },
   "additionalProperties": false

--- a/spec/fixtures/events/valid-conversation-resume-decision.json
+++ b/spec/fixtures/events/valid-conversation-resume-decision.json
@@ -1,0 +1,17 @@
+{
+  "seq": 16,
+  "ts": "2026-07-26T03:10:49.181Z",
+  "type": "conversation.resume.decision",
+  "instance": "resumefix-84906",
+  "v": 1,
+  "workspace": "25D7C803-EA62-4BB7-8253-FB76FB286341",
+  "surface": "F27C88D4-C927-4019-A889-6C6A0F90B3F2",
+  "payload": {
+    "kind": "claude-code",
+    "conversation_id": "e6373b1d-273c-4132-9b86-473cbd08813c",
+    "mode": "dirty",
+    "decision": "skip",
+    "skip_code": "transcript-missing",
+    "reason": "transcript not found"
+  }
+}

--- a/spec/fixtures/events/valid-conversation-resume-mode.json
+++ b/spec/fixtures/events/valid-conversation-resume-mode.json
@@ -1,0 +1,10 @@
+{
+  "seq": 2,
+  "ts": "2026-07-26T03:10:48.883Z",
+  "type": "conversation.resume.mode",
+  "instance": "resumefix-84906",
+  "v": 1,
+  "payload": {
+    "mode": "clean"
+  }
+}


### PR DESCRIPTION
## Summary

- emit durable `conversation.resume.mode` and per-surface `conversation.resume.decision` events, including the resolved recovery mode and stable skip code
- capture OMP's exact UUID, effective cwd, and JSONL path from its tty pointer after the first message persists
- add a c11-scoped Grok wrapper that injects a UUID for new interactive sessions and publishes it only after Grok creates the matching session directory
- resume OMP and Grok by exact id and verify their persisted paths during dirty recovery

Empty/unprompted sessions remain intentionally unsupported. This does not relax Claude Code's transcript gate or add a fresh-launch fallback for transcript-less sessions.

## Corrected experiment

The initial report used never-prompted surfaces, so I reran the experiment with one real Claude Code, OMP, Grok, OpenCode, and Pi surface. Each received:

> Reply with the single word READY. Do not use tools.

All five visibly replied `READY` before the graceful quit.

On the instrumentation-only control build, Claude Code, OpenCode, and Pi resumed. OMP and Grok did not. The new events made the causes explicit:

| Harness | Decision |
|---|---|
| Claude Code | `command` |
| OMP | `skip`, code `placeholder` (`wrapper-claim placeholder`) |
| Grok | `skip`, code `conversation-unavailable` |
| OpenCode | `command` |
| Pi | `command` |

That confirms the Claude behavior in the original report was an empty-session artifact. No Claude behavior change is included here. OMP and Grok still failed after real replies, so those are the two behavior fixes in this PR.

## Process-table evidence

Before graceful quit, scoped to descendants of the tagged `resumefix` app:

```text
92558 84750 ttys013  /Users/atin/.local/bin/claude --session-id fab6911a-7de0-4da9-bd55-7ca18681e83c --settings .../c11-claude-hooks-92558.json
92766 84773 ttys014  /Users/atin/.grok/bin/grok --session-id 3C1F7107-FB3A-4560-A833-A61F274058B3 --always-approve
92895 84802 ttys016  opencode
93019 84830 ttys017  pi
92625 91366 ttys018  bun /Users/atin/.bun/bin/omp
```

After `C11_QA_LAUNCH=resume`, again scoped to descendants of the tagged app:

```text
2352 1580 ttys014  /Users/atin/.local/bin/claude --settings .../c11-claude-hooks-2352.json --dangerously-skip-permissions --resume fab6911a-7de0-4da9-bd55-7ca18681e83c
2392 1586 ttys016  bun /Users/atin/.bun/bin/omp --resume=019f9c92-e89a-7000-a725-9278761532d6
2387 1595 ttys017  /Users/atin/.grok/bin/grok --always-approve --resume 3C1F7107-FB3A-4560-A833-A61F274058B3
2431 1607 ttys018  opencode -s ses_0636ccd6bffezXWW38177WiVxi
2449 1642 ttys019  pi
```

The same restore emitted `mode=clean` plus five `decision=command` records and zero skips.

## Validation

- `C11_QA_LAUNCH=fresh ./scripts/reload.sh --tag resumefix` — `BUILD SUCCEEDED`; tagged socket returned `PONG`
- real five-harness prompt → reply → graceful quit → QA resume cycle — all 5 processes returned
- `xcodebuild ... -scheme c11-logic ... build-for-testing` — `TEST BUILD SUCCEEDED` (compiled tests only; no local test action per repository policy)
- isolated event schema/fixture parity: `3 passed`
- `bash -n Resources/bin/omp Resources/bin/grok`
- tagged bundle copies of both wrappers match source and are executable
- installed c11 skill synced and verified against `skills/c11`
