### PR TITLE
C11-185: Agent activity tooltips and Surface Details timing

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -65569,6 +65569,241 @@
         }
       }
     },
+    "surfaceManifest.detail.activity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティビティ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "活動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활동"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активность"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Активність"
+          }
+        }
+      }
+    },
+    "surfaceManifest.detail.created": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Created"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成日時"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "创建时间"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "建立時間"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "생성 시각"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Создано"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Створено"
+          }
+        }
+      }
+    },
+    "surfaceManifest.detail.lastActivity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last activity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最終アクティビティ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近活动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最近活動"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마지막 활동"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Последняя активность"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Остання активність"
+          }
+        }
+      }
+    },
+    "surfaceManifest.detail.notRecorded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not recorded"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未记录"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未記錄"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록되지 않음"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не записано"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не записано"
+          }
+        }
+      }
+    },
+    "surfaceManifest.detail.timestampWithAge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — %2$@"
+          }
+        }
+      }
+    },
     "surfaceManifest.copyButton.short": {
       "extractionState": "manual",
       "localizations": {
@@ -65706,6 +65941,335 @@
           "stringUnit": {
             "state": "translated",
             "value": "Позначено: %@"
+          }
+        }
+      }
+    },
+    "surface.activity.cold": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cold"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コールド"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "冷态"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "冷態"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "콜드"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Холодная"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Холодна"
+          }
+        }
+      }
+    },
+    "surface.activity.durationFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ for %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@（%2$@経過）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@，已持续 %2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@，已持續 %2$@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%2$@ 동안 %1$@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — уже %2$@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ — уже %2$@"
+          }
+        }
+      }
+    },
+    "surface.activity.flagged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flagged: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フラグ付き：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已标记：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已標記：%@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "플래그됨: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Отмечено: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Позначено: %@"
+          }
+        }
+      }
+    },
+    "surface.activity.idle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Idle"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイドル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "空闲"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閒置"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "유휴"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Простой"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Простій"
+          }
+        }
+      }
+    },
+    "surface.activity.suppressed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suppressed"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "抑制中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已抑制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已抑制"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "억제됨"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подавлено"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Приглушено"
+          }
+        }
+      }
+    },
+    "surface.activity.waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting for your response"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "応答を待っています"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待你的回复"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "等待你的回覆"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "응답을 기다리는 중"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ожидает вашего ответа"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Очікує на вашу відповідь"
+          }
+        }
+      }
+    },
+    "surface.activity.working": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Working"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行中"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行中"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 중"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Работает"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Працює"
           }
         }
       }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8674,6 +8674,10 @@ struct VerticalTabsSidebar: View {
                                                 : nil
                                         )
                                         let attention = tab.attentionSnapshot(panelId: panelId)
+                                        let activityHelp = tab.resolvedAgentActivityHelp(
+                                            panelId: panelId,
+                                            activityState: resolved
+                                        )
                                         agents.append(
                                             WorkspacePulseAgent(
                                                 surfaceId: panelId,
@@ -8681,7 +8685,8 @@ struct VerticalTabsSidebar: View {
                                                 context: context,
                                                 flagged: attention.isFlagged,
                                                 suppressed: attention.suppressed,
-                                                flagReason: attention.flagReason
+                                                flagReason: attention.flagReason,
+                                                activityHelp: activityHelp
                                             )
                                         )
                                     }
@@ -11485,6 +11490,57 @@ enum ActivityMarkSettings {
     static let defaultStaticMarks = false
 }
 
+/// Native tooltip/accessibility leaf for an individual sidebar mark.
+///
+/// Elapsed text is refreshed on appearance and hover entry, so no per-agent
+/// timer or date formatting reaches the typing-hot workspace row body.
+private struct WorkspacePulseActivityHelpTarget<Content: View>: View {
+    let activityHelp: AgentActivityHelpProjection
+    let accessibilityLabel: String
+    @ViewBuilder let content: () -> Content
+
+    @State private var tooltipText: String
+    @State private var accessibilityText: String
+
+    init(
+        activityHelp: AgentActivityHelpProjection,
+        accessibilityLabel: String,
+        @ViewBuilder content: @escaping () -> Content
+    ) {
+        self.activityHelp = activityHelp
+        self.accessibilityLabel = accessibilityLabel
+        self.content = content
+        _tooltipText = State(
+            initialValue: ([activityHelp.help.stateLabel] + activityHelp.help.detailLines)
+                .joined(separator: "\n")
+        )
+        _accessibilityText = State(initialValue: activityHelp.accessibilityValue)
+    }
+
+    var body: some View {
+        content()
+            .contentShape(Rectangle())
+            .onAppear { refreshHelp() }
+            .onHover { hovering in
+                guard hovering else { return }
+                refreshHelp()
+            }
+            .help(tooltipText)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(accessibilityLabel))
+            .accessibilityValue(Text(accessibilityText))
+    }
+
+    private func refreshHelp() {
+        let now = Date()
+        tooltipText = activityHelp.text(at: now)
+        accessibilityText = BonsplitTabActivityHelpFormatter.accessibilityValue(
+            for: activityHelp.help,
+            at: now
+        )
+    }
+}
+
 /// Leaf-isolated workspace-pulse mark. This is the c11 renderer half of the
 /// shared 9pt vocabulary; its clock and phase sampling are the same Bonsplit
 /// primitives used by surface-tab marks.
@@ -12117,6 +12173,29 @@ private struct TabItemView: View, Equatable {
         )
     }
 
+    @ViewBuilder
+    private func workspacePulseMarkTarget(
+        for agent: WorkspacePulseAgent,
+        width: CGFloat,
+        height: CGFloat
+    ) -> some View {
+        let mark = workspacePulseMark(for: agent)
+            .frame(width: width, height: height)
+        if let activityHelp = agent.activityHelp {
+            WorkspacePulseActivityHelpTarget(
+                activityHelp: activityHelp,
+                accessibilityLabel: workspacePulseMarkAccessibilityLabel(agent)
+            ) {
+                mark
+            }
+        } else {
+            mark
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(Text(workspacePulseMarkAccessibilityLabel(agent)))
+                .accessibilityValue(Text(workspacePulseLabel(for: agent.presentedState)))
+        }
+    }
+
     private var workspacePulseVisibleAgents: [WorkspacePulseAgent] {
         Array(workspacePulse.relevantAgents.prefix(2))
     }
@@ -12126,13 +12205,11 @@ private struct TabItemView: View, Equatable {
     }
 
     private func workspacePulseMarkAccessibilityLabel(_ agent: WorkspacePulseAgent) -> String {
-        if agent.flagged {
-            return String(
-                localized: "sidebar.workspacePulse.flagged.accessibility",
-                defaultValue: "Flagged agent: \(agent.flagReason ?? "")"
+        agent.context?.title
+            ?? String(
+                localized: "surfaceManifest.detail.activity",
+                defaultValue: "Activity"
             )
-        }
-        return agent.context?.title ?? workspacePulseLabel(for: agent.presentedState)
     }
 
     private func openWorkspacePulseAgent(_ agent: WorkspacePulseAgent) {
@@ -12151,8 +12228,7 @@ private struct TabItemView: View, Equatable {
     ) -> some View {
         let context = agent.context
         let content = HStack(spacing: 7) {
-            workspacePulseMark(for: agent)
-                .frame(width: 16, height: 16)
+            workspacePulseMarkTarget(for: agent, width: 16, height: 16)
 
             Group {
                 if agent.flagged, let reason = agent.flagReason {
@@ -12181,14 +12257,14 @@ private struct TabItemView: View, Equatable {
             .buttonStyle(.plain)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
-            .accessibilityLabel(
-                agent.flagged
-                    ? Text(String(
-                        localized: "sidebar.workspacePulse.flagged.accessibility",
-                        defaultValue: "Flagged agent: \(agent.flagReason ?? "")"
-                    ))
-                    : Text(workspacePulseLabel(for: agent.presentedState))
-            )
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(Text(
+                agent.context?.title ?? workspacePulseMarkAccessibilityLabel(agent)
+            ))
+            .accessibilityValue(Text(
+                agent.activityHelp?.accessibilityValue
+                    ?? workspacePulseLabel(for: agent.presentedState)
+            ))
         } else {
             content
         }
@@ -12328,11 +12404,11 @@ private struct TabItemView: View, Equatable {
                 }
 
                 ForEach(visible) { agent in
-                    workspacePulseMark(for: agent)
-                        .frame(width: layout.slot, height: 14)
-                        .accessibilityElement(children: .ignore)
-                        .accessibilityLabel(Text(workspacePulseMarkAccessibilityLabel(agent)))
-                        .accessibilityValue(Text(workspacePulseLabel(for: agent.presentedState)))
+                    workspacePulseMarkTarget(
+                        for: agent,
+                        width: layout.slot,
+                        height: 14
+                    )
                 }
             }
             .frame(width: proxy.size.width, height: 14, alignment: .trailing)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1857,6 +1857,7 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     let id: UUID
+    let createdAt: Date?
     let panelType: PanelType = .browser
 
     /// The workspace ID this panel belongs to
@@ -2602,6 +2603,7 @@ final class BrowserPanel: Panel, ObservableObject {
     ///   snapshot store) so `Resume Workspace` has a destination.
     init(
         id: UUID? = nil,
+        createdAt: Date? = Date(),
         workspaceId: UUID,
         profileID: UUID? = nil,
         initialURL: URL? = nil,
@@ -2612,6 +2614,7 @@ final class BrowserPanel: Panel, ObservableObject {
         pendingHibernate: Bool = false
     ) {
         self.id = id ?? UUID()
+        self.createdAt = createdAt
         self.workspaceId = workspaceId
         let requestedProfileID = profileID ?? BrowserProfileStore.shared.effectiveLastUsedProfileID
         let resolvedProfileID = BrowserProfileStore.shared.profileDefinition(id: requestedProfileID) != nil

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -24,6 +24,7 @@ enum MarkdownSegment: Identifiable {
 @MainActor
 final class MarkdownPanel: Panel, ObservableObject {
     let id: UUID
+    let createdAt: Date?
     let panelType: PanelType = .markdown
 
     /// Absolute path to the markdown file being displayed, or nil when the
@@ -137,8 +138,14 @@ final class MarkdownPanel: Panel, ObservableObject {
     /// - Parameter filePath: Absolute path to a markdown file, or `nil` to
     ///   create an unbound panel (empty state — user binds via drag-drop or
     ///   the in-panel "Open Markdown File" button).
-    init(id: UUID? = nil, workspaceId: UUID, filePath: String? = nil) {
+    init(
+        id: UUID? = nil,
+        createdAt: Date? = Date(),
+        workspaceId: UUID,
+        filePath: String? = nil
+    ) {
         self.id = id ?? UUID()
+        self.createdAt = createdAt
         self.workspaceId = workspaceId
         self.filePath = filePath
         self.displayTitle = Self.titleForFilePath(filePath)

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -79,6 +79,10 @@ public protocol Panel: AnyObject, Identifiable, ObservableObject where ID == UUI
     /// Unique identifier for this panel
     var id: UUID { get }
 
+    /// Logical creation time for this surface. Legacy restored panels keep
+    /// this nil rather than inventing a timestamp at app launch.
+    var createdAt: Date? { get }
+
     /// The type of panel
     var panelType: PanelType { get }
 

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -8,6 +8,7 @@ import Bonsplit
 @MainActor
 final class TerminalPanel: Panel, ObservableObject {
     let id: UUID
+    let createdAt: Date?
     let panelType: PanelType = .terminal
 
     /// The underlying terminal surface
@@ -94,8 +95,9 @@ final class TerminalPanel: Panel, ObservableObject {
         surface.requestedWorkingDirectory
     }
 
-    init(workspaceId: UUID, surface: TerminalSurface) {
+    init(workspaceId: UUID, surface: TerminalSurface, createdAt: Date? = Date()) {
         self.id = surface.id
+        self.createdAt = createdAt
         self.workspaceId = workspaceId
         self.surface = surface
         self.lifecycle = SurfaceLifecycleController(
@@ -139,6 +141,7 @@ final class TerminalPanel: Panel, ObservableObject {
     /// app restarts (Tier 1 persistence, Phase 1).
     convenience init(
         id: UUID? = nil,
+        createdAt: Date? = Date(),
         workspaceId: UUID,
         context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_SPLIT,
         configTemplate: ghostty_surface_config_s? = nil,
@@ -159,7 +162,7 @@ final class TerminalPanel: Panel, ObservableObject {
             additionalEnvironment: additionalEnvironment
         )
         surface.portOrdinal = portOrdinal
-        self.init(workspaceId: workspaceId, surface: surface)
+        self.init(workspaceId: workspaceId, surface: surface, createdAt: createdAt)
     }
 
     func updateTitle(_ newTitle: String) {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -321,6 +321,9 @@ struct SessionMarkdownPanelSnapshot: Codable, Sendable {
 
 struct SessionPanelSnapshot: Codable, Sendable {
     var id: UUID
+    /// Logical surface creation time. Optional so legacy snapshots remain
+    /// honest: absence means "not recorded", never "created on restore".
+    var createdAt: Date? = nil
     var type: PanelType
     var title: String?
     var customTitle: String?
@@ -375,6 +378,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
         case id, type, title, customTitle, customColor, directory, isPinned,
              isManuallyUnread, gitBranch, listeningPorts, ttyName,
              terminal, browser, markdown, metadata, metadataSources
+        case createdAt = "created_at"
         case surfaceConversations = "surface_conversations"
         case lastActivityAt = "last_activity_at"
     }

--- a/Sources/Sidebar/SidebarActivityProjector.swift
+++ b/Sources/Sidebar/SidebarActivityProjector.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Bonsplit
 
 /// Coarse, derived activity classification for a workspace, computed from
 /// low-level surface signals when no agent has explicitly reported status.
@@ -22,6 +23,108 @@ enum WorkspacePulseState: String, CaseIterable {
     case cold
 }
 
+/// One c11-owned projection of the lifecycle and attention truth shown by
+/// top-tab/sidebar tooltips and Surface Details.
+///
+/// Renderers receive this immutable payload; they never infer lifecycle or
+/// consult metadata/activity/notification stores themselves.
+struct AgentActivityHelpProjection: Equatable {
+    let presentedState: WorkspacePulseState
+    let stateStartedAt: Date?
+    let help: BonsplitTabActivityHelp
+    let accessibilityValue: String
+    let lastActivityAt: Date?
+    let flagReason: String?
+    let flagRaisedAt: Date?
+    let suppressed: Bool
+
+    static func project(
+        state: WorkspacePulseState,
+        lastActivityAt: Date?,
+        waitingStartedAt: Date?,
+        coldAfterSeconds: TimeInterval,
+        flagReason: String?,
+        flagRaisedAt: Date?,
+        suppressed: Bool,
+        now: Date = Date()
+    ) -> AgentActivityHelpProjection {
+        let stateStartedAt: Date?
+        switch state {
+        case .waiting:
+            stateStartedAt = waitingStartedAt
+        case .working, .idle:
+            stateStartedAt = lastActivityAt
+        case .cold:
+            stateStartedAt = lastActivityAt?.addingTimeInterval(max(0, coldAfterSeconds))
+        }
+
+        let normalizedReason = flagReason?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        var detailLines: [String] = []
+        if let normalizedReason, !normalizedReason.isEmpty {
+            detailLines.append(String(
+                localized: "surface.activity.flagged",
+                defaultValue: "Flagged: \(normalizedReason)"
+            ))
+        }
+        if suppressed {
+            detailLines.append(String(
+                localized: "surface.activity.suppressed",
+                defaultValue: "Suppressed"
+            ))
+        }
+
+        let help = BonsplitTabActivityHelp(
+            stateLabel: localizedStateLabel(state),
+            startedAt: stateStartedAt,
+            durationFormat: String(
+                localized: "surface.activity.durationFormat",
+                defaultValue: "%1$@ for %2$@"
+            ),
+            detailLines: detailLines
+        )
+        return AgentActivityHelpProjection(
+            presentedState: state,
+            stateStartedAt: stateStartedAt,
+            help: help,
+            accessibilityValue: BonsplitTabActivityHelpFormatter.accessibilityValue(
+                for: help,
+                at: now
+            ),
+            lastActivityAt: lastActivityAt,
+            flagReason: normalizedReason.flatMap { $0.isEmpty ? nil : $0 },
+            flagRaisedAt: flagRaisedAt,
+            suppressed: suppressed
+        )
+    }
+
+    func text(at now: Date) -> String {
+        BonsplitTabActivityHelpFormatter.text(for: help, at: now)
+    }
+
+    private static func localizedStateLabel(_ state: WorkspacePulseState) -> String {
+        switch state {
+        case .waiting:
+            return String(
+                localized: "surface.activity.waiting",
+                defaultValue: "Waiting for your response"
+            )
+        case .working:
+            return String(localized: "surface.activity.working", defaultValue: "Working")
+        case .idle:
+            return String(localized: "surface.activity.idle", defaultValue: "Idle")
+        case .cold:
+            return String(localized: "surface.activity.cold", defaultValue: "Cold")
+        }
+    }
+}
+
+struct SurfaceActivityDetailsSnapshot: Equatable {
+    let activityHelp: AgentActivityHelpProjection?
+    let createdAt: Date?
+    let lastActivityAt: Date?
+}
+
 struct WorkspacePulseAgent: Equatable, Identifiable {
     let surfaceId: UUID
     let state: WorkspacePulseState
@@ -32,6 +135,7 @@ struct WorkspacePulseAgent: Equatable, Identifiable {
     let flagged: Bool
     let suppressed: Bool
     let flagReason: String?
+    let activityHelp: AgentActivityHelpProjection?
 
     var id: UUID { surfaceId }
 
@@ -41,7 +145,8 @@ struct WorkspacePulseAgent: Equatable, Identifiable {
         context: WorkspacePulseAgentContext?,
         flagged: Bool = false,
         suppressed: Bool = false,
-        flagReason: String? = nil
+        flagReason: String? = nil,
+        activityHelp: AgentActivityHelpProjection? = nil
     ) {
         self.surfaceId = surfaceId
         self.state = state
@@ -49,6 +154,7 @@ struct WorkspacePulseAgent: Equatable, Identifiable {
         self.flagged = flagged
         self.suppressed = suppressed
         self.flagReason = flagReason
+        self.activityHelp = activityHelp
     }
 
     /// Suppression is a lifecycle projection, and a flag wins when both

--- a/Sources/SurfaceManifestView.swift
+++ b/Sources/SurfaceManifestView.swift
@@ -39,11 +39,28 @@ struct SurfaceHandleInfo {
 struct SurfaceManifestSnapshot {
     let metadata: [String: Any]
     let sources: [String: [String: Any]]
+    let activity: SurfaceActivityDetailsSnapshot
     let capturedAt: Date
 
+    @MainActor
     static func capture(workspaceId: UUID, surfaceId: UUID) -> SurfaceManifestSnapshot {
         let result = SurfaceMetadataStore.shared.getMetadata(workspaceId: workspaceId, surfaceId: surfaceId)
-        return SurfaceManifestSnapshot(metadata: result.metadata, sources: result.sources, capturedAt: Date())
+        let workspace = AppDelegate.shared?
+            .tabManagerFor(tabId: workspaceId)?
+            .tabs
+            .first(where: { $0.id == workspaceId })
+        let activity = workspace?.surfaceActivityDetailsSnapshot(panelId: surfaceId)
+            ?? SurfaceActivityDetailsSnapshot(
+                activityHelp: nil,
+                createdAt: nil,
+                lastActivityAt: nil
+            )
+        return SurfaceManifestSnapshot(
+            metadata: result.metadata,
+            sources: result.sources,
+            activity: activity,
+            capturedAt: Date()
+        )
     }
 
     var prettyJSON: String {
@@ -180,47 +197,95 @@ struct SurfaceManifestView: View {
     }
 
     private var detailsSection: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            row(
-                label: String(localized: "surfaceManifest.detail.type", defaultValue: "Type"),
-                value: kind.localizedLabel
-            )
-            if let terminalType = handle.terminalType, !terminalType.isEmpty {
+        TimelineView(.periodic(from: .now, by: 30)) { context in
+            VStack(alignment: .leading, spacing: 4) {
                 row(
-                    label: String(localized: "surfaceManifest.detail.terminalType", defaultValue: "Terminal type"),
-                    value: terminalType
+                    label: String(localized: "surfaceManifest.detail.type", defaultValue: "Type"),
+                    value: kind.localizedLabel
+                )
+                if let terminalType = handle.terminalType, !terminalType.isEmpty {
+                    row(
+                        label: String(localized: "surfaceManifest.detail.terminalType", defaultValue: "Terminal type"),
+                        value: terminalType
+                    )
+                }
+                if let tty = handle.tty, !tty.isEmpty {
+                    row(
+                        label: String(localized: "surfaceManifest.detail.tty", defaultValue: "TTY"),
+                        value: tty
+                    )
+                }
+                if let cwd = handle.workingDirectory, !cwd.isEmpty {
+                    row(
+                        label: String(localized: "surfaceManifest.detail.directory", defaultValue: "Directory"),
+                        value: cwd
+                    )
+                }
+                if let url = handle.url, !url.isEmpty {
+                    row(
+                        label: String(localized: "surfaceManifest.detail.url", defaultValue: "URL"),
+                        value: url
+                    )
+                }
+                if let file = handle.filePath, !file.isEmpty {
+                    row(
+                        label: String(localized: "surfaceManifest.detail.file", defaultValue: "File"),
+                        value: file
+                    )
+                }
+                row(
+                    label: String(localized: "surfaceManifest.detail.activity", defaultValue: "Activity"),
+                    value: snapshot.activity.activityHelp?.text(at: context.date)
+                        ?? notRecordedText
+                )
+                row(
+                    label: String(localized: "surfaceManifest.detail.created", defaultValue: "Created"),
+                    value: snapshot.activity.createdAt.map {
+                        Self.timestampFormatter.string(from: $0)
+                    }
+                        ?? notRecordedText
+                )
+                row(
+                    label: String(
+                        localized: "surfaceManifest.detail.lastActivity",
+                        defaultValue: "Last activity"
+                    ),
+                    value: lastActivityText(at: context.date)
+                )
+                row(
+                    label: String(localized: "surfaceManifest.header.capturedAt", defaultValue: "Captured"),
+                    value: Self.timestampFormatter.string(from: snapshot.capturedAt)
                 )
             }
-            if let tty = handle.tty, !tty.isEmpty {
-                row(
-                    label: String(localized: "surfaceManifest.detail.tty", defaultValue: "TTY"),
-                    value: tty
-                )
-            }
-            if let cwd = handle.workingDirectory, !cwd.isEmpty {
-                row(
-                    label: String(localized: "surfaceManifest.detail.directory", defaultValue: "Directory"),
-                    value: cwd
-                )
-            }
-            if let url = handle.url, !url.isEmpty {
-                row(
-                    label: String(localized: "surfaceManifest.detail.url", defaultValue: "URL"),
-                    value: url
-                )
-            }
-            if let file = handle.filePath, !file.isEmpty {
-                row(
-                    label: String(localized: "surfaceManifest.detail.file", defaultValue: "File"),
-                    value: file
-                )
-            }
-            row(
-                label: String(localized: "surfaceManifest.header.capturedAt", defaultValue: "Captured"),
-                value: Self.timestampFormatter.string(from: snapshot.capturedAt)
-            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var notRecordedText: String {
+        String(
+            localized: "surfaceManifest.detail.notRecorded",
+            defaultValue: "Not recorded"
+        )
+    }
+
+    private func lastActivityText(at now: Date) -> String {
+        guard let lastActivityAt = snapshot.activity.lastActivityAt else {
+            return notRecordedText
+        }
+        let absolute = Self.timestampFormatter.string(from: lastActivityAt)
+        let relative = Self.activityRelativeAgeFormatter.localizedString(
+            for: lastActivityAt,
+            relativeTo: now
+        )
+        return String(
+            format: String(
+                localized: "surfaceManifest.detail.timestampWithAge",
+                defaultValue: "%1$@ — %2$@"
+            ),
+            locale: .current,
+            absolute,
+            relative
+        )
     }
 
     private func row(label: String, value: String) -> some View {
@@ -425,7 +490,14 @@ struct SurfaceManifestView: View {
 
     private static let timestampFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        f.dateFormat = "yyyy-MM-dd HH:mm:ss zzz (ZZZZZ)"
+        return f
+    }()
+
+    private static let activityRelativeAgeFormatter: RelativeDateTimeFormatter = {
+        let f = RelativeDateTimeFormatter()
+        f.dateTimeStyle = .numeric
+        f.unitsStyle = .full
         return f
     }()
 

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -924,6 +924,18 @@ final class TerminalNotificationStore: ObservableObject {
         indexes.unreadByTabSurface.contains(TabSurfaceKey(tabId: tabId, surfaceId: surfaceId))
     }
 
+    /// Exact creation boundary for the signal-eligible unread notification
+    /// driving one surface into waiting. Callers use this as tooltip timing
+    /// evidence; absence stays nil rather than manufacturing an age.
+    func unreadNotificationCreatedAt(forTabId tabId: UUID, surfaceId: UUID) -> Date? {
+        notifications.first {
+            !$0.isRead
+                && $0.tabId == tabId
+                && $0.surfaceId == surfaceId
+                && Self.isSignalEligible($0)
+        }?.createdAt
+    }
+
     func hasRawUnreadNotification(forTabId tabId: UUID, surfaceId: UUID?) -> Bool {
         indexes.rawUnreadByTabSurface.contains(TabSurfaceKey(tabId: tabId, surfaceId: surfaceId))
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -908,6 +908,7 @@ extension Workspace {
         }
         return SessionPanelSnapshot(
             id: panelId,
+            createdAt: panel.createdAt,
             type: panel.panelType,
             title: panelTitle,
             customTitle: customTitle,
@@ -1065,7 +1066,8 @@ extension Workspace {
                 focus: false,
                 workingDirectory: workingDirectory,
                 startupEnvironment: replayEnvironment,
-                panelId: restoredPanelId
+                panelId: restoredPanelId,
+                createdAt: snapshot.createdAt
             ) else {
                 return nil
             }
@@ -1091,7 +1093,8 @@ extension Workspace {
                 focus: false,
                 preferredProfileID: snapshot.browser?.profileID,
                 panelId: restoredPanelId,
-                pendingHibernate: restoredHibernated
+                pendingHibernate: restoredHibernated,
+                createdAt: snapshot.createdAt
             ) else {
                 return nil
             }
@@ -1102,7 +1105,8 @@ extension Workspace {
                 inPane: paneId,
                 filePath: snapshot.markdown?.filePath,
                 focus: false,
-                panelId: restoredPanelId
+                panelId: restoredPanelId,
+                createdAt: snapshot.createdAt
             ) else {
                 return nil
             }
@@ -6780,22 +6784,74 @@ final class Workspace: Identifiable, ObservableObject {
         activityState: BonsplitTabActivityState?
     ) -> BonsplitTabActivityPresentation? {
         let attention = attentionSnapshot(panelId: panelId)
-        if let reason = attention.flagReason {
-            return BonsplitTabActivityPresentation(
-                colorOverrideHex: "#9D8AD9",
-                motion: activityState == .waiting ? .binaryFlash : .breathe,
-                alternateCoreColorHex: activityState == .waiting ? "#FFFFFF" : nil,
-                suppressesDefaultMotion: true,
-                accessibilityValue: String(
-                    localized: "surface.flag.accessibility",
-                    defaultValue: "Flagged: \(reason)"
-                )
+        let help = resolvedAgentActivityHelp(
+            panelId: panelId,
+            activityState: activityState
+        )
+        guard help != nil || attention.isFlagged || attention.suppressed else {
+            return nil
+        }
+        return BonsplitTabActivityPresentation(
+            colorOverrideHex: attention.isFlagged ? "#9D8AD9" : nil,
+            motion: attention.isFlagged
+                ? (activityState == .waiting ? .binaryFlash : .breathe)
+                : nil,
+            alternateCoreColorHex: attention.isFlagged && activityState == .waiting
+                ? "#FFFFFF"
+                : nil,
+            suppressesDefaultMotion: attention.isFlagged || attention.suppressed,
+            accessibilityValue: help?.accessibilityValue,
+            help: help?.help
+        )
+    }
+
+    func resolvedAgentActivityHelp(
+        panelId: UUID,
+        activityState: BonsplitTabActivityState?
+    ) -> AgentActivityHelpProjection? {
+        let state: WorkspacePulseState
+        switch activityState {
+        case .waiting: state = .waiting
+        case .running: state = .working
+        case .idle: state = .idle
+        case .cold: state = .cold
+        case nil: return nil
+        }
+        let attention = attentionSnapshot(panelId: panelId)
+        let lastActivityAt = SurfaceActivityTracker.shared.lastActivity(
+            for: panelId.uuidString
+        )
+        let waitingStartedAt = state == .waiting
+            ? AppDelegate.shared?.notificationStore?.unreadNotificationCreatedAt(
+                forTabId: id,
+                surfaceId: panelId
             )
-        }
-        if attention.suppressed {
-            return BonsplitTabActivityPresentation(suppressesDefaultMotion: true)
-        }
-        return nil
+            : nil
+        return AgentActivityHelpProjection.project(
+            state: state,
+            lastActivityAt: lastActivityAt,
+            waitingStartedAt: waitingStartedAt,
+            coldAfterSeconds: SidebarAgentColdSettings.thresholdSeconds(),
+            flagReason: attention.flagReason,
+            flagRaisedAt: attention.flagRaisedAt,
+            suppressed: attention.suppressed
+        )
+    }
+
+    func surfaceActivityDetailsSnapshot(
+        panelId: UUID
+    ) -> SurfaceActivityDetailsSnapshot {
+        let activityState = resolvedSurfaceTabActivityState(panelId: panelId)
+        let activityHelp = resolvedAgentActivityHelp(
+            panelId: panelId,
+            activityState: activityState
+        )
+        return SurfaceActivityDetailsSnapshot(
+            activityHelp: activityHelp,
+            createdAt: panels[panelId]?.createdAt,
+            lastActivityAt: activityHelp?.lastActivityAt
+                ?? SurfaceActivityTracker.shared.lastActivity(for: panelId.uuidString)
+        )
     }
 
     func syncSurfaceTabActivityStateForPanel(
@@ -8657,7 +8713,8 @@ final class Workspace: Identifiable, ObservableObject {
         focus: Bool? = nil,
         workingDirectory: String? = nil,
         startupEnvironment: [String: String] = [:],
-        panelId: UUID? = nil
+        panelId: UUID? = nil,
+        createdAt: Date? = Date()
     ) -> TerminalPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let previousFocusedPanelId = focusedPanelId
@@ -8669,6 +8726,7 @@ final class Workspace: Identifiable, ObservableObject {
         // Create new terminal panel
         let newPanel = TerminalPanel(
             id: panelId,
+            createdAt: createdAt,
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
@@ -8841,7 +8899,8 @@ final class Workspace: Identifiable, ObservableObject {
         preferredProfileID: UUID? = nil,
         bypassInsecureHTTPHostOnce: String? = nil,
         panelId: UUID? = nil,
-        pendingHibernate: Bool = false
+        pendingHibernate: Bool = false,
+        createdAt: Date? = Date()
     ) -> BrowserPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let sourcePanelId = effectiveSelectedPanelId(inPane: paneId)
@@ -8850,6 +8909,7 @@ final class Workspace: Identifiable, ObservableObject {
 
         let browserPanel = BrowserPanel(
             id: panelId,
+            createdAt: createdAt,
             workspaceId: id,
             profileID: resolvedNewBrowserProfileID(
                 preferredProfileID: preferredProfileID,
@@ -8967,13 +9027,19 @@ final class Workspace: Identifiable, ObservableObject {
         inPane paneId: PaneID,
         filePath: String? = nil,
         focus: Bool? = nil,
-        panelId: UUID? = nil
+        panelId: UUID? = nil,
+        createdAt: Date? = Date()
     ) -> MarkdownPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalPanel?.hostedView
 
-        let markdownPanel = MarkdownPanel(id: panelId, workspaceId: id, filePath: filePath)
+        let markdownPanel = MarkdownPanel(
+            id: panelId,
+            createdAt: createdAt,
+            workspaceId: id,
+            filePath: filePath
+        )
         panels[markdownPanel.id] = markdownPanel
         panelTitles[markdownPanel.id] = markdownPanel.displayTitle
 

--- a/c11Tests/NotificationAndMenuBarTests.swift
+++ b/c11Tests/NotificationAndMenuBarTests.swift
@@ -561,6 +561,50 @@ final class NotificationAndMenuBarTests: XCTestCase {
         XCTAssertEqual(store.latestNotification(forTabId: tabB)?.id, notificationBUnread.id)
     }
 
+    func testUnreadNotificationCreationBoundaryUsesExactEligibleSurfaceSignal() {
+        let tab = UUID()
+        let targetSurface = UUID()
+        let otherSurface = UUID()
+        let targetCreatedAt = Date(timeIntervalSince1970: 1_700_000_123)
+        let store = TerminalNotificationStore.shared
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: tab,
+                surfaceId: otherSurface,
+                title: "Other",
+                subtitle: "",
+                body: "",
+                createdAt: targetCreatedAt.addingTimeInterval(30),
+                isRead: false
+            ),
+            TerminalNotification(
+                id: UUID(),
+                tabId: tab,
+                surfaceId: targetSurface,
+                title: "Target",
+                subtitle: "",
+                body: "",
+                createdAt: targetCreatedAt,
+                isRead: false
+            ),
+        ])
+
+        XCTAssertEqual(
+            store.unreadNotificationCreatedAt(
+                forTabId: tab,
+                surfaceId: targetSurface
+            ),
+            targetCreatedAt
+        )
+        XCTAssertNil(
+            store.unreadNotificationCreatedAt(
+                forTabId: tab,
+                surfaceId: UUID()
+            )
+        )
+    }
+
     func testNotificationIndexesUpdateAfterReadAndClearMutations() {
         let tab = UUID()
         let surfaceUnread = UUID()

--- a/c11Tests/SessionPersistenceTests.swift
+++ b/c11Tests/SessionPersistenceTests.swift
@@ -293,6 +293,50 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNil(decoded.lastActivityAt)
     }
 
+    func testSessionPanelSnapshotLogicalCreationRoundTrip() throws {
+        let createdAt = Date(timeIntervalSince1970: 1_700_000_456)
+        let snapshot = SessionPanelSnapshot(
+            id: UUID(),
+            createdAt: createdAt,
+            type: .browser,
+            title: nil,
+            customTitle: nil,
+            customColor: nil,
+            directory: nil,
+            isPinned: false,
+            isManuallyUnread: false,
+            gitBranch: nil,
+            listeningPorts: [],
+            ttyName: nil,
+            terminal: nil,
+            browser: nil,
+            markdown: nil,
+            metadata: nil,
+            metadataSources: nil
+        )
+
+        let encoded = try JSONEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: encoded)
+        XCTAssertEqual(decoded.createdAt, createdAt)
+    }
+
+    func testSessionPanelSnapshotLegacyCreationIsNotInvented() throws {
+        let panelId = UUID()
+        let legacyJSON = """
+        {
+          "id": "\(panelId.uuidString)",
+          "type": "markdown",
+          "isPinned": false,
+          "isManuallyUnread": false,
+          "listeningPorts": []
+        }
+        """
+
+        let data = try XCTUnwrap(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(SessionPanelSnapshot.self, from: data)
+        XCTAssertNil(decoded.createdAt)
+    }
+
     func testWorkspaceCustomColorDecodeSupportsMissingLegacyField() throws {
         var snapshot = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
         snapshot.windows[0].tabManager.workspaces[0].customColor = nil

--- a/c11Tests/SurfaceLivenessDeriverTests.swift
+++ b/c11Tests/SurfaceLivenessDeriverTests.swift
@@ -204,6 +204,100 @@ final class SurfaceLivenessDeriverTests: XCTestCase {
         ))
     }
 
+    func testActivityHelpUsesHonestStateBoundariesAndMissingEvidence() {
+        let now = Date(timeIntervalSince1970: 20_000)
+        let lastActivity = now.addingTimeInterval(-10 * 60)
+        let waitingStarted = now.addingTimeInterval(-2 * 60)
+
+        let working = AgentActivityHelpProjection.project(
+            state: .working,
+            lastActivityAt: lastActivity,
+            waitingStartedAt: nil,
+            coldAfterSeconds: 5 * 60,
+            flagReason: nil,
+            flagRaisedAt: nil,
+            suppressed: false,
+            now: now
+        )
+        XCTAssertEqual(working.help.startedAt, lastActivity)
+        XCTAssertEqual(working.stateStartedAt, lastActivity)
+        XCTAssertEqual(working.lastActivityAt, lastActivity)
+
+        let waiting = AgentActivityHelpProjection.project(
+            state: .waiting,
+            lastActivityAt: lastActivity,
+            waitingStartedAt: waitingStarted,
+            coldAfterSeconds: 5 * 60,
+            flagReason: nil,
+            flagRaisedAt: nil,
+            suppressed: false,
+            now: now
+        )
+        XCTAssertEqual(waiting.help.startedAt, waitingStarted)
+
+        let cold = AgentActivityHelpProjection.project(
+            state: .cold,
+            lastActivityAt: lastActivity,
+            waitingStartedAt: nil,
+            coldAfterSeconds: 5 * 60,
+            flagReason: nil,
+            flagRaisedAt: nil,
+            suppressed: false,
+            now: now
+        )
+        XCTAssertEqual(
+            cold.help.startedAt,
+            lastActivity.addingTimeInterval(5 * 60),
+            "Cold age begins at threshold crossing, not at the start of idle time"
+        )
+
+        let missing = AgentActivityHelpProjection.project(
+            state: .idle,
+            lastActivityAt: nil,
+            waitingStartedAt: nil,
+            coldAfterSeconds: 5 * 60,
+            flagReason: nil,
+            flagRaisedAt: nil,
+            suppressed: false,
+            now: now
+        )
+        XCTAssertNil(missing.help.startedAt)
+        XCTAssertEqual(missing.help.stateLabel, missing.text(at: now))
+    }
+
+    func testSuppressedWaitingAndFlagModifierCompositionPreserveLifecycle() {
+        let now = Date(timeIntervalSince1970: 20_000)
+        XCTAssertEqual(
+            SurfaceTabActivityResolver.resolve(
+                hasExactSurfaceNotification: true,
+                derivedActivity: .idle,
+                terminalType: "codex",
+                flagged: false,
+                suppressed: true
+            ),
+            .idle
+        )
+
+        let help = AgentActivityHelpProjection.project(
+            state: .idle,
+            lastActivityAt: now.addingTimeInterval(-7 * 60),
+            waitingStartedAt: nil,
+            coldAfterSeconds: 10 * 60,
+            flagReason: "Need a decision",
+            flagRaisedAt: now.addingTimeInterval(-60),
+            suppressed: true,
+            now: now
+        )
+        XCTAssertEqual(help.help.detailLines.count, 2)
+        XCTAssertEqual(help.flagReason, "Need a decision")
+        XCTAssertEqual(help.flagRaisedAt, now.addingTimeInterval(-60))
+        XCTAssertTrue(help.suppressed)
+        XCTAssertTrue(help.help.detailLines[0].contains("Need a decision"))
+        XCTAssertEqual(help.help.detailLines[1], "Suppressed")
+        XCTAssertTrue(help.text(at: now).hasPrefix("Idle"))
+        XCTAssertTrue(help.text(at: now).contains("\nFlagged: Need a decision\nSuppressed"))
+    }
+
     func testDetectedShellTurnsDeclaredAgentIntoTerminalPresentation() {
         XCTAssertEqual(
             SurfaceActivityTerminalKindResolver.resolve(

--- a/c11Tests/WorkspaceUnitTests.swift
+++ b/c11Tests/WorkspaceUnitTests.swift
@@ -2523,6 +2523,39 @@ final class WorkspacePulseSurfaceCensusProjectionTests: XCTestCase {
 }
 
 @MainActor
+final class WorkspaceLogicalCreationPersistenceTests: XCTestCase {
+    func testSnapshotAndRestorePreserveCreationAcrossPanelKinds() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let paneId = try XCTUnwrap(workspace.bonsplitController.allPaneIds.first)
+        let terminal = try XCTUnwrap(workspace.focusedTerminalPanel)
+        let browser = try XCTUnwrap(
+            workspace.newBrowserSurface(inPane: paneId, focus: false)
+        )
+        let markdown = try XCTUnwrap(
+            workspace.newMarkdownSurface(inPane: paneId, focus: false)
+        )
+
+        let expected = [
+            terminal.id: try XCTUnwrap(terminal.createdAt),
+            browser.id: try XCTUnwrap(browser.createdAt),
+            markdown.id: try XCTUnwrap(markdown.createdAt),
+        ]
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        for panel in snapshot.panels {
+            XCTAssertEqual(panel.createdAt, expected[panel.id])
+        }
+
+        let restored = Workspace()
+        defer { restored.teardownAllPanels() }
+        restored.restoreSessionSnapshot(snapshot)
+        for (panelId, createdAt) in expected {
+            XCTAssertEqual(restored.panels[panelId]?.createdAt, createdAt)
+        }
+    }
+}
+
+@MainActor
 final class WorkspacePulseMarkRowMetricsTests: XCTestCase {
     private let sidebarCardContentWidth: CGFloat = 178
 


### PR DESCRIPTION
## Summary

- add one c11-owned activity help projection shared by top-tab marks, both individual sidebar mark locations, accessibility, and Surface Details
- show locale-aware lifecycle durations only from trustworthy c11 evidence, preserving flagged/suppressed modifiers and honest missing-timestamp fallbacks
- persist logical `created_at` for terminal, browser, and markdown panels while keeping legacy snapshots as `Not recorded`
- extend Bonsplit with generic host-provided mark help and hover-time accessibility refresh (`Stage-11-Agentics/bonsplit@a219665`)
- localize all new c11 copy across English, Japanese, Ukrainian, Korean, Simplified Chinese, Traditional Chinese, and Russian

## Validation

- `c11-logic`: 24 focused projection, modifier, sidebar, and session-codec tests passed
- safe hosted XCTest: exact unread-notification epoch passed
- safe hosted XCTest: terminal/browser/markdown creation snapshot + restore passed
- Bonsplit: 9 focused help, accessibility, motion, and geometry tests passed
- localization: `jq`, seven-locale coverage, placeholder parity, `xcstringstool` compilation, and all seven Bonsplit catalogs passed
- `git diff --check`
- tagged QA build/launch: `c11-185-tooltips` built successfully with startup dialogs suppressed; isolated socket responded `PONG` as c11 0.61.0 (123)
- visible hover and Surface Details evidence: pending explicit operator approval for computer-use/accessibility automation

## Notes

- No CLI/socket expansion or lifecycle color, shape, motion, threshold, flag, or suppression-eligibility changes.
- The generic Bonsplit tooltip capability is a candidate to offer upstream.
