### PR TITLE
Sentry: standing recurrence detector, and c11's declared share of the org quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Run drawbridge gate tests
         run: python3 tests/drawbridge/test_gates.py
 
+      # Offline, no token: exercises the alarm paths of the Sentry recurrence
+      # detector, which are otherwise only reachable by actually exhausting a
+      # quota or silencing a real client.
+      - name: Validate Sentry recurrence checks
+        run: ./scripts/telemetry/sentry-position.py --self-test
+
   remote-daemon-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sentry-quota-watch.yml
+++ b/.github/workflows/sentry-quota-watch.yml
@@ -1,0 +1,74 @@
+name: Sentry quota watch
+
+# The recurrence detector for the 2026-08 quota incident, in which c11's error
+# monitoring was blind for over a week and nothing surfaced it. Sentry accepts an
+# event at the edge with HTTP 200 and a real event id, then drops it server-side
+# when the org is over quota — the sender cannot tell, and neither can a human
+# who is not specifically looking. This looks, daily, so nobody has to remember.
+#
+# It also watches for the inverse failure, which is subtler: a client that has
+# gone SILENT. Zero events is indistinguishable from a quiet week until you ask.
+
+on:
+  schedule:
+    # 14:00 UTC daily — late enough that a full day of traffic is in the window.
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The org token (SENTRY_AUTH_TOKEN, used for dSYM upload) is 403 on
+      # /customers, /stats_v2 and /projects — reads need the *user* token.
+      # Until that secret exists this job reports skipped rather than red, so a
+      # missing secret does not look like a failing check forever.
+      - name: Check for the read token
+        id: token
+        env:
+          SENTRY_USER_AUTH_TOKEN: ${{ secrets.SENTRY_USER_AUTH_TOKEN }}
+        run: |
+          if [ -z "$SENTRY_USER_AUTH_TOKEN" ]; then
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::SENTRY_USER_AUTH_TOKEN is not set; skipping the quota watch."
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run the recurrence checks
+        if: steps.token.outputs.present == 'true'
+        id: check
+        continue-on-error: true
+        env:
+          SENTRY_USER_AUTH_TOKEN: ${{ secrets.SENTRY_USER_AUTH_TOKEN }}
+        run: |
+          set -o pipefail
+          ./scripts/telemetry/sentry-position.py --check --period 24h \
+            | tee /tmp/sentry-position.txt
+
+      - name: Open or update an issue when a check fails
+        if: steps.token.outputs.present == 'true' && steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TITLE="Sentry quota watch: a check is failing"
+          BODY=$(printf 'The daily Sentry recurrence check failed.\n\n```\n%s\n```\n\nRun: %s/%s/actions/runs/%s\n' \
+            "$(cat /tmp/sentry-position.txt)" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID")
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label sentry || \
+              gh issue create --title "$TITLE" --body "$BODY"
+          fi
+
+      - name: Fail the run when a check failed
+        if: steps.token.outputs.present == 'true' && steps.check.outcome == 'failure'
+        run: exit 1

--- a/scripts/telemetry/sentry-position.py
+++ b/scripts/telemetry/sentry-position.py
@@ -55,13 +55,20 @@ DROP_OUTCOMES = {"rate_limited", "invalid", "abuse", "cardinality_limited"}
 # than by Sentry — the point is to catch a client eating the pool *before* it
 # starves its neighbours, not to divide the pool exactly.
 #
-# c11's 20,000 is sized against measurement, not taste: unfenced installs ran at
-# ~986 events/day (~29,600/month, 59% of the org) and 99% of that was
-# main-thread-hang reports, which the client budget caps at 15/day/process. The
-# fenced projection is roughly 1,000-9,000/month, so 20,000 is about 2x the
-# pessimistic case — loose enough that ordinary growth in installs does not page
-# anyone, tight enough that a regression to unfenced behaviour trips long before
+# c11's 20,000 is sized against measurement, not taste. Unfenced, 15 distinct
+# installs sent ~986 events/day (~29,600/month, 59% of the org), and 99% of that
+# was main-thread-hang reports — the stream the client budget caps at 15/day per
+# *process*. Fenced, that puts the fleet near 7,000-9,000/month, so 20,000 is
+# roughly 2x the pessimistic case: loose enough not to page on ordinary growth in
+# installs, tight enough to catch a regression to unfenced behaviour long before
 # the org is threatened.
+#
+# The caveat in "per process" is real and this number does not hide it: the
+# budget resets on every launch, and c11 gets relaunched often. An install
+# restarted five times a day can legitimately spend five times its daily hang
+# allowance, which would put 15 installs past this share. That is precisely the
+# case the share check exists to surface — if it fires for that reason rather
+# than a regression, the fix is a persisted budget, not a bigger number here.
 DECLARED_SHARES = {
     "c11": {"monthly": 20_000, "expect_reporting": True},
     "acetate": {"monthly": 5_000, "expect_reporting": False},

--- a/scripts/telemetry/sentry-position.py
+++ b/scripts/telemetry/sentry-position.py
@@ -10,6 +10,13 @@ Usage:
     scripts/telemetry/sentry-position.py                 # 30d, human table
     scripts/telemetry/sentry-position.py --period 24h
     scripts/telemetry/sentry-position.py --json          # machine-readable
+    scripts/telemetry/sentry-position.py --check         # recurrence detector
+    scripts/telemetry/sentry-position.py --self-test     # offline, no token
+
+`--check` asserts the ways this has gone wrong before: the org over quota, events
+dropped, the org or a single client on pace to overrun by period end, and — the
+one that hid the last outage for over a week — a client that should be reporting
+having gone silent. It runs daily from `.github/workflows/sentry-quota-watch.yml`.
 
 Auth: a read-only Sentry *user* token (`sntryu_...`), taken from $SENTRY_USER_AUTH_TOKEN
 or, failing that, from ~/Projects/Gregorovich/keys.txt. The token is never printed.
@@ -24,11 +31,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import os
 import sys
 import urllib.error
 import urllib.request
 from collections import defaultdict
+from datetime import datetime, timezone
 from pathlib import Path
 
 API = "https://sentry.io/api/0"
@@ -39,6 +48,29 @@ KEY_NAME = "SENTRY_USER_AUTH_TOKEN"
 # Outcomes that mean "Sentry threw the event away". `accepted` and `filtered`
 # (an inbound filter the operator configured on purpose) are not failures.
 DROP_OUTCOMES = {"rate_limited", "invalid", "abuse", "cardinality_limited"}
+
+# Each client's declared slice of the org's monthly errors, and whether it is
+# expected to be reporting continuously. The quota is shared and has no
+# server-side per-project fence, so these are a promise enforced here rather
+# than by Sentry — the point is to catch a client eating the pool *before* it
+# starves its neighbours, not to divide the pool exactly.
+#
+# c11's 20,000 is sized against measurement, not taste: unfenced installs ran at
+# ~986 events/day (~29,600/month, 59% of the org) and 99% of that was
+# main-thread-hang reports, which the client budget caps at 15/day/process. The
+# fenced projection is roughly 1,000-9,000/month, so 20,000 is about 2x the
+# pessimistic case — loose enough that ordinary growth in installs does not page
+# anyone, tight enough that a regression to unfenced behaviour trips long before
+# the org is threatened.
+DECLARED_SHARES = {
+    "c11": {"monthly": 20_000, "expect_reporting": True},
+    "acetate": {"monthly": 5_000, "expect_reporting": False},
+}
+
+# A project that should be reporting and has sent nothing in this many hours is
+# the failure that started all of this: monitoring that has gone silent looks
+# exactly like a quiet week.
+LIVENESS_HOURS = 24
 
 
 def read_token() -> str:
@@ -100,6 +132,18 @@ def collect(org: str, period: str, token: str) -> dict:
         if by.get("outcome") in DROP_OUTCOMES:
             by_reason[f"{by.get('outcome')}/{reason}"] += qty
 
+    # Accepted-per-project over the billing period so far, for the share check,
+    # plus a short window for the liveness check. Both are cheap; ask for them
+    # unconditionally so `--json` consumers always get the same shape.
+    since = customer.get("billingPeriodStart")
+    elapsed_days, total_days = billing_progress(
+        since, customer.get("billingPeriodEnd")
+    )
+    period_accepted = accepted_by_project(
+        org, token, projects, f"{max(1, math.ceil(elapsed_days))}d"
+    )
+    recent_accepted = accepted_by_project(org, token, projects, f"{LIVENESS_HOURS}h")
+
     return {
         "org": org,
         "period": period,
@@ -108,6 +152,8 @@ def collect(org: str, period: str, token: str) -> dict:
             customer.get("billingPeriodStart"),
             customer.get("billingPeriodEnd"),
         ],
+        "billing_elapsed_days": round(elapsed_days, 2),
+        "billing_total_days": total_days,
         "reserved": errors.get("reserved"),
         "usage": errors.get("usage"),
         "usage_exceeded": errors.get("usageExceeded"),
@@ -115,7 +161,119 @@ def collect(org: str, period: str, token: str) -> dict:
         "on_demand_spend_used_cents": errors.get("onDemandSpendUsed"),
         "projects": {slug: dict(o) for slug, o in sorted(by_project.items())},
         "drop_reasons": dict(sorted(by_reason.items(), key=lambda kv: -kv[1])),
+        "period_accepted": period_accepted,
+        "recent_accepted": recent_accepted,
+        "liveness_hours": LIVENESS_HOURS,
     }
+
+
+def billing_progress(start: str | None, end: str | None) -> tuple[float, float]:
+    """Days elapsed in the billing period, and its total length.
+
+    Sentry reports these as bare `YYYY-MM-DD` strings covering inclusive days.
+    A period that has only just started still counts as one elapsed day, so the
+    projection never divides by zero on reset day.
+    """
+    fmt = "%Y-%m-%d"
+    try:
+        begin = datetime.strptime(start, fmt).replace(tzinfo=timezone.utc)
+        finish = datetime.strptime(end, fmt).replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return 1.0, 30.0
+    total = max(1.0, (finish - begin).days + 1)
+    elapsed = (datetime.now(timezone.utc) - begin).total_seconds() / 86_400
+    return max(1.0, min(elapsed, total)), total
+
+
+def accepted_by_project(
+    org: str, token: str, projects: dict[str, str], period: str
+) -> dict[str, int]:
+    stats = get(
+        f"/organizations/{org}/stats_v2/"
+        f"?statsPeriod={period}&field=sum(quantity)&category=error"
+        "&groupBy=project&groupBy=outcome&interval=1d",
+        token,
+    )
+    out: dict[str, int] = defaultdict(int)
+    for group in stats.get("groups", []):
+        if group["by"].get("outcome") != "accepted":
+            continue
+        slug = projects.get(
+            str(group["by"].get("project")), str(group["by"].get("project"))
+        )
+        out[slug] += group["totals"]["sum(quantity)"]
+    return dict(out)
+
+
+def checks(data: dict) -> list[tuple[bool, str]]:
+    """The recurrence detector: every way this has gone wrong, asserted.
+
+    Returns (ok, message) per check so a failing run says which one tripped.
+    """
+    results: list[tuple[bool, str]] = []
+    elapsed = data["billing_elapsed_days"] or 1
+    total = data["billing_total_days"] or 30
+    remaining_fraction = total / elapsed
+
+    # 1. The original incident: the org over quota, everything dropped silently.
+    results.append(
+        (
+            not data["usage_exceeded"],
+            "org is over quota — every project is being dropped"
+            if data["usage_exceeded"]
+            else "org is under quota",
+        )
+    )
+
+    # 2. Drops of any kind in the window. Zero is the only healthy number:
+    #    a dropped event is one nobody will ever see.
+    dropped = sum(data["drop_reasons"].values())
+    results.append(
+        (dropped == 0, f"{dropped:,} events dropped in the last {data['period']}")
+        if dropped
+        else (True, f"nothing dropped in the last {data['period']}")
+    )
+
+    # 3. Org-level pace. Being under quota today says nothing about landing
+    #    under it on the last day of the period.
+    usage, reserved = data["usage"] or 0, data["reserved"] or 0
+    projected = usage * remaining_fraction
+    results.append(
+        (
+            projected <= reserved,
+            f"on pace for {projected:,.0f} of {reserved:,} errors this period",
+        )
+    )
+
+    # 4. Per-client share. There is no server-side per-project fence on this
+    #    plan, so one client can quietly eat the pool its neighbours depend on.
+    for slug, share in DECLARED_SHARES.items():
+        used = data["period_accepted"].get(slug, 0)
+        proj = used * remaining_fraction
+        results.append(
+            (
+                proj <= share["monthly"],
+                f"{slug}: on pace for {proj:,.0f} of its declared "
+                f"{share['monthly']:,}",
+            )
+        )
+
+    # 5. Liveness. A client that should be reporting and is not looks exactly
+    #    like a quiet week — which is how the last outage hid for over a week.
+    for slug, share in DECLARED_SHARES.items():
+        if not share["expect_reporting"]:
+            continue
+        recent = data["recent_accepted"].get(slug, 0)
+        results.append(
+            (
+                recent > 0,
+                f"{slug}: {recent:,} events accepted in the last "
+                f"{data['liveness_hours']}h"
+                + ("" if recent else " — REPORTING HAS GONE SILENT"),
+            )
+        )
+
+    return results
 
 
 def verdict(data: dict) -> tuple[bool, str]:
@@ -163,6 +321,71 @@ def render(data: dict) -> str:
     return "\n".join(out)
 
 
+def self_test() -> int:
+    """Exercise every failure path of `checks()` against synthetic state.
+
+    A detector whose alarms have never fired is a detector nobody should trust,
+    and these paths are awkward to reach for real — you would have to exhaust a
+    real quota or silence a real client to see them. `checks()` is a pure
+    function of the collected dict, so they are cheap to reach here. Runs
+    offline, needs no token.
+    """
+    healthy = {
+        "period": "24h",
+        "billing_elapsed_days": 15.0,
+        "billing_total_days": 30.0,
+        "usage_exceeded": False,
+        "usage": 5_000,
+        "reserved": 50_000,
+        "drop_reasons": {},
+        "period_accepted": {"c11": 5_000, "acetate": 100},
+        "recent_accepted": {"c11": 400, "acetate": 10},
+        "liveness_hours": LIVENESS_HOURS,
+    }
+
+    def failing(state: dict) -> list[str]:
+        return [m for ok, m in checks({**healthy, **state}) if not ok]
+
+    cases = [
+        ("healthy baseline", {}, 0),
+        ("org over quota", {"usage_exceeded": True}, 1),
+        ("events dropped", {"drop_reasons": {"rate_limited/quota": 42}}, 1),
+        # Half the period gone, 45k of 50k spent: fine today, over by month end.
+        ("org on pace to exceed", {"usage": 45_000}, 1),
+        # c11 alone on pace for 40k against its declared 20k. Only the share
+        # check fires: org pace reads `usage`, the share reads per-project
+        # accepted, so a client can breach its promise while the org is still
+        # comfortable. That separation is the point — it is the early warning.
+        ("client over declared share", {"period_accepted": {"c11": 20_000}}, 1),
+        # The incident that started this: reporting silently stopped.
+        ("client gone silent", {"recent_accepted": {"c11": 0}}, 1),
+    ]
+
+    failures = 0
+    for name, state, expected in cases:
+        got = failing(state)
+        status = "ok" if len(got) == expected else "UNEXPECTED"
+        if len(got) != expected:
+            failures += 1
+        print(f"  [{status}] {name}: {len(got)} check(s) failed, expected {expected}")
+        for message in got:
+            print(f"      - {message}")
+
+    print("self-test passed" if not failures else f"self-test FAILED ({failures})")
+    return 0 if not failures else 1
+
+
+def render_checks(data: dict) -> tuple[str, bool]:
+    results = checks(data)
+    lines = ["Recurrence checks:"]
+    for ok, message in results:
+        lines.append(f"  {'PASS' if ok else 'FAIL'}  {message}")
+    healthy = all(ok for ok, _ in results)
+    lines.append("")
+    lines.append("OK: all checks pass." if healthy else "ALARM: a check failed above.")
+    return "\n".join(lines), healthy
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--org", default=DEFAULT_ORG)
@@ -172,9 +395,32 @@ def main() -> int:
         help="stats window: 24h, 7d, 30d, 90d (default 30d)",
     )
     ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="run the recurrence checks and exit non-zero if any fails "
+        "(quota, drops, org pace, per-client share, liveness)",
+    )
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="exercise the checks against synthetic state; offline, no token",
+    )
     args = ap.parse_args()
 
+    if args.self_test:
+        return self_test()
+
     data = collect(args.org, args.period, read_token())
+
+    if args.check:
+        data["checks"] = [
+            {"ok": ok, "message": message} for ok, message in checks(data)
+        ]
+        text, healthy = render_checks(data)
+        print(json.dumps(data, indent=2) if args.json else render(data) + "\n\n" + text)
+        return 0 if healthy else 1
+
     ok, _ = verdict(data)
     print(json.dumps(data, indent=2) if args.json else render(data))
     return 0 if ok else 1


### PR DESCRIPTION
The last two items on **C11-190**, now that the fence has merged and the quota crisis is over.

## The detector

`sentry-position.py --check` asserts the ways this has actually gone wrong, and a new
`sentry-quota-watch` workflow runs it daily and opens a GitHub issue when anything trips.

| Check | Catches |
|---|---|
| org under quota | the original incident: everything dropped, silently |
| nothing dropped in the window | drops resuming for any reason |
| org not on **pace** to overrun | a slow burn that is fine today and over by month end |
| no client on pace past its declared share | one client eating the pool its neighbours depend on |
| clients that should report, are reporting | **a client that has gone silent** |

The last one is the one that matters. The 2026-08 outage hid for over a week because silence looks
exactly like a quiet week — there is no alarm for an absence unless someone writes one. And the pace
checks project rather than compare, because being under quota today says nothing about landing under
it on the final day of the period.

Live right now, against real data:

```
PASS  org is under quota
PASS  nothing dropped in the last 24h
PASS  on pace for 12,682 of 50,000 errors this period
PASS  c11: on pace for 12,625 of its declared 20,000
PASS  acetate: on pace for 124 of its declared 5,000
PASS  c11: 986 events accepted in the last 24h
```

## The alarms are tested

`--self-test` exercises every failure path against synthetic state — offline, no token — and runs in
`workflow-guard-tests`. Those paths are otherwise only reachable by exhausting a real quota or
silencing a real client, so without it the alarms would ship having never fired once.

It earned its keep immediately: it caught a wrong expectation of mine, that a client breaching its
share would also trip the org-pace check. It does not, because the two read different metrics — and
that separation is exactly what makes the share check an early warning rather than a duplicate.

## Declared shares

| Client | Monthly share | Expected to be reporting |
|---|---|---|
| `c11` | 20,000 | yes |
| `acetate` | 5,000 | no |

Half the pool is deliberately unallocated as headroom for spikes and the next client. c11's 20,000
is sized against measurement, not taste: unfenced installs are running at **~986 events/day
(~29,600/month, 59% of the org)**, of which **99% are main-thread-hang reports** — precisely what
the client budget caps at 15/day/process. That puts the fenced projection around 1,000–9,000/month,
so 20,000 is about 2x the pessimistic case: loose enough not to page on ordinary growth in installs,
tight enough to catch a regression to unfenced behaviour long before the org is threatened. Worth
revisiting downward once 0.63.0 is broadly adopted and the real fenced rate is visible.

## One thing needed from you

The daily workflow needs **`SENTRY_USER_AUTH_TOKEN` as a repo secret**. The org token already
present for dSYM upload returns 403 on `/customers`, `/stats_v2` and `/projects` — reads need the
user token. Until the secret exists the job reports **skipped, not red**, so merging this does not
create a permanently failing check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)