### PR TITLE
C11-198: runloop-idle never reports, and stops swallowing nested run loops

### DIFF
--- a/Sources/MainThreadHangMonitor.swift
+++ b/Sources/MainThreadHangMonitor.swift
@@ -102,10 +102,22 @@ enum MainThreadHangSignature {
     /// How far down "which module is main working in" is decided.
     private static let moduleWindow = 8
 
-    /// Main parked at the top of the run loop. Named because the reporting path
-    /// treats it differently from every other cause: it is a late heartbeat, not
-    /// a wedged thread.
+    /// Main parked at the top of the app's **outermost** event loop. Named
+    /// because the reporting path treats it differently from every other cause:
+    /// it is a late heartbeat, not a wedged thread.
+    ///
+    /// The `-[NSApplication run]` requirement in `cause` is what makes that
+    /// claim true. Without it the bucket also swallows every *nested* run loop
+    /// the app enters on purpose (a modal alert, a menu track, a socket command
+    /// spinning `CFRunLoopRun` on main), which are real blocks with our own
+    /// frames on the stack. On 7,926 real captures the frame separates the two
+    /// populations exactly: present on all 2,895 outermost-idle captures and on
+    /// none of the 5,031 nested ones.
     static let runLoopIdleCause = "runloop-idle"
+
+    /// The frame that proves the run loop being serviced is the app's own top
+    /// level, not one nested inside a callback.
+    private static let outermostEventLoopSymbol = "-[NSApplication run]"
 
     /// `backtrace_symbols` emits `"%-4d%-35s 0x%016lx %s + %lu"`. The load
     /// address is the only reliable delimiter: image names may contain spaces
@@ -151,11 +163,14 @@ enum MainThreadHangSignature {
         }) {
             return rule.cause
         }
-        // Parked at the top of the run loop waiting for work: main is idle, and
-        // the watchdog's heartbeat should have been serviced. Its own bucket so
-        // it can be judged separately from a thread wedged in compute.
+        // Parked at the top of the app's own event loop waiting for work: main
+        // is idle, and the watchdog's heartbeat should have been serviced. Its
+        // own bucket so it can be judged separately from a thread wedged in
+        // compute. A *nested* run loop reaches the same mach_msg leaf but is a
+        // genuine block, so it must fall through to the module rules below.
         if leaf.symbol.contains("mach_msg2_trap"),
-           window.contains(where: { $0.symbol.contains("CFRunLoopServiceMachPort") }) {
+           window.contains(where: { $0.symbol.contains("CFRunLoopServiceMachPort") }),
+           window.contains(where: { $0.symbol.contains(outermostEventLoopSymbol) }) {
             return runLoopIdleCause
         }
         let modules = frames.prefix(moduleWindow).map(\.module)
@@ -284,13 +299,14 @@ struct MainThreadHangDetector {
 /// Sampled on the main thread from AppKit notifications and read by the watchdog
 /// while main is wedged — AppKit is main-thread-only, and the value wanted is
 /// precisely the last one main managed to publish before it stopped answering.
+///
+/// Rides along as the `hang.app_active` / `hang.window_visible` tags and in the
+/// local log header: a stall behind an occluded window and one under the
+/// operator's cursor are different bugs with identical stacks. It does not gate
+/// reporting: which cause a capture is, not who was looking, decides that.
 struct AppVisibility: Equatable {
     let appIsActive: Bool
     let hasVisibleWindow: Bool
-
-    /// Frontmost *and* showing something. Either alone is not a viewer: a
-    /// fully-occluded active app is as invisible as a backgrounded one.
-    var isWatched: Bool { appIsActive && hasVisibleWindow }
 
     static let unwatched = AppVisibility(appIsActive: false, hasVisibleWindow: false)
 }
@@ -559,7 +575,7 @@ final class MainThreadHangMonitor: @unchecked Sendable {
         signature: MainThreadHangDescriptor,
         visibility: AppVisibility
     ) {
-        if shouldReportHangToSentry(gapMs: gapMs, cause: signature.cause, visibility: visibility) {
+        if shouldReportHangToSentry(gapMs: gapMs, cause: signature.cause) {
             let top = MainThreadHangSignature
                 .reportedStack(stack, ownModule: ProcessInfo.processInfo.processName)
                 .joined(separator: "\n")
@@ -611,33 +627,37 @@ final class MainThreadHangMonitor: @unchecked Sendable {
     /// charging it here as well would spend two slots of the global allowance
     /// on every hang report.
     ///
-    /// `runloop-idle` never reports from behind an unwatched window: main is
-    /// parked at the top of the run loop with the heartbeat still undelivered,
-    /// which is a late ack, not a wedge. Off-screen that is App Nap and timer
-    /// coalescing doing their job. It was **46.5% of 5,311 local episodes** — the
+    /// `runloop-idle` never reports, whoever was looking. The stack it is
+    /// classified from is main sitting in `-[NSApplication run]` → `_DPSNextEvent`,
+    /// blocked on the event port: an app *ready to dequeue the next user event*.
+    /// Whatever delayed the heartbeat (the background-QoS watchdog thread losing
+    /// the CPU, App Nap, timer coalescing), it was not main being unavailable to
+    /// anyone, so "was the window watched" does not change the verdict.
+    ///
+    /// It is also unactionable by construction: the capture carries no frame of
+    /// ours below `main`, no phase and no culprit, and every event is byte-for-byte
+    /// the same 21 frames. An issue that can only ever say "main was idle" cannot
+    /// drive a fix, and under the global `SentryEventBudgetGate` ceiling it spends
+    /// budget a real wedge needed. It was **46.5% of 5,311 local episodes**, the
     /// single largest slice of what made the aggregate hang issue c11's
-    /// highest-volume report — and none of it was a freeze anyone could see. With
-    /// the window in front of a human the same stack does mean something (the UI
-    /// went dead while they watched), so that half still reports.
+    /// highest-volume report.
+    ///
+    /// The population is not lost: every capture still lands in the local hang log
+    /// and in PostHog, which carries the same `cause` label.
     ///
     /// Called only from the watchdog thread, which captures serially.
-    private func shouldReportHangToSentry(
-        gapMs: Double,
-        cause: String,
-        visibility: AppVisibility
-    ) -> Bool {
+    private func shouldReportHangToSentry(gapMs: Double, cause: String) -> Bool {
         guard gapMs >= sentryReportThresholdMs else { return false }
-        guard Self.isWorthReporting(cause: cause, visibility: visibility) else { return false }
+        guard Self.isWorthReporting(cause: cause) else { return false }
         guard !reportedCurrentEpisode else { return false }
         reportedCurrentEpisode = true
         return true
     }
 
     /// Pure half of the rule above, so it can be tested without a watchdog.
-    /// Every cause but `runloop-idle` reports regardless of who was looking.
-    static func isWorthReporting(cause: String, visibility: AppVisibility) -> Bool {
-        guard cause == MainThreadHangSignature.runLoopIdleCause else { return true }
-        return visibility.isWatched
+    /// Every cause but `runloop-idle` reports.
+    static func isWorthReporting(cause: String) -> Bool {
+        cause != MainThreadHangSignature.runLoopIdleCause
     }
 
     // MARK: Local log

--- a/c11Tests/MainThreadHangDetectorTests.swift
+++ b/c11Tests/MainThreadHangDetectorTests.swift
@@ -184,6 +184,8 @@ final class MainThreadHangSignatureTests: XCTestCase {
     }
 
     func testIdleRunLoopIsSeparatedFromAWedgeInCompute() {
+        // Verbatim shape of every `runloop-idle` report Sentry has received: the
+        // mach_msg leaf is reached from the app's own outermost event loop.
         let d = describe([
             "0   libsystem_kernel.dylib   0x0000000187861c34 mach_msg2_trap + 8",
             "1   libsystem_kernel.dylib   0x000000018786a9c0 mach_msg_overwrite + 480",
@@ -191,8 +193,48 @@ final class MainThreadHangSignatureTests: XCTestCase {
             "3   CoreFoundation   0x00000001879630d8 __CFRunLoopServiceMachPort + 160",
             "4   CoreFoundation   0x00000001879619c4 __CFRunLoopRun + 1188",
             "9   AppKit   0x000000018c43c35c _DPSBlockUntilNextEventMatchingListInMode + 228",
+            "13   AppKit   0x000000019391713c -[NSApplication run] + 368",
         ])
         XCTAssertEqual(d.cause, "runloop-idle")
+    }
+
+    /// A run loop we entered *inside* a callback is a real block, not a late
+    /// heartbeat, so it must not land in the bucket that never reports.
+    func testANestedRunLoopIsNotClassifiedAsIdle() {
+        // c11's socket handler spinning CFRunLoopRun on main while it waits for
+        // a WKWebView callback: 70 episodes across 12 pids in the local log.
+        let socketCommand = describe([
+            "0   libsystem_kernel.dylib   0x0000000187861c34 mach_msg2_trap + 8",
+            "1   libsystem_kernel.dylib   0x000000018786a9c0 mach_msg_overwrite + 480",
+            "2   libsystem_kernel.dylib   0x0000000187861fc0 mach_msg + 24",
+            "3   CoreFoundation   0x00000001879630d8 __CFRunLoopServiceMachPort + 160",
+            "4   CoreFoundation   0x00000001879619c4 __CFRunLoopRun + 1188",
+            "6   CoreFoundation   0x00000001879c81c4 CFRunLoopRun + 64",
+            "7   c11   0x0000000102a1cbd4 $s3c1118TerminalControllerC15v2AwaitCallback + 92",
+            "8   c11   0x0000000102a1cc00 $s3c1118TerminalControllerC15v2RunJavaScript + 40",
+        ])
+        XCTAssertNotEqual(socketCommand.cause, "runloop-idle")
+        XCTAssertTrue(MainThreadHangMonitor.isWorthReporting(cause: socketCommand.cause))
+        XCTAssertEqual(
+            socketCommand.culprit,
+            "$s3c1118TerminalControllerC15v2AwaitCallback",
+            "the c11 frame that entered the nested loop is what names this block"
+        )
+
+        // A modal alert's nested loop: 4,747 captures in the local log, up to
+        // 6.8 hours each, previously filed as benign idle.
+        let modalAlert = describe([
+            "0   libsystem_kernel.dylib   0x0000000187861c34 mach_msg2_trap + 8",
+            "1   libsystem_kernel.dylib   0x000000018786a9c0 mach_msg_overwrite + 480",
+            "2   libsystem_kernel.dylib   0x0000000187861fc0 mach_msg + 24",
+            "3   CoreFoundation   0x00000001879630d8 __CFRunLoopServiceMachPort + 160",
+            "4   CoreFoundation   0x00000001879619c4 __CFRunLoopRun + 1188",
+            "6   HIToolbox   0x000000019c2db560 RunCurrentEventLoopInMode + 320",
+            "9   AppKit   0x000000018c43c35c -[NSApplication _doModalLoop:peek:] + 228",
+            "11   c11   0x0000000102a1cbd4 $s3c1112BrowserPanelC24presentInsecureHTTPAlert + 64",
+        ])
+        XCTAssertNotEqual(modalAlert.cause, "runloop-idle")
+        XCTAssertTrue(MainThreadHangMonitor.isWorthReporting(cause: modalAlert.cause))
     }
 
     func testSwiftUIGraphWorkIsNarrowedByHostPhase() {
@@ -337,46 +379,24 @@ final class MainThreadHangSignatureTests: XCTestCase {
 
 /// The run-loop-idle reporting rule.
 ///
-/// `runloop-idle` means main is parked at the top of the run loop with the
-/// watchdog's heartbeat still undelivered: a late ack, not a wedge. It was 46.5%
-/// of 5,311 local episodes and the largest single slice of the aggregate Sentry
-/// hang issue — and behind an unwatched window it is App Nap and timer coalescing
-/// working as designed, invisible to anyone.
-final class MainThreadHangVisibilityTests: XCTestCase {
+/// `runloop-idle` means main is parked in `-[NSApplication run]` waiting for the
+/// next event: an app ready to serve the user, not a wedge. It was 46.5% of 5,311
+/// local episodes and the largest single slice of the aggregate Sentry hang issue,
+/// and it carries no frame of ours, no phase and no culprit, so no report derived
+/// from it can name a cause. It never reports; the local hang log and PostHog keep
+/// the whole population.
+final class MainThreadHangReportingRuleTests: XCTestCase {
 
-    private let watched = AppVisibility(appIsActive: true, hasVisibleWindow: true)
-
-    func testAnUnwatchedIdleRunLoopIsNotWorthReporting() {
-        for visibility in [
-            AppVisibility.unwatched,
-            AppVisibility(appIsActive: true, hasVisibleWindow: false),
-            AppVisibility(appIsActive: false, hasVisibleWindow: true),
-        ] {
-            XCTAssertFalse(MainThreadHangMonitor.isWorthReporting(
-                cause: MainThreadHangSignature.runLoopIdleCause, visibility: visibility
-            ))
-        }
-    }
-
-    func testAWatchedIdleRunLoopStillReports() {
-        // Same stack, but the window was in front of a human: the UI went dead
-        // while they were looking at it, which is a real report.
-        XCTAssertTrue(MainThreadHangMonitor.isWorthReporting(
-            cause: MainThreadHangSignature.runLoopIdleCause, visibility: watched
+    func testAnIdleRunLoopIsNeverWorthReporting() {
+        XCTAssertFalse(MainThreadHangMonitor.isWorthReporting(
+            cause: MainThreadHangSignature.runLoopIdleCause
         ))
     }
 
-    func testEveryOtherCauseReportsRegardlessOfWhoWasLooking() {
+    func testEveryOtherCauseReports() {
         for cause in ["swiftui-update", "appkit", "lock-wait", "xpc-sync-wait", "generic-metadata", "other", "unknown"] {
-            XCTAssertTrue(MainThreadHangMonitor.isWorthReporting(cause: cause, visibility: .unwatched), cause)
+            XCTAssertTrue(MainThreadHangMonitor.isWorthReporting(cause: cause), cause)
         }
-    }
-
-    func testWatchedRequiresBothFrontmostAndOnScreen() {
-        XCTAssertTrue(watched.isWatched)
-        XCTAssertFalse(AppVisibility(appIsActive: true, hasVisibleWindow: false).isWatched)
-        XCTAssertFalse(AppVisibility(appIsActive: false, hasVisibleWindow: true).isWatched)
-        XCTAssertFalse(AppVisibility.unwatched.isWatched)
     }
 }
 


### PR DESCRIPTION
## The question

C11-198 is a spike: should `runloop-idle` hang captures report to Sentry at all? Filed off #402's observation that main was parked in `mach_msg2_trap`/`CFRunLoopServiceMachPort` while the heartbeat went unserviced, with two candidate readings: a watchdog false positive (clock jump, App Nap, sleep race) or real scheduling starvation.

Neither, quite. **The bucket is two different populations, and the answer differs for each.**

## Method

Classified all **21,253 captures / 5,360 episodes** in `~/Library/Logs/c11/hang.log` (Jun 15 → Aug 9, 55 pids) with the rules as shipped on `main` (`b2fb5caa5`). The port reproduces #402/#411's published distribution (`lock-wait` 44.8% vs their 45.8%, `runloop-idle` 37.3% vs 37.4%), so it is measuring the same thing they did.

`runloop-idle` is **2,491 of 5,360 episodes (46.6%)**, matching #411's 46.5%.

## What is actually in the bucket

| mechanism | episodes | share | pids | p50 peak | max |
|---|---:|---:|---:|---:|---:|
| outermost idle `NSApp` event loop | 2,414 | **96.9%** | 54 | 4.7 s | 30 min |
| nested: `TerminalController.v2AwaitCallback` (socket cmd spinning `CFRunLoopRun` on main) | 70 | 2.8% | 12 | 3.1 s | 6.8 min |
| nested: `BrowserPanel.presentInsecureHTTPAlert` modal | 6 | 0.2% | 1 | 8.5 min | **6.8 h** |
| nested: other modal / menu / sheet | 1 | 0.0% | 1 | 15 min | 15 min |

### 1. The dominant 96.9% is a false positive, watched or not

Its stack is main in `-[NSApplication run]` → `_nextEventMatchingEventMask:` → `_DPSNextEvent` → `ReceiveNextEventCommon`, blocked on the event port. That is an app **ready to dequeue the next user event**. If a human had clicked, the click would have been handled. Whatever delayed the heartbeat (the background-QoS watchdog thread losing the CPU, App Nap, timer coalescing) it was not main being unavailable to anyone.

All **three** `runloop-idle` events Sentry has ever received (`C11-3C`) are exactly that stack: byte-identical, 21 frames, `libsystem_kernel` → `CoreFoundation` → `HIToolbox` → `AppKit` → `SwiftUI` → `main` → `dyld`, with nothing of ours below `main`.

So #411's watched exception ("the UI went dead while they watched") rests on a premise the stack refutes: the UI did not go dead, and watchedness does not change what the stack says. The report is also **unactionable by construction**: no `hang.phase`, no `hang.culprit`, no c11 frame at any depth, identical every time. An issue that can only ever say "main was idle" cannot drive a fix, and under the global `SentryEventBudgetGate` ceiling it spends budget a real wedge needed.

Corroborating the watchdog's own unreliability: against a 2,000 ms detection threshold with a 250 ms tick, only **12.3%** of these episodes are first detected at the 2,000-2,250 ms floor. p50 first detection is 4,110 ms and p90 is 35,813 ms, so in most episodes the watchdog missed 8 to 130+ consecutive ticks before noticing.

### 2. The other 3.1% is real, and was being suppressed

Nested run loops the app enters on purpose. Main is genuinely blocked, our own frames are on the stack, and `hang.culprit` names them. The insecure-HTTP modal alert blocked one pid for up to **6.8 hours**. Under the shipped policy these are `runloop-idle`, so they are dropped whenever the window is unwatched, which for socket-driven browser automation is most of the time.

## The change

**Narrow the classification.** Require `-[NSApplication run]` in the 16-frame cause window for `runLoopIdleCause`. On the corpus this separates the two populations *exactly*: present on all 2,895 outermost-idle captures, absent from all 5,031 nested ones, **zero misclassifications either way**. Nested captures fall through to the existing module rules (`appkit` / `other`) and report normally, carrying the culprit that names them.

**Suppress unconditionally.** `isWorthReporting` drops the visibility argument; `runloop-idle` never reports. `AppVisibility.isWatched` goes with the gate it existed for. `appIsActive` / `hasVisibleWindow` still ride along as `hang.app_active` / `hang.window_visible` tags and in the local log header, which is where they earn their keep.

Simulated over the corpus, `runloop-idle` goes 2,492 → 2,415 episodes (all now silent) and `appkit` / `other` gain the 77 real ones.

**Nothing is lost.** Every capture still lands in the local hang log and in PostHog, which carries the same `cause` label.

## Note on release state

`0.63.0+124` (the build behind the three `C11-3C` events) predates #411, so it has #402's fingerprinting but not the visibility gate, and the events carry no `hang.app_active` tag. **No post-#411 build has produced a `runloop-idle` Sentry event yet** — #411's suppression has never been exercised in the field. The public line is still on the pre-#402 fingerprint (`C11-30`, 3,982 events / 20 users; `C11-31`, 2,799 / 17, both still arriving as of Aug 10).

## Testing

Behavioral tests in the existing suite, so CI's `build` job runs them:

- `testIdleRunLoopIsSeparatedFromAWedgeInCompute` now uses the real outermost-loop shape including the `-[NSApplication run]` frame.
- `testANestedRunLoopIsNotClassifiedAsIdle` (new): the socket-command and modal-alert stacks are not `runloop-idle`, do report, and the socket one's culprit names the frame that entered the loop.
- `MainThreadHangReportingRuleTests` (renamed from `MainThreadHangVisibilityTests`): `runloop-idle` never reports; every other cause does.
- Dropped `testWatchedRequiresBothFrontmostAndOnScreen`, which only exercised the now-removed `isWatched`.

Per the repo's standing instruction, no local `xcodebuild`. Both edited files pass `swiftc -parse`; CI's `build` job is the compile-and-logic gate.

Ticket: C11-198. Related: C11-191 (#411), C11-192 (#402).

🤖 Generated with [Claude Code](https://claude.com/claude-code)