### PR TITLE
Remove the phantom overlay scrollbar from the workspace sidebar

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8762,9 +8762,20 @@ struct VerticalTabsSidebar: View {
                     }
                     .frame(minHeight: proxy.size.height, alignment: .top)
                 }
+                // The sidebar is a card rail, not a document; the overlay
+                // scroller renders as a grey bar over the cards (and the
+                // traffic-light strip) whenever the workspace list overflows.
+                .scrollIndicators(.never)
                 .background(
                     SidebarScrollViewResolver { scrollView in
                         dragAutoScrollController.attach(scrollView: scrollView)
+                        // Backstop for the .scrollIndicators modifier: SwiftUI's
+                        // ScrollView is NSScrollView-backed here, and AppKit can
+                        // still materialize an overlay scroller on scroll.
+                        scrollView?.hasVerticalScroller = false
+                        scrollView?.hasHorizontalScroller = false
+                        scrollView?.verticalScroller = nil
+                        scrollView?.horizontalScroller = nil
                     }
                     .frame(width: 0, height: 0)
                 )


### PR DESCRIPTION
## Problem

When enough workspaces exist that the sidebar's workspace list overflows vertically, scrolling the list makes macOS draw the ScrollView's overlay scroller: a grey bar riding the sidebar's right edge, overlapping the workspace cards and the traffic-light strip. The sidebar is a card rail, not a document; the indicator is pure noise there.

## Fix

The scroller belongs to the workspace-list `ScrollView` in `SidebarView` (`Sources/ContentView.swift`), which spans the full sidebar height (including under the traffic lights — which is why the bar overlapped them).

- `.scrollIndicators(.never)` on that ScrollView.
- Backstop in the existing `SidebarScrollViewResolver` hook: strip the backing `NSScrollView`'s vertical/horizontal scrollers. This also covers the "Always show scroll bars" system setting, which would otherwise force a legacy scroller.

Scrolling behavior is untouched — trackpad/wheel scrolling and the sidebar's drag auto-scroll still work; only the indicator is gone.

## Validation

Tagged build (`scrollbar-fix`) with 14 workspaces, driven by synthetic scroll-wheel events over the sidebar with screenshots captured mid-scroll at the top, middle, and bottom of the list: no scroller appears in any frame. Pane-content scrollbars (terminal, markdown) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)