### PR TITLE
Rebuild agent lifecycle mark vocabulary

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -36333,6 +36333,100 @@
         }
       }
     },
+    "settings.app.staticMarks": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Static marks"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静止マーク"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静态标记"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "靜態標記"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "정적 마크"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статичные метки"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Статичні позначки"
+          }
+        }
+      }
+    },
+    "settings.app.staticMarks.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop normal lifecycle motion. Flagged working and waiting marks remain animated unless Reduce Motion is enabled."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通常のライフサイクルアニメーションを停止します。フラグ付きの「作業中」と「待機中」のマークは、「視差効果を減らす」が有効でない限りアニメーションを続けます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止常规生命周期动画。带旗标的“工作中”和“等待中”标记仍会保持动画，除非启用了“减弱动态效果”。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停止一般的生命週期動畫。帶旗標的「工作中」和「等待中」標記仍會保持動畫，除非已啟用「減少動態效果」。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반적인 라이프사이클 애니메이션을 중지합니다. 플래그가 지정된 작업 중 및 대기 중 마크는 '동작 줄이기'가 켜져 있지 않으면 계속 애니메이션됩니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Останавливает обычную анимацию жизненного цикла. Метки «Работает» и «Ожидает» с флажком продолжают анимироваться, если не включено «Уменьшение движения»."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зупиняє звичайну анімацію життєвого циклу. Позначки «Працює» та «Очікує» з прапорцем продовжують анімуватися, якщо не ввімкнено «Зменшення руху»."
+          }
+        }
+      }
+    },
     "settings.app.telemetry": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11301,13 +11301,13 @@ enum SidebarPathFormatter {
 /// text in it shifts off the left edge of the window. Measuring the real
 /// width and compressing here is what keeps the card inside the sidebar.
 ///
-/// Compression order: gaps first (they carry no information), then the
-/// marks themselves, and only once both bottom out does the row drop
-/// marks in favour of a leading `+N` count.
+/// Compression order: gaps first (they carry no information), then the row
+/// drops marks in favour of a leading `+N` count. The 9pt marks themselves
+/// never shrink — the signal is the element this layout protects.
 enum WorkspacePulseMarkRowMetrics {
     static let preferredSlot: CGFloat = 14
     static let preferredSpacing: CGFloat = 7
-    static let minimumSlot: CGFloat = 8
+    static let minimumSlot: CGFloat = 9
     static let minimumSpacing: CGFloat = 2
     /// Room held back for the `+N` overflow count when marks get dropped.
     static let overflowLabelWidth: CGFloat = 24
@@ -11318,11 +11318,10 @@ enum WorkspacePulseMarkRowMetrics {
         var visibleCount: Int
         var hiddenCount: Int
 
-        /// Square side for a mark in this layout. The preferred slot carries
-        /// 5pt of breathing room around a 9pt square; once the slot itself is
-        /// compressed the square follows it down.
+        /// Square side for a mark in this layout. The slot may yield its
+        /// breathing room, but the mark itself stays at the contractual 9pt.
         var markSide: CGFloat {
-            min(9, slot)
+            9
         }
     }
 
@@ -11397,6 +11396,192 @@ enum WorkspacePulseMarkRowMetrics {
             visibleCount: visible,
             hiddenCount: count - visible
         )
+    }
+}
+
+/// Leaf-isolated workspace-pulse mark. This is the c11 renderer half of the
+/// shared 9pt vocabulary; its clock and phase sampling are the same Bonsplit
+/// primitives used by surface-tab marks.
+private struct WorkspacePulseMark: View {
+    private static let flaggedColor = Color(
+        nsColor: NSColor(
+            srgbRed: 0x9D / 255,
+            green: 0x8A / 255,
+            blue: 0xD9 / 255,
+            alpha: 1
+        )
+    )
+
+    let state: WorkspacePulseState
+    let lifecycleColor: Color
+    let phaseId: UUID
+    let flagged: Bool
+    let suppressed: Bool
+    let animationEligible: Bool
+
+    @AppStorage(BonsplitActivityMarkSettings.staticMarksKey)
+    private var staticMarks = BonsplitActivityMarkSettings.defaultStaticMarks
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var clockToken: UUID?
+    @State private var visibleWorkingDots = 9
+    @State private var waitingCoreOpacity = 1.0
+    @State private var flaggedWaitingShowsWhite = false
+
+    private var presentedState: WorkspacePulseState {
+        suppressed && !flagged && state == .waiting ? .idle : state
+    }
+
+    private var color: Color {
+        flagged ? Self.flaggedColor : lifecycleColor
+    }
+
+    private var motion: BonsplitActivityMarkMotion? {
+        guard animationEligible, !reduceMotion else { return nil }
+        if flagged {
+            switch presentedState {
+            case .working: return .working
+            case .waiting: return .flaggedWaiting
+            case .idle, .cold: return nil
+            }
+        }
+        guard !suppressed, !staticMarks else { return nil }
+        switch presentedState {
+        case .working: return .working
+        case .waiting: return .waiting
+        case .idle, .cold: return nil
+        }
+    }
+
+    private var motionSignature: Int {
+        switch motion {
+        case .working: return 1
+        case .waiting: return 2
+        case .flaggedWaiting: return 3
+        case nil: return 0
+        }
+    }
+
+    var body: some View {
+        markShape
+            .frame(width: 9, height: 9)
+            .onAppear { refreshClockSubscription() }
+            .onChange(of: motionSignature) { _, _ in refreshClockSubscription() }
+            .onChange(of: phaseId) { _, _ in refreshClockSubscription() }
+            .onDisappear { unsubscribeFromClock() }
+    }
+
+    @ViewBuilder
+    private var markShape: some View {
+        switch presentedState {
+        case .working:
+            ZStack {
+                Rectangle()
+                    .fill(color.opacity(0.25))
+                    .frame(width: 9, height: 9)
+                VStack(spacing: 1) {
+                    ForEach(0..<3, id: \.self) { row in
+                        HStack(spacing: 1) {
+                            ForEach(0..<3, id: \.self) { column in
+                                let rank = (2 - row) * 3 + column
+                                Rectangle()
+                                    .fill(color)
+                                    .frame(width: 2, height: 2)
+                                    .opacity(rank < visibleWorkingDots ? 1 : 0)
+                            }
+                        }
+                    }
+                }
+            }
+
+        case .waiting:
+            ZStack {
+                Rectangle()
+                    .strokeBorder(color, lineWidth: 1.5)
+                Rectangle()
+                    .fill(color)
+                    .frame(width: 4, height: 4)
+                    .opacity(flagged ? 1 : waitingCoreOpacity)
+                if flagged {
+                    Rectangle()
+                        .fill(Color.white)
+                        .frame(width: 4, height: 4)
+                        .opacity(flaggedWaitingShowsWhite ? 1 : 0)
+                }
+            }
+
+        case .idle:
+            Rectangle()
+                .strokeBorder(color, lineWidth: 1)
+
+        case .cold:
+            Rectangle()
+                .fill(color)
+                .frame(width: 9, height: 2)
+        }
+    }
+
+    private func refreshClockSubscription() {
+        unsubscribeFromClock()
+        guard let motion else {
+            resetToStaticState()
+            return
+        }
+        clockToken = BonsplitActivityAnimationClock.shared.subscribe { elapsed in
+            apply(elapsed: elapsed, motion: motion)
+        }
+    }
+
+    private func unsubscribeFromClock() {
+        guard let clockToken else { return }
+        BonsplitActivityAnimationClock.shared.unsubscribe(clockToken)
+        self.clockToken = nil
+    }
+
+    private func resetToStaticState() {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            visibleWorkingDots = 9
+            waitingCoreOpacity = 1
+            flaggedWaitingShowsWhite = false
+        }
+    }
+
+    private func apply(elapsed: TimeInterval, motion: BonsplitActivityMarkMotion) {
+        switch motion {
+        case .working:
+            let dots = BonsplitActivityMarkAnimation.visibleWorkingDots(
+                at: elapsed,
+                id: phaseId
+            )
+            guard dots != visibleWorkingDots else { return }
+            var transaction = Transaction(animation: nil)
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                visibleWorkingDots = dots
+            }
+
+        case .waiting:
+            let opacity = BonsplitActivityMarkAnimation.waitingCoreOpacity(
+                at: elapsed,
+                id: phaseId
+            )
+            withAnimation(.linear(duration: BonsplitActivityMarkAnimation.clockInterval)) {
+                waitingCoreOpacity = opacity
+            }
+
+        case .flaggedWaiting:
+            let showsWhite = BonsplitActivityMarkAnimation.flaggedWaitingShowsWhite(
+                at: elapsed,
+                id: phaseId
+            )
+            guard showsWhite != flaggedWaitingShowsWhite else { return }
+            var transaction = Transaction(animation: nil)
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                flaggedWaitingShowsWhite = showsWhite
+            }
+        }
     }
 }
 
@@ -11808,32 +11993,16 @@ private struct TabItemView: View, Equatable {
         }
     }
 
-    /// Agent-state mark: a hard-edged terminal cell, matching the surface-tab
-    /// chips bonsplit draws. Fill state carries the meaning — solid for
-    /// working, hollow for idle, a flat line for cold, solid gold for waiting —
-    /// so the state reads without relying on color alone. Nothing animates.
-    @ViewBuilder
-    private func workspacePulseMark(
-        for state: WorkspacePulseState,
-        summaryScale: Bool = false,
-        side overrideSide: CGFloat? = nil
-    ) -> some View {
-        let color = workspacePulseColor(for: state)
-        let side: CGFloat = overrideSide ?? (summaryScale ? 10 : 9)
-        switch state {
-        case .waiting, .working:
-            Rectangle()
-                .fill(color)
-                .frame(width: side, height: side)
-        case .idle:
-            Rectangle()
-                .strokeBorder(color, lineWidth: 1)
-                .frame(width: side, height: side)
-        case .cold:
-            Rectangle()
-                .fill(color)
-                .frame(width: side, height: 2)
-        }
+    /// Leaf-isolated 9pt mark matching the Bonsplit surface-tab vocabulary.
+    private func workspacePulseMark(for agent: WorkspacePulseAgent) -> some View {
+        WorkspacePulseMark(
+            state: agent.state,
+            lifecycleColor: workspacePulseColor(for: agent.presentedState),
+            phaseId: agent.surfaceId,
+            flagged: agent.flagged,
+            suppressed: agent.suppressed,
+            animationEligible: isActive
+        )
     }
 
     private var workspacePulseVisibleAgents: [WorkspacePulseAgent] {
@@ -11849,7 +12018,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private func openWorkspacePulseAgent(_ agent: WorkspacePulseAgent) {
-        guard agent.state == .waiting else { return }
+        guard agent.presentedState == .waiting else { return }
         _ = AppDelegate.shared?.openNotification(
             tabId: tab.id,
             surfaceId: agent.surfaceId,
@@ -11864,7 +12033,7 @@ private struct TabItemView: View, Equatable {
     ) -> some View {
         let context = agent.context
         let content = HStack(spacing: 7) {
-            workspacePulseMark(for: agent.state, summaryScale: true)
+            workspacePulseMark(for: agent)
                 .frame(width: 16, height: 16)
 
             Group {
@@ -11874,7 +12043,7 @@ private struct TabItemView: View, Equatable {
                         + Text(verbatim: context.subtitle.map { " · \($0)" } ?? "")
                     )
                 } else {
-                    Text(verbatim: workspacePulseLabel(for: agent.state))
+                    Text(verbatim: workspacePulseLabel(for: agent.presentedState))
                 }
             }
             .font(.system(size: chromeTokens.sidebarWorkspaceDetail + 1))
@@ -11885,7 +12054,7 @@ private struct TabItemView: View, Equatable {
             Spacer(minLength: 0)
         }
 
-        if agent.state == .waiting {
+        if agent.presentedState == .waiting {
             Button(action: { openWorkspacePulseAgent(agent) }) {
                 content
             }
@@ -12031,11 +12200,11 @@ private struct TabItemView: View, Equatable {
                 }
 
                 ForEach(visible) { agent in
-                    workspacePulseMark(for: agent.state, side: layout.markSide)
+                    workspacePulseMark(for: agent)
                         .frame(width: layout.slot, height: 14)
                         .accessibilityElement(children: .ignore)
-                        .accessibilityLabel(Text(agent.context?.title ?? workspacePulseLabel(for: agent.state)))
-                        .accessibilityValue(Text(workspacePulseLabel(for: agent.state)))
+                        .accessibilityLabel(Text(agent.context?.title ?? workspacePulseLabel(for: agent.presentedState)))
+                        .accessibilityValue(Text(workspacePulseLabel(for: agent.presentedState)))
                 }
             }
             .frame(width: proxy.size.width, height: 14, alignment: .trailing)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11399,6 +11399,11 @@ enum WorkspacePulseMarkRowMetrics {
     }
 }
 
+enum ActivityMarkSettings {
+    static let staticMarksKey = "staticActivityMarks"
+    static let defaultStaticMarks = false
+}
+
 /// Leaf-isolated workspace-pulse mark. This is the c11 renderer half of the
 /// shared 9pt vocabulary; its clock and phase sampling are the same Bonsplit
 /// primitives used by surface-tab marks.
@@ -11419,9 +11424,10 @@ private struct WorkspacePulseMark: View {
     let suppressed: Bool
     let animationEligible: Bool
 
-    @AppStorage(BonsplitActivityMarkSettings.staticMarksKey)
-    private var staticMarks = BonsplitActivityMarkSettings.defaultStaticMarks
+    @AppStorage(ActivityMarkSettings.staticMarksKey)
+    private var staticMarks = ActivityMarkSettings.defaultStaticMarks
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     @State private var clockToken: UUID?
     @State private var visibleWorkingDots = 9
     @State private var waitingCoreOpacity = 1.0
@@ -11436,27 +11442,27 @@ private struct WorkspacePulseMark: View {
     }
 
     private var motion: BonsplitActivityMarkMotion? {
-        guard animationEligible, !reduceMotion else { return nil }
+        guard animationEligible, scenePhase == .active, !reduceMotion else { return nil }
         if flagged {
             switch presentedState {
-            case .working: return .working
-            case .waiting: return .flaggedWaiting
+            case .working: return .steppedFill
+            case .waiting: return .binaryFlash
             case .idle, .cold: return nil
             }
         }
         guard !suppressed, !staticMarks else { return nil }
         switch presentedState {
-        case .working: return .working
-        case .waiting: return .waiting
+        case .working: return .steppedFill
+        case .waiting: return .easedDip
         case .idle, .cold: return nil
         }
     }
 
     private var motionSignature: Int {
         switch motion {
-        case .working: return 1
-        case .waiting: return 2
-        case .flaggedWaiting: return 3
+        case .steppedFill: return 1
+        case .easedDip: return 2
+        case .binaryFlash: return 3
         case nil: return 0
         }
     }
@@ -11549,7 +11555,7 @@ private struct WorkspacePulseMark: View {
 
     private func apply(elapsed: TimeInterval, motion: BonsplitActivityMarkMotion) {
         switch motion {
-        case .working:
+        case .steppedFill:
             let dots = BonsplitActivityMarkAnimation.visibleWorkingDots(
                 at: elapsed,
                 id: phaseId
@@ -11561,7 +11567,7 @@ private struct WorkspacePulseMark: View {
                 visibleWorkingDots = dots
             }
 
-        case .waiting:
+        case .easedDip:
             let opacity = BonsplitActivityMarkAnimation.waitingCoreOpacity(
                 at: elapsed,
                 id: phaseId
@@ -11570,8 +11576,8 @@ private struct WorkspacePulseMark: View {
                 waitingCoreOpacity = opacity
             }
 
-        case .flaggedWaiting:
-            let showsWhite = BonsplitActivityMarkAnimation.flaggedWaitingShowsWhite(
+        case .binaryFlash:
+            let showsWhite = BonsplitActivityMarkAnimation.binaryFlashShowsAlternate(
                 at: elapsed,
                 id: phaseId
             )

--- a/Sources/Sidebar/SidebarActivityProjector.swift
+++ b/Sources/Sidebar/SidebarActivityProjector.swift
@@ -26,8 +26,34 @@ struct WorkspacePulseAgent: Equatable, Identifiable {
     let surfaceId: UUID
     let state: WorkspacePulseState
     let context: WorkspacePulseAgentContext?
+    /// Forward-compatible attention modifiers. C11-184 owns the metadata and
+    /// signal primitives that will populate them; false defaults preserve the
+    /// current lifecycle-only projection until that wiring lands.
+    let flagged: Bool
+    let suppressed: Bool
 
     var id: UUID { surfaceId }
+
+    init(
+        surfaceId: UUID,
+        state: WorkspacePulseState,
+        context: WorkspacePulseAgentContext?,
+        flagged: Bool = false,
+        suppressed: Bool = false
+    ) {
+        self.surfaceId = surfaceId
+        self.state = state
+        self.context = context
+        self.flagged = flagged
+        self.suppressed = suppressed
+    }
+
+    /// Suppression is a lifecycle projection, and a flag wins when both
+    /// modifiers are present. The stored `state` remains the source truth for
+    /// C11-184; renderers and summary counts consume this presented value.
+    var presentedState: WorkspacePulseState {
+        suppressed && !flagged && state == .waiting ? .idle : state
+    }
 }
 
 struct WorkspacePulseSummary: Equatable {
@@ -77,12 +103,12 @@ struct WorkspacePulseSummary: Equatable {
     }
 
     func agentCount(for state: WorkspacePulseState) -> Int {
-        agents.lazy.filter { $0.state == state }.count
+        agents.lazy.filter { $0.presentedState == state }.count
     }
 
     var relevantAgents: [WorkspacePulseAgent] {
         WorkspacePulseState.allCases.flatMap { state in
-            agents.filter { $0.state == state }
+            agents.filter { $0.presentedState == state }
         }
     }
 }
@@ -125,15 +151,15 @@ enum WorkspacePulseProjector {
         browserCount: Int = 0,
         documentCount: Int = 0
     ) -> WorkspacePulseSummary {
-        var waiting = agents.filter { $0.state == .waiting }.count
+        var waiting = agents.filter { $0.presentedState == .waiting }.count
         if hasWorkspaceDemand && waiting == 0 {
             waiting = 1
         }
         return WorkspacePulseSummary(
             waitingCount: waiting,
-            workingCount: agents.filter { $0.state == .working }.count,
-            idleCount: agents.filter { $0.state == .idle }.count,
-            coldCount: agents.filter { $0.state == .cold }.count,
+            workingCount: agents.filter { $0.presentedState == .working }.count,
+            idleCount: agents.filter { $0.presentedState == .idle }.count,
+            coldCount: agents.filter { $0.presentedState == .cold }.count,
             agents: agents,
             terminalCount: max(0, terminalCount),
             browserCount: max(0, browserCount),

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -215,6 +215,9 @@ struct WorkspaceContentView: View {
                 bonsplitView
             }
         }
+        // Unselected workspaces stay mounted for instant restoration, but
+        // their surface-tab marks must not keep clock subscriptions alive.
+        .environment(\.bonsplitActivityAnimationEnabled, isWorkspaceInputActive)
         .overlay(
             WorkspaceFrame(
                 workspace: workspace,

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -19,9 +19,13 @@ struct WorkspaceContentView: View {
     @State private var config = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "stateInit")
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
+    @AppStorage(ActivityMarkSettings.staticMarksKey)
+    private var staticActivityMarks = ActivityMarkSettings.defaultStaticMarks
     @AppStorage(ThemeAppStorage.Keys.m1bWorkspaceContentViewContextMigrated, store: ThemeAppStorage.defaults)
     private var m1bWorkspaceContentViewContextMigrated = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject var notificationStore: TerminalNotificationStore
 
     private var isMinimalMode: Bool {
@@ -215,9 +219,16 @@ struct WorkspaceContentView: View {
                 bonsplitView
             }
         }
-        // Unselected workspaces stay mounted for instant restoration, but
-        // their surface-tab marks must not keep clock subscriptions alive.
-        .environment(\.bonsplitActivityAnimationEnabled, isWorkspaceInputActive)
+        // c11 owns mark policy. Bonsplit receives only the resolved generic
+        // permission to subscribe: no user-default, accessibility, or
+        // application-lifecycle semantics cross the package boundary.
+        .environment(
+            \.bonsplitActivityAnimationEnabled,
+            isWorkspaceInputActive
+                && scenePhase == .active
+                && !reduceMotion
+                && !staticActivityMarks
+        )
         .overlay(
             WorkspaceFrame(
                 workspace: workspace,

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4468,8 +4468,8 @@ struct SettingsView: View {
     @AppStorage(LastSurfaceCloseShortcutSettings.key)
     private var closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
-    @AppStorage(BonsplitActivityMarkSettings.staticMarksKey)
-    private var staticActivityMarks = BonsplitActivityMarkSettings.defaultStaticMarks
+    @AppStorage(ActivityMarkSettings.staticMarksKey)
+    private var staticActivityMarks = ActivityMarkSettings.defaultStaticMarks
     @AppStorage(SidebarWorkspaceDetailSettings.hideAllDetailsKey)
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
     @AppStorage(SidebarWorkspaceDetailSettings.showNotificationMessageKey)
@@ -5460,7 +5460,7 @@ struct SettingsView: View {
                 String(localized: "settings.app.staticMarks", defaultValue: "Static marks"),
                 subtitle: String(
                     localized: "settings.app.staticMarks.subtitle",
-                    defaultValue: "Stop normal lifecycle motion. Flagged marks remain animated unless Reduce Motion is enabled."
+                    defaultValue: "Stop normal lifecycle motion. Flagged working and waiting marks remain animated unless Reduce Motion is enabled."
                 )
             ) {
                 Toggle("", isOn: $staticActivityMarks)

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4468,6 +4468,8 @@ struct SettingsView: View {
     @AppStorage(LastSurfaceCloseShortcutSettings.key)
     private var closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
+    @AppStorage(BonsplitActivityMarkSettings.staticMarksKey)
+    private var staticActivityMarks = BonsplitActivityMarkSettings.defaultStaticMarks
     @AppStorage(SidebarWorkspaceDetailSettings.hideAllDetailsKey)
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
     @AppStorage(SidebarWorkspaceDetailSettings.showNotificationMessageKey)
@@ -5450,6 +5452,23 @@ struct SettingsView: View {
                 Toggle("", isOn: $workspaceAutoReorder)
                     .labelsHidden()
                     .controlSize(.small)
+            }
+
+            SettingsCardDivider()
+
+            SettingsCardRow(
+                String(localized: "settings.app.staticMarks", defaultValue: "Static marks"),
+                subtitle: String(
+                    localized: "settings.app.staticMarks.subtitle",
+                    defaultValue: "Stop normal lifecycle motion. Flagged marks remain animated unless Reduce Motion is enabled."
+                )
+            ) {
+                Toggle("", isOn: $staticActivityMarks)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .accessibilityLabel(
+                        String(localized: "settings.app.staticMarks", defaultValue: "Static marks")
+                    )
             }
         }
 

--- a/c11Tests/SidebarActivityProjectorTests.swift
+++ b/c11Tests/SidebarActivityProjectorTests.swift
@@ -178,6 +178,60 @@ final class SidebarActivityProjectorTests: XCTestCase {
         XCTAssertEqual(summary.terminalCount, 2)
     }
 
+    func testWorkspacePulseSuppressesUnflaggedWaitingIntoIdle() {
+        let agent = WorkspacePulseAgent(
+            surfaceId: UUID(),
+            state: .waiting,
+            context: nil,
+            suppressed: true
+        )
+
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: false,
+            agents: [agent],
+            terminalCount: 1
+        )
+
+        XCTAssertEqual(agent.state, .waiting, "The source lifecycle remains available to C11-184")
+        XCTAssertEqual(agent.presentedState, .idle)
+        XCTAssertEqual(summary.waitingCount, 0)
+        XCTAssertEqual(summary.idleCount, 1)
+        XCTAssertEqual(summary.relevantAgents.map(\.presentedState), [.idle])
+    }
+
+    func testWorkspacePulseFlagOverridesSuppression() {
+        let agent = WorkspacePulseAgent(
+            surfaceId: UUID(),
+            state: .waiting,
+            context: nil,
+            flagged: true,
+            suppressed: true
+        )
+
+        let summary = WorkspacePulseProjector.project(
+            hasWorkspaceDemand: false,
+            agents: [agent],
+            terminalCount: 1
+        )
+
+        XCTAssertEqual(agent.presentedState, .waiting)
+        XCTAssertEqual(summary.waitingCount, 1)
+        XCTAssertEqual(summary.idleCount, 0)
+        XCTAssertEqual(summary.relevantAgents.map(\.presentedState), [.waiting])
+    }
+
+    func testWorkspacePulseModifierDefaultsPreserveLifecycle() {
+        let agent = WorkspacePulseAgent(
+            surfaceId: UUID(),
+            state: .working,
+            context: nil
+        )
+
+        XCTAssertFalse(agent.flagged)
+        XCTAssertFalse(agent.suppressed)
+        XCTAssertEqual(agent.presentedState, .working)
+    }
+
     func testWorkspacePulseFallsThroughWorkingIdleAndCold() {
         XCTAssertEqual(
             WorkspacePulseProjector.project(

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -2516,14 +2516,14 @@ final class WorkspacePulseMarkRowMetricsTests: XCTestCase {
         XCTAssertEqual(layout.hiddenCount, 0)
     }
 
-    func testVeryCrowdedRosterShrinksMarksAndKeepsThemAllVisible() {
+    func testVeryCrowdedRosterYieldsSlotsButKeepsNinePointMarks() {
         let layout = WorkspacePulseMarkRowMetrics.layout(count: 16, availableWidth: sidebarCardContentWidth)
         XCTAssertEqual(layout.spacing, WorkspacePulseMarkRowMetrics.minimumSpacing)
         XCTAssertLessThan(layout.slot, WorkspacePulseMarkRowMetrics.preferredSlot)
         XCTAssertGreaterThanOrEqual(layout.slot, WorkspacePulseMarkRowMetrics.minimumSlot)
         XCTAssertEqual(layout.visibleCount, 16)
         XCTAssertEqual(layout.hiddenCount, 0)
-        XCTAssertEqual(layout.markSide, min(9, layout.slot), accuracy: 0.01)
+        XCTAssertEqual(layout.markSide, 9, accuracy: 0.01)
         XCTAssertLessThanOrEqual(layout.markSide, layout.slot)
     }
 
@@ -2554,6 +2554,7 @@ final class WorkspacePulseMarkRowMetricsTests: XCTestCase {
         for width in stride(from: 1.0, through: 55.0, by: 3.0) {
             let layout = WorkspacePulseMarkRowMetrics.layout(count: 24, availableWidth: CGFloat(width))
             XCTAssertGreaterThanOrEqual(layout.slot, WorkspacePulseMarkRowMetrics.minimumSlot)
+            XCTAssertEqual(layout.markSide, 9)
             XCTAssertGreaterThanOrEqual(layout.spacing, WorkspacePulseMarkRowMetrics.minimumSpacing)
             XCTAssertGreaterThanOrEqual(layout.visibleCount, 0)
             XCTAssertEqual(layout.visibleCount + layout.hiddenCount, 24)


### PR DESCRIPTION
## Summary

- replace the old activity indicator with one shared 9 pt, hard-edged lifecycle vocabulary across workspace pulse rows and surface tabs
- add the default-on shared animation clock with stable per-surface phases, leaf isolation, and eligibility gating for workspace selection, pane collapse, tab overflow, app activity, Reduce Motion, and the new Static marks setting
- add renderer seams for the downstream `flagged` and `suppressed` fields: suppression filters waiting to idle; flagged working keeps the normal stepped fill; only flagged waiting uses the 0.4 s violet/white hard flash
- localize the Static marks label and subtitle in English, Japanese, Ukrainian, Korean, Simplified Chinese, Traditional Chinese, and Russian
- keep Bonsplit policy-free and upstream-ready; c11 owns flag/suppression colors and application/settings policy

## Why

The existing indicator did not provide a single instinctive visual language for working, waiting, idle, and cold agents across the sidebar and tab bar. This gives each lifecycle state a fixed shape and slot while preserving the timing from the approved HTML prototype.

## Validation

- Bonsplit focused mark/visibility tests: 5/5 passed; final reactive chrome-edge test: 1/1 passed
- `c11LogicTests/SidebarActivityProjectorTests`: 18/18 passed
- `c11-unit` build-for-testing: `TEST BUILD SUCCEEDED`
- independent focused re-review: PASS at parent `aeeba3137699a987db6f7e74ade4af55123d3707`; the only later change is the catalog-only localization commit
- localization catalog: valid JSON; both new keys contain `en`, `ja`, `uk`, `ko`, `zh-Hans`, `zh-Hant`, and `ru`
- tagged QA build: `C11_QA_LAUNCH=fresh ./scripts/reload.sh --tag c11-183-mark-vocabulary` → `BUILD SUCCEEDED`; isolated app launched and its socket answered `list-workspaces`
- final parent SHA: `39766765320f10ac969e0c46f66e2316173a5ac0`
- Bonsplit SHA: `7fc911fbdc099a61ca5a1f311471683eb7660e2f` (pushed to the Stage 11 fork before the parent pointer)

## Draft gate status

Per operator direction, this pass intentionally skips the dedicated 20+ agent typing-latency harness and the full screenshot matrix. This PR therefore makes no fleet-performance or human-visible screenshot claim and remains draft. The implementation uses one shared clock with visibility/lifecycle subscription gating, but that architectural evidence is not a substitute for the deferred measurements.

## Upstream note

The Bonsplit portion is generic shape/timing/host-driven animation infrastructure and is a candidate to offer upstream. No upstream PR is opened here.
