### PR TITLE
Keep xcframework artifact releases out of the latest slot

### DIFF
--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -113,10 +113,15 @@ jobs:
         run: |
           set -euo pipefail
           TAG="xcframework-${{ steps.ghostty-sha.outputs.sha }}"
+          # Must never become the repo's "latest" release: Sparkle's feed URL is
+          # releases/latest/download/appcast.xml, and a build-artifact release
+          # holding the latest slot 404s that path for every shipped client.
           gh release create "$TAG" \
             --repo Stage-11-Agentics/c11 \
             --title "GhosttyKit xcframework (${{ steps.ghostty-sha.outputs.sha }})" \
             --notes "Pre-built GhosttyKit.xcframework for commit ${{ steps.ghostty-sha.outputs.sha }}" \
+            --prerelease \
+            --latest=false \
             GhosttyKit.xcframework.tar.gz
           echo "Published release $TAG"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,8 @@ When the ghostty submodule SHA changes, `scripts/ghosttykit-checksums.txt` must 
 
 **`GHOSTTY_RELEASE_TOKEN` is not configured on this fork.** Any workflow step using that secret will get an empty `GH_TOKEN` and fail with exit code 4. xcframework releases are published to `Stage-11-Agentics/c11` using `GITHUB_TOKEN` with `permissions: contents: write`. If you copy a workflow from upstream that references `GHOSTTY_RELEASE_TOKEN`, replace it.
 
+**Artifact releases must never hold the `latest` slot.** Sparkle's feed URL is `https://github.com/Stage-11-Agentics/c11/releases/latest/download/appcast.xml`, so whichever release GitHub calls *latest* must be a real versioned release carrying an `appcast.xml` asset. Any workflow that publishes a build artifact as a GitHub release (`xcframework-*`, nightlies, anything future) has to pass `--prerelease --latest=false` (or `prerelease: true` / `make_latest: false` for `action-gh-release`). Getting this wrong 404s the feed and every shipped c11 reports `SUSparkleErrorDomain(2001)` on update check, with no other symptom. Quick check: `gh api repos/Stage-11-Agentics/c11/releases/latest --jq .tag_name` should always print a `v*` tag.
+
 **Workflows that commit back to the branch must use `ref: ${{ github.head_ref || github.ref_name }}`** on their `actions/checkout` step. Without it, Actions checks out a detached merge commit and `git push` fails with exit 128.
 
 ## Release


### PR DESCRIPTION
## Problem

Production c11 instances started failing update checks with:

```
SUSparkleErrorDomain(2001) — An error occurred in retrieving update information.
feed=https://github.com/Stage-11-Agentics/c11/releases/latest/download/appcast.xml
```

## Root cause

`build-ghosttykit.yml` publishes its `GhosttyKit.xcframework.tar.gz` as a **normal release**. On 2026-08-04T20:49Z it published `xcframework-7604624d…`, which became the repo's *latest* release. Sparkle's feed URL is `releases/latest/download/appcast.xml`, so that path started resolving to the xcframework release, which has no `appcast.xml` asset: HTTP 404, hence the Sparkle download error.

Timeline from `~/Library/Logs/cmux-update.log` matches exactly: `appcast loaded (items=1, first=0.61.0)` at 20:37, xcframework release at 20:49, errors after.

Nothing expired and no service lapsed: purely a release-metadata collision.

## Fix

- Workflow now creates these artifact releases with `--prerelease --latest=false`.
- All three existing `xcframework-*` releases flipped to prerelease by hand; `releases/latest` is back to `v0.61.0` and the feed serves 200 with the 0.61.0 item.

`nightly.yml` already sets `prerelease: true` / `make_latest: false`; `release.yml` correctly claims the latest slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)