### PR TITLE
A-button split control: caret + long-press open the picker; markdown button becomes a setting

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -66649,6 +66649,194 @@
           }
         }
       }
+    },
+    "workspace.tooltip.chooseAgent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose Agent to Launch…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "起動するエージェントを選択…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вибрати агента для запуску…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행할 에이전트 선택…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择要启动的代理..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇要啟動的代理..."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выбрать агента для запуска..."
+          }
+        }
+      }
+    },
+    "settings.app.markdownSpawnButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown Button in Tab Bar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブバーのマークダウンボタン"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кнопка Markdown на панелі вкладок"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 바의 마크다운 버튼"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标签栏中的 Markdown 按钮"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標籤列中的 Markdown 按鈕"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кнопка Markdown на панели вкладок"
+          }
+        }
+      }
+    },
+    "settings.app.markdownSpawnButton.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The tab bar shows the Markdown spawn button. Turn off to reclaim the slot; markdown surfaces stay available via the CLI and command palette."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブバーにマークダウン作成ボタンが表示されます。オフにするとその分のスペースを取り戻せます。マークダウンのサーフェスはCLIとコマンドパレットから引き続き利用できます。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель вкладок показує кнопку створення Markdown. Вимкніть, щоб звільнити місце; поверхні Markdown залишаються доступними через CLI та палітру команд."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 바에 마크다운 생성 버튼이 표시됩니다. 끄면 그 자리를 되찾을 수 있습니다. 마크다운 서피스는 CLI와 명령어 팔레트를 통해 계속 사용할 수 있습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标签栏显示 Markdown 生成按钮。关闭可腾出该位置；Markdown 界面仍可通过 CLI 和命令面板使用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標籤列顯示 Markdown 建立按鈕。關閉可騰出該位置；Markdown 介面仍可透過 CLI 和指令面板使用。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Панель вкладок показывает кнопку создания Markdown. Отключите, чтобы освободить место; поверхности Markdown остаются доступны через CLI и палитру команд."
+          }
+        }
+      }
+    },
+    "settings.app.markdownSpawnButton.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Markdown spawn button is hidden. Markdown surfaces remain fully available via the CLI and command palette."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マークダウン作成ボタンは非表示になります。マークダウンのサーフェスはCLIとコマンドパレットから引き続き完全に利用できます。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кнопку створення Markdown приховано. Поверхні Markdown залишаються повністю доступними через CLI та палітру команд."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "마크다운 생성 버튼이 숨겨집니다. 마크다운 서피스는 CLI와 명령어 팔레트를 통해 계속 완전히 사용할 수 있습니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown 生成按钮已隐藏。Markdown 界面仍可通过 CLI 和命令面板完全使用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown 建立按鈕已隱藏。Markdown 介面仍可透過 CLI 和指令面板完全使用。"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Кнопка создания Markdown скрыта. Поверхности Markdown остаются полностью доступны через CLI и палитру команд."
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/SurfaceTypeAvailability.swift
+++ b/Sources/SurfaceTypeAvailability.swift
@@ -25,6 +25,11 @@ enum SurfaceTypeAvailability {
     static let internalBrowserEnabledKey = "internalBrowserEnabled"
     /// `@AppStorage` key — `true` (or unset) means markdown surfaces can be spawned.
     static let markdownSurfacesEnabledKey = "markdownSurfacesEnabled"
+    /// `@AppStorage` key — `true` (or unset) shows the Markdown spawn button in
+    /// the tab bar. Distinct from `markdownSurfacesEnabledKey`: hiding the
+    /// button keeps markdown surfaces fully available to the CLI, socket, and
+    /// command palette — it only reclaims the toolbar slot.
+    static let markdownSpawnButtonVisibleKey = "markdownSpawnButtonVisible"
 
     /// Truthy in the environment forces the internal browser off (tests/headless).
     static let disableBrowserEnvKey = "C11_DISABLE_BROWSER"
@@ -58,6 +63,18 @@ enum SurfaceTypeAvailability {
                 environment: environment
             )
         }
+    }
+
+    /// Whether the tab bar shows the Markdown spawn button. Requires markdown
+    /// surfaces to be enabled at all; on top of that, the visibility toggle
+    /// (default on) can reclaim the toolbar slot without disabling the surface
+    /// type.
+    static func isMarkdownSpawnButtonVisible(defaults: UserDefaults = .standard) -> Bool {
+        guard isEnabled(.markdown, defaults: defaults) else { return false }
+        if defaults.object(forKey: markdownSpawnButtonVisibleKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: markdownSpawnButtonVisibleKey)
     }
 
     private static func resolve(
@@ -99,6 +116,7 @@ final class SurfaceAvailabilityObserver: NSObject {
     private static let observedKeys = [
         SurfaceTypeAvailability.internalBrowserEnabledKey,
         SurfaceTypeAvailability.markdownSurfacesEnabledKey,
+        SurfaceTypeAvailability.markdownSpawnButtonVisibleKey,
     ]
     private let defaults: UserDefaults
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -5625,6 +5625,7 @@ final class Workspace: Identifiable, ObservableObject {
             newAgent: DefaultAgentResolver.resolvedDefaultTooltip(
                 userDefault: DefaultAgentConfigStore.shared.current
             ),
+            chooseAgent: String(localized: "workspace.tooltip.chooseAgent", defaultValue: "Choose Agent to Launch…"),
             newTerminal: KeyboardShortcutSettings.Action.newSurface.tooltip(
                 String(localized: "workspace.tooltip.newTerminal", defaultValue: "New Terminal")
             ),
@@ -5823,7 +5824,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// surfaces are untouched — this only governs the spawn affordances.
     func applySurfaceAvailability() {
         let browserOn = SurfaceTypeAvailability.isEnabled(.browser)
-        let markdownOn = SurfaceTypeAvailability.isEnabled(.markdown)
+        let markdownOn = SurfaceTypeAvailability.isMarkdownSpawnButtonVisible()
         var next = bonsplitController.configuration
         guard next.showsBrowserSpawnButton != browserOn
             || next.showsMarkdownSpawnButton != markdownOn else { return }
@@ -6010,7 +6011,7 @@ final class Workspace: Identifiable, ObservableObject {
             // disabled those surface types. `applySurfaceAvailability()` keeps
             // these live as the toggles change.
             showsBrowserSpawnButton: SurfaceTypeAvailability.isEnabled(.browser),
-            showsMarkdownSpawnButton: SurfaceTypeAvailability.isEnabled(.markdown),
+            showsMarkdownSpawnButton: SurfaceTypeAvailability.isMarkdownSpawnButtonVisible(),
             appearance: appearance
         )
         self.bonsplitController = BonsplitController(configuration: config)

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -4429,6 +4429,8 @@ struct SettingsView: View {
     private var internalBrowserEnabled = SurfaceTypeAvailability.defaultEnabled
     @AppStorage(SurfaceTypeAvailability.markdownSurfacesEnabledKey)
     private var markdownSurfacesEnabled = SurfaceTypeAvailability.defaultEnabled
+    @AppStorage(SurfaceTypeAvailability.markdownSpawnButtonVisibleKey)
+    private var markdownSpawnButtonVisible = SurfaceTypeAvailability.defaultEnabled
     @AppStorage(TabOrdinalDisplaySettings.showSurfaceIdsInTabTitlesKey)
     private var showSurfaceIdsInTabTitles = TabOrdinalDisplaySettings.defaultShowSurfaceIds
     @AppStorage(ClaudeCodeIntegrationSettings.hooksEnabledKey)
@@ -5161,6 +5163,21 @@ struct SettingsView: View {
                 Toggle("", isOn: $markdownSurfacesEnabled)
                     .labelsHidden()
                     .controlSize(.small)
+            }
+
+            if markdownSurfacesEnabled {
+                SettingsCardDivider()
+
+                SettingsCardRow(
+                    String(localized: "settings.app.markdownSpawnButton", defaultValue: "Markdown Button in Tab Bar"),
+                    subtitle: markdownSpawnButtonVisible
+                        ? String(localized: "settings.app.markdownSpawnButton.subtitleOn", defaultValue: "The tab bar shows the Markdown spawn button. Turn off to reclaim the slot; markdown surfaces stay available via the CLI and command palette.")
+                        : String(localized: "settings.app.markdownSpawnButton.subtitleOff", defaultValue: "The Markdown spawn button is hidden. Markdown surfaces remain fully available via the CLI and command palette.")
+                ) {
+                    Toggle("", isOn: $markdownSpawnButtonVisible)
+                        .labelsHidden()
+                        .controlSize(.small)
+                }
             }
 
             SettingsCardDivider()


### PR DESCRIPTION
Third slice of the picker design pass (after #395, #396) — operator-approved item 1: make the launch picker *visible* without costing the one-click launch.

## Split-button A (bonsplit [406271c](https://github.com/Stage-11-Agentics/bonsplit/commit/406271c))
`AgentSpawnButtonCluster` renders the agent control as the macOS split-button idiom:
- **A zone** — click launches the effective default (unchanged); **press-and-hold ~0.4s** opens the picker; right/ctrl-click opens the picker (as shipped in #395).
- **▾ caret zone** — narrow, its own hover highlight and localized tooltip ("Choose Agent to Launch…", seven locales); any click opens the picker.
- Every pointer path runs through `RightClickCatchView`, which grew an optional full-ownership mode: quick click fires primary on mouse-up-inside (release-outside cancels — real button semantics), hold fires the context callback and swallows the release. Deterministic on the real event; no SwiftUI gesture/timing dependence, no suppress-flag dances.

## Markdown spawn button becomes a visibility setting
To keep the toolbar from crowding as the A control widens: new **"Markdown Button in Tab Bar"** toggle (default **on**, nested under Markdown Surfaces in Settings). Unlike the existing `markdownSurfacesEnabled` kill-switch, hiding the button only reclaims the toolbar slot — markdown surfaces stay fully available to the CLI, socket, and command palette. Live-updates through the existing `SurfaceAvailabilityObserver` (new key added to its observed set).

## Validation
- Tagged build `picker-ux` compiles clean and is running for operator hands-on (click / hold / caret / right-click / settings toggle).
- All four new strings translated (ja, uk, ko, zh-Hans, zh-Hant, ru), `jq` validation passed.
- bonsplit `swift build` clean; pushed to its main before the pointer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)