### PR TITLE
C11-192: send the wedged main thread as a Sentry threads payload

### DIFF
--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -6,8 +6,15 @@ import Foundation
 ///
 /// `cause` answers "what is main blocked on" and `phase` narrows the largest
 /// cause (SwiftUI graph work) to the host operation driving it. Together they
-/// form the Sentry fingerprint. `culprit` and `topSymbol` are per-report detail
-/// that rides along as tags — searchable inside an issue without splitting it.
+/// form the Sentry fingerprint. `culprit` rides along as a tag — searchable
+/// inside an issue without splitting it, and the one thing Sentry cannot
+/// aggregate from the stacktrace itself.
+///
+/// `topSymbol` is not emitted: the event now carries the wedged stack as a
+/// structured, server-symbolicated stacktrace, so the leaf frame is visible
+/// natively. Tagging it would only add an unbounded indexed dimension —
+/// unresolved frames symbolicate to a raw address, minting a fresh tag value
+/// every launch.
 struct MainThreadHangDescriptor: Equatable {
     let cause: String
     let phase: String?
@@ -172,6 +179,27 @@ enum MainThreadHangSignature {
         // stack.
         frames.first { $0.module == ownModule && $0.symbol != "main" }?.symbol
     }
+}
+
+/// One capture of the wedged main thread, in the two shapes its consumers need.
+///
+/// `symbols` is what the local hang log prints and what the classifier reads.
+/// `frames` carries the raw addresses Sentry needs to symbolicate server-side —
+/// the same unwind, unsymbolicated, so the Sentry UI can render a real
+/// stacktrace instead of a text blob.
+struct MainThreadBacktrace {
+    struct Frame {
+        let instructionAddress: UInt
+        /// Load address of the containing Mach-O image. The Sentry SDK builds
+        /// the event's debug-image list purely from these, so a nil here costs
+        /// symbolication for the whole frame.
+        let imageAddress: UInt?
+    }
+
+    let symbols: [String]
+    let frames: [Frame]
+
+    static let empty = MainThreadBacktrace(symbols: [], frames: [])
 }
 
 /// Pure decision core for main-thread hang detection.
@@ -361,7 +389,8 @@ final class MainThreadHangMonitor: @unchecked Sendable {
 
     private func handleHang(gapMs: Double, recapture: Bool) {
         if !recapture { reportedCurrentEpisode = false }
-        let stack = captureMainBacktrace()
+        let backtrace = captureMainBacktrace()
+        let stack = backtrace.symbols
         let kind = recapture ? "hang.persist" : "hang.begin"
 
         var lines: [String] = []
@@ -376,7 +405,7 @@ final class MainThreadHangMonitor: @unchecked Sendable {
         lines.append("")
         appendToLog(lines.joined(separator: "\n") + "\n")
 
-        reportTelemetry(gapMs: gapMs, recapture: recapture, stack: stack)
+        reportTelemetry(gapMs: gapMs, recapture: recapture, backtrace: backtrace)
     }
 
     private func handleRecovery(durationMs: Double) {
@@ -399,25 +428,46 @@ final class MainThreadHangMonitor: @unchecked Sendable {
     /// stripping, which isn't exposed to Swift; `backtrace_from_fp` is unusable
     /// here because it validates the FP against the *calling* thread's stack and so
     /// can't read another thread's frames.
-    private func captureMainBacktrace() -> [String] {
-        guard mainThread != mach_port_t(MACH_PORT_NULL) else { return [] }
+    private func captureMainBacktrace() -> MainThreadBacktrace {
+        guard mainThread != mach_port_t(MACH_PORT_NULL) else { return .empty }
 
         // Nothing inside the suspend window may allocate or take an app-level
         // lock: if main is suspended while holding (e.g.) the malloc lock, any
         // allocation here would block forever and wedge the process. The buffer
         // is preallocated; the C unwinder only reads memory via mach_vm calls.
         guard thread_suspend(mainThread) == KERN_SUCCESS else {
-            return ["<thread_suspend failed>"]
+            return MainThreadBacktrace(symbols: ["<thread_suspend failed>"], frames: [])
         }
         let frameCount = frameBuffer.withUnsafeMutableBufferPointer { buffer -> Int in
             Int(c11_capture_thread_backtrace(mainThread, buffer.baseAddress!, Int32(maxFrames)))
         }
         thread_resume(mainThread)
 
-        guard frameCount > 0 else { return ["<no frames captured>"] }
-        // Symbolication (which allocates and can take locks the suspended thread
-        // may have held) happens only after resume.
-        return symbolicate((0..<frameCount).map { UnsafeMutableRawPointer(bitPattern: frameBuffer[$0]) })
+        guard frameCount > 0 else {
+            return MainThreadBacktrace(symbols: ["<no frames captured>"], frames: [])
+        }
+        // Everything below allocates and takes locks the suspended thread may
+        // have held, so it runs only after resume.
+        let addresses = (0..<frameCount).map { frameBuffer[$0] }
+        return MainThreadBacktrace(
+            symbols: symbolicate(addresses.map { UnsafeMutableRawPointer(bitPattern: $0) }),
+            frames: addresses.map { address in
+                // Sentry symbolicates server-side from (instruction address,
+                // image load address) against the dSYMs uploaded by
+                // release.yml/nightly.yml. `imageAddress` is not optional
+                // polish: the SDK derives the event's whole debug-image list
+                // from these values, so leaving it nil yields an empty
+                // `debugMeta` and a stack that renders as bare addresses.
+                var info = Dl_info()
+                let resolved = UnsafeRawPointer(bitPattern: address).map {
+                    dladdr($0, &info) != 0
+                } ?? false
+                return MainThreadBacktrace.Frame(
+                    instructionAddress: address,
+                    imageAddress: resolved ? UInt(bitPattern: info.dli_fbase) : nil
+                )
+            }
+        )
     }
 
     private func symbolicate(_ addrs: [UnsafeMutableRawPointer?]) -> [String] {
@@ -439,7 +489,11 @@ final class MainThreadHangMonitor: @unchecked Sendable {
 
     // MARK: Telemetry
 
-    private func reportTelemetry(gapMs: Double, recapture: Bool, stack: [String]) {
+    private func reportTelemetry(gapMs: Double, recapture: Bool, backtrace: MainThreadBacktrace) {
+        let stack = backtrace.symbols
+        // Kept as a fallback: if a build's dSYMs never reached Sentry, the
+        // structured stacktrace renders as bare addresses and this text is the
+        // only readable copy.
         let top = stack.prefix(24).enumerated()
             .map { "\($0.offset)\t\($0.element)" }
             .joined(separator: "\n")
@@ -453,24 +507,41 @@ final class MainThreadHangMonitor: @unchecked Sendable {
                 stack: stack,
                 ownModule: ProcessInfo.processInfo.processName
             )
-            var tags = ["hang.cause": signature.cause, "hang.recapture": recapture ? "true" : "false"]
-            tags["hang.phase"] = signature.phase
+            var tags = [
+                "hang.cause": signature.cause,
+                "hang.recapture": recapture ? "true" : "false",
+                // Bucketed, never raw: a tag is an indexed dimension, and
+                // per-millisecond values would mint one for every report. The
+                // exact figure stays in context below.
+                "hang.duration_bucket": Self.durationBucket(ms: gapMs),
+                // Explicit "none" rather than an omitted key, so the rate of
+                // unclassified SwiftUI hangs is a measurable number. A silently
+                // absent tag is how a classifier rots without anyone noticing:
+                // Apple rotates a private symbol, phase goes nil fleet-wide, the
+                // issue forks, and the reset trend reads as "the fix worked".
+                "hang.phase": signature.cause == "swiftui-update"
+                    ? (signature.phase ?? "none")
+                    : "n/a",
+            ]
+            // Truncated for the tag (Sentry rejects values past its limit) and
+            // repeated untruncated in context, because a clipped mangled symbol
+            // will not demangle — on exactly the field that points at our code.
             tags["hang.culprit"] = signature.culprit
-            tags["hang.top_symbol"] = signature.topSymbol
             // The duration is not the grouping key, so it does not belong in
             // the title: the message names the cause and `stalled_ms` stays in
             // the event context.
-            sentryCaptureWarning(
+            sentryCaptureMainThreadHang(
                 "main thread hang (\(signature.label))",
-                category: sentryHangCategory,
                 data: [
                     "stalled_ms": Int(gapMs),
                     "recapture": recapture,
+                    "culprit": signature.culprit ?? "",
                     "stack": top,
                 ],
-                contextKey: "hang",
                 fingerprint: signature.fingerprint,
-                tags: tags
+                tags: tags,
+                frames: backtrace.frames,
+                threadId: UInt64(mainThread)
             )
         }
         PostHogAnalytics.shared.captureMainThreadHang(
@@ -478,6 +549,19 @@ final class MainThreadHangMonitor: @unchecked Sendable {
             recapture: recapture,
             topFrame: stack.first ?? ""
         )
+    }
+
+    /// Coarse severity band for the issue list. Dropping the duration from the
+    /// message made every hang the same row; without this a 2s stutter and a
+    /// 600s wedge are indistinguishable until you open an event.
+    static func durationBucket(ms: Double) -> String {
+        switch ms {
+        case ..<5_000: return "2-5s"
+        case ..<15_000: return "5-15s"
+        case ..<60_000: return "15-60s"
+        case ..<300_000: return "1-5m"
+        default: return "5m+"
+        }
     }
 
     /// At most one Sentry event per hang episode, and only for episodes that

--- a/Sources/SentryHelper.swift
+++ b/Sources/SentryHelper.swift
@@ -280,6 +280,76 @@ func sentryCaptureWarning(
     )
 }
 
+/// Report a main-thread hang as a structured event carrying the **wedged main
+/// thread** as its stacktrace.
+///
+/// The watchdog reports from its own thread, so an ordinary `capture(message:)`
+/// hands Sentry the watchdog's loop as the thread of interest: the stack panel
+/// shows the reporter rather than the wedge, and the captured stack survives
+/// only as a text blob in context. Synthesizing the threads payload puts the
+/// real stack where Sentry expects one — rendered, symbolicated server-side
+/// against the uploaded dSYMs, and reachable by server-side fingerprint rules.
+///
+/// Grouping stays on the explicit `fingerprint`. Handing Sentry's own grouper
+/// these stacks would shatter one cause across hundreds of issues, because each
+/// capture is a single sample of a moving thread — measured on 875 real reports:
+/// 645 groups, 607 of them singletons.
+func sentryCaptureMainThreadHang(
+    _ message: String,
+    data: [String: Any],
+    fingerprint: [String],
+    tags: [String: String],
+    frames: [MainThreadBacktrace.Frame],
+    threadId: UInt64
+) {
+    guard TelemetrySettings.enabledForCurrentLaunch else { return }
+
+    let event = Event(level: .warning)
+    event.message = SentryMessage(formatted: message)
+    event.fingerprint = fingerprint
+    event.context = ["hang": data]
+
+    var allTags = tags
+    // `beforeSend` reads this tag to charge the event against the hang
+    // sub-budget rather than the general allowance. Losing it would let a
+    // wedged install spend the whole org's quota.
+    allTags["category"] = sentryHangCategory
+    event.tags = allTags.compactMapValues { value in
+        value.isEmpty ? nil : String(value.prefix(sentryTagValueLimit))
+    }
+
+    if !frames.isEmpty {
+        let thread = SentryThread(threadId: NSNumber(value: threadId))
+        thread.isMain = true
+        // `current` is what Sentry renders as the thread of interest. Nothing
+        // crashed, so `crashed` stays false — this is a live, recovered process.
+        thread.current = true
+        thread.crashed = false
+        thread.name = "main"
+        // Sentry orders frames caller-to-callee (oldest first); the unwinder
+        // produces them leaf-first. Reversing is not cosmetic — get it wrong and
+        // every stack renders upside down.
+        thread.stacktrace = SentryStacktrace(
+            frames: frames.reversed().map { frame in
+                let out = Frame()
+                out.instructionAddress = String(format: "0x%016llx", UInt64(frame.instructionAddress))
+                if let imageAddress = frame.imageAddress {
+                    out.imageAddress = String(format: "0x%016llx", UInt64(imageAddress))
+                }
+                return out
+            },
+            registers: [:]
+        )
+        event.threads = [thread]
+    }
+
+    // The SDK leaves a caller-supplied `threads` alone and derives `debugMeta`
+    // from it, so the frames above are what gets symbolicated. That is also why
+    // every frame carries `imageAddress`: the debug-image list is built purely
+    // from those values.
+    SentrySDK.capture(event: event)
+}
+
 func sentryCaptureError(
     _ message: String,
     category: String = "ui",

--- a/c11Tests/MainThreadHangDetectorTests.swift
+++ b/c11Tests/MainThreadHangDetectorTests.swift
@@ -268,6 +268,35 @@ final class MainThreadHangSignatureTests: XCTestCase {
         )
     }
 
+    // MARK: - Severity banding
+
+    func testDurationBucketsCoverTheObservedRangeAndAreOrdered() {
+        // Real reports span 2s (the detector's floor) to 604s. Every band must
+        // be reachable, or the issue list cannot distinguish a stutter from a
+        // ten-minute wedge — the reason duration left the message.
+        let observed: [(Double, String)] = [
+            (2_016, "2-5s"),      // shortest real report
+            (4_999, "2-5s"),
+            (5_000, "5-15s"),     // boundary is inclusive-low
+            (10_422, "5-15s"),    // the stall C11-192 was filed on
+            (14_653, "5-15s"),    // production p50
+            (15_000, "15-60s"),
+            (75_000, "1-5m"),     // production p90
+            (300_000, "5m+"),
+            (604_040, "5m+"),     // longest real report
+        ]
+        for (ms, expected) in observed {
+            XCTAssertEqual(
+                MainThreadHangMonitor.durationBucket(ms: ms), expected,
+                "\(ms)ms should band as \(expected)"
+            )
+        }
+        // A bounded set: this is an indexed Sentry dimension, not a measurement.
+        let distinct = Set(stride(from: 0.0, through: 900_000.0, by: 137.0)
+            .map(MainThreadHangMonitor.durationBucket(ms:)))
+        XCTAssertEqual(distinct.count, 5)
+    }
+
     // MARK: - Degenerate input
 
     func testEmptyOrUnparseableCaptureStillYieldsAStableFingerprint() {


### PR DESCRIPTION
Follow-up to #402. Operator call on the trident review's **S4 design fork**: fix
the event shape rather than work around it. S3 (server-side rules) and I4 fold in.

## What changes

Hang reports now carry the wedged main thread as a structured `threads` payload
with `current = true`. Three consequences:

1. **The Sentry stack panel shows the wedge**, not the watchdog loop that reported
   it. #402 fixed *grouping*; the displayed stack was still the reporter's, with
   the real one surviving only as a text blob in context.
2. **Frames symbolicate server-side** against the dSYMs `release.yml`/`nightly.yml`
   already upload — so the stack renders demangled, instead of the 24-line
   `backtrace_symbols` string truncated into an extra field.
3. **Server-side fingerprint rules become possible** (S3). They operate on
   structured stacktraces; a context string is unreachable to them. That also
   answers the review's point that the taxonomy was compiled into the binary with
   no rollback path — it no longer has to be.

Grouping stays on the explicit fingerprint from #402, as directed.

## Two SDK behaviours this depends on — read, not assumed

From `sentry-cocoa` 9.3.0, the pinned version:

```objc
// SentryClient.m:699-711
BOOL threadsNotAttached = !(nil != event.threads && event.threads.count > 0);
if (!isFatalEvent && shouldAttachStacktrace && threadsNotAttached) {
    event.threads = [self.threadInspector getCurrentThreads];
}
BOOL debugMetaNotAttached = !(nil != event.debugMeta && event.debugMeta.count > 0);
if (!isFatalEvent && shouldAttachStacktrace && debugMetaNotAttached && event.threads != nil) {
    event.debugMeta = [self.debugImageProvider getDebugImagesFromCacheForThreads:event.threads];
}
```

- A caller-supplied `event.threads` **is left alone** — our payload wins over
  `attachStacktrace`.
- `debugMeta` **is derived for us** from those threads — but the provider builds
  it purely from `frame.imageAddress`:
  `set.formUnion(frames.compactMap { $0.imageAddress })`
  (`SentryDebugImageProvider.swift:65`). Leaving `imageAddress` nil yields an
  empty debug-image list and a stack that renders as **bare addresses**, silently
  defeating the entire change. So every frame carries one, resolved with `dladdr`
  after the suspend window (never inside it — `dladdr` allocates).

Frames are **reversed** on the way out: Sentry orders caller-to-callee, oldest
first (`SentryStacktraceBuilder.m:103`, *"The frames must be ordered from caller
to callee, or oldest to youngest"*); the unwinder produces leaf-first. Get this
backwards and every stack renders upside down.

## The three approved follow-ups, each checked against this design first

| item | verdict |
|---|---|
| `hang.top_symbol` cardinality (I5) | **Obsoleted — dropped.** The leaf frame is now visible in the rendered stack, so the tag was redundant *and* was the unbounded-cardinality risk: an unresolved frame symbolicates to a raw address, minting a fresh tag value every launch. Deleting it is the whole fix. |
| `hang.duration_bucket` (S5) | **Not obsoleted — added.** Removing duration from the message made a 2s stutter and a 604s wedge the same row in the issue list. Five bands, covering the real 2s–604s range. |
| explicit `phase="none"` (M3) | **Not obsoleted — added.** `"none"` when a SwiftUI hang doesn't match a phase rule, `"n/a"` for other causes. A silently absent tag is how a classifier rots unnoticed: Apple rotates a private symbol, phase goes nil fleet-wide, the issue forks, and the reset trend reads as "the fix worked". |

Also from I5: the untruncated culprit is repeated in event context, because a
190-char clip of a mangled Swift symbol will not demangle — on exactly the field
that points at c11's own code.

## Preserved

- The `category` tag still routes through `sentryHangCategory`, so `beforeSend`
  charges these against the hang sub-budget rather than the general allowance.
  (Rebased onto #401's constant.)
- The 24-line symbolicated text stays in context as a **fallback**: if a build's
  dSYMs never reached Sentry, it is the only readable copy.
- The local hang log format is byte-identical.
- The classifier is unchanged — re-verified by compiling the pure region
  standalone and replaying all 875 production stacks: same 12 signatures, same
  distribution.

## Tests

`testDurationBucketsCoverTheObservedRangeAndAreOrdered` — banding at every
boundary using real observed values (2016ms shortest, 10422ms the stall this
ticket was filed on, 14653ms p50, 75000ms p90, 604040ms longest), plus an
assertion that the tag's value set stays bounded at five.

Existing `MainThreadHangSignatureTests` and `MainThreadHangDetectorTests` unchanged.

Local `xcodebuild` deferred to CI per the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)