### PR TITLE
Launch picker polish: scrollable shortlist, not-installed feedback, agent-maintained cost catalog

### DIFF
--- a/CLI/ModelCostsCommand.swift
+++ b/CLI/ModelCostsCommand.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// Thin CLI shim for the `c11 model-costs` family. All logic lives in
+// `Sources/ModelCostCatalog.swift` (`ModelCostsCommandCore`, linked into both
+// the app and this CLI target). Every subcommand operates directly on the
+// state-root `model-costs.json` — app-down capable, no socket — and is
+// dispatched from CLI/c11.swift before the socket connect, mirroring
+// `c11 config` (C11-180).
+
+func runModelCostsCommand(commandArgs: [String]) throws {
+    guard let store = ModelCostCatalogStore.shared else {
+        throw CLIError(message: "model-costs: c11 state directory is unavailable")
+    }
+    do {
+        print(try ModelCostsCommandCore.run(args: commandArgs, store: store))
+    } catch let failure as ModelCostsCommandCore.Failure {
+        throw CLIError(message: failure.message)
+    }
+}

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -1724,6 +1724,14 @@ struct CMUXCLI {
             return
         }
 
+        // Agent-maintained model token-cost catalog feeding the launch
+        // picker's cost column: file-first like `config`, never needs the
+        // socket.
+        if command == "model-costs" {
+            try runModelCostsCommand(commandArgs: commandArgs)
+            return
+        }
+
         let client = SocketClient(path: resolvedSocketPath)
         if resolvedSocketPath != socketPath {
             cliTelemetry.breadcrumb(
@@ -17273,6 +17281,7 @@ struct CMUXCLI {
           set-agent --type <terminal_type> [--model <id>] [--task <id>] [--role <id>] [--surface <id|ref>] [--workspace <id|ref>]
           default-agent {get | set <type> | launch [--in-surface <id|ref> | --pane <id>] [--agent <type>] [--cwd <path>] [--prompt <text> | --prompt-file <path>]}
           launch-agent --type <kind> [--model <id>] [--effort <tier>] [--system-prompt-mode inherit|append|replace] [--system-prompt <text> | --system-prompt-file <path>] [--task <id>] [--pane <id|ref> | --workspace <id|ref> | --new-workspace] [--cwd <path>] [--prompt <text> | --prompt-file <path>] [--title <text>] [--flag <reason>] [--suppressed] [--env K=V ...] [--json]
+          model-costs {list [--json] | get <model> [--json] | set <model> --in <usd> --out <usd> [--source <url>] [--notes <text>] | rm <model> | import <path|-> [--replace]}
           raise-flag --surface <id|ref> "<reason>"
           lower-flag --surface <id|ref>
           suppress --surface <id|ref>

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		4BF73AE4358BED37E9D90771 /* WorkspaceApplyChromeScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000A00A1B2C3D4E5F014 /* WorkspaceApplyChromeScaleTests.swift */; };
 		4D11AA01B2C3D4E5F6071920 /* MarkdownPanelFontScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D11AA02B2C3D4E5F6071921 /* MarkdownPanelFontScaleTests.swift */; };
 		4EC81DFCF528D45999D2463D /* ConfigCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC6775014AC879E643E79D6 /* ConfigCommand.swift */; };
+		C4B4DCA031042170CC8F0C9F /* ModelCostsCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D2879EEABCEB73C55BFE42 /* ModelCostsCommand.swift */; };
 		4EE5E828CC9D3BA957B86380 /* copilot in Copy CLI */ = {isa = PBXBuildFile; fileRef = D13A1E9CE25B945CC90A8D02 /* copilot */; };
 		505E486F8B252007A3CFE688 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
 		53A8353DD72E0C6954D5F42A /* ChromeScaleSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000400A1B2C3D4E5F011 /* ChromeScaleSettingsTests.swift */; };
@@ -105,6 +106,7 @@
 		6B3658A83D3C83E088A1FD10 /* SurfaceActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25359D87534E2AF54EA0E5F /* SurfaceActivityTests.swift */; };
 		6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */; };
 		6BA398A053EA878A1E1D2197 /* AgentPickerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */; };
+		F6859C5263C0005FE35CF033 /* ModelCostCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9CD81A501C496DECFAB3F2 /* ModelCostCatalogTests.swift */; };
 		6E7E7BF7FE70B34844D472DB /* PaneMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7011BF1A1B2C3D4E5F60718 /* PaneMetadataStoreTests.swift */; };
 		6F3E766AEE928B3A98ADC170 /* MailboxDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D710FBF1A1B2C3D4E5F60718 /* MailboxDispatcherTests.swift */; };
 		712589D9F145582CB62150FF /* WorkspaceIdentityRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7004BF1A1B2C3D4E5F60718 /* WorkspaceIdentityRestoreTests.swift */; };
@@ -146,6 +148,7 @@
 		9B5A20F1BAE65BF29D60D115 /* WorkspaceBlueprintStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8015BF1A1B2C3D4E5F60718 /* WorkspaceBlueprintStoreTests.swift */; };
 		9C51A1CE6AEEBF2E0B4C3E61 /* ChromeScaleTokensTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C116000600A1B2C3D4E5F012 /* ChromeScaleTokensTests.swift */; };
 		9CFE781967963703AEA37DB8 /* AgentLaunchStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */; };
+		139D042B6811CF51F88ECA87 /* ModelCostCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C6DD21C072B005162E855C /* ModelCostCatalog.swift */; };
 		9E41ED7321B6C6644A698D8C /* WorkspaceDerivedActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A99FEE21A45CCAB920CC627 /* WorkspaceDerivedActivityTests.swift */; };
 		A056D19646BEEAE184A3016B /* MarkdownFeedbackHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFAF4E88F20968661D2D0886 /* MarkdownFeedbackHandlers.swift */; };
 		A11C0DE0000000000040051F /* UpdateInstallerFailureMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11C0DE0000000000040052F /* UpdateInstallerFailureMappingTests.swift */; };
@@ -341,9 +344,11 @@
 		CC40100BA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC40100AA1B2C3D4E5F60719 /* FullDiskAccessProbe.swift */; };
 		CFA9529EA1B3835E1A2586A2 /* DescriptionSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7002BF1A1B2C3D4E5F60718 /* DescriptionSanitizerTests.swift */; };
 		CFC9066EE8F234F5B82C0B63 /* AgentPickerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */; };
+		691F36408DA65A37B08F9CF7 /* ModelCostCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F9CD81A501C496DECFAB3F2 /* ModelCostCatalogTests.swift */; };
 		D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */; };
 		D0E0F0B2A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0E0F0B3A1B2C3D4E5F60718 /* BrowserOmnibarSuggestionsUITests.swift */; };
 		D1510386129C337B5868E50D /* AgentLaunchStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */; };
+		A13BF7CAE32BDF8A7DA81FDA /* ModelCostCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C6DD21C072B005162E855C /* ModelCostCatalog.swift */; };
 		D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */ = {isa = PBXBuildFile; fileRef = D1BEF00001A1B2C3D4E5F719 /* open */; };
 		D315C25B997B06679DD201C1 /* SnapshotHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01822B693A5DD01EFE28F75F /* SnapshotHandlers.swift */; };
 		D3A97DA994E2DA451F6020CF /* DefaultAgentConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6B62D2ECDC52E5244D9C6E3 /* DefaultAgentConfig.swift */; };
@@ -512,6 +517,7 @@
 		01822B693A5DD01EFE28F75F /* SnapshotHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnapshotHandlers.swift; sourceTree = "<group>"; };
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
 		06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentLaunchStats.swift; sourceTree = "<group>"; };
+		28C6DD21C072B005162E855C /* ModelCostCatalog.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelCostCatalog.swift; sourceTree = "<group>"; };
 		0AC6B52BF66E258E170A6B92 /* c11LogicTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = c11LogicTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 		14920F1F89F560F631520E65 /* ScrapeCapturePipeline.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Conversation/ScrapeCapturePipeline.swift; sourceTree = "<group>"; };
@@ -872,6 +878,7 @@
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		DA7A10CA710E000000000005 /* welcome.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = welcome.md; sourceTree = "<group>"; };
 		DEC6775014AC879E643E79D6 /* ConfigCommand.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigCommand.swift; sourceTree = "<group>"; };
+		F1D2879EEABCEB73C55BFE42 /* ModelCostsCommand.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelCostsCommand.swift; sourceTree = "<group>"; };
 		DH001BF1A1B2C3D4E5F60718 /* HealthCommandCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCommandCore.swift; sourceTree = "<group>"; };
 		DH002BF1A1B2C3D4E5F60719 /* HealthCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthCommand.swift; sourceTree = "<group>"; };
 		DH010BF1A1B2C3D4E5F60718 /* HealthIPSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthIPSParserTests.swift; sourceTree = "<group>"; };
@@ -908,6 +915,7 @@
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
 		F6B62D2ECDC52E5244D9C6E3 /* DefaultAgentConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DefaultAgentConfig.swift; sourceTree = "<group>"; };
 		F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AgentPickerModelTests.swift; sourceTree = "<group>"; };
+		7F9CD81A501C496DECFAB3F2 /* ModelCostCatalogTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ModelCostCatalogTests.swift; sourceTree = "<group>"; };
 		F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
 		F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 		F81492660FA7D00E8115BD46 /* ConversationRefTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConversationRefTests.swift; sourceTree = "<group>"; };
@@ -1233,6 +1241,7 @@
 				CE575BF7FF16088778D40E17 /* EventLog.swift */,
 				00B9399C201ED734873E67B9 /* EventEmitter.swift */,
 				06DBF89CEAC123699A1BCDB6 /* AgentLaunchStats.swift */,
+				28C6DD21C072B005162E855C /* ModelCostCatalog.swift */,
 				9A03BB65CC01C2029DF83337 /* AgentConfigLibraryStore.swift */,
 				6EBC71594BF2FF8B59D1AE28 /* ConfigCommandCore.swift */,
 				66D6015281A02515593B40AA /* AgentPickerModel.swift */,
@@ -1294,6 +1303,7 @@
 				DH002BF1A1B2C3D4E5F60719 /* HealthCommand.swift */,
 				DH021BF1A1B2C3D4E5F60719 /* DoctorCommand.swift */,
 				DEC6775014AC879E643E79D6 /* ConfigCommand.swift */,
+				F1D2879EEABCEB73C55BFE42 /* ModelCostsCommand.swift */,
 			);
 			path = CLI;
 			sourceTree = "<group>";
@@ -1456,6 +1466,7 @@
 				B0C8786B9F13542B2C4D9D35 /* AgentLaunchOverlayCompositionTests.swift */,
 				D4C7E212A580905DBF388D79 /* ConfigCommandCoreTests.swift */,
 				F6CC2386622AB585E06FE61C /* AgentPickerModelTests.swift */,
+				7F9CD81A501C496DECFAB3F2 /* ModelCostCatalogTests.swift */,
 			);
 			path = c11Tests;
 			sourceTree = "<group>";
@@ -1800,6 +1811,7 @@
 				5A86082FF691F6FBCBDE52CB /* AgentLaunchOverlayCompositionTests.swift in Sources */,
 				154C8F2336C14C870CB0C531 /* ConfigCommandCoreTests.swift in Sources */,
 				6BA398A053EA878A1E1D2197 /* AgentPickerModelTests.swift in Sources */,
+				F6859C5263C0005FE35CF033 /* ModelCostCatalogTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2011,6 +2023,7 @@
 				1FD750B08EDEB2C775C05971 /* EventLog.swift in Sources */,
 				88A8E702E9D54BBCAD7025C7 /* EventEmitter.swift in Sources */,
 				9CFE781967963703AEA37DB8 /* AgentLaunchStats.swift in Sources */,
+				139D042B6811CF51F88ECA87 /* ModelCostCatalog.swift in Sources */,
 				BAEDB3843B3F408AB2B39E44 /* AgentConfigLibraryStore.swift in Sources */,
 				38115B4DA9AAE3904F1B7871 /* ConfigCommandCore.swift in Sources */,
 				E7B858CDF649114D83838A26 /* ConfigHandlers.swift in Sources */,
@@ -2038,9 +2051,11 @@
 				75B580E4A1859423B310E203 /* EventLogLayout.swift in Sources */,
 				365F4BE2806EC0D12A9336BD /* EventEnvelope.swift in Sources */,
 				D1510386129C337B5868E50D /* AgentLaunchStats.swift in Sources */,
+				A13BF7CAE32BDF8A7DA81FDA /* ModelCostCatalog.swift in Sources */,
 				8AA1B79D6D4CFC42CF277864 /* AgentConfigLibraryStore.swift in Sources */,
 				B33BAA37AE6B8D449B5CD405 /* ConfigCommandCore.swift in Sources */,
 				4EC81DFCF528D45999D2463D /* ConfigCommand.swift in Sources */,
+				C4B4DCA031042170CC8F0C9F /* ModelCostsCommand.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2115,6 +2130,7 @@
 				ACB000000000000000000104 /* BrowserCompanionPortalTests.swift in Sources */,
 				ACB000000000000000000105 /* BrowserCompanionChromeTests.swift in Sources */,
 				CFC9066EE8F234F5B82C0B63 /* AgentPickerModelTests.swift in Sources */,
+				691F36408DA65A37B08F9CF7 /* ModelCostCatalogTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1600,6 +1600,53 @@
         }
       }
     },
+    "agentPicker.notice.notInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ isn't on PATH — install it, or pin the row as default anyway"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ が PATH 上に見つかりません。インストールするか、このままデフォルトとして固定できます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不在 PATH 中 —— 请安装它，或仍将此行固定为默认"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 不在 PATH 中 —— 請安裝它，或仍將此列固定為預設"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@이(가) PATH에 없습니다 — 설치하거나, 그래도 이 행을 기본값으로 고정할 수 있습니다"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ отсутствует в PATH — установите его или всё равно закрепите строку по умолчанию"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ відсутній у PATH — встановіть його або все одно закріпіть рядок як типовий"
+          }
+        }
+      }
+    },
     "agentPicker.pin.help": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AgentPickerView.swift
+++ b/Sources/AgentPickerView.swift
@@ -36,6 +36,10 @@ private enum PickerPalette {
 /// wire in. Reference type so the NSEvent key monitor can capture it safely.
 final class AgentPickerController: ObservableObject {
     @Published var model: AgentPickerModel
+    /// Transient inline notice shown above the footer after a plain launch of a
+    /// not-installed row (§5.6). Auto-clears; a newer notice supersedes the timer.
+    @Published var notInstalledNotice: String?
+    private var noticeGeneration = 0
 
     /// Launch a specific config now (row click / ⏎ / 1–9 / recent).
     var onLaunch: (SavedAgentConfig) -> Void = { _ in }
@@ -91,12 +95,28 @@ final class AgentPickerController: ObservableObject {
         switch action {
         case .launch(let c): onLaunch(c); onClose()
         case .pin(let c): pin(c)                     // stays open, ● moves (prototype)
-        case .notInstalled(let c): onNotInstalledHint(c)
+        case .notInstalled(let c): showNotInstalledNotice(for: c); onNotInstalledHint(c)
         case .toggleFollowRecent: toggleFollowRecent()
         case .viewAll: onViewAll(); onClose()
         case .stats: onStats(); onClose()
         case .close: onClose()
         case .none: break
+        }
+    }
+
+    private func showNotInstalledNotice(for config: SavedAgentConfig) {
+        let harness = AgentRegistry.shared.manifest(forKind: config.config.harness)?.displayName
+            ?? AgentType(rawValue: config.config.harness)?.displayName
+            ?? config.config.harness
+        notInstalledNotice = String(
+            localized: "agentPicker.notice.notInstalled",
+            defaultValue: "\(harness) isn't on PATH — install it, or pin the row as default anyway"
+        )
+        noticeGeneration += 1
+        let generation = noticeGeneration
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) { [weak self] in
+            guard let self, self.noticeGeneration == generation else { return }
+            self.notInstalledNotice = nil
         }
     }
 
@@ -118,26 +138,27 @@ struct AgentPickerView: View {
 
     private var content: AgentPickerContent { controller.model.content }
 
+    /// Rows visible before the shortlist scrolls (operator call: scroll, don't cap).
+    private static let maxVisibleShortlistRows = 8
+    /// Approximate rendered row height (two fixed text lines + 8pt vertical padding
+    /// + divider); used only to size the scroll viewport, so drift is cosmetic.
+    private static let shortlistRowHeight: CGFloat = 50
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
-            ForEach(Array(content.shortlist.enumerated()), id: \.element.config.id) { idx, row in
-                PickerRowView(
-                    row: row,
-                    isFocused: controller.model.selectedIndex == idx,
-                    followRecent: content.followRecent,
-                    onClick: { opt in controller.clickRow(row, option: opt) },
-                    onPin: { controller.clickPinGlyph(row) }
-                )
-                Divider().overlay(BrandColors.ruleSwiftUI.opacity(0.55))
-            }
+            shortlistSection
             if let recent = content.recent {
                 sectionRule(String(localized: "agentPicker.recent.section", defaultValue: "recent"))
                 RecentRowView(
                     row: recent,
                     isFocused: controller.model.selectedIndex == content.shortlist.count,
+                    showsCostColumn: showsCostColumn,
                     onClick: { controller.clickRecent() }
                 )
+            }
+            if let notice = controller.notInstalledNotice {
+                noticeBar(notice)
             }
             footer
             hintBar
@@ -152,6 +173,62 @@ struct AgentPickerView: View {
     }
 
     // MARK: Sections
+
+    /// The saved-config rows. Up to 8 render inline; past that the list scrolls
+    /// inside a fixed viewport (with a half-row peek so the overflow is visible)
+    /// and keyboard navigation keeps the focused row in view. Recent, footer,
+    /// and hints stay pinned below the scroll region.
+    @ViewBuilder private var shortlistSection: some View {
+        if content.shortlist.count > Self.maxVisibleShortlistRows {
+            ScrollViewReader { proxy in
+                ScrollView(.vertical) {
+                    VStack(alignment: .leading, spacing: 0) { shortlistRows }
+                }
+                .frame(height: (CGFloat(Self.maxVisibleShortlistRows) + 0.5) * Self.shortlistRowHeight)
+                .onChange(of: controller.model.selectedIndex) { _, idx in
+                    guard idx >= 0, idx < content.shortlist.count else { return }
+                    proxy.scrollTo(content.shortlist[idx].config.id, anchor: .center)
+                }
+            }
+        } else {
+            shortlistRows
+        }
+    }
+
+    /// The `$in/$out` column renders only when at least one visible row has a
+    /// catalog price — an unfilled catalog must not reserve dead trailing space.
+    private var showsCostColumn: Bool {
+        content.shortlist.contains { $0.cost != nil } || content.recent?.cost != nil
+    }
+
+    private var shortlistRows: some View {
+        ForEach(Array(content.shortlist.enumerated()), id: \.element.config.id) { idx, row in
+            PickerRowView(
+                row: row,
+                isFocused: controller.model.selectedIndex == idx,
+                followRecent: content.followRecent,
+                showsCostColumn: showsCostColumn,
+                onClick: { opt in controller.clickRow(row, option: opt) },
+                onPin: { controller.clickPinGlyph(row) }
+            )
+            .id(row.config.id)
+            Divider().overlay(BrandColors.ruleSwiftUI.opacity(0.55))
+        }
+    }
+
+    private func noticeBar(_ text: String) -> some View {
+        HStack(spacing: 0) {
+            Text(text)
+                .font(.system(size: 10.5, design: .monospaced))
+                .foregroundStyle(BrandColors.goldSwiftUI)
+                .lineLimit(2)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .background(PickerPalette.goldGhost)
+        .overlay(alignment: .top) { ruleLine }
+    }
 
     private var header: some View {
         HStack {
@@ -243,6 +320,7 @@ private struct PickerRowView: View {
     let row: AgentPickerRow
     let isFocused: Bool
     let followRecent: Bool
+    let showsCostColumn: Bool
     let onClick: (Bool) -> Void
     let onPin: () -> Void
 
@@ -274,11 +352,19 @@ private struct PickerRowView: View {
             HStack(spacing: 7) {
                 if let sys = row.sysChip { SysChipView(sys) }
                 if let effort = row.effortChip { EffortChipView(effort) }
-                Text(row.cost ?? "")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
-                    .frame(minWidth: 82, alignment: .trailing)
-                KeyCap("\(row.keyBadge)").frame(width: 16)
+                if showsCostColumn {
+                    Text(row.cost ?? "")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
+                        .frame(minWidth: 82, alignment: .trailing)
+                }
+                // Digit launch badges exist for the first nine rows only; rows
+                // past 9 keep the empty slot so trailing columns stay aligned.
+                if row.keyBadge <= 9 {
+                    KeyCap("\(row.keyBadge)").frame(width: 16)
+                } else {
+                    Color.clear.frame(width: 16, height: 1)
+                }
             }
         }
         .padding(.leading, 10)
@@ -311,6 +397,7 @@ private struct PickerRowView: View {
 private struct RecentRowView: View {
     let row: AgentPickerRecentRow
     let isFocused: Bool
+    let showsCostColumn: Bool
     let onClick: () -> Void
 
     @State private var hovering = false
@@ -341,10 +428,12 @@ private struct RecentRowView: View {
             Spacer(minLength: 6)
             HStack(spacing: 7) {
                 if row.showLiveHint { LiveHintBadge(harness: row.harnessDisplayName) }
-                Text(row.cost ?? "")
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
-                    .frame(minWidth: 82, alignment: .trailing)
+                if showsCostColumn {
+                    Text(row.cost ?? "")
+                        .font(.system(size: 11, design: .monospaced))
+                        .foregroundStyle(BrandColors.whiteSwiftUI.opacity(0.68))
+                        .frame(minWidth: 82, alignment: .trailing)
+                }
                 // Empty key-cap slot so the recent cost aligns with shortlist costs.
                 Color.clear.frame(width: 16, height: 1)
             }
@@ -583,6 +672,14 @@ enum AgentHarnessInstallProbe {
         let result = probe(harnessKind)
         cache[harnessKind] = result
         return result
+    }
+
+    /// Drop the cached probe results so the next lookup re-checks PATH. Called
+    /// on every picker open — a harness installed mid-session should light its
+    /// row back up on the next right-click, not after an app relaunch.
+    static func invalidate() {
+        lock.lock(); defer { lock.unlock() }
+        cache.removeAll()
     }
 
     private static func probe(_ harnessKind: String) -> Bool {

--- a/Sources/ModelCostCatalog.swift
+++ b/Sources/ModelCostCatalog.swift
@@ -1,0 +1,310 @@
+import Foundation
+
+// MARK: - Model token-cost catalog (picker cost column, agent-maintained)
+//
+// The launch picker's `$in/$out` per-Mtok column reads from one JSON file at
+// the c11 state root, `model-costs.json`. There is no bundled price table and
+// no network fetch: the catalog is filled and refreshed by agents over
+// `c11 model-costs` (file-first, app-down capable, same rail as `c11 config`),
+// so prices carry their own `source` + `observed_at` provenance instead of
+// silently rotting inside a release binary. Values are API list prices — on
+// subscription plans the marginal cost differs; the column is a relative
+// magnitude signal, not billing truth.
+//
+// Schema (keys are model ids as c11 knows them — short forms like `opus`,
+// full ids like `claude-opus-5`, router forms like `deepseek/deepseek-chat`):
+//
+//   { "<model-id>": { "in_usd": 15, "out_usd": 75,
+//                     "source": "<url>", "observed_at": "2026-07-30",
+//                     "notes": "<optional caveat>" } }
+
+/// One model's USD-per-million-token pricing plus provenance.
+struct ModelCostEntry: Codable, Equatable {
+    var inUSD: Double
+    var outUSD: Double
+    var source: String?
+    var observedAt: String?
+    var notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case inUSD = "in_usd"
+        case outUSD = "out_usd"
+        case source
+        case observedAt = "observed_at"
+        case notes
+    }
+}
+
+/// Queue-confined file store for the catalog. Reads are fresh from disk (the
+/// picker rebuilds per open; agents may have updated the file since), writes
+/// are atomic whole-file replaces.
+final class ModelCostCatalogStore: @unchecked Sendable {
+    static let fileName = "model-costs.json"
+
+    private let fileURL: URL
+    private let queue = DispatchQueue(label: "com.stage11.c11.model-costs")
+
+    init(directory: URL) {
+        self.fileURL = directory.appendingPathComponent(Self.fileName)
+    }
+
+    /// Process-wide store at the c11 state root; `nil` only when the state
+    /// directory is unresolvable (sandboxed test hosts) — callers degrade to
+    /// "no cost column".
+    static let shared: ModelCostCatalogStore? = {
+        guard let root = try? EventLogLayout.defaultStateURL() else { return nil }
+        return ModelCostCatalogStore(directory: root)
+    }()
+
+    // MARK: Reads
+
+    func catalog() -> [String: ModelCostEntry] {
+        queue.sync { loadLocked() }
+    }
+
+    /// Picker lookup. Tries the exact id, the lowercased id, then the
+    /// provider-stripped form (`deepseek/deepseek-chat` → `deepseek-chat`).
+    /// `nil` model (inherit) or no entry → no cost shown; deliberately no
+    /// fuzzy matching beyond that, so a wrong price can't attach to a
+    /// look-alike model.
+    func cost(forModel model: String?) -> (inUSD: Double, outUSD: Double)? {
+        guard let model = model?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !model.isEmpty else { return nil }
+        let entries = catalog()
+        let lowered = model.lowercased()
+        var candidates = [model, lowered]
+        if let slash = lowered.firstIndex(of: "/") {
+            candidates.append(String(lowered[lowered.index(after: slash)...]))
+        }
+        for key in candidates {
+            if let e = entries[key] { return (e.inUSD, e.outUSD) }
+        }
+        return nil
+    }
+
+    // MARK: Writes
+
+    func set(model: String, entry: ModelCostEntry) throws {
+        try queue.sync {
+            var entries = loadLocked()
+            entries[model] = entry
+            try writeLocked(entries)
+        }
+    }
+
+    @discardableResult
+    func remove(model: String) throws -> Bool {
+        try queue.sync {
+            var entries = loadLocked()
+            guard entries.removeValue(forKey: model) != nil else { return false }
+            try writeLocked(entries)
+            return true
+        }
+    }
+
+    /// Bulk import. `replace: false` merges (incoming keys win); `true` swaps
+    /// the whole catalog for the incoming one.
+    func importCatalog(_ incoming: [String: ModelCostEntry], replace: Bool) throws {
+        try queue.sync {
+            var entries = replace ? [:] : loadLocked()
+            for (k, v) in incoming { entries[k] = v }
+            try writeLocked(entries)
+        }
+    }
+
+    // MARK: Locked internals
+
+    private func loadLocked() -> [String: ModelCostEntry] {
+        guard let data = try? Data(contentsOf: fileURL) else { return [:] }
+        return (try? JSONDecoder().decode([String: ModelCostEntry].self, from: data)) ?? [:]
+    }
+
+    private func writeLocked(_ entries: [String: ModelCostEntry]) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(entries)
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: fileURL, options: .atomic)
+    }
+}
+
+// MARK: - CLI core (`c11 model-costs …`, file-first)
+
+/// Shared logic for the `model-costs` CLI family. Lives beside the store so
+/// the app target and the CLI target compile one implementation, mirroring
+/// `ConfigCommandCore` (C11-180). All subcommands are file-first: they work
+/// with the app down and never touch the socket.
+struct ModelCostsCommandCore {
+    struct Failure: Error { let message: String }
+
+    static let usage = """
+    Usage: c11 model-costs <subcommand>
+
+      list [--json]                     Print the catalog (model → $in/$out per Mtok)
+      get <model> [--json]              Print one model's entry
+      set <model> --in <usd> --out <usd> [--source <url>] [--notes <text>]
+                                        Add or update a model (stamps observed_at)
+      rm <model>                        Remove a model
+      import <path|-> [--replace]       Bulk import a catalog JSON (merge by default)
+
+    The catalog is model-costs.json at the c11 state root — agent-maintained
+    API list prices feeding the launch picker's cost column.
+    """
+
+    /// Run a subcommand against `store`. `now` is injectable for tests.
+    static func run(
+        args: [String],
+        store: ModelCostCatalogStore,
+        now: Date = Date()
+    ) throws -> String {
+        guard let sub = args.first?.lowercased() else { throw Failure(message: usage) }
+        let rest = Array(args.dropFirst())
+        switch sub {
+        case "list":
+            return try list(store: store, json: rest.contains("--json"))
+        case "get":
+            guard let model = firstPositional(rest) else {
+                throw Failure(message: "model-costs get: missing <model>")
+            }
+            return try get(model: model, store: store, json: rest.contains("--json"))
+        case "set":
+            return try set(args: rest, store: store, now: now)
+        case "rm":
+            guard let model = firstPositional(rest) else {
+                throw Failure(message: "model-costs rm: missing <model>")
+            }
+            guard try store.remove(model: model) else {
+                throw Failure(message: "model-costs rm: no entry for '\(model)'")
+            }
+            return "OK removed \(model)"
+        case "import":
+            return try importCatalog(args: rest, store: store)
+        case "help", "--help", "-h":
+            return usage
+        default:
+            throw Failure(message: "model-costs: unknown subcommand '\(sub)'\n\n\(usage)")
+        }
+    }
+
+    // MARK: Subcommands
+
+    private static func list(store: ModelCostCatalogStore, json: Bool) throws -> String {
+        let entries = store.catalog()
+        if json {
+            return try encodeJSON(entries)
+        }
+        guard !entries.isEmpty else {
+            return "model-costs: catalog is empty (state root model-costs.json)"
+        }
+        let width = entries.keys.map(\.count).max() ?? 0
+        return entries.sorted { $0.key < $1.key }.map { key, e in
+            let padded = key.padding(toLength: max(width, key.count), withPad: " ", startingAt: 0)
+            var line = "\(padded)  $\(trim(e.inUSD))/$\(trim(e.outUSD))"
+            if let observed = e.observedAt { line += "  (\(observed))" }
+            return line
+        }.joined(separator: "\n")
+    }
+
+    private static func get(model: String, store: ModelCostCatalogStore, json: Bool) throws -> String {
+        guard let entry = store.catalog()[model] else {
+            throw Failure(message: "model-costs get: no entry for '\(model)'")
+        }
+        if json { return try encodeJSON([model: entry]) }
+        var out = "\(model)  $\(trim(entry.inUSD))/$\(trim(entry.outUSD)) per Mtok"
+        if let s = entry.source { out += "\n  source: \(s)" }
+        if let o = entry.observedAt { out += "\n  observed: \(o)" }
+        if let n = entry.notes { out += "\n  notes: \(n)" }
+        return out
+    }
+
+    private static func set(args: [String], store: ModelCostCatalogStore, now: Date) throws -> String {
+        guard let model = firstPositional(args) else {
+            throw Failure(message: "model-costs set: missing <model>")
+        }
+        guard let inRaw = option(args, "--in"), let inUSD = Double(inRaw), inUSD >= 0 else {
+            throw Failure(message: "model-costs set: --in <usd-per-Mtok> is required and must be a non-negative number")
+        }
+        guard let outRaw = option(args, "--out"), let outUSD = Double(outRaw), outUSD >= 0 else {
+            throw Failure(message: "model-costs set: --out <usd-per-Mtok> is required and must be a non-negative number")
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        let entry = ModelCostEntry(
+            inUSD: inUSD,
+            outUSD: outUSD,
+            source: option(args, "--source"),
+            observedAt: formatter.string(from: now),
+            notes: option(args, "--notes")
+        )
+        try store.set(model: model, entry: entry)
+        return "OK \(model) = $\(trim(inUSD))/$\(trim(outUSD)) per Mtok"
+    }
+
+    private static func importCatalog(args: [String], store: ModelCostCatalogStore) throws -> String {
+        guard let path = firstPositional(args) else {
+            throw Failure(message: "model-costs import: missing <path|->")
+        }
+        let data: Data
+        if path == "-" {
+            data = FileHandle.standardInput.readDataToEndOfFile()
+        } else {
+            guard let fileData = FileManager.default.contents(atPath: path) else {
+                throw Failure(message: "model-costs import: cannot read \(path)")
+            }
+            data = fileData
+        }
+        let incoming: [String: ModelCostEntry]
+        do {
+            incoming = try JSONDecoder().decode([String: ModelCostEntry].self, from: data)
+        } catch {
+            throw Failure(message: "model-costs import: invalid catalog JSON — expected {\"<model>\": {\"in_usd\": n, \"out_usd\": n, ...}} (\(error.localizedDescription))")
+        }
+        try store.importCatalog(incoming, replace: args.contains("--replace"))
+        return "OK imported \(incoming.count) entr\(incoming.count == 1 ? "y" : "ies")\(args.contains("--replace") ? " (replaced catalog)" : "")"
+    }
+
+    // MARK: Helpers
+
+    private static func encodeJSON(_ entries: [String: ModelCostEntry]) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return String(data: try encoder.encode(entries), encoding: .utf8) ?? "{}"
+    }
+
+    /// Prototype-matching money format: whole dollars drop decimals, sub-dollar
+    /// keeps two places (`15` / `0.25` / `3.5`).
+    static func trim(_ n: Double) -> String {
+        if n >= 1, n.truncatingRemainder(dividingBy: 1) == 0 { return String(Int(n)) }
+        let two = String(format: "%.2f", n)
+        return two.hasSuffix("0") && n >= 1 ? String(two.dropLast()) : two
+    }
+
+    private static func option(_ args: [String], _ name: String) -> String? {
+        var i = 0
+        while i < args.count {
+            if args[i] == name, i + 1 < args.count { return args[i + 1] }
+            if args[i].hasPrefix(name + "=") { return String(args[i].dropFirst(name.count + 1)) }
+            i += 1
+        }
+        return nil
+    }
+
+    private static func firstPositional(_ args: [String]) -> String? {
+        var i = 0
+        while i < args.count {
+            let a = args[i]
+            if a.hasPrefix("--") {
+                if !a.contains("="), i + 1 < args.count, !args[i + 1].hasPrefix("--") {
+                    i += 2; continue
+                }
+                i += 1; continue
+            }
+            return a
+        }
+        return nil
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12697,6 +12697,10 @@ extension Workspace: BonsplitDelegate {
     ) {
         guard let window = requestedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow else { return }
 
+        // Re-probe PATH on every open so a harness installed mid-session lights
+        // its rows back up without an app relaunch.
+        AgentHarnessInstallProbe.invalidate()
+
         let controller = AgentPickerController(model: makeAgentPickerModel())
         controller.rebuild = { [weak self] in self?.makeAgentPickerModel() }
         controller.onLaunch = { [weak self] config in
@@ -12737,7 +12741,7 @@ extension Workspace: BonsplitDelegate {
             armEditorReturn()
             AppDelegate.shared?.openAgentConfigEditor(focus: .stats, origin: .popover)
         }
-        controller.onNotInstalledHint = { _ in NSSound.beep() }
+        // Not-installed feedback is the controller's inline notice (no beep).
 
         AgentPickerPresenter.shared.present(controller: controller, in: window, anchoringTo: anchorScreenRect)
     }
@@ -12754,7 +12758,7 @@ extension Workspace: BonsplitDelegate {
             },
             provider: { AgentLaunchStats.provider(harness: $0, model: $1) },
             isInstalled: { AgentHarnessInstallProbe.isInstalled($0) },
-            costFor: { _ in nil }, // token-cost catalog is greenfield (design §5.6) → column omitted
+            costFor: { ModelCostCatalogStore.shared?.cost(forModel: $0) },
             now: Date(),
             statsHeadline: Self.agentPickerStatsHeadline()
         )

--- a/c11Tests/ModelCostCatalogTests.swift
+++ b/c11Tests/ModelCostCatalogTests.swift
@@ -1,0 +1,129 @@
+// ModelCostCatalogTests.swift
+//
+// Pure-logic tests for the model token-cost catalog (picker cost column +
+// `c11 model-costs` core). Everything runs against an injected temp directory;
+// no Workspace/TabManager construction.
+
+import XCTest
+@testable import c11
+
+final class ModelCostCatalogTests: XCTestCase {
+    private var tempDir: URL!
+    private var store: ModelCostCatalogStore!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-costs-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        store = ModelCostCatalogStore(directory: tempDir)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func entry(_ inUSD: Double, _ outUSD: Double) -> ModelCostEntry {
+        ModelCostEntry(inUSD: inUSD, outUSD: outUSD, source: nil, observedAt: nil, notes: nil)
+    }
+
+    // MARK: Store
+
+    func testEmptyCatalogReturnsNoCost() {
+        XCTAssertTrue(store.catalog().isEmpty)
+        XCTAssertNil(store.cost(forModel: "opus"))
+        XCTAssertNil(store.cost(forModel: nil))
+        XCTAssertNil(store.cost(forModel: "  "))
+    }
+
+    func testSetThenLookupExactAndCaseInsensitive() throws {
+        try store.set(model: "opus", entry: entry(15, 75))
+        XCTAssertEqual(store.cost(forModel: "opus")?.inUSD, 15)
+        XCTAssertEqual(store.cost(forModel: "Opus")?.outUSD, 75)
+        XCTAssertNil(store.cost(forModel: "opus-mini"))
+    }
+
+    func testProviderPrefixedLookupFallsBackToStrippedForm() throws {
+        try store.set(model: "deepseek-chat-v3.1", entry: entry(0.27, 1.10))
+        let hit = store.cost(forModel: "deepseek/deepseek-chat-v3.1")
+        XCTAssertEqual(hit?.inUSD, 0.27)
+        // The exact prefixed key wins over the stripped form when both exist.
+        try store.set(model: "deepseek/deepseek-chat-v3.1", entry: entry(0.5, 2))
+        XCTAssertEqual(store.cost(forModel: "deepseek/deepseek-chat-v3.1")?.inUSD, 0.5)
+    }
+
+    func testRemoveAndPersistenceAcrossInstances() throws {
+        try store.set(model: "sonnet", entry: entry(3, 15))
+        let reread = ModelCostCatalogStore(directory: tempDir)
+        XCTAssertEqual(reread.cost(forModel: "sonnet")?.inUSD, 3)
+        XCTAssertTrue(try reread.remove(model: "sonnet"))
+        XCTAssertFalse(try reread.remove(model: "sonnet"))
+        XCTAssertNil(ModelCostCatalogStore(directory: tempDir).cost(forModel: "sonnet"))
+    }
+
+    func testCorruptFileDegradesToEmpty() throws {
+        let url = tempDir.appendingPathComponent(ModelCostCatalogStore.fileName)
+        try Data("not json".utf8).write(to: url)
+        XCTAssertTrue(store.catalog().isEmpty)
+        // A write recovers the file.
+        try store.set(model: "opus", entry: entry(15, 75))
+        XCTAssertEqual(store.cost(forModel: "opus")?.inUSD, 15)
+    }
+
+    func testImportMergesByDefaultAndReplacesOnRequest() throws {
+        try store.set(model: "opus", entry: entry(15, 75))
+        try store.importCatalog(["haiku": entry(0.8, 4)], replace: false)
+        XCTAssertEqual(store.catalog().count, 2)
+        try store.importCatalog(["sonnet": entry(3, 15)], replace: true)
+        XCTAssertEqual(store.catalog().count, 1)
+        XCTAssertNil(store.cost(forModel: "opus"))
+    }
+
+    // MARK: CLI core
+
+    func testCoreSetStampsObservedAtAndListsIt() throws {
+        let now = Date(timeIntervalSince1970: 1_786_000_000) // 2026-08-06 UTC
+        _ = try ModelCostsCommandCore.run(
+            args: ["set", "opus", "--in", "15", "--out", "75", "--source", "https://anthropic.com/pricing"],
+            store: store,
+            now: now
+        )
+        let stored = store.catalog()["opus"]
+        XCTAssertEqual(stored?.observedAt, "2026-08-06")
+        XCTAssertEqual(stored?.source, "https://anthropic.com/pricing")
+        let listed = try ModelCostsCommandCore.run(args: ["list"], store: store)
+        XCTAssertTrue(listed.contains("opus"))
+        XCTAssertTrue(listed.contains("$15/$75"))
+    }
+
+    func testCoreSetRejectsMissingOrInvalidNumbers() {
+        XCTAssertThrowsError(try ModelCostsCommandCore.run(args: ["set", "opus", "--in", "x", "--out", "75"], store: store))
+        XCTAssertThrowsError(try ModelCostsCommandCore.run(args: ["set", "opus", "--in", "15"], store: store))
+        XCTAssertThrowsError(try ModelCostsCommandCore.run(args: ["set"], store: store))
+    }
+
+    func testCoreImportFromFileAndRm() throws {
+        let path = tempDir.appendingPathComponent("draft.json").path
+        let draft = #"{"opus": {"in_usd": 15, "out_usd": 75, "source": "s", "observed_at": "2026-07-30"}}"#
+        try Data(draft.utf8).write(to: URL(fileURLWithPath: path))
+        let imported = try ModelCostsCommandCore.run(args: ["import", path], store: store)
+        XCTAssertTrue(imported.contains("1 entry"))
+        XCTAssertEqual(store.cost(forModel: "opus")?.inUSD, 15)
+        _ = try ModelCostsCommandCore.run(args: ["rm", "opus"], store: store)
+        XCTAssertNil(store.cost(forModel: "opus"))
+        XCTAssertThrowsError(try ModelCostsCommandCore.run(args: ["rm", "opus"], store: store))
+    }
+
+    func testCoreUnknownSubcommandAndHelp() throws {
+        XCTAssertThrowsError(try ModelCostsCommandCore.run(args: ["frobnicate"], store: store))
+        XCTAssertTrue(try ModelCostsCommandCore.run(args: ["help"], store: store).contains("model-costs"))
+    }
+
+    // MARK: Money formatting
+
+    func testTrimFormatsLikeThePrototype() {
+        XCTAssertEqual(ModelCostsCommandCore.trim(15), "15")
+        XCTAssertEqual(ModelCostsCommandCore.trim(3.5), "3.5")
+        XCTAssertEqual(ModelCostsCommandCore.trim(0.25), "0.25")
+        XCTAssertEqual(ModelCostsCommandCore.trim(0.8), "0.80")
+    }
+}

--- a/skills/c11/references/api.md
+++ b/skills/c11/references/api.md
@@ -154,6 +154,16 @@ c11 config launch <name|id> [--pane <id|ref> | --workspace <id|ref> | --new-work
     # `default --pin-current` snapshots the most-recent launch into a new saved config
     # and pins it (optional name overrides the auto label). `--window <N>d` = last N days.
 
+c11 model-costs list [--json]                     # model token-cost catalog (picker $ column)
+c11 model-costs set <model> --in <usd> --out <usd> [--source <url>] [--notes <text>]
+c11 model-costs get <model> [--json] | rm <model>
+c11 model-costs import <path|-> [--replace]       # bulk JSON: {"<model>": {"in_usd": n, "out_usd": n, ...}}
+    # Agent-maintained API list prices ($/Mtok) at the state root (model-costs.json),
+    # file-first like `config` — works with the app down. Feeds the launch picker's
+    # cost column; keys are model ids (short `opus`, full `claude-opus-5`, router
+    # `provider/model`). `set` stamps observed_at; keep `--source` honest so the next
+    # updater has provenance. Prices are relative-magnitude signal, not billing truth.
+
 # Navigate
 c11 select-workspace --workspace <id|ref>
 c11 focus-pane --pane <id|ref>


### PR DESCRIPTION
Operator-directed refinements from the picker design pass (follow-on to #395):

## Scrollable shortlist
Past 8 saved configs the shortlist scrolls inside a fixed viewport with a half-row peek instead of growing unbounded. Keyboard ↑↓ keeps the focused row in view. Digit launch badges remain 1–9; later rows keep the empty slot so trailing columns align.

## Real not-installed feedback
A plain click on a dimmed (not-installed) row now surfaces an inline localized notice — *"X isn't on PATH — install it, or pin the row as default anyway"* — in all seven locales (translation pass done, `%@` token verified in every locale), replacing the bare `NSSound.beep()`. The PATH install probe invalidates on every popover open, so a harness installed mid-session lights back up without relaunching c11.

## Agent-maintained model cost catalog
The design's cost column existed as a permanently-empty reserved 82pt space. Now:
- `model-costs.json` at the c11 state root, schema `{"<model>": {"in_usd", "out_usd", "source", "observed_at", "notes"}}`.
- New **file-first `c11 model-costs` family** (`list/get/set/rm/import`), mirroring the `c11 config` rail — app-down capable, no socket, agent-updatable, provenance stamped (`set` stamps `observed_at`; `--source` carries the URL). Skill `api.md` documents the verbs (installed copy synced).
- The picker reads the catalog fresh per open; the column renders only when a visible row has a price and **collapses entirely when the catalog is empty** — no more dead trailing space.
- Prices are API list prices: a relative-magnitude signal, deliberately not subscription billing truth (documented in code + skill).
- First fill is being produced by a web-verified research agent; it will land via `c11 model-costs import` — no code change needed.

## Validation
- Tagged build (`picker-ux`) compiles clean; `c11 model-costs` smoke-tested end to end against the real state root (set → list → get → rm, catalog left clean).
- New `ModelCostCatalogTests` logic suite: store round-trips, lookup fallbacks (case, provider-prefix), corrupt-file degradation, import merge/replace, CLI core arg validation, money formatting.
- No pbxproj gem churn — memberships hand-mirrored (+16 lines only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)