### PR TITLE
C11-191: stop reporting late heartbeats as hangs, and send the frames that name one

### DIFF
--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -102,6 +102,11 @@ enum MainThreadHangSignature {
     /// How far down "which module is main working in" is decided.
     private static let moduleWindow = 8
 
+    /// Main parked at the top of the run loop. Named because the reporting path
+    /// treats it differently from every other cause: it is a late heartbeat, not
+    /// a wedged thread.
+    static let runLoopIdleCause = "runloop-idle"
+
     /// `backtrace_symbols` emits `"%-4d%-35s 0x%016lx %s + %lu"`. The load
     /// address is the only reliable delimiter: image names may contain spaces
     /// (`c11 DEV`), so splitting on whitespace alone mis-parses dev builds.
@@ -151,7 +156,7 @@ enum MainThreadHangSignature {
         // it can be judged separately from a thread wedged in compute.
         if leaf.symbol.contains("mach_msg2_trap"),
            window.contains(where: { $0.symbol.contains("CFRunLoopServiceMachPort") }) {
-            return "runloop-idle"
+            return runLoopIdleCause
         }
         let modules = frames.prefix(moduleWindow).map(\.module)
         if modules.contains(where: swiftUIModules.contains) { return "swiftui-update" }
@@ -164,6 +169,39 @@ enum MainThreadHangSignature {
             return rule.phase
         }
         return nil
+    }
+
+    /// The frames worth carrying in the outbound payload.
+    ///
+    /// The capture is up to 96 frames deep; the report is not. A straight prefix
+    /// loses exactly the frames that name the workload: SwiftUI's update spine is
+    /// routinely deeper than the window, so 73% of one 1,231-event production
+    /// sample arrived with *no* frame from our own binary — every frame a system
+    /// frame, and the hang unattributable no matter how many of them there were.
+    ///
+    /// So: the top window verbatim, then the own-module frames from below it, up
+    /// to `ownFrames`. Kept frames keep their true index and the gap is marked, so
+    /// the two runs can never be misread as contiguous.
+    static func reportedStack(
+        _ stack: [String],
+        ownModule: String,
+        topFrames: Int = 24,
+        ownFrames: Int = 8
+    ) -> [String] {
+        func line(_ index: Int) -> String { "\(index)\t\(stack[index])" }
+        guard stack.count > topFrames, topFrames >= 0 else {
+            return stack.indices.map(line)
+        }
+
+        var lines = (0..<topFrames).map(line)
+        let below = topFrames..<stack.count
+        let ownBelow = below.filter { parse(stack[$0])?.module == ownModule }.prefix(ownFrames)
+        let elided = below.count - ownBelow.count
+        if elided > 0 {
+            lines.append("\u{2026}\t\(elided) frame\(elided == 1 ? "" : "s") elided")
+        }
+        lines.append(contentsOf: ownBelow.map(line))
+        return lines
     }
 
     static func culprit(_ frames: [Frame], ownModule: String) -> String? {
@@ -241,6 +279,22 @@ struct MainThreadHangDetector {
     var isInEpisode: Bool { inEpisode }
 }
 
+/// Whether a human was in a position to see a stall.
+///
+/// Sampled on the main thread from AppKit notifications and read by the watchdog
+/// while main is wedged — AppKit is main-thread-only, and the value wanted is
+/// precisely the last one main managed to publish before it stopped answering.
+struct AppVisibility: Equatable {
+    let appIsActive: Bool
+    let hasVisibleWindow: Bool
+
+    /// Frontmost *and* showing something. Either alone is not a viewer: a
+    /// fully-occluded active app is as invisible as a backgrounded one.
+    var isWatched: Bool { appIsActive && hasVisibleWindow }
+
+    static let unwatched = AppVisibility(appIsActive: false, hasVisibleWindow: false)
+}
+
 /// Real-time main-thread watchdog.
 ///
 /// A dedicated background thread pings the main thread on a fixed heartbeat. When
@@ -267,6 +321,8 @@ final class MainThreadHangMonitor: @unchecked Sendable {
     private let lock = NSLock()
     private var lastAckUptime: TimeInterval = 0
     private var pingOutstanding = false
+    /// Written on main from AppKit notifications, read by the watchdog thread.
+    private var visibility: AppVisibility = .unwatched
 
     private var mainThread: thread_t = mach_port_t(MACH_PORT_NULL)
     private var installed = false
@@ -298,6 +354,7 @@ final class MainThreadHangMonitor: @unchecked Sendable {
         mainThread = pthread_mach_thread_np(pthread_self())
         let now = ProcessInfo.processInfo.systemUptime
         lock.lock(); lastAckUptime = now; lock.unlock()
+        observeVisibility()
 
         let thread = Thread { [weak self] in self?.runLoop() }
         thread.name = "com.stage11.c11.hang-monitor"
@@ -314,6 +371,40 @@ final class MainThreadHangMonitor: @unchecked Sendable {
         if env["XCTestConfigurationFilePath"] != nil { return false }
         if NSClassFromString("XCTestCase") != nil { return false }
         return true
+    }
+
+    // MARK: Visibility
+
+    /// Track "is a human looking at this window" on the main thread. Occlusion
+    /// covers the case AppKit activation misses: a frontmost app whose windows
+    /// are all behind something else.
+    private func observeVisibility() {
+        let center = NotificationCenter.default
+        for name in [
+            NSApplication.didBecomeActiveNotification,
+            NSApplication.didResignActiveNotification,
+            NSWindow.didChangeOcclusionStateNotification,
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didMiniaturizeNotification,
+            NSWindow.didDeminiaturizeNotification,
+        ] {
+            center.addObserver(
+                forName: name, object: nil, queue: .main
+            ) { [weak self] _ in self?.refreshVisibility() }
+        }
+        refreshVisibility()
+    }
+
+    /// Main thread only.
+    private func refreshVisibility() {
+        let app = NSApplication.shared
+        let snapshot = AppVisibility(
+            appIsActive: app.isActive,
+            hasVisibleWindow: app.windows.contains {
+                $0.isVisible && !$0.isMiniaturized && $0.occlusionState.contains(.visible)
+            }
+        )
+        lock.lock(); visibility = snapshot; lock.unlock()
     }
 
     // MARK: Watchdog loop (runs on the background thread)
@@ -363,9 +454,25 @@ final class MainThreadHangMonitor: @unchecked Sendable {
         if !recapture { reportedCurrentEpisode = false }
         let stack = captureMainBacktrace()
         let kind = recapture ? "hang.persist" : "hang.begin"
+        // `processName` is the "own binary" match for culprit extraction: it
+        // equals the Mach-O image name `backtrace_symbols` reports for both the
+        // shipped bundle (`c11`) and dev builds (`c11 DEV`). Best-effort anyway —
+        // absent whenever the capture window never reaches our code — so a
+        // mismatch degrades to no tag.
+        let signature = MainThreadHangSignature.describe(
+            stack: stack,
+            ownModule: ProcessInfo.processInfo.processName
+        )
+        lock.lock(); let visibility = self.visibility; lock.unlock()
 
         var lines: [String] = []
-        lines.append("=== c11 \(kind) \(Self.timestamp()) stalledMs=\(Int(gapMs)) pid=\(getpid()) ===")
+        // The header carries the classification so a forensic pass over months of
+        // log does not have to re-derive it from the frames.
+        lines.append(
+            "=== c11 \(kind) \(Self.timestamp()) stalledMs=\(Int(gapMs)) pid=\(getpid()) "
+                + "cause=\(signature.label) active=\(visibility.appIsActive ? 1 : 0) "
+                + "visible=\(visibility.hasVisibleWindow ? 1 : 0) ==="
+        )
         if stack.isEmpty {
             lines.append("  <no backtrace captured>")
         } else {
@@ -376,7 +483,13 @@ final class MainThreadHangMonitor: @unchecked Sendable {
         lines.append("")
         appendToLog(lines.joined(separator: "\n") + "\n")
 
-        reportTelemetry(gapMs: gapMs, recapture: recapture, stack: stack)
+        reportTelemetry(
+            gapMs: gapMs,
+            recapture: recapture,
+            stack: stack,
+            signature: signature,
+            visibility: visibility
+        )
     }
 
     private func handleRecovery(durationMs: Double) {
@@ -439,24 +552,26 @@ final class MainThreadHangMonitor: @unchecked Sendable {
 
     // MARK: Telemetry
 
-    private func reportTelemetry(gapMs: Double, recapture: Bool, stack: [String]) {
-        let top = stack.prefix(24).enumerated()
-            .map { "\($0.offset)\t\($0.element)" }
-            .joined(separator: "\n")
-        if shouldReportHangToSentry(gapMs: gapMs) {
-            // `processName` is the "own binary" match for culprit extraction:
-            // it equals the Mach-O image name `backtrace_symbols` reports for
-            // both the shipped bundle (`c11`) and dev builds (`c11 DEV`). The
-            // tag is best-effort anyway — absent whenever the capture window
-            // never reaches our code — so a mismatch degrades to no tag.
-            let signature = MainThreadHangSignature.describe(
-                stack: stack,
-                ownModule: ProcessInfo.processInfo.processName
-            )
+    private func reportTelemetry(
+        gapMs: Double,
+        recapture: Bool,
+        stack: [String],
+        signature: MainThreadHangDescriptor,
+        visibility: AppVisibility
+    ) {
+        if shouldReportHangToSentry(gapMs: gapMs, cause: signature.cause, visibility: visibility) {
+            let top = MainThreadHangSignature
+                .reportedStack(stack, ownModule: ProcessInfo.processInfo.processName)
+                .joined(separator: "\n")
             var tags = ["hang.cause": signature.cause, "hang.recapture": recapture ? "true" : "false"]
             tags["hang.phase"] = signature.phase
             tags["hang.culprit"] = signature.culprit
             tags["hang.top_symbol"] = signature.topSymbol
+            // Was anyone in a position to see it? A stall behind an occluded
+            // window and a stall under the operator's cursor are different bugs
+            // with identical stacks.
+            tags["hang.app_active"] = visibility.appIsActive ? "true" : "false"
+            tags["hang.window_visible"] = visibility.hasVisibleWindow ? "true" : "false"
             // The duration is not the grouping key, so it does not belong in
             // the title: the message names the cause and `stalled_ms` stays in
             // the event context.
@@ -476,7 +591,8 @@ final class MainThreadHangMonitor: @unchecked Sendable {
         PostHogAnalytics.shared.captureMainThreadHang(
             stalledMs: gapMs,
             recapture: recapture,
-            topFrame: stack.first ?? ""
+            topFrame: stack.first ?? "",
+            cause: signature.label
         )
     }
 
@@ -495,12 +611,33 @@ final class MainThreadHangMonitor: @unchecked Sendable {
     /// charging it here as well would spend two slots of the global allowance
     /// on every hang report.
     ///
+    /// `runloop-idle` never reports from behind an unwatched window: main is
+    /// parked at the top of the run loop with the heartbeat still undelivered,
+    /// which is a late ack, not a wedge. Off-screen that is App Nap and timer
+    /// coalescing doing their job. It was **46.5% of 5,311 local episodes** — the
+    /// single largest slice of what made the aggregate hang issue c11's
+    /// highest-volume report — and none of it was a freeze anyone could see. With
+    /// the window in front of a human the same stack does mean something (the UI
+    /// went dead while they watched), so that half still reports.
+    ///
     /// Called only from the watchdog thread, which captures serially.
-    private func shouldReportHangToSentry(gapMs: Double) -> Bool {
+    private func shouldReportHangToSentry(
+        gapMs: Double,
+        cause: String,
+        visibility: AppVisibility
+    ) -> Bool {
         guard gapMs >= sentryReportThresholdMs else { return false }
+        guard Self.isWorthReporting(cause: cause, visibility: visibility) else { return false }
         guard !reportedCurrentEpisode else { return false }
         reportedCurrentEpisode = true
         return true
+    }
+
+    /// Pure half of the rule above, so it can be tested without a watchdog.
+    /// Every cause but `runloop-idle` reports regardless of who was looking.
+    static func isWorthReporting(cause: String, visibility: AppVisibility) -> Bool {
+        guard cause == MainThreadHangSignature.runLoopIdleCause else { return true }
+        return visibility.isWatched
     }
 
     // MARK: Local log

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -83,13 +83,17 @@ final class PostHogAnalytics {
 
     /// Capture a main-thread hang detected by `MainThreadHangMonitor`. Self-gated
     /// on telemetry consent (`isEnabled`) and SDK start, like every other event.
-    func captureMainThreadHang(stalledMs: Double, recapture: Bool, topFrame: String) {
+    /// `cause` is the same signature label Sentry groups on, so the two surfaces
+    /// can be read against each other — PostHog keeps the whole population
+    /// (including the run-loop-idle episodes Sentry no longer hears about).
+    func captureMainThreadHang(stalledMs: Double, recapture: Bool, topFrame: String, cause: String) {
         dispatchAsyncOnWorkQueue { [weak self] in
             guard let self, self.didStart, self.isEnabled else { return }
             PostHogSDK.shared.capture("c11_main_thread_hang", properties: [
                 "stalled_ms": Int(stalledMs),
                 "recapture": recapture,
                 "top_frame": topFrame,
+                "cause": cause,
             ])
         }
     }

--- a/c11Tests/MainThreadHangDetectorTests.swift
+++ b/c11Tests/MainThreadHangDetectorTests.swift
@@ -278,6 +278,106 @@ final class MainThreadHangSignatureTests: XCTestCase {
         }
         XCTAssertEqual(describe([]).cause, "unknown")
     }
+
+    // MARK: - What rides along in the payload
+
+    /// A 96-frame capture whose own-module frames all sit below the top window —
+    /// the shape 73% of one 1,231-event production sample arrived in, every frame
+    /// a system frame and the hang consequently unattributable.
+    private func deepSwiftUIStack() -> [String] {
+        var stack = (0..<40).map { "\($0)   SwiftUICore   0x\($0) $s7SwiftUI9GraphHostC16updatePreferencesyyF + \($0)" }
+        stack.append("40   c11   0xaa $s3c1119VerticalTabsSidebarV4bodyQrvg + 12")
+        stack += (41..<60).map { "\($0)   AppKit   0x\($0) -[NSView _layoutSubtreeWithOldSize:] + \($0)" }
+        stack.append("60   c11   0xbb $s3c1111ContentViewV4bodyQrvg + 44")
+        stack.append("61   c11   0xcc main + 64")
+        return stack
+    }
+
+    func testReportedStackCarriesOwnFramesFromBelowTheTopWindow() {
+        let reported = MainThreadHangSignature.reportedStack(deepSwiftUIStack(), ownModule: "c11")
+        XCTAssertTrue(
+            reported.contains { $0.contains("VerticalTabsSidebar") },
+            "the frame that names the workload sits at index 40 and is the whole point of the report"
+        )
+        XCTAssertTrue(reported.contains { $0.contains("ContentView") })
+        XCTAssertTrue(reported.contains { $0.contains("main + 64") })
+        // Nothing from the elided middle rides along.
+        XCTAssertFalse(reported.contains { $0.contains("_layoutSubtreeWithOldSize") })
+    }
+
+    func testReportedStackKeepsTrueIndicesAndMarksTheGap() {
+        let reported = MainThreadHangSignature.reportedStack(deepSwiftUIStack(), ownModule: "c11")
+        XCTAssertEqual(reported.prefix(24).count, 24)
+        XCTAssertTrue(reported[0].hasPrefix("0\t"))
+        XCTAssertTrue(reported[23].hasPrefix("23\t"))
+        guard let gap = reported.firstIndex(where: { $0.hasPrefix("\u{2026}\t") }) else {
+            return XCTFail("an elided run must be marked, or the two halves read as contiguous")
+        }
+        // 62 frames total, 24 kept up top, 3 own frames kept below.
+        XCTAssertEqual(reported[gap], "\u{2026}\t35 frames elided")
+        XCTAssertTrue(reported[gap + 1].hasPrefix("40\t"), "kept frames keep their capture index")
+    }
+
+    func testReportedStackIsUnchangedWhenTheCaptureFitsTheWindow() {
+        let stack = (0..<10).map { "\($0)   SwiftUI   0x\($0) frame\($0)" }
+        let reported = MainThreadHangSignature.reportedStack(stack, ownModule: "c11")
+        XCTAssertEqual(reported.count, 10)
+        XCTAssertFalse(reported.contains { $0.hasPrefix("\u{2026}") })
+        XCTAssertEqual(reported.last, "9\t\(stack[9])")
+    }
+
+    func testReportedStackBoundsHowManyOwnFramesItAppends() {
+        var stack = (0..<24).map { "\($0)   SwiftUI   0x\($0) frame\($0)" }
+        stack += (24..<44).map { "\($0)   c11   0x\($0) $s3c11deep\($0)" }
+        let reported = MainThreadHangSignature.reportedStack(stack, ownModule: "c11", ownFrames: 8)
+        XCTAssertEqual(reported.count, 24 + 1 + 8)
+        XCTAssertEqual(reported.last, "31\t\(stack[31])", "the own frames nearest the leaf are the useful ones")
+    }
+}
+
+/// The run-loop-idle reporting rule.
+///
+/// `runloop-idle` means main is parked at the top of the run loop with the
+/// watchdog's heartbeat still undelivered: a late ack, not a wedge. It was 46.5%
+/// of 5,311 local episodes and the largest single slice of the aggregate Sentry
+/// hang issue — and behind an unwatched window it is App Nap and timer coalescing
+/// working as designed, invisible to anyone.
+final class MainThreadHangVisibilityTests: XCTestCase {
+
+    private let watched = AppVisibility(appIsActive: true, hasVisibleWindow: true)
+
+    func testAnUnwatchedIdleRunLoopIsNotWorthReporting() {
+        for visibility in [
+            AppVisibility.unwatched,
+            AppVisibility(appIsActive: true, hasVisibleWindow: false),
+            AppVisibility(appIsActive: false, hasVisibleWindow: true),
+        ] {
+            XCTAssertFalse(MainThreadHangMonitor.isWorthReporting(
+                cause: MainThreadHangSignature.runLoopIdleCause, visibility: visibility
+            ))
+        }
+    }
+
+    func testAWatchedIdleRunLoopStillReports() {
+        // Same stack, but the window was in front of a human: the UI went dead
+        // while they were looking at it, which is a real report.
+        XCTAssertTrue(MainThreadHangMonitor.isWorthReporting(
+            cause: MainThreadHangSignature.runLoopIdleCause, visibility: watched
+        ))
+    }
+
+    func testEveryOtherCauseReportsRegardlessOfWhoWasLooking() {
+        for cause in ["swiftui-update", "appkit", "lock-wait", "xpc-sync-wait", "generic-metadata", "other", "unknown"] {
+            XCTAssertTrue(MainThreadHangMonitor.isWorthReporting(cause: cause, visibility: .unwatched), cause)
+        }
+    }
+
+    func testWatchedRequiresBothFrontmostAndOnScreen() {
+        XCTAssertTrue(watched.isWatched)
+        XCTAssertFalse(AppVisibility(appIsActive: true, hasVisibleWindow: false).isWatched)
+        XCTAssertFalse(AppVisibility(appIsActive: false, hasVisibleWindow: true).isWatched)
+        XCTAssertFalse(AppVisibility.unwatched.isWatched)
+    }
 }
 
 /// Pure, in-process tests for `SentryEventBudget` — the client-side ceiling on


### PR DESCRIPTION
## What this is

`C11-30` — "main thread hang 2335ms" — has been c11's highest-volume live Sentry issue. It is
not a bug. Its fingerprint is `{{ default }}`, one hash, and a 1,500-event sample of it spans
**eleven release strings** (0.52.0 → 0.61.0 plus four debug builds) and every stack shape there
is: Sentry groups message events by the stack of the thread that *reported* them, which for a
hang report is the watchdog's own loop, byte-identical every time. C11-192 (#402) fixed the
grouping. This PR fixes what the reports contain, so the buckets it creates are worth reading.

Both changes are measured against the operator's local `hang.log` — 21,192 captures / 5,311
episodes / 63 pids, Jun 15 → Aug 6 — re-classified with the shipped `MainThreadHangSignature`
rules, i.e. exactly the buckets the next release will produce:

| bucket | episodes | share | pids |
|---|---|---|---|
| `runloop-idle` | 2470 | **46.5%** | 53 |
| `appkit` | 822 | 15.5% | 45 |
| `swiftui-update/hosting-begin-transaction` | 776 | 14.6% | 38 |
| `swiftui-update/hosting-layout` | 546 | 10.3% | 39 |
| `other` | 259 | 4.9% | 32 |
| `swiftui-update` (unphased) | 176 | 3.3% | 30 |
| `generic-metadata` | 131 | 2.5% | 28 |
| `lock-wait` | 76 | 1.4% | 16 |
| `xpc-sync-wait` | 42 | 0.8% | 17 |
| `swiftui-update/preferences` | 13 | 0.2% | 7 |

## 1. `runloop-idle` stops reporting from behind an unwatched window

Main parked at the top of the run loop with the watchdog's heartbeat still undelivered is a
**late ack, not a wedge**. Off-screen that is App Nap and timer coalescing doing their job. It
is 46.5% of all episodes — the largest single slice of the volume that made this the top issue —
and none of it is a freeze anyone could see.

With the window in front of a human the same stack does mean something (the UI went dead while
they watched), so that half still reports. The whole population still lands in the local hang log
and in PostHog; only the outbound Sentry event is suppressed.

Visibility is sampled on the main thread from AppKit notifications (activation, occlusion,
miniaturization) into a lock-protected snapshot the watchdog reads while main is wedged — AppKit
is main-thread-only, and the value wanted is precisely the last one main managed to publish
before it stopped answering.

## 2. Reports now carry the frames that name the workload

`reportTelemetry` sent `stack.prefix(24)`. SwiftUI's update spine is routinely deeper than that,
so **73% of busy `0.58.0+116` events arrived with no frame from our own binary at all** — every
frame a system frame, the hang unattributable.

Measured on the local corpus, here is exactly what widening the window buys (2,241 busy episodes,
full 96-frame captures):

| | busy episodes | share |
|---|---|---|
| own frame within the top 24 (already visible) | 404 | 18.0% |
| own frame only **below** 24 — what this recovers | 68 | **3.0%** |
| no own frame anywhere in 96 frames | 1769 | 78.9% |

A 3-point lift, 18.0% → 21.0% of busy reports naming our code. Modest, and worth stating plainly
rather than letting the 73% figure imply the change recovers most of it: in ~79% of busy episodes
main genuinely is inside SwiftUI/AppKit internals with none of our code on the stack at any depth,
and only 165 of 5,311 captures hit the 96-frame cap, so the frames are not hiding below it either.

What the 3% looks like in practice — the shipped `MainThreadHangSignature` run over a real
96-frame capture from the log (pid 17480, 2123 ms, `swiftui-update/hosting-layout`):

```
OLD payload (prefix 24): own-module frames carried = 0
NEW payload: 32 lines
  23  AppKit  NSPerformVisuallyAtomicChange + 128
  …   65 frames elided
  51  c11  WindowTerminalPortal.synchronizeLayoutHierarchy + 52
  52  c11  WindowTerminalPortal.ensureInstalled + 1216
  53  c11  WindowTerminalPortal.synchronizeHostedView(withId:) + 60
  54  c11  WindowTerminalPortal.bind(hostedView:to:visibleInUI:zPriority:workspaceFrameStyle:) + 3380
  55  c11  TerminalWindowPortalRegistry.bind(...) + 784
  56  c11  GhosttyTerminalView.updateNSView(_:context:) + 652
  57  c11  GhosttyTerminalView.HostContainerView.viewDidMoveToWindow() + 100
```

Under the old payload that event named nothing; under the new one it names the whole portal-bind
chain under an `NSView _layoutSubtreeWithOldSize:` pass. The cost is ≤8 extra lines.

`MainThreadHangSignature.reportedStack` keeps the top window verbatim and appends the own-module
frames from below it (≤8), with true capture indices and the elided run marked so the two runs
can't be misread as contiguous.

## 3. Along the way

- `hang.app_active` / `hang.window_visible` tags: a stall behind an occluded window and one under
  the operator's cursor are different bugs with identical stacks.
- The local log header carries `cause=` / `active=` / `visible=`, so a forensic pass over months
  of log doesn't have to re-derive the classification from the frames (this PR's analysis did).
- PostHog carries the same `cause` label Sentry groups on, so the two surfaces can be read
  against each other — PostHog keeps the population Sentry no longer hears about.

## What this PR does *not* do

C11-191 carried a candidate root cause from plan review: an unguarded `onPreferenceChange` →
`@State` → `.frame(width:)` cycle in `vendor/bonsplit` `TabBarView.swift` 730-749 / 794-809.
**Refuted.** `swiftui-update/preferences` is 0.2% of episodes; `updatePreferences` appears
anywhere in 3.6% and `TabBarView` in 0.5%, with both together in 0.23% (12 of 5,311). Reading the
code: the two preference writers measure the trailing accessory and the split buttons, and the
`@State` they set feeds `.frame(width:)` on the *backdrop gradient sibling* inside the same
`ZStack`, not on the measured subtree; `resolvedEffectiveChromeWidth` reads the state only in its
zero-measurement fallback and returns it unchanged. Idempotent, not divergent — which is why no
capture in seven weeks ever shows those keys spinning. **No submodule change in this PR.**

The real user-visible freeze is `swiftui-update/*` (28.2% combined, median 2.5–2.8 s at
detection). A successor ticket (C11-202) chases it. Note from the table above: ~79% of those
episodes name none of our code at any stack depth, so C11-202 needs a profiler against a driven
repro, not deeper post-hoc sampling — this PR sharpens the attributable minority, it does not
solve attribution.

## Testing

New behavioral tests in `c11LogicTests` (`MainThreadHangDetectorTests.swift`), so CI's `build`
job runs them:

- `reportedStack` carries own-module frames from below the top window, keeps true capture
  indices, marks the elided run, is a no-op when the capture fits, and bounds how many own frames
  it appends.
- `runloop-idle` does not report unwatched (and not when active-but-occluded, or visible-but-
  backgrounded); it does report watched; every other cause reports regardless.

Per the repo's standing instruction, no local `xcodebuild` — CI's `build` job is the
compile-and-logic gate.

Ticket: C11-191. Related: C11-192 (#402, fingerprinting), C11-186 (hang survivability),
C11-200 (#403, the separate `ghostty_surface_set_display_id` deadlock split out of this ticket).

Branch name (`c11-191-tabbar-preference-loop`) predates the refutation; kept because Lattice
already links it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

