### PR TITLE
Sentry: charge the outbound budget once per event (C11-190 validation)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -462,7 +462,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: stage-11-kl
-          SENTRY_PROJECT: stage11-c11
+          SENTRY_PROJECT: c11
         run: |
           if [ -z "$SENTRY_AUTH_TOKEN" ]; then
             echo "SENTRY_AUTH_TOKEN not set, skipping dSYM upload"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: stage-11-kl
-          SENTRY_PROJECT: stage11-c11
+          SENTRY_PROJECT: c11
         run: |
           if [ -z "$SENTRY_AUTH_TOKEN" ]; then
             echo "SENTRY_AUTH_TOKEN not set, skipping dSYM upload"

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2621,7 +2621,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 // a single issue can exhaust the quota and blind everything else.
                 // Crashes (fatal) are never throttled.
                 options.beforeSend = { event in
-                    let kind: SentryEventBudget.Kind = event.level == .fatal ? .crash : .other
+                    let kind = SentryEventBudget.Kind.classify(
+                        isFatal: event.level == .fatal,
+                        categoryTag: event.tags?["category"]
+                    )
                     guard SentryEventBudgetGate.shared.allow(kind) else { return nil }
                     return event
                 }

--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -462,7 +462,7 @@ final class MainThreadHangMonitor: @unchecked Sendable {
             // the event context.
             sentryCaptureWarning(
                 "main thread hang (\(signature.label))",
-                category: "hang",
+                category: sentryHangCategory,
                 data: [
                     "stalled_ms": Int(gapMs),
                     "recapture": recapture,
@@ -490,11 +490,15 @@ final class MainThreadHangMonitor: @unchecked Sendable {
     /// ~98% of c11's entire event volume and bought nothing, because Sentry
     /// groups them into a single issue anyway.
     ///
+    /// This is a shape filter, not the budget. The outbound ceiling is applied
+    /// once, in `beforeSend`, which classifies the event by its `category` tag;
+    /// charging it here as well would spend two slots of the global allowance
+    /// on every hang report.
+    ///
     /// Called only from the watchdog thread, which captures serially.
     private func shouldReportHangToSentry(gapMs: Double) -> Bool {
         guard gapMs >= sentryReportThresholdMs else { return false }
         guard !reportedCurrentEpisode else { return false }
-        guard SentryEventBudgetGate.shared.allow(.hang) else { return false }
         reportedCurrentEpisode = true
         return true
     }

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -115,6 +115,10 @@ struct SlidingWindowCounter {
     var count: Int { stamps.count }
 }
 
+/// The `category` tag hang reports carry. `beforeSend` reads it to charge a hang
+/// against the hang sub-budget rather than the general allowance.
+let sentryHangCategory = "hang"
+
 /// Client-side ceiling on what this process sends to Sentry.
 ///
 /// The org's error quota is shared across every Stage 11 project and there are
@@ -130,6 +134,19 @@ struct SentryEventBudget {
         case hang
         /// Everything else (captured warnings and handled errors).
         case other
+
+        /// Classify an outbound event from the only two facts `beforeSend` has.
+        ///
+        /// The budget is consulted in exactly one place — `beforeSend` — because
+        /// it is the single egress every event passes through. A second gate on
+        /// the producing side would charge the same event twice against the
+        /// global ceiling, which silently shrinks the allowance for everything
+        /// else in proportion to how much the app is hanging.
+        static func classify(isFatal: Bool, categoryTag: String?) -> Kind {
+            if isFatal { return .crash }
+            if categoryTag == sentryHangCategory { return .hang }
+            return .other
+        }
     }
 
     private var globalHourly: SlidingWindowCounter

--- a/c11Tests/MainThreadHangDetectorTests.swift
+++ b/c11Tests/MainThreadHangDetectorTests.swift
@@ -349,6 +349,48 @@ final class SentryEventBudgetTests: XCTestCase {
         XCTAssertFalse(budget.allow(.other, now: 130))
     }
 
+    func testClassificationDrivesWhichAllowanceAnEventSpends() {
+        // `beforeSend` sees only the level and the tags, so the whole policy
+        // rests on this mapping being right.
+        XCTAssertEqual(
+            SentryEventBudget.Kind.classify(isFatal: true, categoryTag: nil), .crash
+        )
+        // A fatal event stays exempt whatever else it is tagged as.
+        XCTAssertEqual(
+            SentryEventBudget.Kind.classify(isFatal: true, categoryTag: sentryHangCategory), .crash
+        )
+        XCTAssertEqual(
+            SentryEventBudget.Kind.classify(isFatal: false, categoryTag: sentryHangCategory), .hang
+        )
+        XCTAssertEqual(
+            SentryEventBudget.Kind.classify(isFatal: false, categoryTag: "socket"), .other
+        )
+        XCTAssertEqual(
+            SentryEventBudget.Kind.classify(isFatal: false, categoryTag: nil), .other
+        )
+    }
+
+    func testAHangReportSpendsExactlyOneSlotOfTheGlobalAllowance() {
+        // Regression for a double-charge found by running the real app (C11-190):
+        // the hang watchdog consulted the budget and then `beforeSend` consulted
+        // it again for the same event, so three hang reports quietly cost six of
+        // the twenty hourly slots and the ceiling behaved as 17.
+        var budget = SentryEventBudget(
+            globalPerHour: 20, globalPerDay: 100, hangsPerHour: 3, hangsPerDay: 15
+        )
+        var allowed = 0
+        // Three hangs, then non-hang events until the global ceiling refuses one.
+        for i in 0..<3 where budget.allow(.hang, now: Double(i)) { allowed += 1 }
+        XCTAssertEqual(allowed, 3)
+        for i in 0..<17 {
+            XCTAssertTrue(
+                budget.allow(.other, now: Double(100 + i)),
+                "global allowance exhausted early at event \(allowed + i + 1) of 20"
+            )
+        }
+        XCTAssertFalse(budget.allow(.other, now: 200))
+    }
+
     func testDeniedEventsDoNotConsumeBudget() {
         var budget = SentryEventBudget(
             globalPerHour: 10, globalPerDay: 100, hangsPerHour: 1, hangsPerDay: 1

--- a/scripts/telemetry/sentry-position.py
+++ b/scripts/telemetry/sentry-position.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Read the Sentry org's error position: quota, and accepted vs dropped per project.
+
+Sentry's edge accepts an event with HTTP 200 and a real event id and *then* drops it
+server-side when the org is over quota or spike protection fires. The sender cannot
+tell. `stats_v2` is the only surface that can, which is why this exists: so nobody has
+to rediscover the incantation the next time monitoring goes quiet.
+
+Usage:
+    scripts/telemetry/sentry-position.py                 # 30d, human table
+    scripts/telemetry/sentry-position.py --period 24h
+    scripts/telemetry/sentry-position.py --json          # machine-readable
+
+Auth: a read-only Sentry *user* token (`sntryu_...`), taken from $SENTRY_USER_AUTH_TOKEN
+or, failing that, from ~/Projects/Gregorovich/keys.txt. The token is never printed.
+
+Exit codes:
+    0  healthy: nothing dropped in the window and the quota is not exhausted
+    1  degraded: the org is over quota, or events were dropped in the window
+    2  could not read (no token, network/API failure)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+
+API = "https://sentry.io/api/0"
+DEFAULT_ORG = "stage-11-kl"
+KEYS_FILE = Path.home() / "Projects" / "Gregorovich" / "keys.txt"
+KEY_NAME = "SENTRY_USER_AUTH_TOKEN"
+
+# Outcomes that mean "Sentry threw the event away". `accepted` and `filtered`
+# (an inbound filter the operator configured on purpose) are not failures.
+DROP_OUTCOMES = {"rate_limited", "invalid", "abuse", "cardinality_limited"}
+
+
+def read_token() -> str:
+    token = os.environ.get(KEY_NAME, "").strip()
+    if token:
+        return token
+    if KEYS_FILE.exists():
+        for line in KEYS_FILE.read_text().splitlines():
+            if line.startswith(f"{KEY_NAME}="):
+                return line.split("=", 1)[1].strip()
+    sys.exit(
+        f"error: no {KEY_NAME}. Export it, or add it to {KEYS_FILE}.\n"
+        "       It is the read-only user token (sntryu_...), not the org token."
+    )
+
+
+def get(path: str, token: str):
+    req = urllib.request.Request(
+        f"{API}{path}", headers={"Authorization": f"Bearer {token}"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.load(resp)
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:400]
+        sys.exit(f"error: GET {path} -> HTTP {exc.code}\n{body}")
+    except urllib.error.URLError as exc:
+        sys.exit(f"error: GET {path} -> {exc.reason}")
+
+
+def collect(org: str, period: str, token: str) -> dict:
+    customer = get(f"/customers/{org}/", token)
+    errors = customer.get("categories", {}).get("errors", {})
+
+    # stats_v2 groups by numeric project id; the projects endpoint returns it as a
+    # string. Key on str both sides or every row renders as a bare id.
+    projects = {
+        str(p["id"]): p["slug"] for p in get(f"/organizations/{org}/projects/", token)
+    }
+
+    # interval must be < the period or the API 400s; 1d works for every period we use.
+    stats = get(
+        f"/organizations/{org}/stats_v2/"
+        f"?statsPeriod={period}&field=sum(quantity)&category=error"
+        "&groupBy=project&groupBy=outcome&groupBy=reason&interval=1d",
+        token,
+    )
+
+    by_project: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    by_reason: dict[str, int] = defaultdict(int)
+    for group in stats.get("groups", []):
+        by = group["by"]
+        slug = projects.get(str(by.get("project")), str(by.get("project")))
+        qty = group["totals"]["sum(quantity)"]
+        if not qty:
+            continue
+        by_project[slug][by.get("outcome", "?")] += qty
+        reason = by.get("reason") or "none"
+        if by.get("outcome") in DROP_OUTCOMES:
+            by_reason[f"{by.get('outcome')}/{reason}"] += qty
+
+    return {
+        "org": org,
+        "period": period,
+        "plan": customer.get("plan"),
+        "billing_period": [
+            customer.get("billingPeriodStart"),
+            customer.get("billingPeriodEnd"),
+        ],
+        "reserved": errors.get("reserved"),
+        "usage": errors.get("usage"),
+        "usage_exceeded": errors.get("usageExceeded"),
+        "on_demand_max_spend_cents": customer.get("onDemandMaxSpend"),
+        "on_demand_spend_used_cents": errors.get("onDemandSpendUsed"),
+        "projects": {slug: dict(o) for slug, o in sorted(by_project.items())},
+        "drop_reasons": dict(sorted(by_reason.items(), key=lambda kv: -kv[1])),
+    }
+
+
+def verdict(data: dict) -> tuple[bool, str]:
+    if data["usage_exceeded"]:
+        return False, "OVER QUOTA — every project on this org is being dropped."
+    dropped = sum(data["drop_reasons"].values())
+    if dropped:
+        return False, f"{dropped:,} events dropped in the window — see drop reasons."
+    return True, "healthy — nothing dropped in the window."
+
+
+def render(data: dict) -> str:
+    reserved = data["reserved"] or 0
+    usage = data["usage"] or 0
+    pct = (usage / reserved * 100) if reserved else 0
+    out = [
+        f"Sentry org {data['org']} — plan {data['plan']}",
+        f"  billing period  {data['billing_period'][0]} -> {data['billing_period'][1]}",
+        f"  errors          {usage:,} / {reserved:,} ({pct:.1f}%)"
+        f"{'  *** QUOTA EXCEEDED ***' if data['usage_exceeded'] else ''}",
+        f"  on-demand       ${(data['on_demand_spend_used_cents'] or 0)/100:.2f}"
+        f" used of ${(data['on_demand_max_spend_cents'] or 0)/100:.2f} ceiling",
+        "",
+        f"Per project, last {data['period']}:",
+    ]
+
+    outcomes = sorted({o for p in data["projects"].values() for o in p})
+    if outcomes:
+        width = max(len(s) for s in data["projects"]) + 2
+        out.append("  " + "project".ljust(width) + "  ".join(o.rjust(16) for o in outcomes))
+        for slug, counts in data["projects"].items():
+            row = "  " + slug.ljust(width)
+            row += "  ".join(f"{counts.get(o, 0):,}".rjust(16) for o in outcomes)
+            out.append(row)
+    else:
+        out.append("  (no error events in the window)")
+
+    if data["drop_reasons"]:
+        out += ["", "Why events were dropped:"]
+        for reason, qty in data["drop_reasons"].items():
+            out.append(f"  {reason:<40} {qty:>12,}")
+
+    ok, note = verdict(data)
+    out += ["", ("OK: " if ok else "ALARM: ") + note]
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--org", default=DEFAULT_ORG)
+    ap.add_argument(
+        "--period",
+        default="30d",
+        help="stats window: 24h, 7d, 30d, 90d (default 30d)",
+    )
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    data = collect(args.org, args.period, read_token())
+    ok, _ = verdict(data)
+    print(json.dumps(data, indent=2) if args.json else render(data))
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
Validation half of **C11-190**. The budget merged in #401 had never been run: green tests, no
real artifact. Running it on a tagged build found a real defect and produced the evidence the
ticket asks for.

## The bug

The global ceiling was charged **twice for every hang report**. `MainThreadHangMonitor` consulted
`SentryEventBudgetGate` before capturing, and then `beforeSend` consulted it again for the same
event — classifying it `.other`, because it only looked at the level. Three hang reports therefore
spent six of the twenty hourly slots.

Measured on a tagged build driven through 23 real main-thread hang episodes: the global ceiling
behaved as **17 events/hour, not 20**. It fails safe, so the fence held — but the shortfall scales
with how much the app is hanging, which is exactly when the remaining allowance matters.

## The fix

The budget is now consulted in exactly one place: `beforeSend`, the single egress every event
passes through. It classifies by level (`fatal` → exempt) and by the `category` tag the hang path
already sets. The watchdog keeps its shape filters — episodes ≥5s, one report per episode — and no
longer touches the budget.

Side effect worth having: once the hang allowance is spent, an episode now makes **one** suppressed
attempt instead of one per capture, so `sentrySuppressed=` in the hang log counts episodes rather
than recaptures.

## Evidence, on a real build

Tagged `c11-190` build, launched with stdout captured, main thread wedged from outside the process
via `lldb` (`+[NSThread sleepUntilDate:]` enqueued on the main queue, then detach — a genuine
beachball, no test seam in the app).

| | before the fix | after the fix |
|---|---|---|
| hang episodes driven | 23 | 17 |
| local captures in `hang.log` | 67 | 61 |
| hang warnings sent | 3 (the 3/hour cap) | 3 (the 3/hour cap) |
| suppressed hang attempts | 3 per episode | 1 per episode |
| non-fatal events allowed before the global ceiling refused one | **17** | **19, none refused** |

Also confirmed on the running artifact:

- **Sentry still initializes.** `SDK initialized! Version: 9.3.0`, HTTP transport created, on both
  builds. `beforeSend` was added to a startup path, so this was worth checking rather than assuming.
- **Sub-5s episodes cost nothing.** A real 2,882 ms episode produced local captures and zero
  outbound attempts — `sentrySuppressed` did not move.
- **The classifier works.** Exactly 3 hang warnings escaped in an hour where 16 app-hang events did.
  If hang events were still misclassified as `.other`, the 3/hour hang cap could not have bound.
- **Crashes are still exempt, end to end.** `SIGABRT` on the tagged build → crash report flushed on
  next launch → `level = fatal`, mechanism `signal/SIGABRT` → HTTP 200 → **stored** server-side
  (`96cb1c971b6245889b891058332adcaf`, `dateReceived` present). Not "the SDK returned an event id" —
  read back from the API, which is the distinction this whole incident turned on.

One honest limit: a crash necessarily ends the process, so a crash report is always sent from a
*fresh* process whose budget is empty. The exhausted-budget case for `.crash` is covered by unit
test, not by the artifact.

## Also here

`scripts/telemetry/sentry-position.py` — reads the org's quota position and a per-project
accepted / client_discard / rate_limited table with drop reasons. Sentry's edge accepts an event
with HTTP 200 and a real event id and *then* drops it server-side when the org is over quota; only
`stats_v2` can see that, and having to rediscover the incantation is how the last outage stayed
invisible for a week. Exits non-zero when events are being dropped, so it works as a check and not
just a report. `platform/sentry.md` points at it (committed separately, `9782d7c`).

Used it to answer the ticket's first open item: the org's billing period reset on 2026-08-04 and
**c11 events are being accepted again** — one-hour brackets show `accepted` and zero `rate_limited`
after the reset, where the hours before were entirely `rate_limited/error_usage_exceeded`.

## Not done here

Post-release verification still stands: once a release ships with this, confirm via `stats_v2` that
the monthly accepted total lands in the low thousands rather than the ~40k/month the project was on
track for. Worth noting the shipped 0.58.0 build is visible in the same data doing the old thing —
~60 events/hour, sub-5s hangs and every persist recapture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second defect, found while validating: dSYMs upload to a project that does not exist

`SENTRY_PROJECT` was `stage11-c11` in both `release.yml` and `nightly.yml`.
`GET /projects/stage-11-kl/stage11-c11/` returns **404**, and the real `c11` project has **zero**
debug files. Every dSYM upload since the integration landed has gone nowhere, and the step carries
`continue-on-error: true`, so it failed quietly every time — the same shape as the quota incident
this ticket exists for: monitoring that looks wired and is not. Production crash stacks on Sentry
are unsymbolicated, which is most of what a crash report is for.

Verify after the next release ships:

```bash
curl -sS -H "Authorization: Bearer $SENTRY_USER_AUTH_TOKEN" \
  https://sentry.io/api/0/projects/stage-11-kl/c11/files/dsyms/
```

## Re-validated after rebasing onto #402

#402 (C11-192) rewrote the hang report path underneath this work — new message text, a fingerprint,
and a `tags:` parameter carrying `hang.cause` / `hang.culprit` / `hang.top_symbol`. The classifier
here keys on the `category` tag, so a tags rewrite is exactly the change that could have quietly
broken it. Rebuilt and re-ran on the rebased tree:

- `category = hang` still arrives at `beforeSend`, alongside #402's new `hang.*` tags (read off the
  serialized event on the running process)
- 6 episodes, 13 local captures, exactly **3** outbound hang events (the 3/hour cap), then 1
  suppressed attempt per episode
- Sentry still initializes

The measured claims above therefore hold against what is in this PR, not only the tree they were
first taken on.
