### PR TITLE
C11-192: fingerprint main-thread hangs by the wedged stack, not the watchdog's

### DIFF
--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -82,13 +82,17 @@ enum MainThreadHangSignature {
     /// SwiftUI host operations, most specific first — these say *which* graph
     /// pass is running, which is the difference between a layout bug and a
     /// transaction-flush bug.
+    ///
+    /// Only `swiftui-update` is narrowed by phase (see `describe`). Every other
+    /// cause already names something more actionable than the host operation
+    /// above it, and splitting them by phase would fragment the small buckets
+    /// that matter most: applied to all causes on the same corpora, this splits
+    /// `generic-metadata` three ways for no diagnostic gain.
     private static let phaseRules: [(phase: String, needle: String)] = [
         ("hosting-begin-transaction", "NSHostingViewC16beginTransaction"),
         ("hosting-layout", "NSHostingViewC6layout"),
         ("display-list-render", "ViewGraphRootValueUpdaterPAAE6render"),
         ("preferences", "updatePreferences"),
-        ("nsview-layout", "_layoutSubtreeWithOldSize"),
-        ("menu", "NSMenu"),
     ]
 
     /// How far down the stack the cause rules look. Blocking waits and metadata
@@ -440,6 +444,11 @@ final class MainThreadHangMonitor: @unchecked Sendable {
             .map { "\($0.offset)\t\($0.element)" }
             .joined(separator: "\n")
         if shouldReportHangToSentry(gapMs: gapMs) {
+            // `processName` is the "own binary" match for culprit extraction:
+            // it equals the Mach-O image name `backtrace_symbols` reports for
+            // both the shipped bundle (`c11`) and dev builds (`c11 DEV`). The
+            // tag is best-effort anyway — absent whenever the capture window
+            // never reaches our code — so a mismatch degrades to no tag.
             let signature = MainThreadHangSignature.describe(
                 stack: stack,
                 ownModule: ProcessInfo.processInfo.processName

--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -2,6 +2,174 @@ import AppKit
 import Darwin
 import Foundation
 
+/// What a captured main-thread backtrace says the wedge actually is.
+///
+/// `cause` answers "what is main blocked on" and `phase` narrows the largest
+/// cause (SwiftUI graph work) to the host operation driving it. Together they
+/// form the Sentry fingerprint. `culprit` and `topSymbol` are per-report detail
+/// that rides along as tags — searchable inside an issue without splitting it.
+struct MainThreadHangDescriptor: Equatable {
+    let cause: String
+    let phase: String?
+    /// Deepest frame belonging to this app's own binary, if the captured window
+    /// reached one. Mangled — run it through `swift demangle`.
+    let culprit: String?
+    let topSymbol: String?
+
+    /// Human-readable signature, used as the Sentry message so an issue's title
+    /// names its cause instead of whichever stall duration happened to be first.
+    var label: String {
+        guard let phase else { return cause }
+        return "\(cause)/\(phase)"
+    }
+
+    var fingerprint: [String] {
+        var parts = ["main-thread-hang", cause]
+        if let phase { parts.append(phase) }
+        return parts
+    }
+}
+
+/// Reduces a captured main-thread backtrace to a stable grouping signature.
+///
+/// Sentry groups message events by the stack of the thread that *reported*
+/// them. For hang reports that is always the watchdog's own loop, byte-identical
+/// every time, so every main-thread hang — whatever wedged main — collapses into
+/// one issue. Fingerprinting on the wedged stack instead is what makes causes
+/// separable at all.
+///
+/// Deliberately coarse. The capture is a single sample of a moving thread, so
+/// fingerprinting on leaf frames splits one cause across hundreds of issues:
+/// over 875 real reports, a top-5-frame fingerprint produced 645 groups, 607 of
+/// them singletons. Classifying *what main is blocked on* produced a handful of
+/// durable buckets instead.
+enum MainThreadHangSignature {
+
+    /// One parsed `backtrace_symbols` line: `"12  AppKit  0x1854  -[NSView layout] + 96"`.
+    struct Frame: Equatable {
+        let module: String
+        let symbol: String
+    }
+
+    // Ordered: the first match wins, so a blocking wait outranks whatever
+    // library asked for it. A thread parked in a semaphore is a lock problem
+    // no matter how pretty the frames above it look.
+    private static let causeRules: [(cause: String, needles: [String])] = [
+        ("xpc-sync-wait", [
+            "_dispatch_mach_send_and_wait_for_reply",
+            "xpc_connection_send_message_with_reply_sync",
+            "CFXPCSendMessageWithReply",
+        ]),
+        ("lock-wait", [
+            "psynch_mutexwait", "psynch_cvwait", "semaphore_wait",
+            "semaphore_timedwait", "ulock_wait", "_pthread_cond_wait",
+        ]),
+        ("generic-metadata", [
+            "swift_getTypeByMangledName", "_gatherGenericParameters",
+            "swift_getOpaqueTypeMetadata", "instantiateGenericMetadata",
+            "_swift_getGenericMetadata", "MetadataCacheKey",
+        ]),
+    ]
+
+    private static let swiftUIModules: Set<String> = [
+        "SwiftUI", "SwiftUICore", "AttributeGraph",
+    ]
+
+    private static let renderingModules: Set<String> = [
+        "AppKit", "QuartzCore", "CoreGraphics", "CoreText", "HIToolbox",
+    ]
+
+    /// SwiftUI host operations, most specific first — these say *which* graph
+    /// pass is running, which is the difference between a layout bug and a
+    /// transaction-flush bug.
+    private static let phaseRules: [(phase: String, needle: String)] = [
+        ("hosting-begin-transaction", "NSHostingViewC16beginTransaction"),
+        ("hosting-layout", "NSHostingViewC6layout"),
+        ("display-list-render", "ViewGraphRootValueUpdaterPAAE6render"),
+        ("preferences", "updatePreferences"),
+        ("nsview-layout", "_layoutSubtreeWithOldSize"),
+        ("menu", "NSMenu"),
+    ]
+
+    /// How far down the stack the cause rules look. Blocking waits and metadata
+    /// instantiation sit near the leaf; searching the whole 96-frame capture
+    /// would let an unrelated deep frame decide the bucket.
+    private static let causeWindow = 16
+    /// How far down "which module is main working in" is decided.
+    private static let moduleWindow = 8
+
+    /// `backtrace_symbols` emits `"%-4d%-35s 0x%016lx %s + %lu"`. The load
+    /// address is the only reliable delimiter: image names may contain spaces
+    /// (`c11 DEV`), so splitting on whitespace alone mis-parses dev builds.
+    static func parse(_ line: String) -> Frame? {
+        var tokens = line.split(separator: " ", omittingEmptySubsequences: true).map(String.init)
+        if let first = tokens.first, Int(first) != nil { tokens.removeFirst() }
+        guard let addressIndex = tokens.firstIndex(where: { $0.hasPrefix("0x") }) else { return nil }
+
+        let module = tokens[tokens.startIndex..<addressIndex].joined(separator: " ")
+        var rest = Array(tokens[tokens.index(after: addressIndex)...])
+        // Trailing "+ <offset>" moves with every build; it is noise for grouping.
+        if rest.count >= 2, rest[rest.count - 2] == "+", Int(rest[rest.count - 1]) != nil {
+            rest.removeLast(2)
+        }
+        let symbol = rest.joined(separator: " ")
+        guard !module.isEmpty, !symbol.isEmpty else { return nil }
+        return Frame(module: module, symbol: symbol)
+    }
+
+    static func describe(stack: [String], ownModule: String) -> MainThreadHangDescriptor {
+        let frames = stack.compactMap(parse)
+        guard !frames.isEmpty else {
+            return MainThreadHangDescriptor(
+                cause: "unknown", phase: nil, culprit: nil, topSymbol: nil
+            )
+        }
+
+        let cause = self.cause(frames)
+        return MainThreadHangDescriptor(
+            cause: cause,
+            phase: cause == "swiftui-update" ? phase(frames) : nil,
+            culprit: culprit(frames, ownModule: ownModule),
+            topSymbol: frames[0].symbol
+        )
+    }
+
+    static func cause(_ frames: [Frame]) -> String {
+        guard let leaf = frames.first else { return "unknown" }
+        let window = frames.prefix(causeWindow)
+        for rule in causeRules where window.contains(where: { frame in
+            rule.needles.contains { frame.symbol.contains($0) }
+        }) {
+            return rule.cause
+        }
+        // Parked at the top of the run loop waiting for work: main is idle, and
+        // the watchdog's heartbeat should have been serviced. Its own bucket so
+        // it can be judged separately from a thread wedged in compute.
+        if leaf.symbol.contains("mach_msg2_trap"),
+           window.contains(where: { $0.symbol.contains("CFRunLoopServiceMachPort") }) {
+            return "runloop-idle"
+        }
+        let modules = frames.prefix(moduleWindow).map(\.module)
+        if modules.contains(where: swiftUIModules.contains) { return "swiftui-update" }
+        if modules.contains(where: renderingModules.contains) { return "appkit" }
+        return "other"
+    }
+
+    static func phase(_ frames: [Frame]) -> String? {
+        for rule in phaseRules where frames.contains(where: { $0.symbol.contains(rule.needle) }) {
+            return rule.phase
+        }
+        return nil
+    }
+
+    static func culprit(_ frames: [Frame], ownModule: String) -> String? {
+        // `main` is in every capture and names nothing; skip it so the tag
+        // stays empty rather than useless when nothing else of ours is on the
+        // stack.
+        frames.first { $0.module == ownModule && $0.symbol != "main" }?.symbol
+    }
+}
+
 /// Pure decision core for main-thread hang detection.
 ///
 /// Split out from `MainThreadHangMonitor` so the stall/recovery state machine
@@ -272,15 +440,28 @@ final class MainThreadHangMonitor: @unchecked Sendable {
             .map { "\($0.offset)\t\($0.element)" }
             .joined(separator: "\n")
         if shouldReportHangToSentry(gapMs: gapMs) {
+            let signature = MainThreadHangSignature.describe(
+                stack: stack,
+                ownModule: ProcessInfo.processInfo.processName
+            )
+            var tags = ["hang.cause": signature.cause, "hang.recapture": recapture ? "true" : "false"]
+            tags["hang.phase"] = signature.phase
+            tags["hang.culprit"] = signature.culprit
+            tags["hang.top_symbol"] = signature.topSymbol
+            // The stall duration belongs in the message only if it is not the
+            // grouping key — it isn't, so the title names the cause and the
+            // duration stays a searchable tag/context value.
             sentryCaptureWarning(
-                "main thread hang \(Int(gapMs))ms\(recapture ? " (persist)" : "")",
+                "main thread hang (\(signature.label))",
                 category: "hang",
                 data: [
                     "stalled_ms": Int(gapMs),
                     "recapture": recapture,
                     "stack": top,
                 ],
-                contextKey: "hang"
+                contextKey: "hang",
+                fingerprint: signature.fingerprint,
+                tags: tags
             )
         }
         PostHogAnalytics.shared.captureMainThreadHang(

--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -448,9 +448,9 @@ final class MainThreadHangMonitor: @unchecked Sendable {
             tags["hang.phase"] = signature.phase
             tags["hang.culprit"] = signature.culprit
             tags["hang.top_symbol"] = signature.topSymbol
-            // The stall duration belongs in the message only if it is not the
-            // grouping key — it isn't, so the title names the cause and the
-            // duration stays a searchable tag/context value.
+            // The duration is not the grouping key, so it does not belong in
+            // the title: the message names the cause and `stalled_ms` stays in
+            // the event context.
             sentryCaptureWarning(
                 "main thread hang (\(signature.label))",
                 category: "hang",

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -211,12 +211,18 @@ func sentryBreadcrumb(_ message: String, category: String = "ui", data: [String:
     SentrySDK.addBreadcrumb(crumb)
 }
 
+/// Sentry caps tag values; anything longer is rejected outright rather than
+/// truncated, which would silently drop the tag we most want to facet on.
+private let sentryTagValueLimit = 190
+
 private func sentryCaptureMessage(
     _ message: String,
     level: SentryLevel,
     category: String,
     data: [String: Any]?,
-    contextKey: String?
+    contextKey: String?,
+    fingerprint: [String]?,
+    tags: [String: String]?
 ) {
     guard TelemetrySettings.enabledForCurrentLaunch else { return }
     _ = SentrySDK.capture(message: message) { scope in
@@ -225,6 +231,16 @@ private func sentryCaptureMessage(
         if let data {
             scope.setContext(value: data, key: contextKey ?? category)
         }
+        // Without an explicit fingerprint Sentry groups a message event by the
+        // stack of the thread that captured it. For anything reported from a
+        // dedicated worker (the hang watchdog) that stack is identical every
+        // time, so unrelated events pile into one issue.
+        if let fingerprint, !fingerprint.isEmpty {
+            scope.setFingerprint(fingerprint)
+        }
+        for (key, value) in tags ?? [:] where !value.isEmpty {
+            scope.setTag(value: String(value.prefix(sentryTagValueLimit)), key: key)
+        }
     }
 }
 
@@ -232,18 +248,38 @@ func sentryCaptureWarning(
     _ message: String,
     category: String = "ui",
     data: [String: Any]? = nil,
-    contextKey: String? = nil
+    contextKey: String? = nil,
+    fingerprint: [String]? = nil,
+    tags: [String: String]? = nil
 ) {
-    sentryCaptureMessage(message, level: .warning, category: category, data: data, contextKey: contextKey)
+    sentryCaptureMessage(
+        message,
+        level: .warning,
+        category: category,
+        data: data,
+        contextKey: contextKey,
+        fingerprint: fingerprint,
+        tags: tags
+    )
 }
 
 func sentryCaptureError(
     _ message: String,
     category: String = "ui",
     data: [String: Any]? = nil,
-    contextKey: String? = nil
+    contextKey: String? = nil,
+    fingerprint: [String]? = nil,
+    tags: [String: String]? = nil
 ) {
-    sentryCaptureMessage(message, level: .error, category: category, data: data, contextKey: contextKey)
+    sentryCaptureMessage(
+        message,
+        level: .error,
+        category: category,
+        data: data,
+        contextKey: contextKey,
+        fingerprint: fingerprint,
+        tags: tags
+    )
 }
 
 /// Telemetry-independent launch sentinel. Catches Force Quit, SIGKILL, jetsam,

--- a/c11Tests/MainThreadHangDetectorTests.swift
+++ b/c11Tests/MainThreadHangDetectorTests.swift
@@ -110,6 +110,176 @@ final class MainThreadHangDetectorTests: XCTestCase {
     }
 }
 
+/// Pure, in-process tests for `MainThreadHangSignature` — the grouping key the
+/// watchdog attaches to every outbound hang report.
+///
+/// Fixtures are verbatim `backtrace_symbols` lines from real production reports
+/// on `com.stage11.c11@0.58.0+116`, so these exercise the parser against the
+/// exact text it will see rather than a tidied-up approximation.
+final class MainThreadHangSignatureTests: XCTestCase {
+
+    private func describe(_ stack: [String], ownModule: String = "c11") -> MainThreadHangDescriptor {
+        MainThreadHangSignature.describe(stack: stack, ownModule: ownModule)
+    }
+
+    // MARK: - Frame parsing
+
+    func testParseDropsFrameIndexAddressAndOffset() {
+        let frame = MainThreadHangSignature.parse(
+            "9   AppKit                              0x000000018c43c35c _DPSBlockUntilNextEventMatchingListInMode + 228"
+        )
+        XCTAssertEqual(frame, MainThreadHangSignature.Frame(
+            module: "AppKit", symbol: "_DPSBlockUntilNextEventMatchingListInMode"
+        ))
+    }
+
+    func testParseKeepsSymbolsThatCarryNoOffset() {
+        let frame = MainThreadHangSignature.parse("0   c11   0x0000000100371b98 main")
+        XCTAssertEqual(frame, MainThreadHangSignature.Frame(module: "c11", symbol: "main"))
+    }
+
+    func testParseRejectsGarbage() {
+        XCTAssertNil(MainThreadHangSignature.parse(""))
+        XCTAssertNil(MainThreadHangSignature.parse("   "))
+        // Module with no symbol column carries nothing worth grouping on.
+        XCTAssertNil(MainThreadHangSignature.parse("3   SwiftUI   0x00000001b6d4ad7c"))
+    }
+
+    // MARK: - Cause classification
+
+    func testSynchronousXPCWaitOutranksTheLibraryThatAskedForIt() {
+        // Main is parked in mach_msg, but the reason is a blocking XPC round
+        // trip to LaunchServices — grouping it as "idle in mach_msg" would hide
+        // the real defect.
+        let d = describe([
+            "0   libsystem_kernel.dylib   0x0000000180e03c34 mach_msg2_trap + 8",
+            "1   libsystem_kernel.dylib   0x0000000180e0c9c0 mach_msg_overwrite + 480",
+            "2   libsystem_kernel.dylib   0x0000000180e03fc0 mach_msg + 24",
+            "3   libdispatch.dylib   0x0000000180ca7c64 _dispatch_mach_send_and_wait_for_reply + 548",
+            "4   libdispatch.dylib   0x0000000180ca8004 dispatch_mach_send_with_result_and_wait_for_reply + 60",
+            "5   libxpc.dylib   0x0000000180b21eb0 xpc_connection_send_message_with_reply_sync + 284",
+            "6   LaunchServices   0x00000001813ec0b4 _ZN26LSClientToServerConnection13sendWithReplyEPv + 68",
+        ])
+        XCTAssertEqual(d.cause, "xpc-sync-wait")
+        XCTAssertNil(d.phase)
+        XCTAssertEqual(d.label, "xpc-sync-wait")
+    }
+
+    func testGenericMetadataInstantiationIsItsOwnCause() {
+        // The stack C11-192 was filed on: the Swift runtime building metadata
+        // for an opaque `some View` under SwiftUI.Button.body.
+        let d = describe([
+            "0   libswiftCore.dylib   0x0000000194571728 _ZL24_gatherGenericParametersPKN5swift23TargetContextDescriptorINS_9InProcessEEE + 1548",
+            "1   libswiftCore.dylib   0x000000019457e5a4 _ZNK12_GLOBAL__N_122DecodedMetadataBuilder22createBoundGenericTypeE + 264",
+            "6   libswiftCore.dylib   0x000000019456d874 swift_getTypeByMangledName + 336",
+            "7   libswiftCore.dylib   0x0000000194570604 _ZL31swift_getOpaqueTypeMetadataImplN5swift15MetadataRequestE + 384",
+            "8   SwiftUI   0x00000001b6d4ad7c $s7SwiftUI6ButtonV4bodyQrvg + 304",
+            "9   SwiftUICore   0x000000022d9b1aa8 $s7SwiftUI16ViewBodyAccessorV06updateD02of7changedyx_SbtFyyScMYcXEfU_ + 1152",
+        ])
+        // SwiftUI frames are present and would otherwise win; the runtime work
+        // is the actionable classification, so it has to outrank them.
+        XCTAssertEqual(d.cause, "generic-metadata")
+        XCTAssertNil(d.phase, "phase only narrows the swiftui-update bucket")
+        XCTAssertTrue(d.topSymbol?.hasPrefix("_ZL24_gatherGenericParameters") == true)
+    }
+
+    func testIdleRunLoopIsSeparatedFromAWedgeInCompute() {
+        let d = describe([
+            "0   libsystem_kernel.dylib   0x0000000187861c34 mach_msg2_trap + 8",
+            "1   libsystem_kernel.dylib   0x000000018786a9c0 mach_msg_overwrite + 480",
+            "2   libsystem_kernel.dylib   0x0000000187861fc0 mach_msg + 24",
+            "3   CoreFoundation   0x00000001879630d8 __CFRunLoopServiceMachPort + 160",
+            "4   CoreFoundation   0x00000001879619c4 __CFRunLoopRun + 1188",
+            "9   AppKit   0x000000018c43c35c _DPSBlockUntilNextEventMatchingListInMode + 228",
+        ])
+        XCTAssertEqual(d.cause, "runloop-idle")
+    }
+
+    func testSwiftUIGraphWorkIsNarrowedByHostPhase() {
+        let layout = describe([
+            "0   AttributeGraph   0x00000001b73c6384 _ZN2AG5Graph11UpdateStack6updateEv + 496",
+            "1   AttributeGraph   0x00000001b73c6aec _ZN2AG5Graph16update_attributeE + 352",
+            "2   SwiftUICore   0x000000022e87ed7c $s7SwiftUI25ViewGraphRootValueUpdaterPAAE6render8interval + 872",
+            "3   SwiftUI   0x00000001b64e46b0 $s7SwiftUI13NSHostingViewC6layoutyyF + 480",
+        ])
+        XCTAssertEqual(layout.cause, "swiftui-update")
+        XCTAssertEqual(layout.phase, "hosting-layout")
+        XCTAssertEqual(layout.label, "swiftui-update/hosting-layout")
+
+        let transaction = describe([
+            "0   AttributeGraph   0x00000001b73c6384 _ZN2AG8Subgraph6updateEj + 668",
+            "1   SwiftUICore   0x0000000236eb37a0 $s7SwiftUI9GraphHostC17flushTransactionsyyF + 180",
+            "2   SwiftUI   0x00000001bf07a2dc $s7SwiftUI13NSHostingViewC16beginTransactionyyFyycfU_ + 24",
+        ])
+        XCTAssertEqual(transaction.phase, "hosting-begin-transaction")
+
+        // The two must not collapse together — they are different bugs.
+        XCTAssertNotEqual(layout.fingerprint, transaction.fingerprint)
+    }
+
+    func testUnrelatedCausesNeverShareAFingerprint() {
+        let stacks: [[String]] = [
+            ["0   libsystem_kernel.dylib   0x1 mach_msg2_trap + 8",
+             "3   libdispatch.dylib   0x2 _dispatch_mach_send_and_wait_for_reply + 548"],
+            ["0   libswiftCore.dylib   0x3 swift_getTypeByMangledName + 336"],
+            ["0   libsystem_kernel.dylib   0x4 psynch_mutexwait + 8"],
+            ["0   CoreText   0x5 _ZN5TFont8SetFlagsEjPK18__CTFontDescriptor + 380",
+             "1   AppKit   0x6 -[NSView layout] + 96"],
+            ["0   libsystem_kernel.dylib   0x7 mach_msg2_trap + 8",
+             "3   CoreFoundation   0x8 __CFRunLoopServiceMachPort + 160"],
+        ]
+        let fingerprints = stacks.map { describe($0).fingerprint }
+        XCTAssertEqual(Set(fingerprints.map { $0.joined(separator: "|") }).count, stacks.count)
+        // Every fingerprint stays namespaced so hang issues are recognizable.
+        for fingerprint in fingerprints {
+            XCTAssertEqual(fingerprint.first, "main-thread-hang")
+        }
+    }
+
+    // MARK: - Culprit
+
+    func testCulpritIsTheDeepestOwnedFrameAndSkipsMain() {
+        let d = describe([
+            "0   libobjc.A.dylib   0x0000000197145844 objc_msgSend + 68",
+            "1   CoreText   0x000000019a47b798 _ZN5TFont8SetFlagsEj + 380",
+            "2   c11   0x0000000101728028 $s8Bonsplit11TabItemViewV17shortcutHintWidth + 1136",
+            "3   c11   0x000000010171fc20 $s8Bonsplit11TabItemViewV4bodyQrvg + 3892",
+            "4   c11   0x0000000100371b98 main + 64",
+        ])
+        XCTAssertEqual(d.culprit, "$s8Bonsplit11TabItemViewV17shortcutHintWidth")
+    }
+
+    func testCulpritIsAbsentWhenTheCaptureNeverReachesOurCode() {
+        let d = describe([
+            "0   libsystem_kernel.dylib   0x1 mach_msg2_trap + 8",
+            "1   CoreFoundation   0x2 __CFRunLoopServiceMachPort + 160",
+        ])
+        XCTAssertNil(d.culprit)
+    }
+
+    func testOwnModuleTracksTheRunningExecutableName() {
+        let stack = ["0   c11 DEV   0x1 $s3c1110TabManagerC26sessionAutosaveFingerprintSiyF + 12"]
+        XCTAssertNil(describe(stack, ownModule: "c11").culprit)
+        // A DEV build's image name differs; the caller supplies it so the
+        // culprit tag keeps working outside the shipped bundle.
+        XCTAssertEqual(
+            describe(stack, ownModule: "c11 DEV").culprit,
+            "$s3c1110TabManagerC26sessionAutosaveFingerprintSiyF"
+        )
+    }
+
+    // MARK: - Degenerate input
+
+    func testEmptyOrUnparseableCaptureStillYieldsAStableFingerprint() {
+        for stack in [[], ["<no frames captured>"], ["<thread_suspend failed>"]] as [[String]] {
+            let d = describe(stack)
+            XCTAssertFalse(d.fingerprint.isEmpty)
+            XCTAssertEqual(d.fingerprint.first, "main-thread-hang")
+        }
+        XCTAssertEqual(describe([]).cause, "unknown")
+    }
+}
+
 /// Pure, in-process tests for `SentryEventBudget` — the client-side ceiling on
 /// outbound Sentry events. The org's error quota is shared across projects and
 /// this plan offers no server-side per-key rate limits, so this policy is the


### PR DESCRIPTION
## The ticket's premise does not survive the data

C11-192 was filed on Sentry issue `C11-31` — "875 events across 7 users, all on
one stack: `swift_getTypeByMangledName` under `SwiftUI.Button.body`" — and asks
for the expensive `Button` to be found and restructured.

I pulled all 875 events and classified each one's **wedged main-thread stack**
(`extra.stack`, which is what the watchdog actually captured):

| what main was blocked on | events | % |
|---|---:|---:|
| SwiftUI / AttributeGraph graph work | 559 | 63.9% |
| other compute | 133 | 15.2% |
| synchronous XPC/IPC wait (blocking on another process) | 96 | 11.0% |
| **Swift generic metadata instantiation — the ticket's stack** | **58** | **6.6%** |
| file I/O syscall | 15 | 1.7% |
| unclassified `mach_msg` | 12 | 1.4% |
| lock / semaphore wait | 10 | 1.1% |

The quoted stack is the **latest event's**, not a shared one. Strictly the
demangler symbols appear in 24 of 875 (2.7%); including all generic-metadata
instantiation it is 50 (5.7%).

**Why they were all one issue.** `attachStacktrace = true` makes the Cocoa SDK
attach the stack of the thread that captured the event, and Sentry fingerprints
a message event on that stack. Hang reports are captured on
`com.stage11.c11.hang-monitor`, whose stack is byte-identical every time
(`runLoop` → `handleHang` → `reportTelemetry`). Verified directly: every event's
`current: true` thread is the watchdog. So *every* main-thread hang, whatever the
cause, lands in one issue, and the issue's title is whichever event was latest.

Two more things the data says:
- **Skew.** One user contributed 816 of 875 events; the other six contributed 59 between them.
- **No c11-owned Button.** None of the metadata-stack events name a `Button` we own. There is no specific expensive `Button` to restructure — which is why this PR does not restructure one.

## What this changes

`MainThreadHangSignature` (pure, in `MainThreadHangMonitor.swift`) reduces a
captured main stack to a grouping signature, and the watchdog attaches it as an
explicit Sentry fingerprint.

Grouping is deliberately **coarse**. The capture is a single sample of a moving
thread, so fingerprinting on leaf frames shatters one cause across hundreds of
issues — measured on the same 875 reports, a top-5-frame fingerprint gives 645
groups, 607 of them singletons. Classifying *what main is blocked on* gives 12.

Per-report detail rides along as tags instead, where it is facetable without
splitting the issue: `hang.cause`, `hang.phase`, `hang.culprit` (deepest c11-owned
frame — lands on 172 of 875 reports, 114 distinct symbols), `hang.top_symbol`.

The message becomes the signature (`main thread hang (swiftui-update/hosting-layout)`)
so an issue title names its cause; `stalled_ms` stays in the event context.

## Evidence

The new code compiled standalone and run over all 875 production stacks turns one
issue into twelve:

```
  291  swiftui-update/hosting-begin-transaction
  179  swiftui-update/hosting-layout
   96  swiftui-update
   96  xpc-sync-wait
   69  other
   58  generic-metadata          <- what C11-192 was filed on
   33  appkit
   22  unknown                   (Sentry server-side [Filtered] events)
   10  runloop-idle
   10  lock-wait
    6  swiftui-update/display-list-render
    5  swiftui-update/preferences
```

**No profile of a metadata instantiation is included, and no fix for one is
claimed.** The premise that one `Button`'s opaque-type metadata costs ten seconds
is not supported: 10422ms is the watchdog's *stall duration at the moment of a
single sample*, not time spent in the sampled frame, and the same issue's other
874 samples land almost anywhere. Establishing whether generic-metadata
instantiation is worth attacking needs its own issue with its own trend — which
is exactly what this PR makes possible.

## Independent corroboration: 20,783 local captures over seven weeks

The same compiled classifier run over `~/Library/Logs/c11/hang.log` — a different
machine, seven weeks instead of one day, and every capture rather than the
budgeted subset that reaches Sentry:

| signature | captures | % |
|---|---:|---:|
| `lock-wait` | 9,519 | 45.8% |
| `runloop-idle` | 7,767 | 37.4% |
| `appkit` | 1,043 | 5.0% |
| `swiftui-update/hosting-begin-transaction` | 934 | 4.5% |
| `swiftui-update/hosting-layout` | 665 | 3.2% |
| `other` | 339 | 1.6% |
| `swiftui-update` | 246 | 1.2% |
| **`generic-metadata`** | **175** | **0.8%** |
| `xpc-sync-wait` | 76 | 0.4% |
| `swiftui-update/preferences` | 19 | 0.1% |

(Both tables are from the classifier as merged; an earlier revision carried two
phase rules that never fired and have since been dropped.)

Two independent datasets agree that generic-metadata instantiation is a minor
class: 5.7% of one production day, 0.8% of seven local weeks.

The `hang.culprit` tag is what makes that table actionable, and it lands on a
known answer:

- **9,413 captures name `GhosttyNSView.attachSurface`** under `lock-wait`. That is
  the 14-hour deadlock C11-186 was filed on, whose own evidence reads "wrote 9,418
  attachSurface frames to `~/Library/Logs/c11/hang.log`". The classifier
  reproduces that incident as its own signature with the right culprit, straight
  from the raw log, with no knowledge of the ticket.
- **4,815 captures name `BrowserPanel.presentInsecureHTTPAlert`** under
  `runloop-idle` — a modal alert runs a nested run loop that does not service the
  main dispatch queue, so the heartbeat never acks and the watchdog reports a hang
  that isn't one. A genuine false-positive class, now separated instead of mixed
  in with real wedges.

So on real data the change turns one undifferentiated issue into buckets that
respectively match a known deadlock ticket, isolate a false positive worth
suppressing, and size the class this ticket was filed on.

## Tests

`MainThreadHangSignatureTests` in `c11LogicTests`, on verbatim `backtrace_symbols`
lines from real `0.58.0+116` reports: frame parsing (index/address/offset stripped,
module names containing spaces such as `c11 DEV` preserved), each cause rule
including the precedence that makes a blocking XPC wait outrank the library that
asked for it and metadata instantiation outrank the SwiftUI frames above it,
phase narrowing, culprit extraction, and degenerate captures.

## Follow-ups this exposes (not in scope here)

- 64% of hangs are SwiftUI graph work, split `hosting-begin-transaction` (291) vs `hosting-layout` (179). C11-191 is in this family.
- 96 events are main blocking on a synchronous XPC round trip, mostly LaunchServices/AppleEvents, up to 604s. That is a real wedge class with no ticket.
- `runloop-idle` (10) is main parked at the top of the run loop while the heartbeat went unserviced — worth deciding whether it should report at all.

Closes C11-192 as filed: the reported defect is a reporting defect, and it is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


