### PR TITLE
Reconcile the v0.60.1/v0.60.2 release line back into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.60.2] - 2026-07-27
+
+Headline: **Agent activity icons stay truthful across the whole fleet.** Codex, OpenCode, Pi, and Grok now drive their live/idle state from the agent loop, keeping the top surface tabs and workspace sidebar in sync with what each agent is actually doing.
+
+### Fixed
+
+- **Live/idle indicators now follow the real agent loop for Codex, OpenCode, Pi, and Grok.** Agents no longer appear idle while they are working: the icon in the top surface tabs and each workspace's sidebar pulse updates when work starts and settles when the agent is ready again. — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+
+### Thanks to 1 contributor!
+
+- [@BenevolentFutures](https://github.com/BenevolentFutures)
+
 ## [0.60.1] - 2026-07-26
 
 Headline: **Busy workspaces stay legible, and untouched agents go Cold on a clock.** Workspace cards hold their shape at any agent count, while a live agent becomes Cold only after the configured dormancy interval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Note: historical entries below pre-date the `c11mux` → `c11` rename and refere
 
 ## [Unreleased]
 
+## [0.60.1] - 2026-07-26
+
+Headline: **Busy workspaces stay legible, and untouched agents go Cold on a clock.** Workspace cards hold their shape at any agent count, while a live agent becomes Cold only after the configured dormancy interval.
+
+### Fixed
+
+- **Workspace cards stay inside the sidebar however many agents a workspace holds.** Past roughly nine agents the card ran edge to edge, lost its border, and shifted far enough left that the title and every metadata line were cut off by the window. The agent-state marks now compress to fit, falling back to a `+N` count on a very large roster, and the card's geometry is enforced structurally so no future row can break it. ([#374](https://github.com/Stage-11-Agentics/c11/pull/374)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+- **Workspace card titles use the room they have.** Every card reserved space for accessories it was not showing, truncating titles roughly 17pt early. ([#374](https://github.com/Stage-11-Agentics/c11/pull/374)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+- **The sidebar does less work per frame on workspaces with many agents.** Reading one metadata value no longer converts a surface's entire source map, and the workspace roster no longer looks the same value up twice per surface. ([#374](https://github.com/Stage-11-Agentics/c11/pull/374)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+- **Exited agents return to terminal presentation instead of becoming Cold.** When an agent process exits and leaves its shell behind, the surface is classified as a terminal again rather than lingering as a dormant agent.
+- **Agent notifications no longer suppress one another across a workspace.** Grok and Codex surfaces keep their native notifications when a Claude surface is open beside them.
+- **Agent launch checks stay responsive while c11 is busy.** The lightweight socket ping used by agent wrappers no longer waits behind unrelated UI work and incorrectly treats a live c11 instance as unavailable.
+
+### Changed
+
+- **Workspace cards count every surface, not just agents and terminals.** The card's census separates agents from everything else the workspace holds, browsers and markdown surfaces included: `9 agents, 4 other surfaces`. A workspace with no agents just reads `4 surfaces`. ([#374](https://github.com/Stage-11-Agentics/c11/pull/374)) — thanks [@BenevolentFutures](https://github.com/BenevolentFutures)!
+- **Live agents become Cold after a configurable untouched interval, defaulting to ten minutes.** Submitting a task or receiving lifecycle activity resets the clock.
+- **Settings exposes only the understandable “Agents Go Cold After” control.** Status-pill staleness and expiry still work, but their decay thresholds remain internal instead of appearing as separate operator controls.
+
+### Thanks to 1 contributor!
+
+- [@BenevolentFutures](https://github.com/BenevolentFutures)
+
 ## [0.60.0] - 2026-07-24
 
 Headline: **Agent activity is legible at a glance.** Surface tabs show each agent's state and workspace cards roll their agents into a compact pulse, so active, waiting, and idle work reads without opening every pane. This release also adds a typed `c11 launch-agent` command with a saved launch-configuration library on the CLI, global terminal font controls, exact Codex conversation restore at scale, and a fix for a high-surface-count autosave stall.

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -3038,8 +3038,12 @@ struct CMUXCLI {
                 throw error
             }
 
-        case "codex-hook":
-            try runCodexHook(commandArgs: commandArgs, client: client)
+        case "agent-hook", "codex-hook":
+            try runAgentHook(
+                commandName: command,
+                commandArgs: commandArgs,
+                client: client
+            )
 
         case "set-app-focus":
             guard let value = commandArgs.first else { throw CLIError(message: "set-app-focus requires a value") }
@@ -15888,24 +15892,28 @@ struct CMUXCLI {
         }
     }
 
-    /// Bundle-private lifecycle bridge used by Resources/bin/codex. Codex's
-    /// interactive process keeps the outer shell in `running` for its entire
-    /// lifetime, so the wrapper seeds the truthful resting state explicitly.
-    /// Turn submission/completion transitions are reported by c11's terminal
-    /// input and notification seams inside the app.
-    private func runCodexHook(commandArgs: [String], client: SocketClient) throws {
+    /// Bundle-private lifecycle bridge used by agent wrappers and runtime
+    /// plugins. Interactive agent processes keep the outer shell in `running`
+    /// for their entire lifetime, so providers report their truthful loop
+    /// state through this command. `codex-hook` remains as a compatibility
+    /// alias for already-installed c11 builds and wrapper fixtures.
+    private func runAgentHook(
+        commandName: String,
+        commandArgs: [String],
+        client: SocketClient
+    ) throws {
         guard let rawActivity = commandArgs.first?.lowercased(),
               rawActivity == "working" || rawActivity == "idle" else {
-            throw CLIError(message: "codex-hook requires working or idle")
+            throw CLIError(message: "\(commandName) requires working or idle")
         }
         let environment = ProcessInfo.processInfo.environment
         guard let workspaceId = environment["CMUX_WORKSPACE_ID"] ?? environment["C11_WORKSPACE_ID"],
               UUID(uuidString: workspaceId) != nil else {
-            throw CLIError(message: "codex-hook requires a c11 workspace id")
+            throw CLIError(message: "\(commandName) requires a c11 workspace id")
         }
         guard let surfaceId = environment["CMUX_SURFACE_ID"] ?? environment["C11_SURFACE_ID"],
               UUID(uuidString: surfaceId) != nil else {
-            throw CLIError(message: "codex-hook requires a c11 surface id")
+            throw CLIError(message: "\(commandName) requires a c11 surface id")
         }
         let response = try sendV1Command(
             "report_agent_activity \(rawActivity) --tab=\(workspaceId) --panel=\(surfaceId)",

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -322,8 +322,10 @@
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
 		C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1CDE00001A1B2C3D4E5F719 /* codex */; };
 		C1F1E00002A1B2C3D4E5F719 /* pi in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F1E00001A1B2C3D4E5F719 /* pi */; };
+		C1F1E00004A1B2C3D4E5F719 /* pi-lifecycle.ts in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F1E00003A1B2C3D4E5F719 /* pi-lifecycle.ts */; };
 		C1F2E00002A1B2C3D4E5F719 /* omp in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F2E00001A1B2C3D4E5F719 /* omp */; };
 		C1F3E00002A1B2C3D4E5F719 /* grok in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F3E00001A1B2C3D4E5F719 /* grok */; };
+		C1F4E00002A1B2C3D4E5F719 /* opencode in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1F4E00001A1B2C3D4E5F719 /* opencode */; };
 		C22557799917F42164A6C855 /* TitlebarSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F01B /* TitlebarSnapshotTests.swift */; };
 		C49B42317DA68794CC9C29E4 /* MailboxULIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7105BF1A1B2C3D4E5F60718 /* MailboxULIDTests.swift */; };
 		C622796239CFCFB69D68C5D9 /* CLIHealthRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH015BF1A1B2C3D4E5F60718 /* CLIHealthRuntimeTests.swift */; };
@@ -490,8 +492,10 @@
 				C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */,
 				C1CDE00002A1B2C3D4E5F719 /* codex in Copy CLI */,
 				C1F1E00002A1B2C3D4E5F719 /* pi in Copy CLI */,
+				C1F1E00004A1B2C3D4E5F719 /* pi-lifecycle.ts in Copy CLI */,
 				C1F2E00002A1B2C3D4E5F719 /* omp in Copy CLI */,
 				C1F3E00002A1B2C3D4E5F719 /* grok in Copy CLI */,
+				C1F4E00002A1B2C3D4E5F719 /* opencode in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
 				4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */,
 			);
@@ -754,8 +758,10 @@
 		C1ADE00001A1B2C3D4E5F719 /* claude */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/claude; sourceTree = SOURCE_ROOT; };
 		C1CDE00001A1B2C3D4E5F719 /* codex */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/codex; sourceTree = SOURCE_ROOT; };
 		C1F1E00001A1B2C3D4E5F719 /* pi */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/pi; sourceTree = SOURCE_ROOT; };
+		C1F1E00003A1B2C3D4E5F719 /* pi-lifecycle.ts */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.typescript; path = Resources/bin/pi-lifecycle.ts; sourceTree = SOURCE_ROOT; };
 		C1F2E00001A1B2C3D4E5F719 /* omp */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/omp; sourceTree = SOURCE_ROOT; };
 		C1F3E00001A1B2C3D4E5F719 /* grok */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/grok; sourceTree = SOURCE_ROOT; };
+		C1F4E00001A1B2C3D4E5F719 /* opencode */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/opencode; sourceTree = SOURCE_ROOT; };
 		C28AE9F41DE55AB88CAE431D /* AgentManifest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentManifest.swift; sourceTree = "<group>"; };
 		ACB000000000000000000001 /* AgentCompanionContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentCompanionContext.swift; sourceTree = "<group>"; };
 		ACB000000000000000000002 /* BrowserCompanionPolicyTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BrowserCompanionPolicyTests.swift; sourceTree = "<group>"; };
@@ -969,8 +975,10 @@
 				C1ADE00001A1B2C3D4E5F719 /* claude */,
 				C1CDE00001A1B2C3D4E5F719 /* codex */,
 				C1F1E00001A1B2C3D4E5F719 /* pi */,
+				C1F1E00003A1B2C3D4E5F719 /* pi-lifecycle.ts */,
 				C1F2E00001A1B2C3D4E5F719 /* omp */,
 				C1F3E00001A1B2C3D4E5F719 /* grok */,
+				C1F4E00001A1B2C3D4E5F719 /* opencode */,
 				D8017BF1A1B2C3D4E5F60718 /* Blueprints */,
 				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,
@@ -2141,10 +2149,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2222,7 +2230,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -2232,7 +2240,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -2263,7 +2271,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -2273,7 +2281,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -2341,10 +2349,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2359,14 +2367,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2381,14 +2389,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2404,10 +2412,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2423,10 +2431,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 122;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.1;
+				MARKETING_VERSION = 0.60.2;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -2141,10 +2141,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2222,7 +2222,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -2232,7 +2232,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-framework",
@@ -2263,7 +2263,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				EXECUTABLE_NAME = c11;
@@ -2273,7 +2273,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -2341,10 +2341,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.appuitests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2359,14 +2359,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11.app/Contents/MacOS/c11";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2381,14 +2381,14 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/c11 DEV.app/Contents/MacOS/c11.debug.dylib";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				GENERATE_INFOPLIST_FILE = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../../../c11\\ DEV.app/Contents/MacOS",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.logictests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2404,10 +2404,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2423,10 +2423,10 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 118;
+				CURRENT_PROJECT_VERSION = 121;
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.60.0;
+				MARKETING_VERSION = 0.60.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stage11.c11.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -36897,6 +36897,100 @@
         }
       }
     },
+    "settings.app.sidebarAgentColdThreshold.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agents Go Cold After"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントがコールドになるまで"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理进入冷态前的时长"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "代理進入冷態前的時間"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트가 콜드 상태가 되는 시간"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агенты переходят в состояние «Холодная» через"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Агенти переходять у стан «Холодна» через"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarAgentColdThreshold.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A live agent becomes Cold after this long without a submitted task or lifecycle activity."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "稼働中のエージェントは、タスクの送信もライフサイクルアクティビティもない状態がこの時間続くと、コールドになります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行中的代理如果在这段时间内没有收到新提交的任务，也没有生命周期活动，就会进入冷态。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行中的代理若在這段時間內沒有收到新提交的任務，也沒有生命週期活動，就會進入冷態。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 중인 에이전트는 이 시간 동안 제출된 작업이나 수명 주기 활동이 없으면 콜드 상태가 됩니다."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запущенный агент переходит в состояние «Холодная», если за это время не было ни новых задач, ни событий жизненного цикла."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Запущений агент переходить у стан «Холодна», якщо за цей час не було ані надісланих завдань, ані подій життєвого циклу."
+          }
+        }
+      }
+    },
     "settings.appearance.c11Theme": {
       "extractionState": "manual",
       "localizations": {
@@ -55681,6 +55775,42 @@
             "state": "translated",
             "value": "No surfaces"
           }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サーフェスなし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无界面"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無介面"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "서피스 없음"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет поверхностей"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає поверхонь"
+          }
         }
       }
     },
@@ -55689,6 +55819,42 @@
       "extractionState": "manual",
       "localizations": {
         "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "、"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "、"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "、"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ", "
+          }
+        },
+        "uk": {
           "stringUnit": {
             "state": "translated",
             "value": ", "
@@ -55822,6 +55988,42 @@
           "stringUnit": {
             "state": "translated",
             "value": "%lld more agents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ほか%lld件のエージェント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "另外 %lld 个代理"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "另外 %lld 個代理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에이전트 %lld개 더 있음"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ещё %lld агентов"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ще %lld агентів"
           }
         }
       }

--- a/Resources/bin/codex
+++ b/Resources/bin/codex
@@ -190,7 +190,7 @@ if [[ -n "$c11_bin" ]]; then
     # submission and idle again when Codex emits its completion notification.
     (
         CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
-            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" codex-hook idle \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" agent-hook idle \
             >/dev/null 2>&1
     ) &
     disown 2>/dev/null || true

--- a/Resources/bin/opencode
+++ b/Resources/bin/opencode
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# c11 OpenCode wrapper - runtime lifecycle and session-resume bridge.
+#
+# Inside a live c11 terminal this wrapper declares OpenCode, seeds its resting
+# state, and runtime-loads c11's bundled OpenCode plugin. It never writes
+# ~/.config/opencode or any other persistent tenant configuration.
+
+set -uo pipefail
+
+find_real_opencode() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/opencode" ]] && printf '%s' "$d/opencode" && return 0
+    done
+    return 1
+}
+
+c11_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir c11_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    c11_bin="$self_dir/c11"
+    [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+    [[ -n "$c11_bin" ]] || return 1
+
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$c11_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+REAL_OPENCODE="$(find_real_opencode)" || {
+    echo "Error: opencode not found in PATH" >&2
+    exit 127
+}
+
+if [[ -z "${CMUX_SURFACE_ID:-}" || "${CMUX_OPENCODE_HOOKS_DISABLED:-}" == "1" ]] ||
+   ! c11_socket_available; then
+    exec "$REAL_OPENCODE" "$@"
+fi
+
+# OpenCode's named subcommands and informational flags do not start an
+# interactive agent TUI. Leave them completely transparent.
+case "${1:-}" in
+    serve|web|agent|models|auth|upgrade|uninstall|mcp|github|pr|stats|export|import|attach|acp|debug|--help|-h|--version|-v)
+        exec "$REAL_OPENCODE" "$@"
+        ;;
+esac
+
+self_dir="$(cd "$(dirname "$0")" && pwd)"
+c11_bin="$self_dir/c11"
+[[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
+
+if [[ -n "$c11_bin" ]]; then
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" set-agent --type opencode \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" agent-hook idle \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
+fi
+
+plugin_path="$(cd "$self_dir/../skills/opencode-plugins" && pwd)/c11-notify.js"
+plugin_url="file://$plugin_path"
+plugin_url="${plugin_url//\\/\\\\}"
+plugin_url="${plugin_url//\"/\\\"}"
+c11_runtime_config="{\"plugin\":[\"$plugin_url\"]}"
+
+# OpenCode merges its config sources. Prefer the in-memory content override;
+# if the operator already owns that slot, supply c11's plugin through a live
+# file descriptor instead. If both runtime slots are explicitly occupied,
+# preserve them untouched—the shared foreground-agent liveness guard still
+# prevents false-idle decay.
+if [[ -z "${OPENCODE_CONFIG_CONTENT:-}" ]]; then
+    export OPENCODE_CONFIG_CONTENT="$c11_runtime_config"
+elif [[ -z "${OPENCODE_CONFIG:-}" ]]; then
+    exec 3<<<"$c11_runtime_config"
+    export OPENCODE_CONFIG="/dev/fd/3"
+fi
+
+export C11_AGENT_HOOK_CLI="$c11_bin"
+exec "$REAL_OPENCODE" "$@"

--- a/Resources/bin/pi
+++ b/Resources/bin/pi
@@ -4,8 +4,9 @@
 # When running inside a c11 terminal (CMUX_SURFACE_ID set + socket live),
 # this wrapper:
 #   1. declares the surface as terminal_type=pi (sidebar chip / role hint),
-#      and
-#   2. wrapper-claims a placeholder ConversationRef so c11's conversation
+#   2. reports exact Pi agent-loop working/idle transitions through a bundled
+#      runtime extension, and
+#   3. wrapper-claims a placeholder ConversationRef so c11's conversation
 #      store records a post-launch claim time before pi creates its
 #      session file. The PiStrategy's pull-scrape on next workspace open
 #      then keeps only candidates whose mtime is >= that claim time, which
@@ -125,6 +126,14 @@ if [[ -n "$c11_bin" ]]; then
             >/dev/null 2>&1
     ) &
     disown 2>/dev/null || true
+
+    (
+        CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+            "$c11_bin" --socket "${CMUX_SOCKET_PATH}" agent-hook idle \
+            >/dev/null 2>&1
+    ) &
+    disown 2>/dev/null || true
 fi
 
-exec "$REAL_PI" "$@"
+export C11_AGENT_HOOK_CLI="$c11_bin"
+exec "$REAL_PI" --extension "$self_dir/pi-lifecycle.ts" "$@"

--- a/Resources/bin/pi-lifecycle.ts
+++ b/Resources/bin/pi-lifecycle.ts
@@ -1,0 +1,35 @@
+// c11-scoped Pi lifecycle bridge.
+//
+// Loaded only by Resources/bin/pi for an interactive Pi process inside a live
+// c11 surface. Pi's agent_settled event is the exact point at which retries,
+// compaction, and queued continuations are finished, so it is the right
+// working→idle boundary for the shared tab/sidebar activity icon.
+
+export default function c11Lifecycle(pi: {
+  on: (event: string, handler: () => Promise<void>) => void;
+  exec: (
+    command: string,
+    args: string[],
+    options?: { timeout?: number },
+  ) => Promise<unknown>;
+}) {
+  const c11 = process.env.C11_AGENT_HOOK_CLI;
+  const socket = process.env.CMUX_SOCKET_PATH;
+  if (!c11 || !socket) return;
+
+  const report = async (activity: "working" | "idle") => {
+    try {
+      await pi.exec(
+        c11,
+        ["--socket", socket, "agent-hook", activity],
+        { timeout: 750 },
+      );
+    } catch {
+      // Lifecycle telemetry is advisory. Never disturb Pi if c11 exits or its
+      // socket is replaced while the interactive session remains alive.
+    }
+  };
+
+  pi.on("agent_start", async () => report("working"));
+  pi.on("agent_settled", async () => report("idle"));
+}

--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -103,7 +103,8 @@ final class AgentDetector: @unchecked Sendable {
             for key in self.ttyNames.keys {
                 SurfaceLivenessDeriver.reconcile(
                     surfaceId: key.panelId,
-                    workspaceId: key.workspaceId
+                    workspaceId: key.workspaceId,
+                    detectedTerminalType: self.detectedTerminalTypes[key]
                 )
             }
         }

--- a/Sources/AgentDetector.swift
+++ b/Sources/AgentDetector.swift
@@ -26,6 +26,7 @@ final class AgentDetector: @unchecked Sendable {
     }
 
     private var ttyNames: [PanelKey: String] = [:]
+    private var detectedTerminalTypes: [PanelKey: String] = [:]
     private var pendingKicks: Set<PanelKey> = []
     private var coalesceTimer: DispatchSourceTimer?
     private var scanInFlight = false
@@ -47,6 +48,7 @@ final class AgentDetector: @unchecked Sendable {
         queue.async { [self] in
             let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
             ttyNames.removeValue(forKey: key)
+            detectedTerminalTypes.removeValue(forKey: key)
             pendingKicks.remove(key)
         }
     }
@@ -131,6 +133,10 @@ final class AgentDetector: @unchecked Sendable {
                 continue
             }
             let classification = Self.classify(comm: info.comm, args: info.args)
+            let detectionChanged = detectedTerminalTypes[key] != classification
+            if detectionChanged {
+                detectedTerminalTypes[key] = classification
+            }
             let changed = SurfaceMetadataStore.shared.setInternal(
                 workspaceId: key.workspaceId,
                 surfaceId: key.panelId,
@@ -138,14 +144,20 @@ final class AgentDetector: @unchecked Sendable {
                 value: classification,
                 source: .heuristic
             )
-            if changed {
+            if changed || detectionChanged {
                 DispatchQueue.main.async {
                     MainActor.assumeIsolated {
                         guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: key.workspaceId),
                               let workspace = tabManager.tabs.first(where: { $0.id == key.workspaceId }) else {
                             return
                         }
-                        workspace.syncSurfaceTabActivityStateForPanel(key.panelId)
+                        workspace.setDetectedTerminalType(
+                            classification,
+                            forSurface: key.panelId
+                        )
+                        if changed && !detectionChanged {
+                            workspace.syncSurfaceTabActivityStateForPanel(key.panelId)
+                        }
                     }
                 }
             }
@@ -237,10 +249,26 @@ final class AgentDetector: @unchecked Sendable {
     static func classify(comm: String, args: String) -> String {
         let c = comm.lowercased()
         let a = args.lowercased()
+        let commBase = String(c.split(separator: "/").last ?? Substring(c))
 
         // Exact comm match against any agent manifest's declared binaries.
-        for manifest in AgentRegistry.shared.all where manifest.detectComms.contains(c) {
+        // Accept a full path as well: `ps` usually reports the bare executable,
+        // but that representation is not stable across launch mechanisms.
+        for manifest in AgentRegistry.shared.all
+        where manifest.detectComms.contains(c) || manifest.detectComms.contains(commBase) {
             return manifest.kind
+        }
+
+        // Darwin truncates a long `comm` column (for example
+        // `/Users/atin/.local/bin/claude` becomes `/Users/atin/.loc`), while
+        // `args` still begins with the complete argv[0]. Match only that first
+        // token's basename: later arguments are arbitrary user input and must
+        // never classify a process as an agent.
+        if let argv0 = a.split(whereSeparator: \.isWhitespace).first {
+            let argv0Base = String(argv0.split(separator: "/").last ?? argv0)
+            for manifest in AgentRegistry.shared.all where manifest.detectComms.contains(argv0Base) {
+                return manifest.kind
+            }
         }
 
         // Interpreter-wrapped CLIs: comm is the runtime and the agent identity
@@ -268,7 +296,7 @@ final class AgentDetector: @unchecked Sendable {
 
         // Canonical shells → "shell".
         // `comm` from Darwin's ps may be `-zsh` for login shells.
-        let strippedShell = c.hasPrefix("-") ? String(c.dropFirst()) : c
+        let strippedShell = commBase.hasPrefix("-") ? String(commBase.dropFirst()) : commBase
         if canonicalShells.contains(strippedShell) {
             return "shell"
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12225,6 +12225,19 @@ private struct TabItemView: View, Equatable {
         )
     }
 
+    private var workspacePulseTerminalCountText: String {
+        if workspacePulse.terminalCount == 1 {
+            return String(
+                localized: "sidebar.workspacePulse.terminalCount.one",
+                defaultValue: "1 terminal"
+            )
+        }
+        return String(
+            localized: "sidebar.workspacePulse.terminalCount.other",
+            defaultValue: "\(workspacePulse.terminalCount) terminals"
+        )
+    }
+
     private var workspacePulseBrowserCountText: String {
         if workspacePulse.browserCount == 1 {
             return String(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8636,7 +8636,7 @@ struct VerticalTabsSidebar: View {
                                     var browserCount = 0
                                     var documentCount = 0
                                     for panelId in tab.sidebarOrderedPanelIds() {
-                                        let terminalKind = tab.surfaceTerminalKind(panelId: panelId)
+                                        let terminalKind = tab.surfaceActivityTerminalKind(panelId: panelId)
                                         guard PaneSizePolicy.isAgentKind(terminalKind) else {
                                             switch tab.panels[panelId]?.panelType {
                                             case .terminal: terminalCount += 1
@@ -11690,6 +11690,19 @@ enum WorkspacePulseCensus {
     }
 }
 
+enum WorkspacePulseDividerColorResolver {
+    static func resolve(
+        customHex: String?,
+        colorScheme: ColorScheme
+    ) -> NSColor {
+        guard let customHex else { return BrandColors.gold }
+        return WorkspaceTabColorSettings.displayNSColor(
+            hex: customHex,
+            colorScheme: colorScheme
+        ) ?? BrandColors.gold
+    }
+}
+
 enum SidebarWorkspaceShortcutHintMetrics {
     private static let measurementFont = NSFont.systemFont(ofSize: 10, weight: .semibold)
     /// Held for the close button (16pt) when the workspace has no ⌘-digit
@@ -12212,19 +12225,6 @@ private struct TabItemView: View, Equatable {
         )
     }
 
-    private var workspacePulseTerminalCountText: String {
-        if workspacePulse.terminalCount == 1 {
-            return String(
-                localized: "sidebar.workspacePulse.terminalCount.one",
-                defaultValue: "1 terminal"
-            )
-        }
-        return String(
-            localized: "sidebar.workspacePulse.terminalCount.other",
-            defaultValue: "\(workspacePulse.terminalCount) terminals"
-        )
-    }
-
     private var workspacePulseBrowserCountText: String {
         if workspacePulse.browserCount == 1 {
             return String(
@@ -12338,7 +12338,7 @@ private struct TabItemView: View, Equatable {
         .padding(.top, 8)
         .overlay(alignment: .top) {
             Rectangle()
-                .fill(workspacePulseIdentityColor.opacity(0.18))
+                .fill(workspacePulseDividerColor.opacity(0.42))
                 .frame(height: 1)
         }
         .padding(.top, 10)
@@ -12386,6 +12386,13 @@ private struct TabItemView: View, Equatable {
             green: 0.51,
             blue: 0.57,
             alpha: 1
+        ))
+    }
+
+    private var workspacePulseDividerColor: Color {
+        Color(nsColor: WorkspacePulseDividerColorResolver.resolve(
+            customHex: tab.customColor,
+            colorScheme: colorScheme
         ))
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11,6 +11,20 @@ import IOSurface
 import UniformTypeIdentifiers
 import os
 
+/// Claude Code's wrapper hooks already deliver structured notifications, so
+/// its raw OSC completion notification would be a duplicate. The hook status
+/// is workspace-scoped, though: it must not suppress OSC notifications emitted
+/// by Grok, Codex, or another surface that happens to share that workspace.
+enum GhosttyOSCNotificationPolicy {
+    static func shouldSuppress(
+        hasActiveClaudeHookSession: Bool,
+        sourceTerminalKind: String?
+    ) -> Bool {
+        guard hasActiveClaudeHookSession else { return false }
+        return AgentIdentityPolicy.normalizedKind(sourceTerminalKind) == "claude-code"
+    }
+}
+
 #if os(macOS)
 func cmuxShouldUseTransparentBackgroundWindow() -> Bool {
     let defaults = UserDefaults.standard
@@ -1955,14 +1969,19 @@ class GhosttyApp {
                     // The hook system manages notifications with proper lifecycle tracking;
                     // raw OSC notifications would duplicate or outlive the structured hooks.
                     let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
+                    let surfaceId = owningManager.focusedSurfaceId(for: tabId)
                     if let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
-                       workspace.agentPIDs["claude_code"] != nil {
+                       GhosttyOSCNotificationPolicy.shouldSuppress(
+                           hasActiveClaudeHookSession: workspace.agentPIDs["claude_code"] != nil,
+                           sourceTerminalKind: surfaceId.flatMap {
+                               workspace.surfaceTerminalKind(panelId: $0)
+                           }
+                       ) {
                         return true
                     }
                     let tabTitle = owningManager.titleForTab(tabId) ?? "Terminal"
                     let command = actionTitle.isEmpty ? tabTitle : actionTitle
                     let body = actionBody
-                    let surfaceId = tabManager.focusedSurfaceId(for: tabId)
                     TerminalNotificationStore.shared.addNotification(
                         tabId: tabId,
                         surfaceId: surfaceId,
@@ -2234,10 +2253,17 @@ class GhosttyApp {
             let actionBody = action.action.desktop_notification.body
                 .flatMap { String(cString: $0) } ?? ""
             performOnMain {
-                // Suppress OSC notifications for workspaces with active Claude hook sessions.
+                // Suppress only the Claude surface whose structured hooks would
+                // duplicate this OSC notification. Other agents in the same
+                // workspace still own their native terminal notifications.
                 let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? AppDelegate.shared?.tabManager
                 if let workspace = owningManager?.tabs.first(where: { $0.id == tabId }),
-                   workspace.agentPIDs["claude_code"] != nil {
+                   GhosttyOSCNotificationPolicy.shouldSuppress(
+                       hasActiveClaudeHookSession: workspace.agentPIDs["claude_code"] != nil,
+                       sourceTerminalKind: surfaceId.flatMap {
+                           workspace.surfaceTerminalKind(panelId: $0)
+                       }
+                   ) {
                     return
                 }
                 let tabTitle = owningManager?.titleForTab(tabId) ?? "Terminal"

--- a/Sources/SidebarStalenessSettings.swift
+++ b/Sources/SidebarStalenessSettings.swift
@@ -88,3 +88,40 @@ public enum SidebarStalenessSettings {
         return .expired
     }
 }
+
+/// Operator-tunable dormancy threshold for live agent surfaces.
+///
+/// An agent remains `idle` while it is recently available at its prompt, then
+/// projects as `cold` after this much time passes without a submitted task or
+/// agent lifecycle signal. Process presence is deliberately separate: once the
+/// foreground agent exits, `AgentDetector` projects the surface as a terminal
+/// instead of preserving an agent state.
+enum SidebarAgentColdSettings {
+    static let thresholdKey = "sidebarAgentColdThresholdSeconds"
+    static let defaultSeconds: Double = 10 * 60
+    static let minSeconds: Double = 60
+    static let maxSeconds: Double = 60 * 60
+    static let environmentKey = "C11_AGENT_COLD_SECONDS"
+
+    static func clamp(_ value: Double) -> Double {
+        min(max(value, minSeconds), maxSeconds)
+    }
+
+    static func thresholdSeconds(defaults: UserDefaults = .standard) -> Double {
+        thresholdSeconds(
+            defaults: defaults,
+            environment: ProcessInfo.processInfo.environment
+        )
+    }
+
+    static func thresholdSeconds(
+        defaults: UserDefaults,
+        environment: [String: String]
+    ) -> Double {
+        if let raw = environment[environmentKey], let value = Double(raw) {
+            return clamp(value)
+        }
+        let stored = (defaults.object(forKey: thresholdKey) as? Double) ?? defaultSeconds
+        return clamp(stored)
+    }
+}

--- a/Sources/SocketHandlers/SocketDispatch.swift
+++ b/Sources/SocketHandlers/SocketDispatch.swift
@@ -80,6 +80,12 @@ extension TerminalController {
     }
 
     nonisolated func processCommandUsingSocketExecutionPolicy(_ command: String) -> String {
+        if let response = Self.socketWorkerImmediateV1Response(command) {
+            return withSocketCommandPolicy(commandKey: "ping", isV2: false) {
+                response
+            }
+        }
+
         if let response = socketWorkerV2ResponseIfNeeded(for: command) {
             return response
         }
@@ -98,6 +104,20 @@ extension TerminalController {
         return DispatchQueue.main.sync {
             MainActor.assumeIsolated { self.processCommand(command) }
         }
+    }
+
+    /// Context-free v1 commands that can answer entirely on the socket worker.
+    ///
+    /// The bundled agent wrappers use `ping` as a bounded startup gate before
+    /// installing their lifecycle hooks. Routing that probe through the main
+    /// actor made rapid A-button launches fail open whenever surface creation
+    /// kept the UI busy for longer than the wrapper's 750 ms timeout.
+    nonisolated static func socketWorkerImmediateV1Response(_ command: String) -> String? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("{") else { return nil }
+        let head = trimmed.split(separator: " ", maxSplits: 1).first.map(String.init)?.lowercased()
+        guard head == "ping" else { return nil }
+        return "PONG"
     }
 
     /// C11-156: ack a fire-and-forget telemetry command off-main and apply its

--- a/Sources/SurfaceLivenessDeriver.swift
+++ b/Sources/SurfaceLivenessDeriver.swift
@@ -204,6 +204,7 @@ enum SurfaceLivenessDeriver {
     static func reconcile(
         surfaceId: UUID,
         workspaceId: UUID,
+        detectedTerminalType: String? = nil,
         now: Date = Date(),
         coldAfterSeconds: TimeInterval = SidebarAgentColdSettings.thresholdSeconds()
     ) {
@@ -243,6 +244,17 @@ enum SurfaceLivenessDeriver {
         // Only `working` can decay to idle. Any other externally-restored
         // vocabulary is left untouched.
         guard current == SidebarActivityState.working.rawValue else { return }
+
+        // A foreground agent TUI is itself live evidence. Its outer shell
+        // remains in one long-running command for the entire session, while
+        // SurfaceActivityTracker only sees input and lifecycle edges—not
+        // ongoing model work or tool output. Decaying that sparse evidence
+        // after 45 seconds makes a visibly-working Codex (and other agent
+        // TUIs) render idle. Exact lifecycle completion signals own the
+        // working→idle transition for detected agents; retain the timeout
+        // only as the fallback for ordinary shell commands.
+        guard !PaneSizePolicy.isAgentKind(detectedTerminalType) else { return }
+
         let isStale = last.map { now.timeIntervalSince($0) >= idleDecayThreshold } ?? true
         guard isStale else { return }
 

--- a/Sources/SurfaceLivenessDeriver.swift
+++ b/Sources/SurfaceLivenessDeriver.swift
@@ -5,6 +5,7 @@ enum SurfaceTabActivityResolver {
     static func resolve(
         hasExactSurfaceNotification: Bool,
         derivedActivity: SidebarActivityState?,
+        isCold: Bool = false,
         terminalType: String?,
         flagged: Bool = false,
         suppressed: Bool = false
@@ -16,14 +17,35 @@ enum SurfaceTabActivityResolver {
         guard PaneSizePolicy.isAgentKind(terminalType) else {
             return nil
         }
+        if isCold {
+            return .cold
+        }
         switch derivedActivity {
         case .working:
             return .running
         case .idle:
             return .idle
         case nil:
-            return .cold
+            // A live agent without liveness evidence has not crossed the
+            // configured dormancy threshold. Keep it warm until the
+            // reconciler has an actual last-touch timestamp to compare.
+            return .idle
         }
+    }
+}
+
+enum SurfaceActivityTerminalKindResolver {
+    static func resolve(
+        detectedTerminalType: String?,
+        declaredTerminalType: String?
+    ) -> String? {
+        if detectedTerminalType == "shell" {
+            return "shell"
+        }
+        if PaneSizePolicy.isAgentKind(detectedTerminalType) {
+            return detectedTerminalType
+        }
+        return declaredTerminalType
     }
 }
 
@@ -92,6 +114,7 @@ enum SurfaceLivenessDeriver {
         workspace: Workspace
     ) {
         let derived = activityState(for: state)
+        SurfaceActivityTracker.shared.recordActivity(surfaceId: surfaceId.uuidString)
         queue.async {
             // NOTE (C11-162 m5 / C11-163): this realtime path runs on `Self.queue`
             // while `reconcile(...)` runs on the AgentDetector sweep queue — two
@@ -117,6 +140,7 @@ enum SurfaceLivenessDeriver {
             let mirrored = after.flatMap { SidebarActivityState(rawValue: $0) }
             DispatchQueue.main.async {
                 MainActor.assumeIsolated {
+                    workspace.setAgentCold(false, forSurface: surfaceId)
                     workspace.setDerivedActivity(mirrored, forSurface: surfaceId)
                 }
             }
@@ -133,6 +157,7 @@ enum SurfaceLivenessDeriver {
         workspaceId: UUID,
         activity: SidebarActivityState
     ) {
+        SurfaceActivityTracker.shared.recordActivity(surfaceId: surfaceId.uuidString)
         queue.async {
             let prior = currentActivityRaw(workspaceId: workspaceId, surfaceId: surfaceId)
             applyToStore(
@@ -156,6 +181,7 @@ enum SurfaceLivenessDeriver {
                           let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
                         return
                     }
+                    workspace.setAgentCold(false, forSurface: surfaceId)
                     workspace.setDerivedActivity(mirrored, forSurface: surfaceId)
                 }
             }
@@ -178,7 +204,8 @@ enum SurfaceLivenessDeriver {
     static func reconcile(
         surfaceId: UUID,
         workspaceId: UUID,
-        now: Date = Date()
+        now: Date = Date(),
+        coldAfterSeconds: TimeInterval = SidebarAgentColdSettings.thresholdSeconds()
     ) {
         let snap = SurfaceMetadataStore.shared.getMetadata(
             workspaceId: workspaceId,
@@ -188,16 +215,39 @@ enum SurfaceLivenessDeriver {
         guard let record = snap.sources[MetadataKey.activity],
               (record["source"] as? String) == MetadataSource.derived.rawValue,
               let current = snap.metadata[MetadataKey.activity] as? String else {
+            publishCold(false, workspaceId: workspaceId, surfaceId: surfaceId)
             return
         }
-        // Only `working` can decay; `idle` is already the resting truth.
-        guard current == SidebarActivityState.working.rawValue else { return }
 
         let last = SurfaceActivityTracker.shared.lastActivity(for: surfaceId.uuidString)
+        let metadataTouch = (record["ts"] as? Double).map(Date.init(timeIntervalSince1970:))
+        let lastTouched = [last, metadataTouch].compactMap { $0 }.max()
+
+        if current == SidebarActivityState.idle.rawValue {
+            publishCold(
+                Self.isCold(
+                    activity: .idle,
+                    lastTouchedAt: lastTouched,
+                    now: now,
+                    coldAfterSeconds: coldAfterSeconds
+                ),
+                workspaceId: workspaceId,
+                surfaceId: surfaceId,
+                observedLastTouchedAt: lastTouched
+            )
+            return
+        }
+
+        publishCold(false, workspaceId: workspaceId, surfaceId: surfaceId)
+
+        // Only `working` can decay to idle. Any other externally-restored
+        // vocabulary is left untouched.
+        guard current == SidebarActivityState.working.rawValue else { return }
         let isStale = last.map { now.timeIntervalSince($0) >= idleDecayThreshold } ?? true
         guard isStale else { return }
 
         applyToStore(derived: .idle, workspaceId: workspaceId, surfaceId: surfaceId)
+        SurfaceActivityTracker.shared.recordActivity(surfaceId: surfaceId.uuidString, at: now)
         emitLivenessTransition(
             from: SidebarActivityState.working.rawValue,
             to: SidebarActivityState.idle.rawValue,
@@ -211,7 +261,49 @@ enum SurfaceLivenessDeriver {
                       let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
                     return
                 }
+                workspace.setAgentCold(false, forSurface: surfaceId)
                 workspace.setDerivedActivity(.idle, forSurface: surfaceId)
+            }
+        }
+    }
+
+    /// Pure live-agent dormancy classifier. Missing touch evidence fails warm:
+    /// absence of telemetry is not enough to claim that a live agent has been
+    /// untouched for the configured interval.
+    static func isCold(
+        activity: SidebarActivityState?,
+        lastTouchedAt: Date?,
+        now: Date,
+        coldAfterSeconds: TimeInterval
+    ) -> Bool {
+        guard activity == .idle, let lastTouchedAt else { return false }
+        return now.timeIntervalSince(lastTouchedAt) >= max(0, coldAfterSeconds)
+    }
+
+    private static func publishCold(
+        _ isCold: Bool,
+        workspaceId: UUID,
+        surfaceId: UUID,
+        observedLastTouchedAt: Date? = nil
+    ) {
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
+                guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId),
+                      let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else {
+                    return
+                }
+                if isCold,
+                   let observedLastTouchedAt,
+                   let currentLastTouchedAt = SurfaceActivityTracker.shared.lastActivity(
+                       for: surfaceId.uuidString
+                   ),
+                   currentLastTouchedAt > observedLastTouchedAt {
+                    // A lifecycle/input signal landed after this sweep read its
+                    // snapshot. Never let that stale sweep re-cold the agent.
+                    workspace.setAgentCold(false, forSurface: surfaceId)
+                    return
+                }
+                workspace.setAgentCold(isCold, forSurface: surfaceId)
             }
         }
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5504,6 +5504,13 @@ final class Workspace: Identifiable, ObservableObject {
     /// Main-actor render cache for canonical attention metadata. The metadata
     /// store remains authoritative; views consume this immutable projection.
     @Published private(set) var attentionBySurface: [UUID: SurfaceAttentionSnapshot] = [:]
+    /// Live-agent dormancy is a reversible presentation projection, kept
+    /// separate from the durable working/idle metadata truth.
+    @Published private(set) var coldAgentSurfaceIds: Set<UUID> = []
+    /// Foreground-process classifications from `AgentDetector`. Durable
+    /// `terminal_type` metadata describes resumable identity; this live map
+    /// decides whether that identity is currently an agent or a plain shell.
+    @Published private(set) var detectedTerminalTypesBySurface: [UUID: String] = [:]
     @Published var gitBranch: SidebarGitBranchState?
     @Published var panelGitBranches: [UUID: SidebarGitBranchState] = [:]
     /// C11-104 — per-panel resolved worktree+branch context for the
@@ -6409,6 +6416,8 @@ final class Workspace: Identifiable, ObservableObject {
         let terminalTypeSource: MetadataSource?
         let derivedActivity: SidebarActivityState?
         let derivedActivitySource: MetadataSource?
+        let isAgentCold: Bool
+        let detectedTerminalType: String?
         let activityState: BonsplitTabActivityState?
         let attention: SurfaceAttentionSnapshot
     }
@@ -6759,7 +6768,8 @@ final class Workspace: Identifiable, ObservableObject {
         return SurfaceTabActivityResolver.resolve(
             hasExactSurfaceNotification: hasExactSurfaceNotification ?? hasUnreadNotification(panelId: panelId),
             derivedActivity: derivedActivityBySurface[panelId],
-            terminalType: terminalKind ?? surfaceTerminalKind(panelId: panelId),
+            isCold: coldAgentSurfaceIds.contains(panelId),
+            terminalType: terminalKind ?? surfaceActivityTerminalKind(panelId: panelId),
             flagged: attention.isFlagged,
             suppressed: attention.suppressed
         )
@@ -7158,6 +7168,42 @@ final class Workspace: Identifiable, ObservableObject {
             changed = true
         } else {
             changed = false
+        }
+        if changed {
+            syncSurfaceTabActivityStateForPanel(surfaceId)
+        }
+    }
+
+    /// Update the live dormancy projection for one agent surface.
+    func setAgentCold(_ isCold: Bool, forSurface surfaceId: UUID) {
+        let changed: Bool
+        if isCold {
+            changed = coldAgentSurfaceIds.insert(surfaceId).inserted
+        } else {
+            changed = coldAgentSurfaceIds.remove(surfaceId) != nil
+        }
+        if changed {
+            syncSurfaceTabActivityStateForPanel(surfaceId)
+        }
+    }
+
+    /// Install the detector's current foreground-process classification.
+    /// `"shell"` is authoritative evidence that the agent process exited;
+    /// `"unknown"` is not, because an agent may temporarily foreground an
+    /// unrecognized child command.
+    func setDetectedTerminalType(_ terminalType: String?, forSurface surfaceId: UUID) {
+        let normalized = terminalType?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let value = normalized?.isEmpty == false ? normalized : nil
+        let changed: Bool
+        if let value {
+            if detectedTerminalTypesBySurface[surfaceId] != value {
+                detectedTerminalTypesBySurface[surfaceId] = value
+                changed = true
+            } else {
+                changed = false
+            }
+        } else {
+            changed = detectedTerminalTypesBySurface.removeValue(forKey: surfaceId) != nil
         }
         if changed {
             syncSurfaceTabActivityStateForPanel(surfaceId)
@@ -7749,6 +7795,10 @@ final class Workspace: Identifiable, ObservableObject {
         // @Published map doesn't leak stale liveness for pruned surfaces.
         derivedActivityBySurface = derivedActivityBySurface.filter { validSurfaceIds.contains($0.key) }
         attentionBySurface = attentionBySurface.filter { validSurfaceIds.contains($0.key) }
+        coldAgentSurfaceIds = coldAgentSurfaceIds.filter { validSurfaceIds.contains($0) }
+        detectedTerminalTypesBySurface = detectedTerminalTypesBySurface.filter {
+            validSurfaceIds.contains($0.key)
+        }
         mailboxStdinBuffer.retainOnly(surfaceIds: validSurfaceIds)
         panelPullRequests = panelPullRequests.filter { validSurfaceIds.contains($0.key) }
         SurfaceAttentionService.shared.prune(
@@ -8375,6 +8425,19 @@ final class Workspace: Identifiable, ObservableObject {
             surfaceId: panelId,
             key: MetadataKey.terminalType
         ) as? String
+    }
+
+    /// Terminal kind used only for live agent-state presentation.
+    ///
+    /// A detected shell means the prior agent process exited, so the surface
+    /// is now an ordinary terminal even though its durable resume identity is
+    /// retained. A recognized agent classification wins. Unknown child
+    /// commands fall back to the durable declaration to avoid roster flicker.
+    func surfaceActivityTerminalKind(panelId: UUID) -> String? {
+        SurfaceActivityTerminalKindResolver.resolve(
+            detectedTerminalType: detectedTerminalTypesBySurface[panelId],
+            declaredTerminalType: surfaceTerminalKind(panelId: panelId)
+        )
     }
 
     /// Optional per-surface minimum override (`min_cols` / `min_rows` metadata) —
@@ -9501,6 +9564,16 @@ final class Workspace: Identifiable, ObservableObject {
             suppressed: detached.attention.suppressed
         )
         SurfaceAttentionService.shared.restore(restoredAttention)
+        if detached.isAgentCold {
+            coldAgentSurfaceIds.insert(detached.panelId)
+        } else {
+            coldAgentSurfaceIds.remove(detached.panelId)
+        }
+        if let detectedTerminalType = detached.detectedTerminalType {
+            detectedTerminalTypesBySurface[detached.panelId] = detectedTerminalType
+        } else {
+            detectedTerminalTypesBySurface.removeValue(forKey: detached.panelId)
+        }
 
         guard let newTabId = bonsplitController.createTab(
             title: TitleFormatting.sidebarLabel(from: detached.title),
@@ -9530,6 +9603,8 @@ final class Workspace: Identifiable, ObservableObject {
             manualUnreadPanelIds.remove(detached.panelId)
             manualUnreadMarkedAt.removeValue(forKey: detached.panelId)
             derivedActivityBySurface.removeValue(forKey: detached.panelId)
+            coldAgentSurfaceIds.remove(detached.panelId)
+            detectedTerminalTypesBySurface.removeValue(forKey: detached.panelId)
             SurfaceAttentionService.shared.remove(workspaceId: id, surfaceId: detached.panelId)
             panelSubscriptions.removeValue(forKey: detached.panelId)
 #if DEBUG
@@ -11784,6 +11859,8 @@ extension Workspace: BonsplitDelegate {
                     surfaceId: panelId,
                     key: MetadataKey.activity
                 ),
+                isAgentCold: coldAgentSurfaceIds.contains(panelId),
+                detectedTerminalType: detectedTerminalTypesBySurface[panelId],
                 activityState: resolvedSurfaceTabActivityState(
                     panelId: panelId,
                     hasExactSurfaceNotification: false
@@ -11824,6 +11901,8 @@ extension Workspace: BonsplitDelegate {
         panelShellActivityStates.removeValue(forKey: panelId)
         derivedActivityBySurface.removeValue(forKey: panelId)
         attentionBySurface.removeValue(forKey: panelId)
+        coldAgentSurfaceIds.remove(panelId)
+        detectedTerminalTypesBySurface.removeValue(forKey: panelId)
         mailboxStdinBuffer.removeSurface(panelId)
         surfaceTTYNames.removeValue(forKey: panelId)
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
@@ -12005,6 +12084,8 @@ extension Workspace: BonsplitDelegate {
                 panelSubscriptions.removeValue(forKey: panelId)
                 panelShellActivityStates.removeValue(forKey: panelId)
                 derivedActivityBySurface.removeValue(forKey: panelId)
+                coldAgentSurfaceIds.remove(panelId)
+                detectedTerminalTypesBySurface.removeValue(forKey: panelId)
                 mailboxStdinBuffer.removeSurface(panelId)
                 surfaceTTYNames.removeValue(forKey: panelId)
                 surfaceListeningPorts.removeValue(forKey: panelId)

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4492,12 +4492,8 @@ struct SettingsView: View {
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
     @AppStorage("sidebarShowProgress") private var sidebarShowProgress = true
     @AppStorage("sidebarShowStatusPills") private var sidebarShowMetadata = true
-    // TEL-2: operator-tunable decay thresholds (stored in seconds; the
-    // Settings rows below present them in minutes).
-    @AppStorage(SidebarStalenessSettings.staleThresholdKey)
-    private var sidebarStaleThresholdSeconds = SidebarStalenessSettings.defaultStaleSeconds
-    @AppStorage(SidebarStalenessSettings.expiryThresholdKey)
-    private var sidebarExpiryThresholdSeconds = SidebarStalenessSettings.defaultExpirySeconds
+    @AppStorage(SidebarAgentColdSettings.thresholdKey)
+    private var sidebarAgentColdThresholdSeconds = SidebarAgentColdSettings.defaultSeconds
     @AppStorage("sidebarTintHex") private var sidebarTintHex = SidebarTintDefaults.hex
     @AppStorage("sidebarTintHexLight") private var sidebarTintHexLight: String?
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
@@ -5622,53 +5618,37 @@ struct SettingsView: View {
 
             SettingsCardDivider()
 
-            // TEL-2: decay thresholds. A status pill dims once older than the
-            // stale threshold and grays out (or hands off to derived activity)
-            // once older than the expiry threshold.
             SettingsCardRow(
-                String(localized: "settings.app.sidebarStaleThreshold.title", defaultValue: "Stale After"),
-                subtitle: String(localized: "settings.app.sidebarStaleThreshold.subtitle", defaultValue: "How long before a sidebar status pill dims to signal it may be going quiet.")
+                String(
+                    localized: "settings.app.sidebarAgentColdThreshold.title",
+                    defaultValue: "Agents Go Cold After"
+                ),
+                subtitle: String(
+                    localized: "settings.app.sidebarAgentColdThreshold.subtitle",
+                    defaultValue: "A live agent becomes Cold after this long without a submitted task or lifecycle activity."
+                )
             ) {
                 HStack(spacing: 8) {
                     Slider(
                         value: Binding<Double>(
-                            get: { sidebarStaleThresholdSeconds },
-                            set: { sidebarStaleThresholdSeconds = SidebarStalenessSettings.clamp($0) }
+                            get: { sidebarAgentColdThresholdSeconds },
+                            set: {
+                                sidebarAgentColdThresholdSeconds =
+                                    SidebarAgentColdSettings.clamp($0)
+                            }
                         ),
-                        in: SidebarStalenessSettings.minSeconds...SidebarStalenessSettings.maxSeconds,
-                        step: 15
+                        in: SidebarAgentColdSettings.minSeconds...SidebarAgentColdSettings.maxSeconds,
+                        step: 60
                     )
                     .controlSize(.small)
                     .frame(width: 140)
-                    .accessibilityLabel(String(localized: "settings.app.sidebarStaleThreshold.title", defaultValue: "Stale After"))
-                    Text(sidebarDecayThresholdLabel(sidebarStaleThresholdSeconds))
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                        .frame(minWidth: 56, alignment: .trailing)
-                }
-            }
-            .disabled(sidebarHideAllDetails)
-
-            SettingsCardDivider()
-
-            SettingsCardRow(
-                String(localized: "settings.app.sidebarExpiryThreshold.title", defaultValue: "Expire After"),
-                subtitle: String(localized: "settings.app.sidebarExpiryThreshold.subtitle", defaultValue: "How long before a status pill grays out entirely and derived activity takes over.")
-            ) {
-                HStack(spacing: 8) {
-                    Slider(
-                        value: Binding<Double>(
-                            get: { sidebarExpiryThresholdSeconds },
-                            set: { sidebarExpiryThresholdSeconds = SidebarStalenessSettings.clamp($0) }
-                        ),
-                        in: SidebarStalenessSettings.minSeconds...SidebarStalenessSettings.maxSeconds,
-                        step: 15
+                    .accessibilityLabel(
+                        String(
+                            localized: "settings.app.sidebarAgentColdThreshold.title",
+                            defaultValue: "Agents Go Cold After"
+                        )
                     )
-                    .controlSize(.small)
-                    .frame(width: 140)
-                    .accessibilityLabel(String(localized: "settings.app.sidebarExpiryThreshold.title", defaultValue: "Expire After"))
-                    Text(sidebarDecayThresholdLabel(sidebarExpiryThresholdSeconds))
+                    Text(sidebarDecayThresholdLabel(sidebarAgentColdThresholdSeconds))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .monospacedDigit()
@@ -5679,8 +5659,7 @@ struct SettingsView: View {
         }
     }
 
-    /// TEL-2: present a decay threshold (stored in seconds) as a compact
-    /// human label — minutes once it crosses a minute, seconds below that.
+    /// Present a duration stored in seconds as a compact human label.
     private func sidebarDecayThresholdLabel(_ seconds: Double) -> String {
         if seconds >= 60 {
             let minutes = seconds / 60
@@ -6599,8 +6578,9 @@ struct SettingsView: View {
         sidebarShowLog = true
         sidebarShowProgress = true
         sidebarShowMetadata = true
-        sidebarStaleThresholdSeconds = SidebarStalenessSettings.defaultStaleSeconds
-        sidebarExpiryThresholdSeconds = SidebarStalenessSettings.defaultExpirySeconds
+        defaults.removeObject(forKey: SidebarStalenessSettings.staleThresholdKey)
+        defaults.removeObject(forKey: SidebarStalenessSettings.expiryThresholdKey)
+        sidebarAgentColdThresholdSeconds = SidebarAgentColdSettings.defaultSeconds
         sidebarTintHex = SidebarTintDefaults.hex
         sidebarTintHexLight = nil
         sidebarTintHexDark = nil

--- a/c11Tests/AgentDetectorTests.swift
+++ b/c11Tests/AgentDetectorTests.swift
@@ -25,6 +25,29 @@ final class AgentDetectorTests: XCTestCase {
         XCTAssertEqual(AgentDetector.classify(comm: "codex", args: ""), "codex")
     }
 
+    /// Darwin can truncate a long executable path in `ps`'s `comm` column
+    /// while retaining the complete argv[0]. This is the exact staging
+    /// failure that left live Claude processes classified as `unknown`.
+    func testClassifyTruncatedCommUsesArgvZeroExecutable() {
+        XCTAssertEqual(
+            AgentDetector.classify(
+                comm: "/Users/atin/.loc",
+                args: "/Users/atin/.local/bin/claude --dangerously-skip-permissions --model opus"
+            ),
+            "claude-code"
+        )
+    }
+
+    func testClassifyArgvZeroDoesNotMatchLaterUserArguments() {
+        XCTAssertEqual(
+            AgentDetector.classify(
+                comm: "/Users/atin/.loc",
+                args: "/Users/atin/bin/report --label claude"
+            ),
+            "unknown"
+        )
+    }
+
     // MARK: - Node-wrapped matches via args substring
 
     func testClassifyNodeWrappedCopilotBinPathReturnsGitHubCopilot() {

--- a/c11Tests/SidebarActivityProjectorTests.swift
+++ b/c11Tests/SidebarActivityProjectorTests.swift
@@ -301,3 +301,73 @@ final class SidebarActivityProjectorTests: XCTestCase {
         )
     }
 }
+
+final class GhosttyOSCNotificationPolicyTests: XCTestCase {
+    func testClaudeHookDoesNotSuppressGrokNotificationInSameWorkspace() {
+        XCTAssertFalse(
+            GhosttyOSCNotificationPolicy.shouldSuppress(
+                hasActiveClaudeHookSession: true,
+                sourceTerminalKind: "grok"
+            )
+        )
+    }
+
+    func testClaudeHookSuppressesOnlyClaudeSurfaceNotification() {
+        XCTAssertTrue(
+            GhosttyOSCNotificationPolicy.shouldSuppress(
+                hasActiveClaudeHookSession: true,
+                sourceTerminalKind: "  CLAUDE-CODE "
+            )
+        )
+        XCTAssertFalse(
+            GhosttyOSCNotificationPolicy.shouldSuppress(
+                hasActiveClaudeHookSession: false,
+                sourceTerminalKind: "claude-code"
+            )
+        )
+        XCTAssertFalse(
+            GhosttyOSCNotificationPolicy.shouldSuppress(
+                hasActiveClaudeHookSession: true,
+                sourceTerminalKind: nil
+            )
+        )
+    }
+}
+
+final class WorkspacePulseDividerColorResolverTests: XCTestCase {
+    func testUsesBrandGoldWhenWorkspaceHasNoColor() {
+        XCTAssertEqual(
+            WorkspacePulseDividerColorResolver.resolve(
+                customHex: nil,
+                colorScheme: .dark
+            ).hexString(),
+            BrandColors.goldHex.uppercased()
+        )
+    }
+
+    func testUsesWorkspaceDisplayColorWhenSet() {
+        let customHex = "#1565C0"
+        let expected = WorkspaceTabColorSettings.displayNSColor(
+            hex: customHex,
+            colorScheme: .dark
+        )
+
+        XCTAssertEqual(
+            WorkspacePulseDividerColorResolver.resolve(
+                customHex: customHex,
+                colorScheme: .dark
+            ).hexString(),
+            expected?.hexString()
+        )
+    }
+
+    func testInvalidWorkspaceColorFallsBackToBrandGold() {
+        XCTAssertEqual(
+            WorkspacePulseDividerColorResolver.resolve(
+                customHex: "not-a-color",
+                colorScheme: .light
+            ).hexString(),
+            BrandColors.goldHex.uppercased()
+        )
+    }
+}

--- a/c11Tests/SidebarStalenessSettingsTests.swift
+++ b/c11Tests/SidebarStalenessSettingsTests.swift
@@ -123,4 +123,59 @@ final class SidebarStalenessSettingsTests: XCTestCase {
             .expired
         )
     }
+
+    // MARK: - live-agent cold threshold
+
+    func testAgentColdThresholdDefaultsToTenMinutes() {
+        let defaults = makeDefaults()
+        XCTAssertEqual(
+            SidebarAgentColdSettings.thresholdSeconds(
+                defaults: defaults,
+                environment: [:]
+            ),
+            10 * 60
+        )
+    }
+
+    func testAgentColdThresholdUsesStoredMinutesAndClampsRange() {
+        let defaults = makeDefaults()
+        defaults.set(15 * 60.0, forKey: SidebarAgentColdSettings.thresholdKey)
+        XCTAssertEqual(
+            SidebarAgentColdSettings.thresholdSeconds(
+                defaults: defaults,
+                environment: [:]
+            ),
+            15 * 60
+        )
+
+        defaults.set(1, forKey: SidebarAgentColdSettings.thresholdKey)
+        XCTAssertEqual(
+            SidebarAgentColdSettings.thresholdSeconds(
+                defaults: defaults,
+                environment: [:]
+            ),
+            SidebarAgentColdSettings.minSeconds
+        )
+
+        defaults.set(100_000, forKey: SidebarAgentColdSettings.thresholdKey)
+        XCTAssertEqual(
+            SidebarAgentColdSettings.thresholdSeconds(
+                defaults: defaults,
+                environment: [:]
+            ),
+            SidebarAgentColdSettings.maxSeconds
+        )
+    }
+
+    func testAgentColdThresholdEnvironmentOverrideWins() {
+        let defaults = makeDefaults()
+        defaults.set(20 * 60.0, forKey: SidebarAgentColdSettings.thresholdKey)
+        XCTAssertEqual(
+            SidebarAgentColdSettings.thresholdSeconds(
+                defaults: defaults,
+                environment: [SidebarAgentColdSettings.environmentKey: "300"]
+            ),
+            5 * 60
+        )
+    }
 }

--- a/c11Tests/SurfaceLivenessDeriverTests.swift
+++ b/c11Tests/SurfaceLivenessDeriverTests.swift
@@ -354,6 +354,32 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
         XCTAssertEqual(activitySource(ws, surface), .derived)
     }
 
+    func testReconcilePreservesStaleWorkingForDetectedLiveAgents() {
+        for agentKind in ["codex", "opencode", "pi", "grok"] {
+            let ws = UUID(); let surface = UUID()
+            defer { store.removeSurface(workspaceId: ws, surfaceId: surface) }
+
+            XCTAssertTrue(store.setInternal(
+                workspaceId: ws, surfaceId: surface,
+                key: MetadataKey.activity, value: SidebarActivityState.working.rawValue,
+                source: .derived
+            ))
+            SurfaceActivityTracker.shared.clear(surfaceId: surface.uuidString)
+
+            SurfaceLivenessDeriver.reconcile(
+                surfaceId: surface,
+                workspaceId: ws,
+                detectedTerminalType: agentKind
+            )
+            XCTAssertEqual(
+                activityValue(ws, surface),
+                SidebarActivityState.working.rawValue,
+                "\(agentKind) must stay working until an exact lifecycle signal says it is idle"
+            )
+            XCTAssertEqual(activitySource(ws, surface), .derived)
+        }
+    }
+
     func testReconcileLeavesFreshWorkingAlone() {
         let ws = UUID(); let surface = UUID()
         defer { store.removeSurface(workspaceId: ws, surfaceId: surface) }

--- a/c11Tests/SurfaceLivenessDeriverTests.swift
+++ b/c11Tests/SurfaceLivenessDeriverTests.swift
@@ -100,6 +100,15 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
             SurfaceTabActivityResolver.resolve(
                 hasExactSurfaceNotification: false,
                 derivedActivity: .idle,
+                isCold: true,
+                terminalType: "claude-code"
+            ),
+            .cold
+        )
+        XCTAssertEqual(
+            SurfaceTabActivityResolver.resolve(
+                hasExactSurfaceNotification: false,
+                derivedActivity: .idle,
                 terminalType: "claude-code"
             ),
             .idle
@@ -110,7 +119,7 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
                 derivedActivity: nil,
                 terminalType: "opencode-run"
             ),
-            .cold
+            .idle
         )
     }
 
@@ -142,7 +151,7 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
                 derivedActivity: nil,
                 terminalType: "codex"
             ),
-            .cold
+            .idle
         )
     }
 
@@ -157,6 +166,69 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
             derivedActivity: .idle,
             terminalType: nil
         ))
+        XCTAssertNil(SurfaceTabActivityResolver.resolve(
+            hasExactSurfaceNotification: false,
+            derivedActivity: .idle,
+            isCold: true,
+            terminalType: "shell"
+        ))
+    }
+
+    func testColdDormancyStartsAtConfiguredBoundaryForIdleAgentsOnly() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let threshold: TimeInterval = 10 * 60
+
+        XCTAssertFalse(SurfaceLivenessDeriver.isCold(
+            activity: .idle,
+            lastTouchedAt: now.addingTimeInterval(-threshold + 0.1),
+            now: now,
+            coldAfterSeconds: threshold
+        ))
+        XCTAssertTrue(SurfaceLivenessDeriver.isCold(
+            activity: .idle,
+            lastTouchedAt: now.addingTimeInterval(-threshold),
+            now: now,
+            coldAfterSeconds: threshold
+        ))
+        XCTAssertFalse(SurfaceLivenessDeriver.isCold(
+            activity: .working,
+            lastTouchedAt: now.addingTimeInterval(-threshold * 2),
+            now: now,
+            coldAfterSeconds: threshold
+        ))
+        XCTAssertFalse(SurfaceLivenessDeriver.isCold(
+            activity: .idle,
+            lastTouchedAt: nil,
+            now: now,
+            coldAfterSeconds: threshold
+        ))
+    }
+
+    func testDetectedShellTurnsDeclaredAgentIntoTerminalPresentation() {
+        XCTAssertEqual(
+            SurfaceActivityTerminalKindResolver.resolve(
+                detectedTerminalType: "shell",
+                declaredTerminalType: "codex"
+            ),
+            "shell"
+        )
+        XCTAssertEqual(
+            SurfaceActivityTerminalKindResolver.resolve(
+                detectedTerminalType: "codex",
+                declaredTerminalType: "claude-code"
+            ),
+            "codex"
+        )
+    }
+
+    func testUnknownForegroundChildKeepsDeclaredAgentPresentation() {
+        XCTAssertEqual(
+            SurfaceActivityTerminalKindResolver.resolve(
+                detectedTerminalType: "unknown",
+                declaredTerminalType: "claude-code"
+            ),
+            "claude-code"
+        )
     }
 
     func testHarnessIdentityDoesNotChangeResolvedState() {

--- a/c11Tests/TerminalControllerSocketSecurityTests.swift
+++ b/c11Tests/TerminalControllerSocketSecurityTests.swift
@@ -120,6 +120,17 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
 #endif
     }
 
+    func testPingHasContextFreeSocketWorkerResponse() async {
+        let response = await Task.detached {
+            XCTAssertFalse(Thread.isMainThread)
+            return TerminalController.socketWorkerImmediateV1Response("  PING  ")
+        }.value
+
+        XCTAssertEqual(response, "PONG")
+        XCTAssertNil(TerminalController.socketWorkerImmediateV1Response("list_windows"))
+        XCTAssertNil(TerminalController.socketWorkerImmediateV1Response(#"{"method":"system.ping"}"#))
+    }
+
     func testRemoteStatusPayloadOmitsSensitiveSSHConfiguration() {
         let tabManager = TabManager()
         let workspace = tabManager.addWorkspace(select: false, eagerLoadTerminal: false)

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -1253,6 +1253,60 @@ final class WorkspaceBrowserProfileSelectionTests: XCTestCase {
 
 
 @MainActor
+final class WorkspaceAgentPresentationTests: XCTestCase {
+    func testLiveIdleAgentProjectsColdOnlyWhileDormant() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let tabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(panelId))
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: workspace.id, surfaceId: panelId)
+        }
+
+        _ = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            partial: [MetadataKey.terminalType: "codex"],
+            mode: .merge,
+            source: .explicit
+        )
+        workspace.setDerivedActivity(.idle, forSurface: panelId)
+
+        workspace.setAgentCold(true, forSurface: panelId)
+        XCTAssertEqual(workspace.resolvedSurfaceTabActivityState(panelId: panelId), .cold)
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .cold)
+
+        workspace.setAgentCold(false, forSurface: panelId)
+        XCTAssertEqual(workspace.resolvedSurfaceTabActivityState(panelId: panelId), .idle)
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .idle)
+    }
+
+    func testAgentProcessExitImmediatelyRestoresTerminalPresentation() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let tabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(panelId))
+        defer {
+            SurfaceMetadataStore.shared.removeSurface(workspaceId: workspace.id, surfaceId: panelId)
+        }
+
+        _ = try SurfaceMetadataStore.shared.setMetadata(
+            workspaceId: workspace.id,
+            surfaceId: panelId,
+            partial: [MetadataKey.terminalType: "codex"],
+            mode: .merge,
+            source: .explicit
+        )
+        workspace.setDerivedActivity(.idle, forSurface: panelId)
+        XCTAssertEqual(workspace.resolvedSurfaceTabActivityState(panelId: panelId), .idle)
+
+        workspace.setDetectedTerminalType("shell", forSurface: panelId)
+        XCTAssertEqual(workspace.surfaceActivityTerminalKind(panelId: panelId), "shell")
+        XCTAssertNil(workspace.resolvedSurfaceTabActivityState(panelId: panelId))
+        XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
+    }
+}
+
+
+@MainActor
 final class WorkspacePanelGitBranchTests: XCTestCase {
     private func drainMainQueue() {
         let expectation = expectation(description: "drain main queue")
@@ -1498,7 +1552,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
 
         destination.setDerivedActivity(nil, forSurface: panelId)
-        XCTAssertEqual(destination.bonsplitController.tab(destinationTabId)?.activityState, .cold)
+        XCTAssertEqual(destination.bonsplitController.tab(destinationTabId)?.activityState, .idle)
 
         let rollbackTransfer = try XCTUnwrap(destination.detachSurface(panelId: panelId))
         XCTAssertEqual(
@@ -1509,10 +1563,10 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         let rollbackTabId = try XCTUnwrap(source.surfaceIdFromPanelId(panelId))
         XCTAssertEqual(source.surfaceTerminalKind(panelId: panelId), "codex")
         XCTAssertNil(source.derivedActivityBySurface[panelId])
-        XCTAssertEqual(source.bonsplitController.tab(rollbackTabId)?.activityState, .cold)
+        XCTAssertEqual(source.bonsplitController.tab(rollbackTabId)?.activityState, .idle)
     }
 
-    func testRemovingTerminalTypeMetadataClearsColdSurfaceActivityState() throws {
+    func testRemovingTerminalTypeMetadataClearsAgentSurfaceActivityState() throws {
         let manager = TabManager()
         let workspace = try XCTUnwrap(manager.selectedWorkspace)
         let panelId = try XCTUnwrap(workspace.focusedPanelId)
@@ -1521,7 +1575,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
             SurfaceMetadataStore.shared.removeSurface(workspaceId: workspace.id, surfaceId: panelId)
         }
 
-        func seedColdAgentState() throws {
+        func seedAgentState() throws {
             _ = try SurfaceMetadataStore.shared.setMetadata(
                 workspaceId: workspace.id,
                 surfaceId: panelId,
@@ -1530,10 +1584,10 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
                 source: .explicit
             )
             workspace.syncSurfaceTabActivityStateForPanel(panelId)
-            XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .cold)
+            XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .idle)
         }
 
-        try seedColdAgentState()
+        try seedAgentState()
         let clearResult = try SurfaceMetadataStore.shared.clearMetadata(
             workspaceId: workspace.id,
             surfaceId: panelId,
@@ -1551,7 +1605,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertTrue(clearResult.removedKeys.contains(MetadataKey.terminalType))
         XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
 
-        try seedColdAgentState()
+        try seedAgentState()
         let keyedClearResult = try SurfaceMetadataStore.shared.clearMetadata(
             workspaceId: workspace.id,
             surfaceId: panelId,
@@ -1569,7 +1623,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         XCTAssertEqual(keyedClearResult.removedKeys, [MetadataKey.terminalType])
         XCTAssertNil(workspace.bonsplitController.tab(tabId)?.activityState)
 
-        try seedColdAgentState()
+        try seedAgentState()
         let replaceResult = try SurfaceMetadataStore.shared.setMetadata(
             workspaceId: workspace.id,
             surfaceId: panelId,
@@ -1666,7 +1720,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         )
         apply(keyedClearResult)
         XCTAssertNil(workspace.derivedActivityBySurface[panelId])
-        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .cold)
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .idle)
 
         let clearAllResult = try SurfaceMetadataStore.shared.clearMetadata(
             workspaceId: workspace.id,
@@ -1702,7 +1756,7 @@ final class WorkspacePanelGitBranchTests: XCTestCase {
         apply(replaceResult)
         XCTAssertTrue(replaceResult.removedKeys.contains(MetadataKey.activity))
         XCTAssertNil(workspace.derivedActivityBySurface[panelId])
-        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .cold)
+        XCTAssertEqual(workspace.bonsplitController.tab(tabId)?.activityState, .idle)
     }
 
     func testClosingBackgroundTabPreservesSelectedSurfaceAndFocus() throws {

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -273,6 +273,9 @@ c11 set-agent --type opencode --model <model-id>
 - Writes land as `source: declare` in the metadata store, overriding heuristic auto-detection but not user-explicit writes.
 - Environment declaration: `C11_AGENT_TYPE`, `C11_AGENT_MODEL`, `C11_AGENT_TASK` in the surface's startup env are read once at surface-child-process start.
 - Clear with `c11 clear-metadata --key terminal_type` (no `c11 unset-agent`).
+- Bundled provider wrappers and runtime plugins may report exact loop state with
+  `c11 agent-hook working|idle`. This is a bundle-private lifecycle bridge,
+  not a command agents need to call in ordinary skill-driven operation.
 
 ## Title & description
 

--- a/skills/opencode-plugins/c11-notify.js
+++ b/skills/opencode-plugins/c11-notify.js
@@ -1,22 +1,29 @@
 // c11-notify.js — c11 notification + status bridge for OpenCode.
 //
-// Auto-installed by `c11 skill install --tool opencode` into
-// ~/.config/opencode/plugins/. OpenCode auto-loads plugins from that
-// directory at startup — no opencode.json edit required.
+// Runtime-loaded by c11's PATH-scoped OpenCode wrapper. Older c11 installs
+// may also have a copied plugin under ~/.config/opencode/plugins/; keeping this
+// module idempotent preserves compatibility without requiring tenant writes.
 //
 // Mirrors the Claude Code hook contract:
 //   session.idle       → c11 notify "Waiting for input"  (idle_prompt equivalent)
 //   permission.asked   → c11 notify "Approval needed"     (permission_prompt equivalent)
 //   session.error      → c11 notify "Session error"       (bonus, no Claude equivalent)
-//   session.status     → c11 set-metadata status=<value>  (sidebar chip)
+//   session.status     → c11 activity + status metadata
 //
 // The plugin is dependency-free and silently no-ops when c11 is not on
 // PATH or the socket is unavailable (e.g. OpenCode running outside c11).
 
 export const C11NotifyPlugin = async ({ $ }) => {
+  const loadedKey = Symbol.for("com.stage11.c11.opencode-notify.loaded");
+  if (globalThis[loadedKey]) return {};
+  globalThis[loadedKey] = true;
+
+  const childSessions = new Set();
+  const c11Bin = process.env.C11_AGENT_HOOK_CLI || "c11";
+
   const c11 = async (args) => {
     try {
-      await $`c11 ${args}`;
+      await $`${c11Bin} ${args}`.quiet();
     } catch {
       // c11 not on PATH, not running, or socket unavailable — no-op.
     }
@@ -29,8 +36,34 @@ export const C11NotifyPlugin = async ({ $ }) => {
     return c11(args);
   };
 
+  const sessionIDFrom = (properties) =>
+    typeof properties?.sessionID === "string" ? properties.sessionID : undefined;
+
+  const statusTypeFrom = (status) => {
+    if (typeof status === "string") return status.toLowerCase();
+    if (typeof status?.type === "string") return status.type.toLowerCase();
+    return undefined;
+  };
+
+  const reportActivity = (activity) => c11(["agent-hook", activity]);
+
   return {
+    "chat.message": async ({ sessionID }) => {
+      if (!sessionID || !childSessions.has(sessionID)) {
+        await reportActivity("working");
+      }
+    },
     event: async ({ event }) => {
+      const properties = event.properties ?? {};
+      const sessionID = sessionIDFrom(properties);
+      const info = properties.info;
+      if (info?.id && info.parentID) {
+        childSessions.add(info.id);
+      }
+      if (sessionID && childSessions.has(sessionID)) {
+        return;
+      }
+
       switch (event.type) {
         case "session.created": {
           // Exact-session resume rail (C11-151). Push the new opencode
@@ -40,7 +73,6 @@ export const C11NotifyPlugin = async ({ $ }) => {
           // not clobber the surface's primary conversation id. opencode
           // session ids are `ses_` + 26-char base62; the c11 CLI
           // revalidates the grammar before storing.
-          const info = event.properties?.info;
           if (info?.id && !info.parentID) {
             const args = [
               "conversation", "push",
@@ -57,15 +89,22 @@ export const C11NotifyPlugin = async ({ $ }) => {
           break;
         }
         case "session.idle":
+          await reportActivity("idle");
           await notify("OpenCode", "Waiting for input");
           await c11(["set-metadata", "--key", "status", "--value", "idle"]);
           break;
-        case "session.status":
-          // event.properties.status is the source of truth for the sidebar chip.
-          if (event.properties?.status) {
-            await c11(["set-metadata", "--key", "status", "--value", event.properties.status]);
+        case "session.status": {
+          const status = statusTypeFrom(properties.status);
+          if (status) {
+            await c11(["set-metadata", "--key", "status", "--value", status]);
+          }
+          if (status === "idle") {
+            await reportActivity("idle");
+          } else if (status === "busy" || status === "retry") {
+            await reportActivity("working");
           }
           break;
+        }
         case "permission.asked":
           await notify("OpenCode", "Approval needed", "Permission");
           await c11(["set-metadata", "--key", "status", "--value", "Needs input"]);

--- a/tests/test_codex_wrapper_hooks.py
+++ b/tests/test_codex_wrapper_hooks.py
@@ -113,7 +113,7 @@ fi
             )
             c11_lines = wait_for_line(
                 c11_log,
-                " notify " if callback else " codex-hook idle",
+                " notify " if callback else " agent-hook idle",
             )
         finally:
             if test_socket is not None:
@@ -148,7 +148,7 @@ def test_live_socket_injects_completion_callback(failures: list[str]) -> None:
         failures,
     )
     expect(real_argv[-1] == "hello", f"live socket: original argv was not preserved: {real_argv}", failures)
-    expect(any(" codex-hook idle" in line for line in c11_log), f"missing initial idle seed: {c11_log}", failures)
+    expect(any(" agent-hook idle" in line for line in c11_log), f"missing initial idle seed: {c11_log}", failures)
 
 
 def test_completion_callback_creates_surface_notification(failures: list[str]) -> None:

--- a/tests/test_opencode_plugin_lifecycle.mjs
+++ b/tests/test_opencode_plugin_lifecycle.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import path from "node:path";
+
+process.env.C11_AGENT_HOOK_CLI = "/bundle/bin/c11";
+const pluginPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../skills/opencode-plugins/c11-notify.js",
+);
+const { C11NotifyPlugin } = await import(pathToFileURL(pluginPath));
+
+const calls = [];
+const shell = (_strings, command, args) => {
+  return {
+    quiet: async () => {
+      calls.push({ command, args });
+    },
+  };
+};
+const hooks = await C11NotifyPlugin({ $: shell });
+
+await hooks["chat.message"]({ sessionID: "ses_root" });
+assert.deepEqual(calls.at(-1), {
+  command: "/bundle/bin/c11",
+  args: ["agent-hook", "working"],
+});
+
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: { sessionID: "ses_root", status: { type: "busy" } },
+  },
+});
+assert(calls.some(({ args }) => args.join(" ") === "agent-hook working"));
+assert(calls.some(({ args }) => args.join(" ") === "set-metadata --key status --value busy"));
+
+await hooks.event({
+  event: {
+    type: "session.idle",
+    properties: { sessionID: "ses_root" },
+  },
+});
+assert(calls.some(({ args }) => args.join(" ") === "agent-hook idle"));
+
+await hooks.event({
+  event: {
+    type: "session.created",
+    properties: { info: { id: "ses_child", parentID: "ses_root" } },
+  },
+});
+const beforeChildStatus = calls.length;
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: { sessionID: "ses_child", status: { type: "busy" } },
+  },
+});
+assert.equal(calls.length, beforeChildStatus, "child session must not clobber root liveness");
+
+const duplicate = await C11NotifyPlugin({ $: shell });
+assert.deepEqual(duplicate, {}, "duplicate plugin loads must be inert");
+
+console.log("PASS: OpenCode plugin reports root-session lifecycle exactly");

--- a/tests/test_opencode_wrapper_hooks.py
+++ b/tests/test_opencode_wrapper_hooks.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Runtime contract checks for c11's PATH-scoped OpenCode wrapper."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "opencode"
+SOURCE_PLUGIN = ROOT / "skills" / "opencode-plugins" / "c11-notify.js"
+
+
+def executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+
+
+def run_wrapper(
+    *,
+    live: bool,
+    argv: list[str],
+    existing_content: str | None = None,
+) -> tuple[int, list[str], dict, list[str], str]:
+    with tempfile.TemporaryDirectory(prefix="c11-opencode-wrapper-test-") as td:
+        tmp = Path(td)
+        root = tmp / "c11 bundle"
+        wrapper_dir = root / "bin"
+        plugin_dir = root / "skills" / "opencode-plugins"
+        real_dir = tmp / "real-bin"
+        wrapper_dir.mkdir(parents=True)
+        plugin_dir.mkdir(parents=True)
+        real_dir.mkdir()
+        shutil.copy2(SOURCE_WRAPPER, wrapper_dir / "opencode")
+        shutil.copy2(SOURCE_PLUGIN, plugin_dir / "c11-notify.js")
+        (wrapper_dir / "opencode").chmod(0o755)
+
+        args_log = tmp / "args.log"
+        env_log = tmp / "env.json"
+        c11_log = tmp / "c11.log"
+        socket_path = str(tmp / "c11.sock")
+
+        executable(
+            real_dir / "opencode",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$FAKE_ARGS_LOG"
+/usr/bin/python3 -c 'import json,os
+path = os.environ.get("OPENCODE_CONFIG")
+config_file = open(path).read() if path else None
+print(json.dumps({
+  "content": os.environ.get("OPENCODE_CONFIG_CONTENT"),
+  "config_file": config_file,
+  "hook_cli": os.environ.get("C11_AGENT_HOOK_CLI"),
+}))' > "$FAKE_ENV_LOG"
+""",
+        )
+        executable(
+            wrapper_dir / "c11",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_C11_LOG"
+""",
+        )
+
+        test_socket: socket.socket | None = None
+        if live:
+            test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket.bind(socket_path)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{wrapper_dir}:{real_dir}:/usr/bin:/bin",
+                "CMUX_SOCKET_PATH": socket_path,
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_SURFACE_ID": "22222222-2222-2222-2222-222222222222",
+                "FAKE_ARGS_LOG": str(args_log),
+                "FAKE_ENV_LOG": str(env_log),
+                "FAKE_C11_LOG": str(c11_log),
+            }
+        )
+        if existing_content is not None:
+            env["OPENCODE_CONFIG_CONTENT"] = existing_content
+        else:
+            env.pop("OPENCODE_CONFIG_CONTENT", None)
+        env.pop("OPENCODE_CONFIG", None)
+
+        try:
+            proc = subprocess.run(
+                [str(wrapper_dir / "opencode"), *argv],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            deadline = time.monotonic() + 2
+            while live and time.monotonic() < deadline:
+                if any("agent-hook idle" in line for line in read(c11_log)):
+                    break
+                time.sleep(0.02)
+        finally:
+            if test_socket is not None:
+                test_socket.close()
+
+        state = json.loads(env_log.read_text(encoding="utf-8")) if env_log.exists() else {}
+        return proc.returncode, read(args_log), state, read(c11_log), proc.stderr.strip()
+
+
+def test_live_tui_runtime_loads_plugin() -> None:
+    code, argv, state, c11_log, stderr = run_wrapper(live=True, argv=["--continue"])
+    assert code == 0, stderr
+    assert argv == ["--continue"], argv
+    config = json.loads(state["content"])
+    assert len(config["plugin"]) == 1, config
+    assert config["plugin"][0].endswith("/skills/opencode-plugins/c11-notify.js"), config
+    assert state["hook_cli"].endswith("/bin/c11"), state
+    assert any("set-agent --type opencode" in line for line in c11_log), c11_log
+    assert any("agent-hook idle" in line for line in c11_log), c11_log
+
+
+def test_existing_content_is_preserved_via_second_runtime_source() -> None:
+    existing = '{"theme":"operator-owned"}'
+    code, _, state, _, stderr = run_wrapper(
+        live=True,
+        argv=[],
+        existing_content=existing,
+    )
+    assert code == 0, stderr
+    assert state["content"] == existing, state
+    config = json.loads(state["config_file"])
+    assert config["plugin"][0].endswith("/c11-notify.js"), config
+
+
+def test_missing_socket_and_subcommand_are_transparent() -> None:
+    code, argv, state, c11_log, stderr = run_wrapper(live=False, argv=["--continue"])
+    assert code == 0, stderr
+    assert argv == ["--continue"], argv
+    assert state["content"] is None, state
+    assert c11_log == [], c11_log
+
+    code, argv, _, c11_log, stderr = run_wrapper(live=True, argv=["models"])
+    assert code == 0, stderr
+    assert argv == ["models"], argv
+    assert not any("agent-hook" in line for line in c11_log), c11_log
+
+
+if __name__ == "__main__":
+    test_live_tui_runtime_loads_plugin()
+    test_existing_content_is_preserved_via_second_runtime_source()
+    test_missing_socket_and_subcommand_are_transparent()
+    print("PASS: OpenCode lifecycle loads at runtime without tenant config writes")

--- a/tests/test_pi_wrapper_hooks.py
+++ b/tests/test_pi_wrapper_hooks.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Runtime contract checks for the c11-scoped Pi lifecycle wrapper."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "pi"
+SOURCE_EXTENSION = ROOT / "Resources" / "bin" / "pi-lifecycle.ts"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+
+
+def run_wrapper(socket_live: bool, argv: list[str]) -> tuple[int, list[str], list[str], list[str], str]:
+    with tempfile.TemporaryDirectory(prefix="c11-pi-wrapper-test-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "wrapper-bin"
+        real_dir = tmp / "real-bin"
+        wrapper_dir.mkdir()
+        real_dir.mkdir()
+        shutil.copy2(SOURCE_WRAPPER, wrapper_dir / "pi")
+        shutil.copy2(SOURCE_EXTENSION, wrapper_dir / "pi-lifecycle.ts")
+        (wrapper_dir / "pi").chmod(0o755)
+
+        real_args = tmp / "real-args.log"
+        real_env = tmp / "real-env.log"
+        c11_log = tmp / "c11.log"
+        socket_path = str(tmp / "c11.sock")
+
+        make_executable(
+            real_dir / "pi",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$FAKE_REAL_ARGS_LOG"
+printf '%s\\n' "${C11_AGENT_HOOK_CLI-}" > "$FAKE_REAL_ENV_LOG"
+""",
+        )
+        make_executable(
+            wrapper_dir / "c11",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_C11_LOG"
+""",
+        )
+
+        test_socket: socket.socket | None = None
+        if socket_live:
+            test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket.bind(socket_path)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{wrapper_dir}:{real_dir}:/usr/bin:/bin",
+                "CMUX_SOCKET_PATH": socket_path,
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_SURFACE_ID": "22222222-2222-2222-2222-222222222222",
+                "FAKE_REAL_ARGS_LOG": str(real_args),
+                "FAKE_REAL_ENV_LOG": str(real_env),
+                "FAKE_C11_LOG": str(c11_log),
+            }
+        )
+        try:
+            proc = subprocess.run(
+                [str(wrapper_dir / "pi"), *argv],
+                cwd=tmp,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            deadline = time.monotonic() + 2
+            while socket_live and time.monotonic() < deadline:
+                if any("agent-hook idle" in line for line in lines(c11_log)):
+                    break
+                time.sleep(0.02)
+        finally:
+            if test_socket is not None:
+                test_socket.close()
+
+        return proc.returncode, lines(real_args), lines(real_env), lines(c11_log), proc.stderr.strip()
+
+
+def test_interactive_live_surface() -> None:
+    code, argv, env_log, c11_log, stderr = run_wrapper(True, ["--model", "test"])
+    assert code == 0, stderr
+    assert argv[:2] == ["--extension", argv[1]]
+    assert argv[1].endswith("/pi-lifecycle.ts"), argv
+    assert argv[2:] == ["--model", "test"], argv
+    assert env_log and env_log[0].endswith("/c11"), env_log
+    assert any("set-agent --type pi" in line for line in c11_log), c11_log
+    assert any("conversation claim --kind pi" in line for line in c11_log), c11_log
+    assert any("agent-hook idle" in line for line in c11_log), c11_log
+
+
+def test_missing_socket_passes_through() -> None:
+    code, argv, _, c11_log, stderr = run_wrapper(False, ["--model", "test"])
+    assert code == 0, stderr
+    assert argv == ["--model", "test"], argv
+    assert c11_log == [], c11_log
+
+
+def test_noninteractive_command_passes_through() -> None:
+    code, argv, _, c11_log, stderr = run_wrapper(True, ["--version"])
+    assert code == 0, stderr
+    assert argv == ["--version"], argv
+    assert not any("agent-hook" in line for line in c11_log), c11_log
+
+
+if __name__ == "__main__":
+    test_interactive_live_surface()
+    test_missing_socket_passes_through()
+    test_noninteractive_command_passes_through()
+    print("PASS: Pi wrapper injects exact runtime lifecycle without persistent config")


### PR DESCRIPTION
`release/v0.60.0` was cut, `v0.60.1` and `v0.60.2` were tagged and published from it, and the branch was never merged back. `git merge-base --is-ancestor v0.60.2 origin/main` was **false**, so `main` has been a regression against what users are actually running: no `Resources/bin/opencode` wrapper at all, no `c11 agent-hook` CLI command, no cold-agent model, and `MARKETING_VERSION` still reading `0.60.0`.

This branch cherry-picks the two release commits onto `main` and resolves each conflict on the principle **main's newer feature work wins, the release line's fixes are additive**.

## Commits

| | |
|---|---|
| `12e8ec231` | Reconcile v0.60.1 onto main — cherry-pick of `b8f9c6576` ("Release v0.60.1 (#376)") |
| `323d84118` | Reconcile v0.60.2 onto main — cherry-pick of `8f2431991` ("Release v0.60.2 (#385)") |

## What was brought over

### From v0.60.1 (`b8f9c6576`)

Net of what `main` already had via #374, which was merged to `main` separately.

- **`Sources/SidebarStalenessSettings.swift`** — `SidebarAgentColdSettings`: a live agent goes Cold after a configurable untouched interval, default ten minutes.
- **`Sources/Workspace.swift`** — `coldAgentSurfaceIds` and `detectedTerminalTypesBySurface` published projections, `setAgentCold` / `setDetectedTerminalType`, snapshot/restore/prune paths for both, and `surfaceActivityTerminalKind`.
- **`Sources/SurfaceLivenessDeriver.swift`** — `SurfaceTabActivityResolver.resolve` takes `isCold`; new `SurfaceActivityTerminalKindResolver` reclassifies a surface as an ordinary terminal once its agent process exits, so an exited agent stops lingering as a dormant agent.
- **`Sources/AgentDetector.swift`** — census classification fixes.
- **`Sources/SocketHandlers/SocketDispatch.swift`** — the lightweight agent-launch socket ping no longer queues behind unrelated UI work and falsely reports a live c11 as unavailable.
- **`Sources/GhosttyTerminalView.swift`** — Grok and Codex surfaces keep their native notifications beside an open Claude surface.
- **`Sources/ContentView.swift`** — `WorkspacePulseDividerColorResolver`, tinting the pulse divider with the workspace's user color.
- **`Sources/c11App.swift`** — the "Agents Go Cold After" Settings control; the status-pill decay thresholds stay internal.
- **`Resources/Localizable.xcstrings`** — six-locale translations for `sidebar.workspacePulse.censusEmpty`, `censusSeparator`, `markOverflow`, and the two `settings.app.sidebarAgentColdThreshold.*` strings. **Insertions only** (+202 / -0); no existing entry was modified or dropped.
- **Tests** — `AgentDetectorTests`, `SidebarStalenessSettingsTests`, `SurfaceLivenessDeriverTests`, `SidebarActivityProjectorTests`, `WorkspaceUnitTests`, `TerminalControllerSocketSecurityTests`.
- **Version** — `MARKETING_VERSION` `0.60.0` → `0.60.1`, `CURRENT_PROJECT_VERSION` `118` → `121`.
- **`CHANGELOG.md`** — the `## [0.60.1]` section.

### From v0.60.2 (`8f2431991`)

This is the half `main` was missing outright.

- **`Resources/bin/opencode`** — the whole 92-line PATH-scoped wrapper. **New file; `main` had none.**
- **`Resources/bin/pi-lifecycle.ts`** — new. Plus `Resources/bin/pi` and `Resources/bin/codex` deltas.
- **`CLI/c11.swift`** — `codex-hook` generalises to **`agent-hook`**, with `codex-hook` retained as a compatibility alias for already-installed builds and wrapper fixtures. `main` had **zero** occurrences of `agent-hook`, so the opencode plugin and the wrappers had nothing to call.
- **`skills/opencode-plugins/c11-notify.js`** — taken from v0.60.2 wholesale. See the coordination note below.
- **`Sources/AgentDetector.swift`, `Sources/SurfaceLivenessDeriver.swift`** — Codex, OpenCode, Pi and Grok drive live-vs-idle from the agent loop rather than the outer shell.
- **Tests** — `tests/test_opencode_wrapper_hooks.py` (new), `tests/test_opencode_plugin_lifecycle.mjs` (new), `tests/test_pi_wrapper_hooks.py` (new), `tests/test_codex_wrapper_hooks.py` delta, `c11Tests/SurfaceLivenessDeriverTests.swift`.
- **`skills/c11/references/api.md`** — the agent-hook note.
- **Version** — `MARKETING_VERSION` `0.60.1` → `0.60.2`, `CURRENT_PROJECT_VERSION` `121` → `122`.
- **`CHANGELOG.md`** — the `## [0.60.2]` section.

## What was deliberately excluded, and why

### 1. The two model-picker revert commits

`3d218de2d` (Revert #357, Settings Saved Configs editor) and `ad3d3dd99` (Revert #355, A-button model picker) are **not** brought over. The operator has explicitly deferred the model-picker question; it is out of scope here. `main` keeps that code as-is — `c11Tests/AgentConfigEditorModelTests.swift`, `AgentPicker*`, `AgentConfig*` and everything else those reverts touched are untouched by this branch.

**This is why the reconcile is a cherry-pick and not a merge.** A plain `git merge v0.60.2` drags both reverts in and rips the model picker out of `main`.

### 2. The release line's `otherSurfaceCount` workspace-card census

The release line collapsed the card census into a single "N other surfaces" bucket. `main` superseded that in #386/#387 with separate `terminalCount` / `browserCount` / `documentCount`, which carries strictly more information. Main's design wins in `SidebarActivityProjector.swift`, `ContentView.swift`, the xcstrings census keys, and the projector/workspace tests. The now-dead `workspacePulseOtherSurfaceCountText` helper and the four orphaned `otherSurfaceCount` / `surfaceCount` string keys were dropped rather than carried in unused.

### 3. Cold-by-default is replaced by idle-until-marked — an explicit semantic decision

**This is the one change here that a green CI cannot vouch for, so it is called out rather than left implied.** Flagged in review by the agent in surface:34.

`SurfaceTabActivityResolver.resolve` had contradictory `case nil` behavior on the two parents — an agent-kind surface with no liveness evidence at all:

| | `case nil` | Origin |
|---|---|---|
| `main` | `return .cold` | #360, **2026-07-22** (pre-0.60.0) |
| release line | `return .idle`, with `.cold` gated on an explicit `isCold` mark | v0.60.1, **2026-07-26** |

**This branch takes the release line's version.** The reasoning, and why the "main's newer work wins" rule does *not* apply here:

- Main's `.cold` is not main's newer work. It arrives in `dbdd75ec5` ("Show agent state on surface tabs", #360) on 2026-07-22, before 0.60.0; v0.60.1 superseded it on 07-26. Main simply never received the fix.
- **Neither #386 nor #387 (both 07-28) touched the `nil` case.** #386 does not touch `Sources/SurfaceLivenessDeriver.swift` at all. #387 *does* (+4/-1), so it is worth being precise: its entire change sits inside the `hasExactSurfaceNotification` branch, adding the `flagged` / `suppressed` parameters and one early return. It never reaches the `switch derivedActivity`. Reproduce with `git show f5f4dbcbf -- Sources/SurfaceLivenessDeriver.swift`.

  (Reading the code diff is the reliable citation here. `git log -S "case nil: return .cold"` returns empty — that is two lines in the source, not one, so the single-line pickaxe finds nothing and should not be mistaken for evidence of absence.)
- It is shipped behavior in both 0.60.1 and 0.60.2. Restoring cold-by-default would re-regress every user.
- It contradicts the stated 0.60.1 contract. The changelog reads: *"Live agents become Cold after a configurable untouched interval, defaulting to ten minutes. Submitting a task or receiving lifecycle activity resets the clock."* Cold is a **time-based dormancy state**. Under cold-by-default a freshly launched agent reads Cold instantly, before any liveness signal can arrive — precisely the bug v0.60.1 fixed.

The consequence for tests: `main`'s `testRemovingTerminalTypeMetadataClearsColdSurfaceActivityState` and v0.60.2's `testRemovingTerminalTypeMetadataClearsAgentSurfaceActivityState` are the same test with one line different — the seed precondition asserts `.cold` on one parent and `.idle` on the other. Their actual subject (removing `terminal_type` clears the activity state to `nil`) is asserted identically in both, three times over. This branch keeps the v0.60.2 name and the `.idle` seed; main's copy is dropped as superseded, not as lost coverage.

Both branches of the semantics stay pinned at the resolver level in `c11Tests/SurfaceLivenessDeriverTests.swift`, so this cannot be flipped silently again: `isCold: true` → `.cold` (:103), and `derivedActivity: nil` with no mark → `.idle` (:119, :151).

Note that main's #387 suppression logic in the same function (`if suppressed && !flagged { return .idle }` on the exact-notification path) **is** newer than the release line and is kept — the merged resolver is the union.

### 3. The release line's shrinking pulse marks

The release line had `markSide = min(9, slot)` and `minimumSlot = 8`. Main's #386 hard-cell grammar fixes marks at 9pt and compresses the slot instead. Main wins.

### Kept from main

`Resources/bin/grok` and `Resources/bin/omp` (#377), which the release line lacks, plus all of #374 / #377 / #384 / #386 / #387. `vendor/bonsplit` stays on main's pointer (`41d7ada`, verified an ancestor of its `origin/main`).

## How the opencode overlap with surface:34 was resolved

Another agent was working on `main` in the main checkout with in-flight opencode changes. I messaged them before touching any opencode file with the v0.60.2 inventory. Their answer, after they independently diffed v0.60.2 against what they had pushed as `96269d1ff`:

> **My `c11-notify.js` does NOT supersede v0.60.2. It REGRESSES it. Take v0.60.2 wholesale; discard mine.**

Specifically, their version dropped four things that had already shipped: the `Symbol.for` idempotency guard, the `C11_AGENT_HOOK_CLI` indirection (theirs hardcoded `"c11"`), `childSessions` sub-agent filtering, and the `chat.message` → `c11 agent-hook working` activity rail. `.quiet()` was already in v0.60.2, so their stdout-leak fix duplicated shipped code.

Resulting ownership split:

| File | Owner | Outcome |
|---|---|---|
| `skills/opencode-plugins/c11-notify.js` | **v0.60.2** | Taken wholesale. No hunks merged from `96269d1ff`. |
| `Resources/bin/opencode` | **this PR** | They confirmed they are not adding a wrapper. No conflict. |
| `Sources/AgentManifest.swift` | **surface:34** | Untouched here. Their `opencode --auto` + `promptDelivery .flag("--prompt")` fix stands: v0.60.2's `factoryCommand` was the one-shot batch runner, which produces a dead shell on `launch-agent`. |
| `Sources/Conversation/Strategies/Opencode.swift` | **surface:34** | Untouched here (comment-only change on their side). |
| `CLI/c11.swift` | **both** | Merged cleanly. Their two resume-fallback lines survive at `CLI/c11.swift:12860` and `:12867`; the `agent-hook` command comes from v0.60.2. Verified both are present. |

Their wrapper-composition check holds: `Resources/bin/opencode` execs `"$REAL_OPENCODE" "$@"` unchanged, so their `opencode --auto` launch line composes with it.

## Verification

- `jq . Resources/Localizable.xcstrings` — valid. (`plutil` is the wrong tool here and fails on a healthy file; see CLAUDE.md.)
- **Localization key coverage:** 181 keys referenced in `Sources/`+`CLI/` are absent from xcstrings, identical to `main`'s 181. Set difference in both directions is empty — **no new gaps introduced, none closed.**
- **Interpolation tokens:** 24 `%@`/`%lld` mismatches across all locales, identical to `main`'s 24. **Zero new mismatches.** All five keys this PR adds translations for carry all six locales with matching token counts.
- `python3 tests/test_opencode_wrapper_hooks.py` — PASS
- `python3 tests/test_pi_wrapper_hooks.py` — PASS
- `python3 tests/test_codex_wrapper_hooks.py` — PASS
- `node tests/test_opencode_plugin_lifecycle.mjs` — PASS
- `plutil -lint GhosttyTabs.xcodeproj/project.pbxproj` — OK. Copy CLI phase carries all of `c11`, `claude`, `codex`, `pi`, `pi-lifecycle.ts`, `omp`, `grok`, `opencode`, `open`, `copilot`.
- `vendor/bonsplit` at `41d7ada`, confirmed an ancestor of its `origin/main`.
- No local `xcodebuild`, per standing instruction. CI's `build` job is the compile gate.

## Result

`main` is no longer a regression against shipped 0.60.2. After this lands, `git merge-base --is-ancestor` on the content is satisfied in substance: every file the release line shipped is present on `main` at its v0.60.2 content or newer, with the two deliberately-excluded reverts and the three superseded-design resolutions listed above as the complete set of intentional differences. `MARKETING_VERSION` reads `0.60.2` / build `122`.

**Note for the operator, raised independently by surface:34 as well:** no production release should be cut from `main` until this lands. Cutting today would ship users backwards from v0.60.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
