### PR TITLE
C11-189: guard legacy Codex notify by root thread

### DIFF
--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2804,6 +2804,10 @@ struct CMUXCLI {
             let surfaceArg = optionValue(commandArgs, name: "--surface") ?? (notifyWsFlag == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
 
             var params: [String: Any] = ["title": title, "subtitle": subtitle, "body": body]
+            if let payload = nonEmptyEnv("CMUX_CODEX_NOTIFY_PAYLOAD_B64")
+                ?? nonEmptyEnv("C11_CODEX_NOTIFY_PAYLOAD_B64") {
+                params["legacy_codex_notify_payload_b64"] = payload
+            }
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)

--- a/CLI/c11.swift
+++ b/CLI/c11.swift
@@ -2804,8 +2804,7 @@ struct CMUXCLI {
             let surfaceArg = optionValue(commandArgs, name: "--surface") ?? (notifyWsFlag == nil && windowId == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
 
             var params: [String: Any] = ["title": title, "subtitle": subtitle, "body": body]
-            if let payload = nonEmptyEnv("CMUX_CODEX_NOTIFY_PAYLOAD_B64")
-                ?? nonEmptyEnv("C11_CODEX_NOTIFY_PAYLOAD_B64") {
+            if let payload = nonEmptyEnv("C11_CODEX_NOTIFY_PAYLOAD_B64") {
                 params["legacy_codex_notify_payload_b64"] = payload
             }
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)

--- a/Resources/bin/codex
+++ b/Resources/bin/codex
@@ -48,11 +48,19 @@ if [[ "${1:-}" == "__c11-notify" ]]; then
     socket="${CMUX_SOCKET_PATH:-${C11_SOCKET_PATH:-}}"
     workspace_id="${CMUX_WORKSPACE_ID:-${C11_WORKSPACE_ID:-}}"
     surface_id="${CMUX_SURFACE_ID:-${C11_SURFACE_ID:-}}"
+    # Preserve the fact that this was the legacy Codex notify path even when
+    # Codex omits or empties the callback payload; the ingest guard must be
+    # able to treat missing `thread-id` as "do not mutate attention".
+    notify_payload_b64="e30="
+    if [[ -n "${2:-}" ]]; then
+        notify_payload_b64="$(printf '%s' "$2" | /usr/bin/base64 | tr -d '\n')"
+    fi
     self_dir="$(cd "$(dirname "$0")" && pwd)"
     c11_bin="$self_dir/c11"
     [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
 
     if [[ -n "$socket" && -S "$socket" && -n "$workspace_id" && -n "$surface_id" && -n "$c11_bin" ]]; then
+        CMUX_CODEX_NOTIFY_PAYLOAD_B64="$notify_payload_b64" \
         CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
             "$c11_bin" --socket "$socket" notify \
             --title "Codex" \

--- a/Resources/bin/codex
+++ b/Resources/bin/codex
@@ -60,7 +60,7 @@ if [[ "${1:-}" == "__c11-notify" ]]; then
     [[ -x "$c11_bin" ]] || c11_bin="$(command -v c11 || true)"
 
     if [[ -n "$socket" && -S "$socket" && -n "$workspace_id" && -n "$surface_id" && -n "$c11_bin" ]]; then
-        CMUX_CODEX_NOTIFY_PAYLOAD_B64="$notify_payload_b64" \
+        C11_CODEX_NOTIFY_PAYLOAD_B64="$notify_payload_b64" \
         CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
             "$c11_bin" --socket "$socket" notify \
             --title "Codex" \

--- a/Sources/SocketHandlers/NotificationHandlers.swift
+++ b/Sources/SocketHandlers/NotificationHandlers.swift
@@ -5,9 +5,43 @@ import Foundation
 import Bonsplit
 import WebKit
 
+private enum LegacyCodexNotifyGuard {
+    static let payloadKey = "legacy_codex_notify_payload_b64"
+}
+
 // C11-159: per-domain socket handler unit extracted verbatim from
 // TerminalController.swift. Mechanical relocation, zero behavior change.
 extension TerminalController {
+    private func shouldDeliverLegacyCodexNotification(
+        params: [String: Any],
+        surfaceId: UUID
+    ) -> Bool {
+        guard let payloadB64 = params[LegacyCodexNotifyGuard.payloadKey] as? String else {
+            return true
+        }
+
+        let capturedRootThreadId: String?? = conversationStoreSync { store in
+            guard let active = await store.active(for: surfaceId.uuidString),
+                  active.kind == "codex",
+                  active.capturedVia == .runtimeEnv,
+                  active.state == .alive,
+                  !active.placeholder else {
+                return nil
+            }
+            return active.id
+        }
+        guard let capturedRootThreadId else { return true }
+        guard let rootThreadId = capturedRootThreadId else { return true }
+        guard let payloadData = Data(base64Encoded: payloadB64),
+              let payloadObject = try? JSONSerialization.jsonObject(with: payloadData) as? [String: Any],
+              let callbackThreadId = (payloadObject["thread-id"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !callbackThreadId.isEmpty else {
+            return false
+        }
+        return callbackThreadId == rootThreadId
+    }
+
     /// v2 dispatch slice for the `notification.*` domain(s).
     /// Byte-identical routing and wire responses to the original processV2Command cases.
     func v2DispatchNotification(_ method: String, id: Any?, params: [String: Any]) -> String {
@@ -43,6 +77,11 @@ extension TerminalController {
                 return
             }
             let surfaceId = ws.focusedPanelId
+            if let surfaceId,
+               !shouldDeliverLegacyCodexNotification(params: params, surfaceId: surfaceId) {
+                result = .ok(["workspace_id": ws.id.uuidString, "surface_id": surfaceId.uuidString])
+                return
+            }
             TerminalNotificationStore.shared.addNotification(
                 tabId: ws.id,
                 surfaceId: surfaceId,
@@ -75,6 +114,10 @@ extension TerminalController {
             }
             guard ws.panels[surfaceId] != nil else {
                 result = .err(code: "not_found", message: "Surface not found", data: ["surface_id": surfaceId.uuidString])
+                return
+            }
+            if !shouldDeliverLegacyCodexNotification(params: params, surfaceId: surfaceId) {
+                result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
                 return
             }
             TerminalNotificationStore.shared.addNotification(
@@ -112,6 +155,10 @@ extension TerminalController {
             }
             guard ws.panels[surfaceId] != nil else {
                 result = .err(code: "not_found", message: "Surface not found", data: ["surface_id": surfaceId.uuidString])
+                return
+            }
+            if !shouldDeliverLegacyCodexNotification(params: params, surfaceId: surfaceId) {
+                result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
                 return
             }
             TerminalNotificationStore.shared.addNotification(

--- a/c11Tests/NotificationAndMenuBarTests.swift
+++ b/c11Tests/NotificationAndMenuBarTests.swift
@@ -34,6 +34,33 @@ final class NotificationAndMenuBarTests: XCTestCase {
         }
     }
 
+    private func waitUntil(
+        timeout: TimeInterval = 2.0,
+        _ condition: () -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.01))
+        }
+        return condition()
+    }
+
+    private func legacyCodexNotifyPayload(threadId: String) throws -> String {
+        let data = try JSONSerialization.data(
+            withJSONObject: [
+                "type": "agent-turn-complete",
+                "thread-id": threadId,
+                "turn-id": UUID().uuidString,
+            ]
+        )
+        return data.base64EncodedString()
+    }
+
+    private var legacyCodexNotifyPayloadKey: String {
+        "legacy_codex_notify_payload_b64"
+    }
+
     override func tearDown() {
         TerminalNotificationStore.shared.resetNotificationSettingsPromptHooksForTesting()
         TerminalNotificationStore.shared.replaceNotificationsForTesting([])
@@ -183,6 +210,205 @@ final class NotificationAndMenuBarTests: XCTestCase {
 
         defaults.set(NotificationSoundSettings.customFileValue, forKey: NotificationSoundSettings.key)
         XCTAssertTrue(NotificationSoundSettings.isCustomFileSelected(defaults: defaults))
+    }
+
+    func testLegacyCodexNotifyMismatchDoesNotMutateAttention() async throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let controller = TerminalController.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+        let originalControllerTabManager = controller.tabManager
+        let originalNotifications = store.notifications
+        let originalAppFocusOverride = AppFocusState.overrideIsFocused
+        var waitingEdges: [Bool] = []
+
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        store.configureWaitingEdgeHandlerForTesting { entered, _ in waitingEdges.append(entered) }
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+        controller.tabManager = manager
+        AppFocusState.overrideIsFocused = false
+
+        defer {
+            store.resetWaitingEdgeHandlerForTesting()
+            store.resetNotificationDeliveryHandlerForTesting()
+            store.replaceNotificationsForTesting(originalNotifications)
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+            controller.tabManager = originalControllerTabManager
+            AppFocusState.overrideIsFocused = originalAppFocusOverride
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let terminalPanel = workspace.focusedTerminalPanel else {
+            return XCTFail("Expected initial focused terminal panel")
+        }
+
+        let rootThreadId = UUID().uuidString.lowercased()
+        let childThreadId = UUID().uuidString.lowercased()
+        _ = await ConversationStore.shared.captureRuntimeEnv(
+            surfaceId: terminalPanel.id.uuidString,
+            id: rootThreadId,
+            cwd: nil
+        )
+        SurfaceLivenessDeriver.onAgentLifecycleChanged(
+            surfaceId: terminalPanel.id,
+            workspaceId: workspace.id,
+            activity: .working
+        )
+        XCTAssertTrue(waitUntil {
+            SurfaceMetadataStore.shared.getMetadata(
+                workspaceId: workspace.id,
+                surfaceId: terminalPanel.id
+            ).metadata[MetadataKey.activity] as? String == SidebarActivityState.working.rawValue
+        })
+
+        let response = controller.v2DispatchNotification(
+            "notification.create_for_surface",
+            id: 1,
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": terminalPanel.id.uuidString,
+                "title": "Codex",
+                legacyCodexNotifyPayloadKey: try legacyCodexNotifyPayload(threadId: childThreadId),
+            ]
+        )
+        XCTAssertTrue(response.contains("\"ok\":true"), "expected success response, got \(response)")
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: terminalPanel.id))
+        XCTAssertTrue(waitUntil {
+            SurfaceMetadataStore.shared.getMetadata(
+                workspaceId: workspace.id,
+                surfaceId: terminalPanel.id
+            ).metadata[MetadataKey.activity] as? String == SidebarActivityState.working.rawValue
+        })
+        XCTAssertEqual(waitingEdges, [])
+    }
+
+    func testLegacyCodexNotifyMatchKeepsCurrentCompletionBehavior() async throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let controller = TerminalController.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+        let originalControllerTabManager = controller.tabManager
+        let originalNotifications = store.notifications
+        let originalAppFocusOverride = AppFocusState.overrideIsFocused
+        var waitingEdges: [Bool] = []
+
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        store.configureWaitingEdgeHandlerForTesting { entered, _ in waitingEdges.append(entered) }
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+        controller.tabManager = manager
+        AppFocusState.overrideIsFocused = false
+
+        defer {
+            store.resetWaitingEdgeHandlerForTesting()
+            store.resetNotificationDeliveryHandlerForTesting()
+            store.replaceNotificationsForTesting(originalNotifications)
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+            controller.tabManager = originalControllerTabManager
+            AppFocusState.overrideIsFocused = originalAppFocusOverride
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let terminalPanel = workspace.focusedTerminalPanel else {
+            return XCTFail("Expected initial focused terminal panel")
+        }
+
+        let rootThreadId = UUID().uuidString.lowercased()
+        _ = await ConversationStore.shared.captureRuntimeEnv(
+            surfaceId: terminalPanel.id.uuidString,
+            id: rootThreadId,
+            cwd: nil
+        )
+        SurfaceLivenessDeriver.onAgentLifecycleChanged(
+            surfaceId: terminalPanel.id,
+            workspaceId: workspace.id,
+            activity: .working
+        )
+        XCTAssertTrue(waitUntil {
+            SurfaceMetadataStore.shared.getMetadata(
+                workspaceId: workspace.id,
+                surfaceId: terminalPanel.id
+            ).metadata[MetadataKey.activity] as? String == SidebarActivityState.working.rawValue
+        })
+
+        let response = controller.v2DispatchNotification(
+            "notification.create_for_surface",
+            id: 2,
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": terminalPanel.id.uuidString,
+                "title": "Codex",
+                legacyCodexNotifyPayloadKey: try legacyCodexNotifyPayload(threadId: rootThreadId),
+            ]
+        )
+        XCTAssertTrue(response.contains("\"ok\":true"), "expected success response, got \(response)")
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: terminalPanel.id))
+        XCTAssertEqual(waitingEdges, [true])
+        XCTAssertTrue(waitUntil {
+            SurfaceMetadataStore.shared.getMetadata(
+                workspaceId: workspace.id,
+                surfaceId: terminalPanel.id
+            ).metadata[MetadataKey.activity] as? String == SidebarActivityState.idle.rawValue
+        })
+    }
+
+    func testLegacyCodexNotifyWithoutRuntimeCaptureFallsBackToCurrentBehavior() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let controller = TerminalController.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+        let originalControllerTabManager = controller.tabManager
+        let originalNotifications = store.notifications
+        let originalAppFocusOverride = AppFocusState.overrideIsFocused
+        var waitingEdges: [Bool] = []
+
+        store.replaceNotificationsForTesting([])
+        store.configureNotificationDeliveryHandlerForTesting { _, _ in }
+        store.configureWaitingEdgeHandlerForTesting { entered, _ in waitingEdges.append(entered) }
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+        controller.tabManager = manager
+        AppFocusState.overrideIsFocused = false
+
+        defer {
+            store.resetWaitingEdgeHandlerForTesting()
+            store.resetNotificationDeliveryHandlerForTesting()
+            store.replaceNotificationsForTesting(originalNotifications)
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+            controller.tabManager = originalControllerTabManager
+            AppFocusState.overrideIsFocused = originalAppFocusOverride
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let terminalPanel = workspace.focusedTerminalPanel else {
+            return XCTFail("Expected initial focused terminal panel")
+        }
+
+        let response = controller.v2DispatchNotification(
+            "notification.create_for_surface",
+            id: 3,
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": terminalPanel.id.uuidString,
+                "title": "Codex",
+                legacyCodexNotifyPayloadKey: try legacyCodexNotifyPayload(threadId: UUID().uuidString.lowercased()),
+            ]
+        )
+        XCTAssertTrue(response.contains("\"ok\":true"), "expected success response, got \(response)")
+        XCTAssertTrue(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: terminalPanel.id))
+        XCTAssertEqual(waitingEdges, [true])
     }
 
     func testNotificationCustomStagingPreservesSourceFileWithCmuxPrefix() {

--- a/tests/test_codex_wrapper_hooks.py
+++ b/tests/test_codex_wrapper_hooks.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import base64
 import os
 import shutil
 import socket
@@ -71,7 +72,7 @@ done
             wrapper_dir / "c11",
             """#!/usr/bin/env bash
 set -euo pipefail
-printf '%s timeout=%s\\n' "$*" "${CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC-__UNSET__}" >> "$FAKE_C11_LOG"
+printf '%s timeout=%s payload=%s\\n' "$*" "${CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC-__UNSET__}" "${CMUX_CODEX_NOTIFY_PAYLOAD_B64-__UNSET__}" >> "$FAKE_C11_LOG"
 if [[ "${1:-}" == "--socket" ]]; then
   shift 2
 fi
@@ -174,6 +175,15 @@ def test_completion_callback_creates_surface_notification(failures: list[str]) -
             f"callback: missing surface scope: {line}",
             failures,
         )
+        encoded_payload = line.split("payload=", 1)[1].split()[0]
+        expect(encoded_payload != "__UNSET__", f"callback: missing forwarded payload: {line}", failures)
+        if encoded_payload != "__UNSET__":
+            decoded_payload = base64.b64decode(encoded_payload).decode("utf-8")
+            expect(
+                decoded_payload == '{"type":"agent-turn-complete"}',
+                f"callback: wrong forwarded payload: {decoded_payload}",
+                failures,
+            )
         expect("timeout=0.75" in line, f"callback: notification call is not bounded: {line}", failures)
 
 

--- a/tests/test_codex_wrapper_hooks.py
+++ b/tests/test_codex_wrapper_hooks.py
@@ -72,7 +72,7 @@ done
             wrapper_dir / "c11",
             """#!/usr/bin/env bash
 set -euo pipefail
-printf '%s timeout=%s payload=%s\\n' "$*" "${CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC-__UNSET__}" "${CMUX_CODEX_NOTIFY_PAYLOAD_B64-__UNSET__}" >> "$FAKE_C11_LOG"
+printf '%s timeout=%s payload=%s\\n' "$*" "${CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC-__UNSET__}" "${C11_CODEX_NOTIFY_PAYLOAD_B64-__UNSET__}" >> "$FAKE_C11_LOG"
 if [[ "${1:-}" == "--socket" ]]; then
   shift 2
 fi


### PR DESCRIPTION
## Summary
- forward the legacy Codex notify payload through the existing c11 notify path
- guard attention mutation on runtime-captured root-thread matches only
- add regression coverage for mismatch, match, and uncaptured fallback

## Verification
- python3 tests/test_codex_wrapper_hooks.py
- local xcodebuild not run per ticket guardrail; Swift compile/test proof deferred to CI

## Deferred
- AC4 tagged-build smoke check requires computer-use approval