### PR TITLE
Fix a set -e trap in the Drawbridge sweep and harden its search calls

### DIFF
--- a/.github/workflows/drawbridge-sweep.yml
+++ b/.github/workflows/drawbridge-sweep.yml
@@ -35,8 +35,34 @@ jobs:
           set -euo pipefail
           MAX_DISPATCH=10
 
+          # search/issues carries GitHub's secondary rate limit, which a sweep can
+          # trip on a busy morning. Retry with backoff before giving up.
+          gh_search() {
+            local attempt
+            for attempt in 1 2 3; do
+              if gh api -X GET search/issues "$@"; then
+                return 0
+              fi
+              echo "search/issues attempt $attempt failed; retrying" >&2
+              sleep $((attempt * 10))
+            done
+            return 1
+          }
+
+          # A count is decoration on the digest, so degrade it rather than losing
+          # the whole digest to a throttled call.
+          count_open() {
+            local n
+            if n="$(gh_search -f q="$1" -f per_page=1 --jq '.total_count')"; then
+              printf '%s' "$n"
+            else
+              echo "::warning::could not count '$1'; reporting as unknown" >&2
+              printf '?'
+            fi
+          }
+
           q="repo:$GITHUB_REPOSITORY is:open -label:\"drawbridge:autonomous\" -label:\"drawbridge:review\" -label:\"drawbridge:close-suggest\""
-          gh api -X GET search/issues -f q="$q" -f per_page=50 \
+          gh_search -f q="$q" -f per_page=50 \
             --jq '.items | map({number, title, is_pr: (has("pull_request")), html_url})' > /tmp/untriaged.json
 
           total="$(jq 'length' /tmp/untriaged.json)"
@@ -52,8 +78,8 @@ jobs:
             dispatched=$((dispatched + 1))
           done < <(jq -c '.[]' /tmp/untriaged.json)
 
-          open_prs="$(gh api -X GET search/issues -f q="repo:$GITHUB_REPOSITORY is:open is:pr" -f per_page=1 --jq '.total_count')"
-          open_issues="$(gh api -X GET search/issues -f q="repo:$GITHUB_REPOSITORY is:open is:issue" -f per_page=1 --jq '.total_count')"
+          open_prs="$(count_open "repo:$GITHUB_REPOSITORY is:open is:pr")"
+          open_issues="$(count_open "repo:$GITHUB_REPOSITORY is:open is:issue")"
 
           {
             echo "🌉 **Nightly sweep** — $open_prs open PRs, $open_issues open issues, $total untriaged."
@@ -61,7 +87,9 @@ jobs:
               echo
               echo "Re-dispatched $dispatched for triage:"
               jq -r '.[] | "- [\(if .is_pr then "PR" else "issue" end) #\(.number): \(.title)](\(.html_url))"' /tmp/untriaged.json | head -n "$MAX_DISPATCH"
-              [[ "$total" -gt "$MAX_DISPATCH" ]] && echo "- …and $((total - MAX_DISPATCH)) more (next sweep)"
+              if [[ "$total" -gt "$MAX_DISPATCH" ]]; then
+                echo "- …and $((total - MAX_DISPATCH)) more (next sweep)"
+              fi
             fi
           } > /tmp/digest.md
 


### PR DESCRIPTION
**This does not fix the red X on the nightly sweep.** I initially misread the failure; correcting that here.

## What is actually failing

The sweep step has succeeded on every run, including the failing ones. The failure is one step later:

```
Post digest: curl: (6) Could not resolve host: zulip.stage11.ai
```

`zulip.stage11.ai` is tailnet-only and served from `pine`, which is offline (last seen 2 days ago). The name does not resolve publicly and does not resolve from a workstation on the tailnet either. Timeline matches exactly: sweep green daily through 2026-07-27 08:26Z, red on 07-28 and 07-29. Same story for the `drawbridge.yml` notify path, which shares the step.

That is infrastructure, not workflow, and it is tracked separately. The red X here is the notification system correctly reporting that notifications are dark, so this PR leaves that behavior alone.

## What this does fix

A real latent bug found while reading the step:

```bash
[[ "$total" -gt "$MAX_DISPATCH" ]] && echo "- …and $((total - MAX_DISPATCH)) more (next sweep)"
```

This is the last command in its `if` body, so whenever `0 < total <= MAX_DISPATCH` the false test propagates non-zero out of the block and `set -euo pipefail` kills the step, after the digest is built but before it is posted. **Any sweep that found a non-empty queue smaller than 10 items would have died here.** It has not fired in production only because recent sweeps found an empty queue. Rewritten as a plain `if`.

## Hardening (not fixing anything observed)

`search/issues` carries GitHub's secondary rate limit. The three search calls now retry with backoff, and the two count queries degrade to `?` rather than costing the whole digest a number that is decoration on a headline. The untriaged query still fails loudly after three attempts: a sweep that cannot read the backlog should not post a reassuring "0 untriaged".

Happy to drop this half if you would rather keep the diff to the one real bug.

## Verification

The step's shell body was extracted from the workflow and run against a stubbed `gh`, on both versions:

| case | before | after |
|---|---|---|
| 2-item dispatch list | **exit 1** | exit 0, full digest |
| counts throttled, 0 untriaged | exit 1, no digest | exit 0, `? open PRs, ? open issues, 0 untriaged` |
| happy path | exit 0 | exit 0 |

Also dispatched for real on this branch ([run 30477842106](https://github.com/Stage-11-Agentics/c11/actions/runs/30477842106)): the sweep step passes, and the run then fails at Post digest on the DNS error above, as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)