### PR TITLE
C11-196: stop issuing synchronous LaunchServices XPC from the main thread

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		C11840000000000000000005 /* AttentionModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11840000000000000000006 /* AttentionModelTests.swift */; };
 		5A86082FF691F6FBCBDE52CB /* AgentLaunchOverlayCompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C8786B9F13542B2C4D9D35 /* AgentLaunchOverlayCompositionTests.swift */; };
 		5AE9C6CE7FCF928F695FE26D /* MainThreadHangMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB26BFF19A91FD51B78AF28E /* MainThreadHangMonitor.swift */; };
+		A1C1196000000000000001AA /* ExpiringValueCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1196000000000000002AA /* ExpiringValueCache.swift */; };
 		5AEB95ABF100C21BFCDB40E4 /* C11ThemeLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F1002001A1B2C3D4E5F015 /* C11ThemeLoaderTests.swift */; };
 		5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */; };
 		5E5FA83B76AB6FA59171D8C2 /* HealthFlagsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DH014BF1A1B2C3D4E5F60718 /* HealthFlagsTests.swift */; };
@@ -436,6 +437,7 @@
 		E81B5FA9C3AF8FAB6C10C623 /* WorkspaceApplyPlanCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8002BF1A1B2C3D4E5F60718 /* WorkspaceApplyPlanCodableTests.swift */; };
 		E883012FE2EFF094545647F6 /* Pi.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE86A069B4ECE7503CE20B95 /* Pi.swift */; };
 		E9E24C866C5E61B887F6E726 /* MainThreadHangDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */; };
+		A1C1196000000000000003AA /* ExpiringValueCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1C1196000000000000004AA /* ExpiringValueCacheTests.swift */; };
 		EAD9B00B1CD68D5F1C61CEDF /* ConversationStrategyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B9B8C3641F9801C6A45757 /* ConversationStrategyTests.swift */; };
 		EC224F7B0F7E77A981DFEC5A /* StateDirectoryMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B78D8232EFC5CF6A718EA7 /* StateDirectoryMigrationTests.swift */; };
 		F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
@@ -910,9 +912,11 @@
 		E1000001A1B2C3D4E5F60718 /* MenuKeyEquivalentRoutingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuKeyEquivalentRoutingUITests.swift; sourceTree = "<group>"; };
 		E1B94CA7E57E1FD8FFF1217B /* OmpScraper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OmpScraper.swift; path = Conversation/Scrapers/OmpScraper.swift; sourceTree = "<group>"; };
 		E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThreadHangDetectorTests.swift; sourceTree = "<group>"; };
+		A1C1196000000000000004AA /* ExpiringValueCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExpiringValueCacheTests.swift; sourceTree = "<group>"; };
 		E25359D87534E2AF54EA0E5F /* SurfaceActivityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceActivityTests.swift; sourceTree = "<group>"; };
 		E2BDE4F4D562EC49C639CF86 /* Kimi.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Kimi.swift; path = Conversation/Strategies/Kimi.swift; sourceTree = "<group>"; };
 		EB26BFF19A91FD51B78AF28E /* MainThreadHangMonitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MainThreadHangMonitor.swift; sourceTree = "<group>"; };
+		A1C1196000000000000002AA /* ExpiringValueCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExpiringValueCache.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
 		EE5E15A4988E33E201CBAE37 /* SocketSurfaceRefValidatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SocketSurfaceRefValidatorTests.swift; sourceTree = "<group>"; };
 		EFAF4E88F20968661D2D0886 /* MarkdownFeedbackHandlers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarkdownFeedbackHandlers.swift; sourceTree = "<group>"; };
@@ -1233,6 +1237,7 @@
 				54017DD4C9F6BE7CFA98C2F7 /* Opencode.swift */,
 				AD94535AC5F0BF88B5CDEDDF /* ClaudeCodeScraper.swift */,
 				EB26BFF19A91FD51B78AF28E /* MainThreadHangMonitor.swift */,
+				A1C1196000000000000002AA /* ExpiringValueCache.swift */,
 				51C0D2C1212976BCF837B620 /* HangBacktrace.c */,
 				BE61F2503F50546EC21A9868 /* HangBacktrace.h */,
 				0095C3D72A7722FFA42A7ED1 /* PaneSizePolicy.swift */,
@@ -1465,6 +1470,7 @@
 				7B4202C77B3590FB8D760708 /* AgentDetectorTests.swift */,
 				C11191F0100000000000001 /* GhosttyDisplayIDGateTests.swift */,
 				E223B0BAFC30EA2CC0F9BAC3 /* MainThreadHangDetectorTests.swift */,
+				A1C1196000000000000004AA /* ExpiringValueCacheTests.swift */,
 				4B2DBF12A2F90CBDE7F6A289 /* PaneSizePolicyTests.swift */,
 				FE01AA00000000000000B002 /* SendKeyVocabularyTests.swift */,
 				A2CADD0C9B7E43A29D723366 /* SurfaceTypeAvailabilityTests.swift */,
@@ -1812,6 +1818,7 @@
 				5C4604660F7CC322D5590BD7 /* AgentDetectorTests.swift in Sources */,
 				C11191A0100000000000001 /* GhosttyDisplayIDGateTests.swift in Sources */,
 				E9E24C866C5E61B887F6E726 /* MainThreadHangDetectorTests.swift in Sources */,
+				A1C1196000000000000003AA /* ExpiringValueCacheTests.swift in Sources */,
 				756290E56A4FC7D6546C1D46 /* PaneSizePolicyTests.swift in Sources */,
 				ACB000000000000000000102 /* BrowserCompanionPolicyTests.swift in Sources */,
 				FE01AA00000000000000B001 /* SendKeyVocabularyTests.swift in Sources */,
@@ -2009,6 +2016,7 @@
 				60785E8E82CF86BCF4A26738 /* Opencode.swift in Sources */,
 				767FF8ADAC0F182A4534E12B /* ClaudeCodeScraper.swift in Sources */,
 				5AE9C6CE7FCF928F695FE26D /* MainThreadHangMonitor.swift in Sources */,
+				A1C1196000000000000001AA /* ExpiringValueCache.swift in Sources */,
 				5535B0220F7520ADFB17EC99 /* HangBacktrace.c in Sources */,
 				27AE9B7E020D938C6013B312 /* PaneSizePolicy.swift in Sources */,
 				ACB000000000000000000101 /* AgentCompanionContext.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -522,6 +522,43 @@ enum TerminalDirectoryOpenTarget: String, CaseIterable {
         Set(commandPaletteShortcutTargets.filter { $0.isAvailable(in: environment) })
     }
 
+    // C11-196: `availableTargets` probes all fourteen editor targets, and every
+    // target that is not found on a candidate path falls back to
+    // `NSWorkspace.fullPath(forApplication:)`, a synchronous XPC round trip to
+    // `launchservicesd`. The command palette rebuilt this set on every keystroke,
+    // so a query in a terminal pane could issue a dozen unbounded LaunchServices
+    // waits per character typed on the main thread.
+    //
+    // The set only changes when the operator installs or removes an editor, so a
+    // short TTL is ample. Callers get the previous answer immediately and the
+    // recompute happens on a utility queue; only the very first call in a process
+    // pays the blocking probe.
+    static let availableTargetsCacheTTL: TimeInterval = 60
+
+    static let sharedAvailableTargetsCache = ExpiringValueCache<Set<TerminalDirectoryOpenTarget>>(
+        ttl: availableTargetsCacheTTL
+    )
+
+    static func availableTargetsCached(
+        in environment: DetectionEnvironment = .live,
+        cache: ExpiringValueCache<Set<TerminalDirectoryOpenTarget>>? = nil,
+        scheduleRefresh: (@escaping () -> Void) -> Void = { work in
+            DispatchQueue.global(qos: .utility).async(execute: work)
+        }
+    ) -> Set<Self> {
+        let cache = cache ?? sharedAvailableTargetsCache
+        guard cache.peek() != nil else {
+            // Cold start: nothing has ever been probed, so block once and seed
+            // the cache rather than reporting "no editors installed".
+            return cache.value(orCompute: { availableTargets(in: environment) })
+        }
+        let cached = cache.valueRefreshingInBackground(
+            scheduleRefresh: scheduleRefresh,
+            refresh: { availableTargets(in: environment) }
+        )
+        return cached ?? availableTargets(in: environment)
+    }
+
     var commandPaletteCommandId: String {
         "palette.terminalOpenDirectory.\(rawValue)"
     }
@@ -7746,10 +7783,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func syncMenuBarExtraVisibility(defaults: UserDefaults = .standard) {
-        if MenuBarExtraSettings.shouldInstallMenuBarExtra(
-            activationPolicy: NSApp.activationPolicy(),
+        // C11-196: this runs on every `UserDefaults.didChangeNotification`, which
+        // c11 emits constantly (window frames, sidebar widths, per-pane state).
+        // Read the activation policy from `AppPresentationPolicy` rather than
+        // `NSApp.activationPolicy()`; the latter is a synchronous XPC round trip
+        // to `launchservicesd` and was captured blocking main for 23.8 s here.
+        let shouldInstall = MenuBarExtraSettings.shouldInstallMenuBarExtra(
+            activationPolicy: AppPresentationPolicy.effectiveActivationPolicy(),
             defaults: defaults
-        ) {
+        )
+
+        // Nothing to do when the resolved answer matches the installed state.
+        // Skipping here also keeps `setupMenuBarExtra()` off the notification
+        // storm's hot path.
+        if shouldInstall == (menuBarExtraController != nil) { return }
+
+        if shouldInstall {
             setupMenuBarExtra()
             return
         }
@@ -13787,8 +13836,47 @@ enum AppPresentationPolicy {
         application: NSApplication = .shared
     ) {
         let targetPolicy = activationPolicy(isRunningUnderXCTest: isRunningUnderXCTest)
-        guard application.activationPolicy() != targetPolicy else { return }
+        let currentPolicy = application.activationPolicy()
+        guard currentPolicy != targetPolicy else {
+            recordActivationPolicy(currentPolicy)
+            return
+        }
         application.setActivationPolicy(targetPolicy)
+        recordActivationPolicy(targetPolicy)
+    }
+
+    // C11-196: `NSApplication.activationPolicy()` forwards to
+    // `-[NSRunningApplication activationPolicy]`, which faults in dynamic
+    // properties through `_LSCopyApplicationInformation`, a synchronous XPC
+    // round trip to `launchservicesd`. Sentry captured main parked there for
+    // 23.8 s inside `syncMenuBarExtraVisibility`, which runs on every
+    // `UserDefaults.didChangeNotification`.
+    //
+    // c11 is the only writer of its own activation policy (`apply` above is the
+    // sole `setActivationPolicy` call site), so the value we last set is
+    // authoritative and can be served without re-asking LaunchServices.
+    private static let policyLock = NSLock()
+    private static var recordedPolicy: NSApplication.ActivationPolicy?
+
+    static func recordActivationPolicy(_ policy: NSApplication.ActivationPolicy) {
+        policyLock.lock()
+        recordedPolicy = policy
+        policyLock.unlock()
+    }
+
+    /// The app's activation policy without a LaunchServices round trip when one
+    /// has already been observed or set. Falls back to the live (blocking) query
+    /// exactly once, then caches it.
+    static func effectiveActivationPolicy(
+        application: NSApplication = .shared
+    ) -> NSApplication.ActivationPolicy {
+        policyLock.lock()
+        let cached = recordedPolicy
+        policyLock.unlock()
+        if let cached { return cached }
+        let live = application.activationPolicy()
+        recordActivationPolicy(live)
+        return live
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4991,7 +4991,10 @@ struct ContentView: View {
               focusedPanelContext?.panel.panelType == .terminal else {
             return []
         }
-        return TerminalDirectoryOpenTarget.availableTargets()
+        // C11-196: cached. The uncached probe issues one synchronous
+        // LaunchServices XPC round trip per editor it cannot find on disk, and
+        // this runs on every command-palette keystroke.
+        return TerminalDirectoryOpenTarget.availableTargetsCached()
     }
 
     private func commandPaletteCommandsContext(
@@ -5214,7 +5217,7 @@ struct ContentView: View {
             snapshot.setBool(CommandPaletteContextKeys.panelHasUnread, hasUnread)
 
             if panelIsTerminal {
-                let availableTargets = terminalOpenTargets ?? TerminalDirectoryOpenTarget.availableTargets()
+                let availableTargets = terminalOpenTargets ?? TerminalDirectoryOpenTarget.availableTargetsCached()
                 for target in TerminalDirectoryOpenTarget.commandPaletteShortcutTargets {
                     snapshot.setBool(
                         CommandPaletteContextKeys.terminalOpenTargetAvailable(target),
@@ -14913,8 +14916,56 @@ private struct DraggableFolderIconRepresentable: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: DraggableFolderNSView, context: Context) {
-        nsView.directory = directory
-        nsView.updateIcon()
+        // C11-196: this fires on every SwiftUI update pass for the sidebar, and
+        // the icon lookup underneath is a synchronous LaunchServices/IconServices
+        // XPC round trip. Only re-resolve when the path actually changed.
+        nsView.setDirectory(directory)
+    }
+}
+
+/// C11-196: `NSWorkspace.icon(forFile:)` reaches IconServices/LaunchServices over
+/// synchronous XPC. The sidebar asked for the same handful of directory icons on
+/// every render pass, on every path-menu popup, and again on every drag start.
+/// Memoize by path so one lookup serves them all.
+///
+/// Entries expire so an operator who assigns a custom folder icon sees it without
+/// relaunching; `NSCache` additionally evicts under memory pressure.
+enum FolderIconCache {
+    static let entryTTL: TimeInterval = 300
+
+    private final class Entry {
+        let image: NSImage
+        let storedAt: TimeInterval
+
+        init(image: NSImage, storedAt: TimeInterval) {
+            self.image = image
+            self.storedAt = storedAt
+        }
+    }
+
+    private static let cache: NSCache<NSString, Entry> = {
+        let cache = NSCache<NSString, Entry>()
+        cache.countLimit = 256
+        return cache
+    }()
+
+    /// A correctly sized icon for `path`, reusing a cached lookup when possible.
+    ///
+    /// The returned image is a copy: callers set `size` on it, and the cached
+    /// base image must not be resized out from under other callers.
+    static func icon(forPath path: String, size: CGFloat) -> NSImage {
+        let key = path as NSString
+        let now = ProcessInfo.processInfo.systemUptime
+        let base: NSImage
+        if let entry = cache.object(forKey: key), now - entry.storedAt < entryTTL {
+            base = entry.image
+        } else {
+            base = NSWorkspace.shared.icon(forFile: path)
+            cache.setObject(Entry(image: base, storedAt: now), forKey: key)
+        }
+        let sized = (base.copy() as? NSImage) ?? base
+        sized.size = NSSize(width: size, height: size)
+        return sized
     }
 }
 
@@ -14923,7 +14974,8 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
         override var mouseDownCanMoveWindow: Bool { false }
     }
 
-    var directory: String
+    private(set) var directory: String
+    private var iconDirectory: String?
     private var imageView: FolderIconImageView!
     private var previousWindowMovableState: Bool?
     private weak var suppressedWindow: NSWindow?
@@ -14966,10 +15018,18 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
         updateIcon()
     }
 
+    /// Point the view at a new directory, refreshing the icon only when the path
+    /// actually changed. SwiftUI calls this on every update pass.
+    func setDirectory(_ newDirectory: String) {
+        guard newDirectory != directory else { return }
+        directory = newDirectory
+        updateIcon()
+    }
+
     func updateIcon() {
-        let icon = NSWorkspace.shared.icon(forFile: directory)
-        icon.size = NSSize(width: 16, height: 16)
-        imageView.image = icon
+        guard iconDirectory != directory || imageView.image == nil else { return }
+        imageView.image = FolderIconCache.icon(forPath: directory, size: 16)
+        iconDirectory = directory
     }
 
     func draggingSession(_ session: NSDraggingSession, sourceOperationMaskFor context: NSDraggingContext) -> NSDragOperation {
@@ -15013,8 +15073,7 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
         let fileURL = URL(fileURLWithPath: directory)
         let draggingItem = NSDraggingItem(pasteboardWriter: fileURL as NSURL)
 
-        let iconImage = NSWorkspace.shared.icon(forFile: directory)
-        iconImage.size = NSSize(width: 32, height: 32)
+        let iconImage = FolderIconCache.icon(forPath: directory, size: 32)
         draggingItem.setDraggingFrame(bounds, contents: iconImage)
 
         let session = beginDraggingSession(with: [draggingItem], event: event, source: self)
@@ -15054,8 +15113,7 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
 
         // Add path components (current dir at top, root at bottom - matches native macOS)
         for pathURL in pathComponents {
-            let icon = NSWorkspace.shared.icon(forFile: pathURL.path)
-            icon.size = NSSize(width: 16, height: 16)
+            let icon = FolderIconCache.icon(forPath: pathURL.path, size: 16)
 
             let displayName: String
             if pathURL.path == "/" {

--- a/Sources/ExpiringValueCache.swift
+++ b/Sources/ExpiringValueCache.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+/// C11-196: LaunchServices-backed AppKit lookups are synchronous XPC round trips.
+///
+/// `NSApplication.activationPolicy()`, `NSWorkspace.fullPath(forApplication:)`,
+/// `NSWorkspace.urlForApplication(withBundleIdentifier:)` and
+/// `NSWorkspace.icon(forFile:)` all reach `launchservicesd` through
+/// `xpc_connection_send_message_with_reply_sync`, and nothing bounds that wait.
+/// Sentry hang captures for c11 show main parked in
+/// `_dispatch_mach_send_and_wait_for_reply` under `_LSCopyApplicationInformation`
+/// for tens of seconds at a time. A single such call is unavoidable; issuing one
+/// per keystroke, per render pass, or per `UserDefaults.didChangeNotification` is
+/// not.
+///
+/// `ExpiringValueCache` is the seam that turns those repeated lookups into one
+/// lookup per TTL window. It deliberately keeps the last value past expiry so a
+/// caller that cannot block (a SwiftUI update pass, a command-palette refresh)
+/// can serve the stale answer immediately and recompute off the main thread.
+///
+/// Thread-safe: every accessor takes an internal lock, so a background refresh
+/// and a main-thread read can race safely.
+final class ExpiringValueCache<Value> {
+    /// How the stored value relates to the TTL window.
+    enum Freshness: Equatable {
+        /// Nothing has been stored yet.
+        case missing
+        /// A value is stored and still inside the TTL window.
+        case fresh
+        /// A value is stored but the TTL window has elapsed.
+        case stale
+    }
+
+    private let ttl: TimeInterval
+    private let now: () -> TimeInterval
+    private let lock = NSLock()
+    private var storedValue: Value?
+    private var storedAt: TimeInterval?
+
+    /// - Parameters:
+    ///   - ttl: How long a stored value stays `.fresh`. Must be >= 0.
+    ///   - now: Monotonic clock source. Defaults to `systemUptime` so a wall-clock
+    ///     or NTP adjustment mid-window cannot make a value look arbitrarily old
+    ///     or arbitrarily new.
+    init(
+        ttl: TimeInterval,
+        now: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+    ) {
+        self.ttl = max(0, ttl)
+        self.now = now
+    }
+
+    var freshness: Freshness {
+        lock.lock()
+        defer { lock.unlock() }
+        return freshnessLocked()
+    }
+
+    /// The last stored value, regardless of age. `nil` only before the first store.
+    func peek() -> Value? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+
+    /// Replace the stored value and restart the TTL window.
+    func store(_ value: Value) {
+        lock.lock()
+        defer { lock.unlock() }
+        storedValue = value
+        storedAt = now()
+    }
+
+    /// Drop the stored value. The next `value(orCompute:)` recomputes.
+    func invalidate() {
+        lock.lock()
+        defer { lock.unlock() }
+        storedValue = nil
+        storedAt = nil
+    }
+
+    /// Return the cached value when fresh, otherwise compute, store, and return.
+    ///
+    /// `compute` runs on the caller's thread, so this blocks the caller for the
+    /// duration of the underlying XPC wait. Use it where a blocking first call is
+    /// acceptable and repetition is not.
+    func value(orCompute compute: () -> Value) -> Value {
+        lock.lock()
+        if freshnessLocked() == .fresh, let storedValue {
+            lock.unlock()
+            return storedValue
+        }
+        lock.unlock()
+
+        // Compute outside the lock: `compute` can park on synchronous XPC for a
+        // long time and must not hold off a concurrent `peek()`/`store()`.
+        let computed = compute()
+        store(computed)
+        return computed
+    }
+
+    /// Never blocks when any value has ever been stored.
+    ///
+    /// Returns the cached value immediately (even if stale) and, when it is stale
+    /// or missing, hands `refresh` to `scheduleRefresh` so the recompute happens
+    /// off the caller's thread. Only the very first call, before anything has been
+    /// stored, returns `nil`.
+    ///
+    /// At most one refresh is in flight at a time; calls made while a refresh is
+    /// running return the current value without scheduling another.
+    func valueRefreshingInBackground(
+        scheduleRefresh: (@escaping () -> Void) -> Void,
+        refresh: @escaping () -> Value
+    ) -> Value? {
+        lock.lock()
+        let current = storedValue
+        let needsRefresh = freshnessLocked() != .fresh && !refreshInFlight
+        if needsRefresh {
+            refreshInFlight = true
+        }
+        lock.unlock()
+
+        guard needsRefresh else { return current }
+
+        scheduleRefresh { [weak self] in
+            guard let self else { return }
+            let value = refresh()
+            self.store(value)
+            self.lock.lock()
+            self.refreshInFlight = false
+            self.lock.unlock()
+        }
+
+        return current
+    }
+
+    private var refreshInFlight = false
+
+    private func freshnessLocked() -> Freshness {
+        guard storedValue != nil, let storedAt else { return .missing }
+        return (now() - storedAt) < ttl ? .fresh : .stale
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2823,7 +2823,9 @@ class TabManager: ObservableObject {
             cancelButton.keyEquivalent = "\u{1b}"
         }
 
-        if NSApp.activationPolicy() == .regular {
+        // C11-196: `NSApp.activationPolicy()` is a synchronous LaunchServices XPC
+        // round trip; read the policy c11 itself set instead.
+        if AppPresentationPolicy.effectiveActivationPolicy() == .regular {
             NSApp.activate(ignoringOtherApps: true)
         }
 

--- a/Sources/c11App.swift
+++ b/Sources/c11App.swift
@@ -6660,7 +6660,19 @@ struct SettingsView: View {
     }
 
     private func refreshDetectedImportBrowsers() {
-        detectedImportBrowsers = InstalledBrowserDetector.detectInstalledBrowsers()
+        // C11-196: the detector probes a dozen browser bundle identifiers through
+        // `NSWorkspace.urlForApplication(withBundleIdentifier:)`, each one a
+        // synchronous XPC round trip to `launchservicesd`. Settings opened this
+        // on the main thread from `.onAppear`; the browser panel's own empty-state
+        // detector already runs it detached, so match that.
+        Task {
+            let browsers = await Task.detached(priority: .utility) {
+                InstalledBrowserDetector.detectInstalledBrowsers()
+            }.value
+            await MainActor.run {
+                detectedImportBrowsers = browsers
+            }
+        }
     }
 }
 

--- a/c11Tests/ExpiringValueCacheTests.swift
+++ b/c11Tests/ExpiringValueCacheTests.swift
@@ -1,0 +1,283 @@
+import XCTest
+
+#if canImport(c11_DEV)
+@testable import c11_DEV
+#elseif canImport(c11)
+@testable import c11
+#endif
+
+/// C11-196: behavioral tests for the memoization seam that keeps repeated
+/// LaunchServices lookups off the main thread's synchronous XPC path.
+///
+/// The clock is injected, so these run in-process with no sleeping and no real
+/// `NSWorkspace` traffic. What they assert is the property the fix depends on:
+/// N reads produce one recompute, not N.
+final class ExpiringValueCacheTests: XCTestCase {
+
+    private final class Clock {
+        var now: TimeInterval = 0
+        func read() -> TimeInterval { now }
+    }
+
+    func testFirstReadComputesAndSubsequentReadsWithinTTLDoNot() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<Int>(ttl: 10, now: clock.read)
+        var computeCount = 0
+
+        let first = cache.value(orCompute: { computeCount += 1; return 42 })
+        XCTAssertEqual(first, 42)
+        XCTAssertEqual(computeCount, 1)
+
+        clock.now = 9.9
+        for _ in 0..<100 {
+            XCTAssertEqual(cache.value(orCompute: { computeCount += 1; return 42 }), 42)
+        }
+        XCTAssertEqual(computeCount, 1, "reads inside the TTL window must reuse the stored value")
+    }
+
+    func testRecomputesOnceTheTTLWindowElapses() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<Int>(ttl: 10, now: clock.read)
+        var computeCount = 0
+        let compute: () -> Int = { computeCount += 1; return computeCount }
+
+        XCTAssertEqual(cache.value(orCompute: compute), 1)
+        clock.now = 10
+        XCTAssertEqual(cache.value(orCompute: compute), 2, "expiry must produce a fresh value")
+        XCTAssertEqual(computeCount, 2)
+    }
+
+    func testFreshnessTracksTheTTLWindow() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<String>(ttl: 5, now: clock.read)
+        XCTAssertEqual(cache.freshness, .missing)
+
+        cache.store("a")
+        XCTAssertEqual(cache.freshness, .fresh)
+
+        clock.now = 4.99
+        XCTAssertEqual(cache.freshness, .fresh)
+
+        clock.now = 5
+        XCTAssertEqual(cache.freshness, .stale)
+        XCTAssertEqual(cache.peek(), "a", "a stale value is still available to serve")
+    }
+
+    func testInvalidateForcesTheNextReadToRecompute() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<Int>(ttl: 100, now: clock.read)
+        var computeCount = 0
+        let compute: () -> Int = { computeCount += 1; return computeCount }
+
+        _ = cache.value(orCompute: compute)
+        cache.invalidate()
+        XCTAssertEqual(cache.freshness, .missing)
+        XCTAssertNil(cache.peek())
+        _ = cache.value(orCompute: compute)
+        XCTAssertEqual(computeCount, 2)
+    }
+
+    func testBackgroundRefreshReturnsNilBeforeAnythingIsStored() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<Int>(ttl: 10, now: clock.read)
+        var scheduled: [() -> Void] = []
+
+        let value = cache.valueRefreshingInBackground(
+            scheduleRefresh: { scheduled.append($0) },
+            refresh: { 7 }
+        )
+
+        XCTAssertNil(value, "cold start has nothing to serve")
+        XCTAssertEqual(scheduled.count, 1, "cold start must schedule the first refresh")
+    }
+
+    func testBackgroundRefreshServesStaleValueWithoutBlocking() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<Int>(ttl: 10, now: clock.read)
+        cache.store(1)
+        var scheduled: [() -> Void] = []
+        var refreshCount = 0
+
+        clock.now = 50
+        let served = cache.valueRefreshingInBackground(
+            scheduleRefresh: { scheduled.append($0) },
+            refresh: { refreshCount += 1; return 2 }
+        )
+
+        XCTAssertEqual(served, 1, "the stale value is returned immediately")
+        XCTAssertEqual(refreshCount, 0, "the recompute must not run on the caller's thread")
+        XCTAssertEqual(scheduled.count, 1)
+
+        scheduled.removeFirst()()
+        XCTAssertEqual(refreshCount, 1)
+        XCTAssertEqual(cache.peek(), 2, "the completed refresh replaces the stored value")
+        XCTAssertEqual(cache.freshness, .fresh)
+    }
+
+    func testBackgroundRefreshDoesNotStackWhileOneIsInFlight() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<Int>(ttl: 10, now: clock.read)
+        cache.store(1)
+        var scheduled: [() -> Void] = []
+
+        clock.now = 50
+        for _ in 0..<25 {
+            _ = cache.valueRefreshingInBackground(
+                scheduleRefresh: { scheduled.append($0) },
+                refresh: { 2 }
+            )
+        }
+
+        XCTAssertEqual(scheduled.count, 1, "a burst of stale reads must coalesce into one refresh")
+
+        scheduled.removeFirst()()
+        clock.now = 200
+        _ = cache.valueRefreshingInBackground(
+            scheduleRefresh: { scheduled.append($0) },
+            refresh: { 3 }
+        )
+        XCTAssertEqual(scheduled.count, 1, "a later staleness window can schedule again")
+    }
+
+    func testFreshReadsNeverScheduleARefresh() {
+        let clock = Clock()
+        let cache = ExpiringValueCache<Int>(ttl: 10, now: clock.read)
+        cache.store(5)
+        var scheduled = 0
+
+        clock.now = 1
+        for _ in 0..<10 {
+            XCTAssertEqual(
+                cache.valueRefreshingInBackground(
+                    scheduleRefresh: { _ in scheduled += 1 },
+                    refresh: { 6 }
+                ),
+                5
+            )
+        }
+        XCTAssertEqual(scheduled, 0)
+    }
+}
+
+/// C11-196: the command palette rebuilt the editor-availability set on every
+/// keystroke, and each target it could not find on disk fell back to
+/// `NSWorkspace.fullPath(forApplication:)`, an unbounded synchronous XPC wait.
+/// These assert the cached accessor collapses that into one probe pass.
+final class TerminalDirectoryOpenTargetCacheTests: XCTestCase {
+
+    private final class ProbeCounter {
+        private(set) var launchServicesLookups = 0
+
+        func environment(
+            existingPaths: Set<String> = [],
+            applicationPathsByName: [String: String] = [:]
+        ) -> TerminalDirectoryOpenTarget.DetectionEnvironment {
+            TerminalDirectoryOpenTarget.DetectionEnvironment(
+                homeDirectoryPath: "/Users/tester",
+                fileExistsAtPath: { existingPaths.contains($0) },
+                isExecutableFileAtPath: { existingPaths.contains($0) },
+                applicationPathForName: { [weak self] name in
+                    self?.launchServicesLookups += 1
+                    return applicationPathsByName[name]
+                }
+            )
+        }
+    }
+
+    func testRepeatedPaletteRefreshesIssueOneLaunchServicesProbePass() {
+        let counter = ProbeCounter()
+        let env = counter.environment(existingPaths: ["/Applications/Visual Studio Code.app"])
+        let cache = ExpiringValueCache<Set<TerminalDirectoryOpenTarget>>(ttl: 60, now: { 0 })
+
+        let first = TerminalDirectoryOpenTarget.availableTargetsCached(
+            in: env,
+            cache: cache,
+            scheduleRefresh: { $0() }
+        )
+        XCTAssertTrue(first.contains(.vscode))
+        let lookupsAfterFirst = counter.launchServicesLookups
+        XCTAssertGreaterThan(
+            lookupsAfterFirst,
+            0,
+            "the cold probe must actually consult LaunchServices for missing apps"
+        )
+
+        // Stand in for a burst of command-palette keystrokes.
+        for _ in 0..<50 {
+            XCTAssertEqual(
+                TerminalDirectoryOpenTarget.availableTargetsCached(
+                    in: env,
+                    cache: cache,
+                    scheduleRefresh: { $0() }
+                ),
+                first
+            )
+        }
+
+        XCTAssertEqual(
+            counter.launchServicesLookups,
+            lookupsAfterFirst,
+            "cached reads must not re-enter the LaunchServices lookup"
+        )
+    }
+
+    func testCachedResultMatchesTheUncachedProbe() {
+        let counter = ProbeCounter()
+        let paths: Set<String> = [
+            "/Applications/Visual Studio Code.app",
+            "/System/Library/CoreServices/Finder.app",
+        ]
+        let env = counter.environment(existingPaths: paths)
+        let cache = ExpiringValueCache<Set<TerminalDirectoryOpenTarget>>(ttl: 60, now: { 0 })
+
+        XCTAssertEqual(
+            TerminalDirectoryOpenTarget.availableTargetsCached(
+                in: env,
+                cache: cache,
+                scheduleRefresh: { $0() }
+            ),
+            TerminalDirectoryOpenTarget.availableTargets(in: env),
+            "caching must not change which targets are reported available"
+        )
+    }
+
+    func testStaleCacheServesPreviousAnswerThenPicksUpANewInstall() {
+        var installedPaths: Set<String> = []
+        let env = TerminalDirectoryOpenTarget.DetectionEnvironment(
+            homeDirectoryPath: "/Users/tester",
+            fileExistsAtPath: { installedPaths.contains($0) },
+            isExecutableFileAtPath: { installedPaths.contains($0) },
+            applicationPathForName: { _ in nil }
+        )
+        var clock: TimeInterval = 0
+        let cache = ExpiringValueCache<Set<TerminalDirectoryOpenTarget>>(ttl: 60, now: { clock })
+        var pending: [() -> Void] = []
+
+        let cold = TerminalDirectoryOpenTarget.availableTargetsCached(
+            in: env,
+            cache: cache,
+            scheduleRefresh: { pending.append($0) }
+        )
+        XCTAssertFalse(cold.contains(.vscode))
+        XCTAssertTrue(pending.isEmpty, "the cold probe runs inline, not as a background refresh")
+
+        installedPaths.insert("/Applications/Visual Studio Code.app")
+        clock = 120
+
+        let stale = TerminalDirectoryOpenTarget.availableTargetsCached(
+            in: env,
+            cache: cache,
+            scheduleRefresh: { pending.append($0) }
+        )
+        XCTAssertFalse(stale.contains(.vscode), "the stale read is served without blocking")
+        XCTAssertEqual(pending.count, 1)
+
+        pending.removeFirst()()
+        let refreshed = TerminalDirectoryOpenTarget.availableTargetsCached(
+            in: env,
+            cache: cache,
+            scheduleRefresh: { pending.append($0) }
+        )
+        XCTAssertTrue(refreshed.contains(.vscode), "the background refresh picks up the new install")
+    }
+}


### PR DESCRIPTION
## Evidence

Pulled 2600 unique hang events from Sentry issues `C11-30` / `C11-31` (`contexts.hang.stack`) and filtered to backtraces containing `xpc_connection_send_message_with_reply_sync` / `_dispatch_mach_send_and_wait_for_reply`. 82 hits across 6 distinct users, clustering into four shapes:

| n | users | max stall | shape |
|---|---|---|---|
| 59 | 1 | 142,654 ms | LS notification -> HIToolbox -> `AESendMessage` -> `_LSCopyApplicationInformationItem` |
| 12 | 5 | 16,264 ms | RunningBoard `rbs_acquire_appnap_assertion` via `CFRunLoopSetOptionsReason` |
| 10 | 3 | 48,908 ms | LS notification -> `NSMenuBarDisplayManager _applicationNameChanged:` -> `NSRunningApplication.processIdentifier` |
| **1** | 1 | **23,823 ms** | **c11 `AppDelegate.syncMenuBarExtraVisibility` -> `NSRunningApplication.activationPolicy`** |

Exactly one cluster carries a c11 frame:

```
5   libxpc.dylib     xpc_connection_send_message_with_reply_sync
6   LaunchServices   LSClientToServerConnection::sendWithReply
7   LaunchServices   _LSCopyApplicationInformation
8   AppKit           -[NSRunningApplication _fetchDynamicProperties]
9   AppKit           -[NSRunningApplication activationPolicy]
10  c11              AppDelegate.syncMenuBarExtraVisibility(defaults:)
11  c11              AppDelegate.installMenuBarVisibilityObserver()...
```

`syncMenuBarExtraVisibility` runs on every `UserDefaults.didChangeNotification`, and `NSApp.activationPolicy()` forwards to `NSRunningApplication` and faults dynamic properties through `_LSCopyApplicationInformation`. Nothing bounds that wait.

Sentry's captured stacks truncate at 24 frames, so the rest of the clusters bottom out in the event loop before any c11 frame could appear. Rather than guess, the same call shape was audited across `Sources/`, which turned up three more LaunchServices-backed lookups on hot main-thread paths.

## Confirmed call sites and fixes

| Site | Why it hurts | Fix |
|---|---|---|
| `AppDelegate.syncMenuBarExtraVisibility` -> `NSApp.activationPolicy()` | Runs on every `UserDefaults.didChangeNotification`; c11 writes defaults constantly | `AppPresentationPolicy` records the policy it sets (it is the only `setActivationPolicy` call site) and serves it from `effectiveActivationPolicy()`. Also short-circuits when the resolved answer matches the installed state. |
| `ContentView.resolveCommandPaletteTerminalOpenTargets` -> `TerminalDirectoryOpenTarget.availableTargets()` | Rebuilt on every palette keystroke; each of 14 targets not found on disk falls back to `NSWorkspace.fullPath(forApplication:)` | `availableTargetsCached()`: 60s TTL, refresh on a utility queue, blocking probe only on the first call in a process |
| `DraggableFolderIconRepresentable.updateNSView` -> `NSWorkspace.icon(forFile:)` | Fires on every SwiftUI update pass for the sidebar, plus every drag start and path-menu popup | `FolderIconCache` memoizes by path (5 min TTL, `NSCache`); the representable only re-resolves when the path actually changed |
| `SettingsView.refreshDetectedImportBrowsers` -> `InstalledBrowserDetector` | A dozen `NSWorkspace.urlForApplication` probes on main from `.onAppear` | Detached task, matching what `BrowserPanelView` already does |
| `TabManager` pre-modal `NSApp.activationPolicy()` | Same LS round trip, rarer path | Reads the recorded policy |

New `Sources/ExpiringValueCache.swift` is the shared seam: a TTL cache with an injectable monotonic clock that serves the previous value immediately when stale and hands the recompute to a caller-supplied scheduler, so callers that cannot block never do after the first read.

## Deliberately left alone

- **The other 81 evidence hits are system-owned.** LaunchServices notification callbacks delivered into c11's idle runloop (`HIToolbox` -> `AESendMessage`, `NSMenuBarDisplayManager` -> `NSRunningApplication.processIdentifier`) and RunningBoard app-nap assertions from `CFRunLoopSetOptionsReason`. No c11 frame appears on any of them; c11 issues no call and cannot bound the wait.
- **`TerminalController.v2AwaitCallback`** main-thread branch. It already slices `CFRunLoopRunInMode` against a caller-supplied deadline. The single hit naming it is cluster A's LS notification running inside that pump, not a c11-issued XPC.
- **`NSWorkspace.shared.open(...)`** call sites. Synchronous, but one shot per explicit user or agent action, and the `Bool` result is consumed inline. Converting them to the completion-handler variant changes the API contract at ~25 sites for no measured gain.
- **`enforceSingleInstance`** -> `NSRunningApplication.runningApplications(withBundleIdentifier:)`. Launch time, once.
- **`NSOpenPanel` / `NSSavePanel`.** User-driven modals, synchronous by design.

## Note on the acceptance criterion

The ticket asks for "no capture exceeds 10s in that bucket" after the classifier ships. The evidence says that is not reachable by fixing c11 call sites alone: 81 of 82 captures are the OS blocking our main thread in an idle runloop with no c11 frame present. Suggest re-scoping the acceptance to the c11-attributable subset, or teaching the `xpc-sync-wait` classifier in `MainThreadHangMonitor` to split "c11 frame present" from "system-owned LS notification delivery" so the bucket measures something we control.

## Tests

`c11Tests/ExpiringValueCacheTests.swift`, added to the `c11LogicTests` target. Behavioral, injected clock, no real `NSWorkspace` traffic:

- TTL semantics: one compute inside the window, recompute after it, freshness transitions, `invalidate()`.
- Background refresh: stale value served without running the recompute on the caller's thread; a burst of stale reads coalesces to one scheduled refresh; fresh reads never schedule.
- `TerminalDirectoryOpenTarget.availableTargetsCached`: 50 simulated palette keystrokes issue exactly one LaunchServices probe pass (counted through the injected `DetectionEnvironment`); the cached answer matches the uncached probe; a stale window serves the old answer and the background refresh picks up a newly installed editor.

No test is added for `FolderIconCache` or the `updateNSView` guard. The property that matters there is "no XPC on the render path", which is not observable without adding an injection seam to an `NSView` subclass that a bare xctest runner cannot construct reliably. Calling that out rather than adding a test that asserts nothing.

Not built or tested locally per the repo's no-local-`xcodebuild` rule. CI is the gate.

Closes C11-196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)